### PR TITLE
docs: add related external tool to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Four commands are installed:
 | [`vault`](#vault) | Encrypted .env backup and sync |
 | [`env-safe`](#env-safe) | Safe .env inspection without exposing values |
 
+
+
 <a id="claude-code-plugins"></a>
 
 ### Claude Code Plugins
@@ -1222,3 +1224,18 @@ Run `make help` for full list. Key commands:
 ## 📄 License
 
 MIT
+
+
+## 🔎 Related / Complementary Tools
+
+- **[clicodelog](https://github.com/monk1337/clicodelog)**  
+  A lightweight, local-first web UI to browse, inspect, and export
+  Claude Code, Codex CLI, and Gemini CLI session logs.
+  
+  Useful for:
+  - Visual inspection of long sessions
+  - Auditing agent behavior and tool usage
+  - Exporting conversations for reports or debugging
+
+  Complements `aichat` by focusing on **post-session inspection**, while
+  `claude-code-tools` focuses on **in-session workflows and continuation**.


### PR DESCRIPTION
This PR adds a small **docs-only** section listing an external, optional tool that some users may find useful alongside `claude-code-tools`.

The tool focuses on **post-session visual inspection and exporting** of Claude Code / Codex / Gemini CLI logs, and does not overlap with `aichat`’s in-session search, resume, or workflow features.

Added near the bottom of the README to keep it clearly out of core functionality. 
Totally fine to remove or reword if this doesn’t fit the repo’s scope.
