### PR TITLE
feat: tmux-cli to use tmux windows instead of panes as default shell container

### DIFF
--- a/claude_code_tools/tmux_cli_controller.py
+++ b/claude_code_tools/tmux_cli_controller.py
@@ -87,20 +87,17 @@ For full documentation, see docs/tmux-cli-instructions.md in the package reposit
 
 
 class TmuxCLIController:
-    """Controller for interacting with CLI applications in tmux panes."""
+    """Controller for interacting with CLI applications in tmux windows."""
     
-    def __init__(self, session_name: Optional[str] = None, window_name: Optional[str] = None):
+    def __init__(self, session_name: Optional[str] = None):
         """
         Initialize the controller.
 
         Args:
             session_name: Name of tmux session (defaults to current)
-            window_name: Name of tmux window (defaults to current)
         """
         self.session_name = session_name
-        self.window_name = window_name
-        self.target_pane = None
-        self.target_window = None  # For window-based operations
+        self.target_window = None
     
     def _run_tmux_command(self, command: List[str]) -> Tuple[str, int]:
         """
@@ -144,64 +141,6 @@ class TmuxCLIController:
         output, code = self._run_tmux_command(['display-message', '-t', pane_id, '-p', '#{pane_current_command}'])
         return output if code == 0 else None
     
-    def format_pane_identifier(self, pane_id: str) -> str:
-        """Convert pane ID to session:window.pane format."""
-        try:
-            # Get session, window index, and pane index for this pane
-            session_output, session_code = self._run_tmux_command(['display-message', '-t', pane_id, '-p', '#{session_name}'])
-            window_output, window_code = self._run_tmux_command(['display-message', '-t', pane_id, '-p', '#{window_index}'])
-            pane_output, pane_code = self._run_tmux_command(['display-message', '-t', pane_id, '-p', '#{pane_index}'])
-            
-            if session_code == 0 and window_code == 0 and pane_code == 0:
-                return f"{session_output}:{window_output}.{pane_output}"
-            else:
-                # Fallback to pane ID
-                return pane_id
-        except:
-            return pane_id
-    
-    def resolve_pane_identifier(self, identifier: str) -> Optional[str]:
-        """Convert various pane identifier formats to pane ID.
-        
-        Supports:
-        - Pane IDs: %123
-        - session:window.pane: mysession:1.2
-        - Just pane index: 2 (for current window)
-        """
-        if not identifier:
-            return None
-        
-        # Convert to string if it's a number
-        identifier = str(identifier)
-            
-        # If it's already a pane ID (%123), return as is
-        if identifier.startswith('%'):
-            return identifier
-            
-        # If it's just a number, treat as pane index in current window
-        if identifier.isdigit():
-            panes = self.list_panes()
-            for pane in panes:
-                if pane['index'] == identifier:
-                    return pane['id']
-            return None
-            
-        # If it's session:window.pane format
-        if ':' in identifier and '.' in identifier:
-            try:
-                session_window, pane_index = identifier.rsplit('.', 1)
-                session, window = session_window.split(':', 1)
-                
-                # Get pane ID from session:window.pane
-                output, code = self._run_tmux_command([
-                    'display-message', '-t', f'{session}:{window}.{pane_index}', '-p', '#{pane_id}'
-                ])
-                return output if code == 0 else None
-            except:
-                return None
-                
-        return None
-    
     def get_current_window_id(self) -> Optional[str]:
         """Get the ID of the current tmux window."""
         # Use TMUX_PANE environment variable to get the pane we're running in
@@ -215,331 +154,7 @@ class TmuxCLIController:
         output, code = self._run_tmux_command(['display-message', '-p', '#{window_id}'])
         return output if code == 0 else None
     
-    def list_panes(self) -> List[Dict[str, str]]:
-        """
-        List all panes in the current window.
-        
-        Returns:
-            List of dicts with pane info (id, index, title, active, size, command, formatted_id)
-        """
-        target = f"{self.session_name}:{self.window_name}" if self.session_name and self.window_name else ""
-        
-        output, code = self._run_tmux_command([
-            'list-panes',
-            '-t', target,
-            '-F', '#{pane_id}|#{pane_index}|#{pane_title}|#{pane_active}|#{pane_width}x#{pane_height}|#{pane_current_command}'
-        ] if target else [
-            'list-panes',
-            '-F', '#{pane_id}|#{pane_index}|#{pane_title}|#{pane_active}|#{pane_width}x#{pane_height}|#{pane_current_command}'
-        ])
-        
-        if code != 0:
-            return []
-        
-        panes = []
-        for line in output.split('\n'):
-            if line:
-                parts = line.split('|')
-                pane_id = parts[0]
-                panes.append({
-                    'id': pane_id,
-                    'index': parts[1],
-                    'title': parts[2],
-                    'active': parts[3] == '1',
-                    'size': parts[4],
-                    'command': parts[5] if len(parts) > 5 else '',
-                    'formatted_id': self.format_pane_identifier(pane_id)
-                })
-        return panes
-    
-    def create_pane(self, vertical: bool = True, size: Optional[int] = None, 
-                   start_command: Optional[str] = None) -> Optional[str]:
-        """
-        Create a new pane in the current window.
-        
-        Args:
-            vertical: If True, split vertically (side by side), else horizontally
-            size: Size percentage for the new pane (e.g., 50 for 50%)
-            start_command: Command to run in the new pane
-            
-        Returns:
-            Pane ID of the created pane
-        """
-        # Get the current window ID to ensure pane is created in this window
-        current_window_id = self.get_current_window_id()
-        
-        cmd = ['split-window']
-        
-        # Target the specific window where tmux-cli was called from
-        if current_window_id:
-            cmd.extend(['-t', current_window_id])
-        
-        if vertical:
-            cmd.append('-h')
-        else:
-            cmd.append('-v')
-        
-        if size:
-            cmd.extend(['-p', str(size)])
-        
-        cmd.extend(['-P', '-F', '#{pane_id}'])
-        
-        if start_command:
-            cmd.append(start_command)
-        
-        output, code = self._run_tmux_command(cmd)
-        
-        if code == 0:
-            self.target_pane = output
-            return output
-        return None
-    
-    def select_pane(self, pane_id: Optional[str] = None, pane_index: Optional[int] = None):
-        """
-        Select a pane as the target for operations.
-        
-        Args:
-            pane_id: Pane ID (e.g., %0, %1)
-            pane_index: Pane index (0-based)
-        """
-        if pane_id:
-            self.target_pane = pane_id
-        elif pane_index is not None:
-            panes = self.list_panes()
-            for pane in panes:
-                if int(pane['index']) == pane_index:
-                    self.target_pane = pane['id']
-                    break
-    
-    def send_keys(self, text: str, pane_id: Optional[str] = None, enter: bool = True,
-                  delay_enter: Union[bool, float] = True):
-        """
-        Send keystrokes to a pane.
-        
-        Args:
-            text: Text to send
-            pane_id: Target pane (uses self.target_pane if not specified)
-            enter: Whether to send Enter key after text
-            delay_enter: If True, use 1.0s delay; if float, use that delay in seconds (default: True)
-        """
-        target = pane_id or self.target_pane
-        if not target:
-            raise ValueError("No target pane specified")
-        
-        if enter and delay_enter:
-            # Send text without Enter first
-            cmd = ['send-keys', '-t', target, text]
-            self._run_tmux_command(cmd)
-            
-            # Determine delay duration
-            if isinstance(delay_enter, bool):
-                delay = 1.0  # Default delay
-            else:
-                delay = float(delay_enter)
-            
-            # Apply delay
-            time.sleep(delay)
-            
-            # Then send just Enter
-            cmd = ['send-keys', '-t', target, 'Enter']
-            self._run_tmux_command(cmd)
-        else:
-            # Original behavior
-            cmd = ['send-keys', '-t', target, text]
-            if enter:
-                cmd.append('Enter')
-            self._run_tmux_command(cmd)
-    
-    def capture_pane(self, pane_id: Optional[str] = None, lines: Optional[int] = None) -> str:
-        """
-        Capture the contents of a pane.
-        
-        Args:
-            pane_id: Target pane (uses self.target_pane if not specified)
-            lines: Number of lines to capture from bottom (captures all if None)
-            
-        Returns:
-            Captured text content
-        """
-        target = pane_id or self.target_pane
-        if not target:
-            raise ValueError("No target pane specified")
-        
-        cmd = ['capture-pane', '-t', target, '-p']
-        
-        if lines:
-            cmd.extend(['-S', f'-{lines}'])
-        
-        output, _ = self._run_tmux_command(cmd)
-        return output
-    
-    def wait_for_prompt(self, prompt_pattern: str, pane_id: Optional[str] = None, 
-                       timeout: int = 10, check_interval: float = 0.5) -> bool:
-        """
-        Wait for a specific prompt pattern to appear in the pane.
-        
-        Args:
-            prompt_pattern: Regex pattern to match
-            pane_id: Target pane
-            timeout: Maximum seconds to wait
-            check_interval: Seconds between checks
-            
-        Returns:
-            True if prompt found, False if timeout
-        """
-        target = pane_id or self.target_pane
-        if not target:
-            raise ValueError("No target pane specified")
-        
-        pattern = re.compile(prompt_pattern)
-        start_time = time.time()
-        
-        while time.time() - start_time < timeout:
-            content = self.capture_pane(target, lines=50)
-            if pattern.search(content):
-                return True
-            time.sleep(check_interval)
-        
-        return False
-    
-    def wait_for_idle(self, pane_id: Optional[str] = None, idle_time: float = 2.0,
-                     check_interval: float = 0.5, timeout: Optional[int] = None) -> bool:
-        """
-        Wait for a pane to become idle (no output changes for idle_time seconds).
-        
-        Args:
-            pane_id: Target pane
-            idle_time: Seconds of no change to consider idle
-            check_interval: Seconds between checks
-            timeout: Maximum seconds to wait (None for no timeout)
-            
-        Returns:
-            True if idle detected, False if timeout
-        """
-        target = pane_id or self.target_pane
-        if not target:
-            raise ValueError("No target pane specified")
-        
-        start_time = time.time()
-        last_change_time = time.time()
-        last_hash = ""
-        
-        while True:
-            if timeout and (time.time() - start_time > timeout):
-                return False
-                
-            content = self.capture_pane(target)
-            content_hash = hashlib.md5(content.encode()).hexdigest()
-            
-            if content_hash != last_hash:
-                last_hash = content_hash
-                last_change_time = time.time()
-            elif time.time() - last_change_time >= idle_time:
-                return True
-                
-            time.sleep(check_interval)
-    
-    def kill_pane(self, pane_id: Optional[str] = None):
-        """
-        Kill a pane.
-        
-        Args:
-            pane_id: Target pane (uses self.target_pane if not specified)
-        """
-        target = pane_id or self.target_pane
-        if not target:
-            raise ValueError("No target pane specified")
-        
-        # Safety check: prevent killing own pane ONLY when explicitly specified
-        # If using target_pane (a pane we created), it should be safe to kill
-        if pane_id is not None:  # Only check when pane_id was explicitly provided
-            current_pane = self.get_current_pane()
-            if current_pane and target == current_pane:
-                raise ValueError("Error: Cannot kill own pane! This would terminate your session.")
-        
-        self._run_tmux_command(['kill-pane', '-t', target])
-        
-        if target == self.target_pane:
-            self.target_pane = None
-    
-    def resize_pane(self, direction: str, amount: int = 5, pane_id: Optional[str] = None):
-        """
-        Resize a pane.
-        
-        Args:
-            direction: One of 'up', 'down', 'left', 'right'
-            amount: Number of cells to resize
-            pane_id: Target pane
-        """
-        target = pane_id or self.target_pane
-        if not target:
-            raise ValueError("No target pane specified")
-        
-        direction_map = {
-            'up': '-U',
-            'down': '-D',
-            'left': '-L',
-            'right': '-R'
-        }
-        
-        if direction not in direction_map:
-            raise ValueError(f"Invalid direction: {direction}")
-        
-        self._run_tmux_command(['resize-pane', '-t', target, direction_map[direction], str(amount)])
-    
-    def focus_pane(self, pane_id: Optional[str] = None):
-        """
-        Focus (select) a pane.
-        
-        Args:
-            pane_id: Target pane
-        """
-        target = pane_id or self.target_pane
-        if not target:
-            raise ValueError("No target pane specified")
-        
-        self._run_tmux_command(['select-pane', '-t', target])
-    
-    def send_interrupt(self, pane_id: Optional[str] = None):
-        """
-        Send Ctrl+C to a pane.
-        
-        Args:
-            pane_id: Target pane
-        """
-        target = pane_id or self.target_pane
-        if not target:
-            raise ValueError("No target pane specified")
-        
-        self._run_tmux_command(['send-keys', '-t', target, 'C-c'])
-    
-    def send_escape(self, pane_id: Optional[str] = None):
-        """
-        Send Escape key to a pane.
-        
-        Args:
-            pane_id: Target pane
-        """
-        target = pane_id or self.target_pane
-        if not target:
-            raise ValueError("No target pane specified")
-        
-        self._run_tmux_command(['send-keys', '-t', target, 'Escape'])
-    
-    def clear_pane(self, pane_id: Optional[str] = None):
-        """
-        Clear the pane screen.
-
-        Args:
-            pane_id: Target pane
-        """
-        target = pane_id or self.target_pane
-        if not target:
-            raise ValueError("No target pane specified")
-
-        self._run_tmux_command(['send-keys', '-t', target, 'C-l'])
-
-    # Window-based operations (preferred over panes)
+    # Window-based operations
 
     def generate_window_name(self, custom_name: Optional[str] = None) -> str:
         """
