### PR TITLE
fix(tmux-cli): improve Enter key reliability with verification and retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,9 +683,30 @@ everything automatically—just describe what you want.
 Vanilla tmux can do everything tmux-cli does. The problem is that LLMs frequently make
 mistakes with raw tmux: forgetting the Enter key, not adding delays between text and
 Enter (causing race conditions with fast CLI apps), or incorrect escaping. `tmux-cli`
-bakes in defaults that address these: Enter is sent automatically with a 1-second delay
+bakes in defaults that address these: Enter is sent automatically with a 1.5-second delay
 (configurable), pane targeting accepts simple numbers instead of `session:window.pane`,
-and there's built-in `wait_idle` to detect when a CLI is ready for input.
+built-in `wait_idle` to detect when a CLI is ready for input, and **Enter key verification
+with automatic retry** to handle intermittent failures.
+
+> **Important: Instruct your AI agent to use `tmux-cli` instead of plain `tmux`**
+>
+> Add this directive to your project's `CLAUDE.md` or agent instructions:
+>
+> ```markdown
+> When interacting with tmux panes, ALWAYS use `tmux-cli send` instead of plain
+> `tmux send-keys`. Plain tmux commands are unreliable because they send text and
+> Enter simultaneously without any delay, causing race conditions where the Enter
+> key is lost before the target application can process the text input.
+> ```
+>
+> **Why plain tmux is unreliable:** When you run `tmux send-keys "text" Enter`, both
+> the text and Enter key are sent in rapid succession. If the target shell or application
+> hasn't fully processed the text input buffer, the Enter key can be lost. This is
+> especially common during shell initialization, with slow terminal emulators, or under
+> system load. `tmux-cli` addresses this by:
+> 1. Sending text first, then waiting 1.5 seconds before sending Enter
+> 2. Verifying the Enter was received by checking if pane content changed
+> 3. Automatically retrying the Enter key (up to 3 times) if verification fails
 
 ## Tmux-cli skill
 

--- a/docs/tmux-cli-instructions.md
+++ b/docs/tmux-cli-instructions.md
@@ -41,8 +41,9 @@ tmux-cli launch "command"
 tmux-cli send "text" --pane=PANE_ID
 # Example: tmux-cli send "print('hello')" --pane=3
 
-# By default, there's a 1-second delay between text and Enter.
-# This ensures compatibility with various CLI applications.
+# By default, there's a 1.5-second delay between text and Enter,
+# plus automatic Enter key verification with retry (up to 3 attempts).
+# This ensures reliability with various CLI applications.
 
 # To send without Enter:
 tmux-cli send "text" --pane=PANE_ID --enter=False


### PR DESCRIPTION
Addresses issue #13 where Enter key sometimes fails to register.

Changes:
- Increase default delay_enter from 1.0s to 1.5s for better reliability
- Add Enter key verification: checks if pane content changed after Enter
- Add automatic retry logic (up to 3 attempts with exponential backoff)
- Add README warning about plain tmux unreliability
- Add directive for users to instruct AI agents to use tmux-cli over tmux
- Update docs to reflect new 1.5s delay and verification behavior

The root cause was that plain `tmux send-keys` sends text and Enter simultaneously, causing race conditions. tmux-cli now:
1. Sends text first, waits 1.5s
2. Sends Enter and verifies pane content changed
3. Retries Enter if verification fails

Fixes #13

https://claude.ai/code/session_01PU4EGd7sASmY2QnggTGkBC