### PR TITLE
fix: filter shell noise in rollover command to prevent jq parse error

### DIFF
--- a/claude_code_tools/claude_continue.py
+++ b/claude_code_tools/claude_continue.py
@@ -142,8 +142,9 @@ def claude_continue(
     try:
         # Run shell in interactive mode to load rc files (for shell functions like ccrja)
         # Use jq to add a marker prefix so we can reliably extract the session ID
+        # Filter to only JSON lines (starting with {) to avoid shell startup noise
         shell = os.environ.get('SHELL', '/bin/sh')
-        cmd = f'{claude_cli} -p {shlex.quote(analysis_prompt)} --output-format json | jq -r \'"SESSION_ID:" + .session_id\''
+        cmd = f'{claude_cli} -p {shlex.quote(analysis_prompt)} --output-format json | grep "^{{" | jq -r \'"SESSION_ID:" + .session_id\''
         print(f"$ {claude_cli} -p '<analysis prompt>' --output-format json | jq ...")
         result = subprocess.run(
             [shell, "-i", "-c", cmd],


### PR DESCRIPTION
## Problem

  `aichat rollover` fails with:
  ❌ Error creating session: Command '['/bin/zsh', '-i', '-c', 'claude -p ... --output-format json | jq -r "SESSION_ID:" + .session_id']' returned non-zero exit status 5.
     stdout:
     stderr: jq: parse error: Invalid numeric literal at line 2, column 6

  ## Environment

  - **Shell**: zsh (likely affects bash users with similar rc file output too)
  - **OS**: macOS (Darwin 25.2.0)
  - **claude-code-tools version**: 1.4.7

  ## How to Reproduce

  1. Have a `.zshrc` that sets terminal title or emits any output on startup (very common)
  2. Run `aichat rollover` on any existing session
  3. Command fails at "Step 2: Creating session and analyzing history..."

  ## Root Cause Analysis

  The rollover command in `claude_continue.py` runs the claude CLI through an interactive shell:

  ```python
  shell = os.environ.get('SHELL', '/bin/sh')
  cmd = f'{claude_cli} -p {shlex.quote(analysis_prompt)} --output-format json | jq -r \'"SESSION_ID:" + .session_id\''
  result = subprocess.run(
      [shell, "-i", "-c", cmd],  # <-- interactive mode loads rc files
      capture_output=True,
      text=True,
      check=True
  )
```
  The -i flag is intentional - it loads shell rc files so that shell functions/aliases like ccrja are available. However, many zsh/bash configurations emit output during initialization:

  - Terminal title sequences: \e]0;dirname\a or ]0;user@host
  - Prompt theme initialization: oh-my-zsh, powerlevel10k, starship
  - conda/pyenv/nvm initialization messages
  - fortune/motd output

  So instead of receiving clean JSON:
```json
  {"session_id": "abc123", "type": "result", ...}
```
  jq receives something like:
```bash
  ]0;~/Projects/myapp
  {"session_id": "abc123", "type": "result", ...}
```

  The ]0; on line 1 is an incomplete terminal escape sequence, which jq tries to parse as JSON, failing at "line 2, column 6" (where the actual JSON { appears).

 ## Solution

  Add grep "^{" to filter only lines starting with { (valid JSON objects) before piping to jq:

  cmd = f'{claude_cli} -p {shlex.quote(analysis_prompt)} --output-format json | grep "^{{" | jq -r \'"SESSION_ID:" + .session_id\''

  This is a minimal, safe fix:
  - grep "^{" only passes lines beginning with {
  - Shell noise (escape sequences, messages) is filtered out
  - Valid JSON output passes through unchanged