@@ -799,37 +414,62 @@ class TmuxCLIController:
         output, _ = self._run_tmux_command(cmd)
         return output
 
-    def launch_cli(self, command: str, vertical: bool = True, size: int = 50, use_pane: bool = False, window_name: Optional[str] = None) -> Optional[str]:
+    def wait_for_idle(self, window_id: Optional[str] = None, idle_time: float = 3.0,
+                     check_interval: float = 0.5, timeout: Optional[int] = None) -> bool:
         """
-        Convenience method to launch a CLI application.
-        By default creates a new window. Set use_pane=True for pane behavior.
+        Wait for a window to become idle (no output changes for idle_time seconds).
+
+        Args:
+            window_id: Target window
+            idle_time: Seconds of no change to consider idle
+            check_interval: Seconds between checks
+            timeout: Maximum seconds to wait (None for no timeout)
+
+        Returns:
+            True if idle detected, False if timeout
+        """
+        target = window_id or self.target_window
+        if not target:
+            raise ValueError("No target window specified")
+
+        start_time = time.time()
+        last_change_time = time.time()
+        last_hash = ""
+
+        while True:
+            if timeout and (time.time() - start_time > timeout):
+                return False
+
+            content = self.capture_window(target)
+            content_hash = hashlib.md5(content.encode()).hexdigest()
+
+            if content_hash != last_hash:
+                last_hash = content_hash
+                last_change_time = time.time()
+            elif time.time() - last_change_time >= idle_time:
+                return True
+
+            time.sleep(check_interval)
+
+    def launch_cli(self, command: str, window_name: Optional[str] = None) -> Optional[str]:
+        """
+        Launch a CLI application in a new window.
 
         Args:
             command: Command to launch
-            vertical: Split direction (only for pane mode)
-            size: Pane size percentage (only for pane mode)
-            use_pane: If True, create a pane instead of window
-            window_name: Custom window name (will be prefixed with 'tmux-cli-', window mode only)
+            window_name: Custom window name (will be prefixed with 'tmux-cli-')
 
         Returns:
-            Window name starting with 'tmux-cli-' (in window mode) or formatted pane identifier (in pane mode)
+            Window name starting with 'tmux-cli-'
         """
