### PR TITLE
Remove `print(content)` to avoid printing pane output twice

### DIFF
--- a/claude_code_tools/tmux_cli_controller.py
+++ b/claude_code_tools/tmux_cli_controller.py
@@ -677,7 +677,6 @@ class CLI:
         else:
             # Remote mode - pass pane_id directly
             content = self.controller.capture_pane(pane_id=pane, lines=lines)
-        print(content)
         return content
     
     def interrupt(self, pane: Optional[str] = None):


### PR DESCRIPTION
Remove double output from pane capture to save tokens