### PR TITLE
fix: use hookSpecificOutput format in file_length_limit_hook

### DIFF
--- a/plugins/safety-hooks/hooks/file_length_limit_hook.py
+++ b/plugins/safety-hooks/hooks/file_length_limit_hook.py
@@ -187,8 +187,11 @@ if __name__ == "__main__":
 
         if should_block:
             print(json.dumps({
-                "decision": "block",
-                "reason": reason
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason
+                }
             }))
         else:
             print(json.dumps({"decision": "approve"}))


### PR DESCRIPTION
## Summary
- Update file_length_limit_hook.py to use correct Claude Code hook output format

The hook was using `{"decision": "block", "reason": ...}` which causes "hook error" messages in the UI. Changed to use the proper `hookSpecificOutput` format with `permissionDecision: "deny"`.

## Test plan
- [ ] Verify reading a file >500 lines shows clean block message (not "hook error")