-        if use_pane:
-            # Pane mode
-            pane_id = self.create_pane(vertical=vertical, size=size, start_command=command)
-            if pane_id:
-                return self.format_pane_identifier(pane_id)
-            return None
-        else:
-            # Window mode (default)
-            return self.create_window(start_command=command, window_name=window_name)
+        return self.create_window(start_command=command, window_name=window_name)
 
 
 class CLI:
     """Unified CLI interface that auto-detects tmux environment.
-    
+
     Automatically uses:
-    - TmuxCLIController when inside tmux (for pane management)
+    - TmuxCLIController when inside tmux (for window management)
     - RemoteTmuxController when outside tmux (for window management)
     """
     
@@ -853,7 +493,7 @@ class CLI:
             self.mode = 'remote'
     
     def status(self):
-        """Show current tmux status, windows, and tmux-cli managed windows."""
+        """Show current tmux status and tmux-cli managed windows."""
         if not self.in_tmux:
             print("Not currently in tmux")
             if hasattr(self.controller, 'session_name'):
@@ -863,10 +503,9 @@ class CLI:
         # Get current location
         session = self.controller.get_current_session()
         window = self.controller.get_current_window()
-        pane_index = self.controller.get_current_pane_index()
 
-        if session and window and pane_index:
-            print(f"Current location: {session}:{window}.{pane_index}")
+        if session and window:
+            print(f"Current location: {session}:{window}")
         else:
             print("Could not determine current tmux location")
 
