### PR TITLE
fix: remove trailing comma in tmux-cli plugin.json

### DIFF
--- a/plugins/tmux-cli/.claude-plugin/plugin.json
+++ b/plugins/tmux-cli/.claude-plugin/plugin.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "description": "Provides tmux-cli skill, to allow Claude-Code to interact with CLI scripts or other code-agents in tmux panes, using the `tmux-cli` command",
   "author": {
-    "name": "Prasad Chalasani",
+    "name": "Prasad Chalasani"
   }
 }


### PR DESCRIPTION
## Summary
- Removes trailing comma in `plugins/tmux-cli/.claude-plugin/plugin.json` that causes JSON parse errors

Fixes #10

The trailing comma after the `author.name` field is invalid JSON syntax and prevents Claude Code from loading the plugin:

```
JSON Parse error: Property name must be a string literal
```

## Test plan
- [x] Verify plugin loads without JSON parse errors in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)