### PR TITLE
fix: prevent terminal backgrounding in alias expansion

### DIFF
--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -27,6 +27,7 @@ def _load_alias_cache() -> dict[str, str]:
             capture_output=True,
             text=True,
             timeout=5,
+            start_new_session=True,
             env={**os.environ, 'PS1': ''},
         )
         output = result.stdout


### PR DESCRIPTION
## Summary
- Fixes terminal backgrounding bug when alias expansion runs inside tmux
- Adds `start_new_session=True` to isolate subprocess from terminal

## Problem
When Claude Code runs in tmux, it occasionally goes to background (appears as if CTRL-Z pressed). After `fg`, terminal is corrupted - shows `^M` instead of interpreting Enter correctly.

## Root Cause
The `_load_alias_cache()` function spawns an interactive shell (`-i` flag) to fetch aliases. Interactive shells call `tcsetpgrp()` to become the foreground process group, which interferes with Claude Code's terminal control.

## Solution
Add `start_new_session=True` to `subprocess.run()`. This calls `setsid()` to create a new session with no controlling terminal. The subprocess:
- Still loads aliases correctly (keeps `-i` flag)
- Cannot grab terminal control (no controlling terminal to grab)
- No race condition for terminal foreground process group

## Test plan
- [ ] Run Claude Code in tmux with shell aliases configured
- [ ] Verify aliases like `gco`, `gcam` still expand correctly
- [ ] Confirm no backgrounding or terminal corruption occurs