@@ -887,42 +526,19 @@ class CLI:
                 active_marker = " *" if win['active'] else "  "
                 command = win.get('command', '')
                 print(f"{active_marker} {win['index']:3} {win['name']:30} {command:20}")
-
-        # List all panes in current window (legacy info)
-        panes = self.controller.list_panes()
-        if panes:
-            print(f"\nPanes in current window (legacy):")
-            for pane in panes:
-                active_marker = " *" if pane['active'] else "  "
-                command = pane.get('command', '')
-                title = pane.get('title', '')
-                print(f"{active_marker} {pane['formatted_id']:15} {command:20} {title}")
-        else:
-            print("\nNo panes found")
     
-    def list_panes(self):
-        """List all panes in current window."""
-        panes = self.controller.list_panes()
-        print(json.dumps(panes, indent=2))
-    
-    def launch(self, command: str, vertical: bool = True, size: int = 50, window_name: Optional[str] = None, use_pane: bool = False):
-        """Launch a command in a new window (default) or pane.
+    def launch(self, command: str, window_name: Optional[str] = None):
+        """Launch a command in a new window.
 
         Args:
             command: Command to launch
-            vertical: Split direction (only used in pane mode)
-            size: Pane size percentage (only used in pane mode)
             window_name: Custom window name (will be prefixed with 'tmux-cli-')
-            use_pane: If True, create a pane instead of window
         """
         if self.mode == 'local':
-            identifier = self.controller.launch_cli(command, vertical=vertical, size=size, use_pane=use_pane, window_name=window_name)
-            if use_pane:
-                print(f"Launched '{command}' in pane: {identifier}")
-            else:
-                print(f"Launched '{command}' in window: {identifier}")
+            identifier = self.controller.launch_cli(command, window_name=window_name)
+            print(f"Launched '{command}' in window: {identifier}")
         else:
-            # Remote mode (always uses windows)
+            # Remote mode
             # Remote controller uses 'name' parameter
             from .tmux_remote_controller import RemoteTmuxController
             if isinstance(self.controller, RemoteTmuxController):
@@ -932,225 +548,154 @@ class CLI:
             print(f"Launched '{command}' in window: {identifier}")
         return identifier
     
-    def send(self, text: str, target: Optional[str] = None, pane: Optional[str] = None,
+    def send(self, text: str, window_name: Optional[str] = None,
              enter: bool = True, delay_enter: Union[bool, float] = True):
-        """Send text to a window or pane.
+        """Send text to a window.
 
         Args:
             text: Text to send
-            target: Target window/pane identifier (window name, pane identifier, etc.)
-            pane: Legacy parameter name (use 'target' instead)
+            window_name: Target window name
             enter: Whether to send Enter key after text
             delay_enter: If True, use 1.0s delay; if float, use that delay in seconds
         """
-        # Support both 'target' and legacy 'pane' parameter
-        identifier = target or pane
-
         if self.mode == 'local':
-            # Try window first (preferred), then fall back to pane
-            if identifier:
-                # First try as window identifier
-                resolved_window = self.controller.resolve_window_identifier(identifier)
-                if resolved_window:
-                    self.controller.send_keys_to_window(text, window_id=resolved_window,
-                                                       enter=enter, delay_enter=delay_enter)
-                else:
-                    # Fall back to pane identifier
-                    resolved_pane = self.controller.resolve_pane_identifier(identifier)
-                    if resolved_pane:
-                        self.controller.send_keys(text, pane_id=resolved_pane,
-                                                enter=enter, delay_enter=delay_enter)
-                    else:
-                        print(f"Could not resolve identifier: {identifier}")
-                        return
+            if window_name:
+                resolved = self.controller.resolve_window_identifier(window_name)
+                if not resolved:
+                    print(f"Could not resolve window: {window_name}")
+                    return
+                self.controller.send_keys_to_window(text, window_id=resolved,
+                                                   enter=enter, delay_enter=delay_enter)
             else:
-                # Use default target (window or pane)
-                if self.controller.target_window:
-                    self.controller.send_keys_to_window(text, enter=enter, delay_enter=delay_enter)
-                else:
-                    self.controller.send_keys(text, enter=enter, delay_enter=delay_enter)
+                self.controller.send_keys_to_window(text, enter=enter, delay_enter=delay_enter)
         else:
-            # Remote mode - pass identifier directly
-            self.controller.send_keys(text, pane_id=identifier, enter=enter,
-                                    delay_enter=delay_enter)
+            # Remote mode
+            self.controller.send_keys(text, pane_id=window_name, enter=enter, delay_enter=delay_enter)
         print("Text sent")
     
-    def capture(self, target: Optional[str] = None, pane: Optional[str] = None, lines: Optional[int] = None):
-        """Capture and print window/pane content.
+    def capture(self, window_name: Optional[str] = None, lines: Optional[int] = None):
+        """Capture window content.
 
         Args:
