### PR TITLE
feat: add GitHub Actions workflow for multi-platform Rust binary releases

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -1,0 +1,101 @@
+name: Release Rust Binaries
+
+on:
+  push:
+    tags:
+      - 'rust-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    name: Test
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run tests
+        run: cargo test --all
+        working-directory: rust-search-ui
+
+  build:
+    name: Build ${{ matrix.target }}
+    needs: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            os: macos-13
+            name: aichat-search-macos-intel
+          - target: aarch64-apple-darwin
+            os: macos-14
+            name: aichat-search-macos-arm64
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            name: aichat-search-linux-x86_64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            name: aichat-search-linux-arm64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            name: aichat-search-windows-x86_64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+        working-directory: rust-search-ui
+
+      - name: Package (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          cd rust-search-ui/target/${{ matrix.target }}/release
+          tar czf ../../../../${{ matrix.name }}.tar.gz aichat-search
+          cd ../../../..
+
+      - name: Package (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          cd rust-search-ui/target/${{ matrix.target }}/release
+          7z a ../../../../${{ matrix.name }}.zip aichat-search.exe
+          cd ../../../..
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: |
+            ${{ matrix.name }}.tar.gz
+            ${{ matrix.name }}.zip
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/**/*.tar.gz
+            artifacts/**/*.zip
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ to parent sessions. Unlike compaction, nothing is lost:
 
 - **Full parent session preserved** — complete history remains accessible, since 
 parent session file paths are added at the end of the first user message in the session.
-- **Lineage chain** — file paths of all ancestor sessions
-- **On-demand retrieval** — the agent can look up any past session to recover
-  specific details when needed
+- **Lineage chain** — file paths of all ancestor sessions (jsonl files).
+- **On-demand retrieval** — the agent can look up any past session in the lineage chain 
+to recover  specific details when needed, or when prompted by the user, e.g. "in the linked prior chats, look up how we figured out the node-ui to Python communication".
 
 ```bash
 aichat resume          # Find latest session and choose a strategy


### PR DESCRIPTION
- Add .github/workflows/release-rust.yml for automated builds
- Builds aichat-search for 5 platforms: macOS (Intel/ARM), Linux (x64/ARM), Windows
- Triggered by pushing rust-v* tags
- Add make aichat-search-release target (bump, tag, push, trigger CI)
- Update aichat-search-publish to depend on aichat-search-release
- Update README and Makefile help

Users can now download pre-built binaries from GitHub Releases instead of
compiling from source with cargo install.