-            target: Target window/pane identifier
-            pane: Legacy parameter name (use 'target' instead)
+            window_name: Target window identifier (window name)
             lines: Number of lines to capture from bottom
         """
-        # Support both 'target' and legacy 'pane' parameter
-        identifier = target or pane
-
         if self.mode == 'local':
-            # Try window first, then fall back to pane
-            if identifier:
-                # First try as window identifier
-                resolved_window = self.controller.resolve_window_identifier(identifier)
-                if resolved_window:
-                    content = self.controller.capture_window(window_id=resolved_window, lines=lines)
-                else:
-                    # Fall back to pane identifier
-                    resolved_pane = self.controller.resolve_pane_identifier(identifier)
-                    if resolved_pane:
-                        content = self.controller.capture_pane(pane_id=resolved_pane, lines=lines)
-                    else:
-                        print(f"Could not resolve identifier: {identifier}")
-                        return ""
+            if window_name:
+                resolved = self.controller.resolve_window_identifier(window_name)
+                if not resolved:
+                    print(f"Could not resolve window: {window_name}")
+                    return ""
+                content = self.controller.capture_window(window_id=resolved, lines=lines)
             else:
-                # Use default target
-                if self.controller.target_window:
-                    content = self.controller.capture_window(lines=lines)
-                else:
-                    content = self.controller.capture_pane(lines=lines)
+                content = self.controller.capture_window(lines=lines)
         else:
-            # Remote mode - pass identifier directly
-            content = self.controller.capture_pane(pane_id=identifier, lines=lines)
+            # Remote mode
+            content = self.controller.capture_pane(pane_id=window_name, lines=lines)
         return content
     
-    def interrupt(self, target: Optional[str] = None, pane: Optional[str] = None):
-        """Send Ctrl+C to a window/pane.
+    def interrupt(self, window_name: Optional[str] = None):
+        """Send Ctrl+C to a window.
 
         Args:
-            target: Target window/pane identifier
-            pane: Legacy parameter name (use 'target' instead)
+            window_name: Target window identifier (window name)
         """
-        # Support both 'target' and legacy 'pane' parameter
-        identifier = target or pane
-
         if self.mode == 'local':
-            if identifier:
-                # Try window first, then pane
-                resolved_window = self.controller.resolve_window_identifier(identifier)
-                if resolved_window:
-                    self.controller.send_keys_to_window('', window_id=resolved_window, enter=False)
-                    self.controller._run_tmux_command(['send-keys', '-t', resolved_window, 'C-c'])
-                else:
-                    resolved_pane = self.controller.resolve_pane_identifier(identifier)
-                    if resolved_pane:
-                        self.controller.send_interrupt(pane_id=resolved_pane)
-                    else:
-                        print(f"Could not resolve identifier: {identifier}")
-                        return
+            if window_name:
+                resolved = self.controller.resolve_window_identifier(window_name)
+                if not resolved:
+                    print(f"Could not resolve window: {window_name}")
+                    return
+                self.controller._run_tmux_command(['send-keys', '-t', resolved, 'C-c'])
             else:
-                self.controller.send_interrupt()
+                self.controller._run_tmux_command(['send-keys', '-t', self.controller.target_window, 'C-c'])
         else:
             # Remote mode
-            target = self.controller._resolve_pane_id(identifier)
-            self.controller.send_interrupt(pane_id=target)
+            target_id = self.controller._resolve_pane_id(window_name)
+            self.controller.send_interrupt(pane_id=target_id)
         print("Sent interrupt signal")
 
-    def escape(self, target: Optional[str] = None, pane: Optional[str] = None):
-        """Send Escape key to a window/pane.
+    def escape(self, window_name: Optional[str] = None):
+        """Send Escape key to a window.
 
         Args:
-            target: Target window/pane identifier
-            pane: Legacy parameter name (use 'target' instead)
+            window_name: Target window identifier (window name)
         """
-        # Support both 'target' and legacy 'pane' parameter
-        identifier = target or pane
-
         if self.mode == 'local':
-            if identifier:
-                # Try window first, then pane
-                resolved_window = self.controller.resolve_window_identifier(identifier)
-                if resolved_window:
-                    self.controller._run_tmux_command(['send-keys', '-t', resolved_window, 'Escape'])
-                else:
-                    resolved_pane = self.controller.resolve_pane_identifier(identifier)
-                    if resolved_pane:
-                        self.controller.send_escape(pane_id=resolved_pane)
-                    else:
-                        print(f"Could not resolve identifier: {identifier}")
-                        return
+            if window_name:
+                resolved = self.controller.resolve_window_identifier(window_name)
+                if not resolved:
+                    print(f"Could not resolve window: {window_name}")
+                    return
+                self.controller._run_tmux_command(['send-keys', '-t', resolved, 'Escape'])
             else:
-                self.controller.send_escape()
+                self.controller._run_tmux_command(['send-keys', '-t', self.controller.target_window, 'Escape'])
         else:
             # Remote mode
-            target = self.controller._resolve_pane_id(identifier)
-            self.controller.send_escape(pane_id=target)
+            target_id = self.controller._resolve_pane_id(window_name)
+            self.controller.send_escape(pane_id=target_id)
         print("Sent escape key")
-    
-    def kill(self, target: Optional[str] = None, pane: Optional[str] = None):
-        """Kill a window or pane.
+
+    def kill(self, window_name: Optional[str] = None):
+        """Kill a window.
 
         Args:
-            target: Target window/pane identifier
-            pane: Legacy parameter name (use 'target' instead)
+            window_name: Target window identifier (window name)
         """
-        # Support both 'target' and legacy 'pane' parameter
-        identifier = target or pane
-
         if self.mode == 'local':
-            if identifier:
-                # Try window first, then pane
-                resolved_window = self.controller.resolve_window_identifier(identifier)
-                if resolved_window:
-                    try:
-                        self.controller.kill_window(window_id=identifier)
-                        print(f"Window '{identifier}' killed")
-                    except ValueError as e:
-                        print(str(e))
-                else:
-                    # Fall back to pane
-                    resolved_pane = self.controller.resolve_pane_identifier(identifier)
-                    if resolved_pane:
-                        try:
-                            self.controller.kill_pane(pane_id=resolved_pane)
-                            print("Pane killed")
-                        except ValueError as e:
-                            print(str(e))
-                    else:
-                        print(f"Could not resolve identifier: {identifier}")
+            if window_name:
+                resolved = self.controller.resolve_window_identifier(window_name)
+                if not resolved:
+                    print(f"Could not resolve window: {window_name}")
+                    return
+                try:
+                    self.controller.kill_window(window_id=window_name)
+                    print(f"Window '{window_name}' killed")
+                except ValueError as e:
+                    print(str(e))
             else:
-                # Kill default target
-                if self.controller.target_window:
-                    try:
-                        self.controller.kill_window()
-                        print("Window killed")
-                    except ValueError as e:
-                        print(str(e))
-                else:
-                    try:
-                        self.controller.kill_pane()
-                        print("Pane killed")
-                    except ValueError as e:
-                        print(str(e))
+                try:
+                    self.controller.kill_window()
+                    print("Window killed")
+                except ValueError as e:
+                    print(str(e))
         else:
-            # Remote mode - kill window
+            # Remote mode
             try:
-                self.controller.kill_window(window_id=identifier)
+                self.controller.kill_window(window_id=window_name)
                 print("Window killed")
             except ValueError as e:
                 print(str(e))
     
-    def wait_idle(self, pane: Optional[str] = None, idle_time: float = 2.0, 
+    def wait_idle(self, window_name: Optional[str] = None, idle_time: float = 3.0,
                   timeout: Optional[int] = None):
-        """Wait for pane to become idle (no output changes)."""
+        """Wait for window to become idle (no output changes).
+
+        Args:
+            window_name: Target window name
+            idle_time: Seconds of no change to consider idle
+            timeout: Maximum seconds to wait
+        """
         if self.mode == 'local':
-            # Local mode - resolve pane identifier
-            if pane:
-                resolved_pane = self.controller.resolve_pane_identifier(pane)
-                if resolved_pane:
-                    self.controller.select_pane(pane_id=resolved_pane)
-                else:
-                    print(f"Could not resolve pane identifier: {pane}")
+            if window_name:
+                resolved = self.controller.resolve_window_identifier(window_name)
+                if not resolved:
+                    print(f"Could not resolve window: {window_name}")
                     return False
-            target = None
+                target = window_name
+            else:
+                target = None
+
+            print(f"Waiting for window to become idle (no changes for {idle_time}s)...")
+            if self.controller.wait_for_idle(window_id=target, idle_time=idle_time, timeout=timeout):
+                print("Window is idle")
+                return True
+            else:
+                print("Timeout waiting for idle")
+                return False
         else:
-            # Remote mode - resolve pane_id
-            target = self.controller._resolve_pane_id(pane)
-        
-        print(f"Waiting for pane to become idle (no changes for {idle_time}s)...")
-        if self.controller.wait_for_idle(pane_id=target, idle_time=idle_time, timeout=timeout):
-            print("Pane is idle")
-            return True
-        else:
-            print("Timeout waiting for idle")
+            # Remote mode
+            print("wait_idle not supported in remote mode")
             return False
     
     def attach(self):

--- a/docs/tmux-cli-instructions.md
+++ b/docs/tmux-cli-instructions.md
@@ -1,27 +1,23 @@
 # tmux-cli Instructions
 
-A command-line tool for controlling CLI applications running in tmux.
+A command-line tool for controlling CLI applications running in tmux windows.
 Automatically detects whether you're inside or outside tmux and uses the appropriate mode.
 
 ## Auto-Detection
-- **Inside tmux (Local Mode)**: Manages windows in your current tmux session (default)
-  - Can also manage panes if needed (use `--use-pane` flag)
+- **Inside tmux (Local Mode)**: Manages windows in your current tmux session
 - **Outside tmux (Remote Mode)**: Creates and manages a separate tmux session with windows
 
 ## Prerequisites
 - tmux must be installed
 - The `tmux-cli` command must be available (installed via `uv tool install`)
 
-## Window and Pane Identification
-
-**Windows (default, recommended):**
+## Window Identification
 
 All tmux-cli managed windows start with the prefix `tmux-cli-` for easy identification and management.
 
 - Auto-generated names: `tmux-cli-1730559234-123` (timestamp-based)
 - Custom names: specified with `--window-name` flag, automatically prefixed
   - Example: `--window-name=my-session` creates window `tmux-cli-my-session`
-- Window indices: Can also reference by index (depends on your tmux `base-index` setting)
 - Full format: `session:window_name` (e.g., `mysession:tmux-cli-my-session`)
 
 **Managed Window Tracking:**
@@ -30,71 +26,58 @@ The `tmux-cli-` prefix allows the tool to:
 - Show them separately in `tmux-cli status`
 - Clean them all up at once with `tmux-cli cleanup`
 
-**Panes:**
-- Pane number: Can reference by index (depends on your tmux `pane-base-index` setting)
-- Full format: `session:window.pane` (e.g., `myapp:1.2`)
-- Note: Pane indices shift when panes are closed, making them less stable than windows
-
 ## ⚠️ IMPORTANT: Always Launch a Shell First!
 
 **Always launch zsh first** to prevent losing output when commands fail:
+
 ```bash
-tmux-cli launch "zsh"  # Do this FIRST
-tmux-cli send "your-command" --pane=2  # Then run commands
+tmux-cli launch "zsh"
+# Returns: tmux-cli-1730559234-123
 ```
 
-If you launch a command directly and it errors, the pane closes immediately and you lose all output!
+If you launch a command directly and it errors, the window closes immediately and you lose all output!
 
 ## Core Commands
 
 ### Launch a CLI application
 ```bash
-# Default: Creates a new window
+# Creates a new window in the background
 tmux-cli launch "command"
 # Example: tmux-cli launch "python3"
 # Returns: tmux-cli-1730559234-123
 
-# With custom window name (gets auto-prefixed):
-tmux-cli launch "python3" --window-name="my-python"
+# With custom window name:
+tmux-cli launch "python3" --window-name=my-python
 # Returns: tmux-cli-my-python
-
-# Using panes instead of windows:
-tmux-cli launch "python3" --use-pane
-# Returns: pane identifier (e.g., session:window.pane format like myapp:1.2)
 ```
 
-### Send input to a window/pane
+### Send input to a window
 ```bash
 # Send to a window (by name):
-tmux-cli send "text" --target=WINDOW_NAME
-# Example: tmux-cli send "print('hello')" --target=tmux-cli-my-python
-
-# Or send to a pane:
-tmux-cli send "text" --pane=PANE_ID
-# Example: tmux-cli send "print('hello')" --pane=3
+tmux-cli send "text" --window-name=WINDOW_NAME
+# Example: tmux-cli send "print('hello')" --window-name=tmux-cli-my-python
 
 # By default, there's a 1-second delay between text and Enter.
 # This ensures compatibility with various CLI applications.
 
 # To send without Enter:
-tmux-cli send "text" --target=WINDOW_NAME --enter=False
+tmux-cli send "text" --window-name=WINDOW_NAME --enter=False
 
 # To send immediately without delay:
-tmux-cli send "text" --target=WINDOW_NAME --delay-enter=False
+tmux-cli send "text" --window-name=WINDOW_NAME --delay-enter=False
 
 # To use a custom delay (in seconds):
-tmux-cli send "text" --target=WINDOW_NAME --delay-enter=0.5
+tmux-cli send "text" --window-name=WINDOW_NAME --delay-enter=0.5
 ```
 
-### Capture output from a window/pane
+### Capture output from a window
 ```bash
 # Capture from a window:
-tmux-cli capture --target=WINDOW_NAME
-# Example: tmux-cli capture --target=tmux-cli-my-python
+tmux-cli capture --window-name=WINDOW_NAME
+# Example: tmux-cli capture --window-name=tmux-cli-my-python
 
-# Or capture from a pane:
-tmux-cli capture --pane=PANE_ID
-# Example: tmux-cli capture --pane=2
+# Capture last N lines:
+tmux-cli capture --window-name=WINDOW_NAME --lines=10
 ```
 
 ### List all windows
@@ -103,18 +86,12 @@ tmux-cli list_windows
 # Shows all windows in the current session with indices, names, and commands
 ```
 
-### List all panes
-```bash
-tmux-cli list_panes
-# Returns: JSON with pane IDs, indices, and status
-```
-
 ### Show current tmux status
 ```bash
 tmux-cli status
-# Shows current location, tmux-cli managed windows, all windows, and panes
+# Shows current location, tmux-cli managed windows, and all windows
 # Example output:
-#   Current location: myapp:main.0
+#   Current location: myapp:main
 #
 #   tmux-cli managed windows:
 #     tmux-cli-1730559234-123      python3
@@ -126,15 +103,11 @@ tmux-cli status
 #     2   tmux-cli-1730559235-456      zsh
 ```
 
-### Kill a window/pane
+### Kill a window
 ```bash
 # Kill a window (by name):
-tmux-cli kill --target=WINDOW_NAME
-# Example: tmux-cli kill --target=tmux-cli-my-python
-
-# Or kill a pane:
-tmux-cli kill --pane=PANE_ID
-# Example: tmux-cli kill --pane=2
+tmux-cli kill --window-name=WINDOW_NAME
+# Example: tmux-cli kill --window-name=tmux-cli-my-python
 ```
 
 ### Clean up all tmux-cli windows
@@ -146,37 +119,19 @@ tmux-cli cleanup
 ### Send interrupt (Ctrl+C)
 ```bash
 # To a window:
-tmux-cli interrupt --target=WINDOW_NAME
-# Example: tmux-cli interrupt --target=tmux-cli-my-python
-
-# Or to a pane:
-tmux-cli interrupt --pane=PANE_ID
-# Example: tmux-cli interrupt --pane=2
+tmux-cli interrupt --window-name=WINDOW_NAME
+# Example: tmux-cli interrupt --window-name=tmux-cli-my-python
 ```
 
 ### Send escape key
 ```bash
 # To a window:
-tmux-cli escape --target=WINDOW_NAME
-# Example: tmux-cli escape --target=tmux-cli-my-python
-
-# Or to a pane:
-tmux-cli escape --pane=PANE_ID
-# Example: tmux-cli escape --pane=3
+tmux-cli escape --window-name=WINDOW_NAME
+# Example: tmux-cli escape --window-name=tmux-cli-my-python
 # Useful for exiting vim-like applications
 ```
 
-### Wait for pane to become idle
-```bash
-tmux-cli wait_idle --pane=PANE_ID
-# Example: tmux-cli wait_idle --pane=2
-# Waits until no output changes for 2 seconds (default)
-
-# Custom idle time and timeout:
-tmux-cli wait_idle --pane=2 --idle-time=3.0 --timeout=60
-```
-
-### Get help
+### Show help
 ```bash
 tmux-cli help
 # Displays this documentation
@@ -192,18 +147,18 @@ tmux-cli help
 
 2. Run your command in the shell:
    ```bash
-   tmux-cli send "python script.py" --target=tmux-cli-1730559234-123
+   tmux-cli send "python script.py" --window-name=tmux-cli-1730559234-123
    ```
 
 3. Interact with the program:
    ```bash
-   tmux-cli send "user input" --target=tmux-cli-1730559234-123
-   tmux-cli capture --target=tmux-cli-1730559234-123  # Check output
+   tmux-cli send "user input" --window-name=tmux-cli-1730559234-123
+   tmux-cli capture --window-name=tmux-cli-1730559234-123  # Check output
    ```
 
 4. Clean up when done:
    ```bash
-   tmux-cli kill --target=tmux-cli-1730559234-123
+   tmux-cli kill --window-name=tmux-cli-1730559234-123
    # Or clean up all tmux-cli windows at once:
    tmux-cli cleanup
    ```
@@ -218,28 +173,22 @@ tmux-cli launch "zsh" --window-name=my-dev
 # Returns: tmux-cli-my-dev
 
 # Now you can use the shorter name:
-tmux-cli send "python script.py" --target=tmux-cli-my-dev
-tmux-cli capture --target=tmux-cli-my-dev
-tmux-cli kill --target=tmux-cli-my-dev
+tmux-cli send "python script.py" --window-name=tmux-cli-my-dev
+tmux-cli capture --window-name=tmux-cli-my-dev
+tmux-cli kill --window-name=tmux-cli-my-dev
 ```
 
 ## Remote Mode Specific Commands
 
 These commands are only available when running outside tmux:
 
-### Attach to session
+### Attach to managed session
 ```bash
 tmux-cli attach
-# Opens the managed tmux session to view live
+# Attaches to the managed session
 ```
 
-### Clean up session
-```bash
-tmux-cli cleanup
-# Kills the entire managed session and all its windows
-```
-
-### List windows
+### List windows (remote)
 ```bash
 tmux-cli list_windows
 # Shows all windows in the managed session
@@ -260,39 +209,74 @@ tmux-cli list_windows
 - Use `capture` to check the current state before sending input
 - If you launch a command directly (not via shell), the window closes when the command exits
 - Windows are isolated from your current workspace
-- Both `--target` and `--pane` parameters are supported
+- Windows launch in the background (don't steal focus)
 
-**Using Panes:**
-- Use `--use-pane` flag with `launch` to create panes instead of windows
-- Pane identifiers: `session:window.pane` format (like `myapp:1.2`) or just indices like `1`, `2`
-- Note: Pane indices shift when panes are closed, making them less stable than windows
-- Panes modify your current window layout; windows don't
+## Window Benefits
 
-## Avoiding Polling
-Instead of repeatedly checking with `capture`, use `wait_idle`:
+- **Stable names**: Window names don't change when other windows are created/destroyed
+- **Independent**: Windows don't affect your current workspace layout
+- **Auto-tracked**: All managed windows have `tmux-cli-` prefix
+- **Bulk cleanup**: Remove all with `tmux-cli cleanup`
+- **Custom names**: Easy identification with `--window-name`
+
+## Error Handling
+
+If you see "Could not resolve window: xxx", check:
+1. Did you save the window name from `launch`?
+2. Is the window still running? Use `tmux-cli status` to check
+3. Did you spell the window name correctly?
+
+## Examples
+
+### Interactive Python REPL
 ```bash
-# Send command to a CLI application
-tmux-cli send "analyze this code" --target=my-session
+# Launch Python in a named window
+WIN=$(tmux-cli launch "python3" --window-name=repl)
 
-# Wait for it to finish (no output for 3 seconds)
-tmux-cli wait_idle --target=my-session --idle-time=3.0
+# Send commands
+tmux-cli send "import sys" --window-name=$WIN
+tmux-cli send "print(sys.version)" --window-name=$WIN
 
-# Now capture the result
-tmux-cli capture --target=my-session
+# Get output
+tmux-cli capture --window-name=$WIN --lines=5
+
+# Clean up
+tmux-cli kill --window-name=$WIN
 ```
 
-## Windows vs Panes
+### Running a script
+```bash
+# Always use a shell first!
+WIN=$(tmux-cli launch "zsh" --window-name=script-runner)
 
-**Windows (default):**
-- Names don't change when other windows are created/destroyed
-- Independent of your current workspace layout
-- Can be accessed from any window in the session
-- Auto-tracked via `tmux-cli-` prefix
-- Bulk cleanup with `tmux-cli cleanup`
-- Custom names supported: `--window-name=my-session` → `tmux-cli-my-session`
+# Run the script
+tmux-cli send "python my_script.py" --window-name=$WIN
 
-**Panes:**
-- Share space within your current window
-- Indices shift when panes are closed (e.g., closing a pane renumbers all subsequent panes)
-- Useful when you want to see multiple things side-by-side
-- Use `--use-pane` flag with launch command
+# Wait a bit
+sleep 5
+
+# Check output
+tmux-cli capture --window-name=$WIN
+
+# Clean up
+tmux-cli kill --window-name=$WIN
+```
+
+### Multiple concurrent sessions
+```bash
+# Launch multiple windows
+WIN1=$(tmux-cli launch "zsh" --window-name=task1)
+WIN2=$(tmux-cli launch "zsh" --window-name=task2)
+WIN3=$(tmux-cli launch "zsh" --window-name=task3)
+
+# Run different tasks
+tmux-cli send "python task1.py" --window-name=$WIN1
+tmux-cli send "python task2.py" --window-name=$WIN2
+tmux-cli send "python task3.py" --window-name=$WIN3
+
+# Check status of all
+tmux-cli status
+
+# Clean up all at once
+tmux-cli cleanup
+```


### PR DESCRIPTION
## Summary

Refactors tmux-cli to use windows by default instead of panes for better stability and easier management.

## Key Changes

- Windows now default (use `--use-pane` for panes)
- All managed windows auto-prefixed with `tmux-cli-` for tracking
- Windows launch in background (don't steal focus)
- Added automated cleanup: `tmux-cli cleanup` removes all managed windows
- Window names are stable (don't shift when windows close, unlike pane indices)

## Breaking Changes

- `launch` creates windows by default (use `--use-pane` for old behavior)
- `--name` renamed to `--window-name`

## Bug Fixes

- Fixed duplicate output in capture command