### PR TITLE
fix: use TMUX_PANE consistently for pane operations in local mode

### DIFF
--- a/claude_code_tools/tmux_cli_controller.py
+++ b/claude_code_tools/tmux_cli_controller.py
@@ -294,6 +294,9 @@ class TmuxCLIController:
         else:
             base_cmd.append('-v')
 
+        # Get list of existing panes BEFORE creating new one (for verification)
+        existing_panes = {p['id'] for p in self.list_panes()}
+
         # Try -l first (tmux 3.4+), fall back to -p (older versions)
         # tmux 3.4 removed -p, but 3.5+ has both; older versions only have -p
         for size_flag in (['-l', f'{size}%'], ['-p', str(size)]) if size else [[]]:
@@ -308,8 +311,22 @@ class TmuxCLIController:
 
             # Validate: code must be 0 and output must be a valid pane ID (starts with %)
             if code == 0 and output and output.startswith('%'):
-                self.target_pane = output
-                return output
+                # Verify the pane actually exists by querying it
+                verify_output, verify_code = self._run_tmux_command(
+                    ['display-message', '-t', output, '-p', '#{pane_id}']
+                )
+                if verify_code == 0 and verify_output == output:
+                    self.target_pane = output
+                    return output
+
+                # Pane ID mismatch - find the actual new pane
+                # This handles edge cases where reported ID doesn't match reality
+                current_panes = {p['id'] for p in self.list_panes()}
+                new_panes = current_panes - existing_panes
+                if new_panes:
+                    actual_pane = new_panes.pop()
+                    self.target_pane = actual_pane
+                    return actual_pane
 
         return None
     
@@ -699,12 +716,24 @@ class CLI:
             if hasattr(self.controller, 'session_name'):
                 print(f"Remote session: {self.controller.session_name}")
             return
-            
-        # Get current location
-        session = self.controller.get_current_session()
-        window = self.controller.get_current_window()
-        pane_index = self.controller.get_current_pane_index()
-        
+
+        # Use TMUX_PANE to get location where this process is running,
+        # not the currently focused pane. This is consistent with where
+        # list_panes() and create_pane() operate.
+        tmux_pane = os.environ.get('TMUX_PANE')
+        if tmux_pane:
+            session, _ = self.controller._run_tmux_command(
+                ['display-message', '-t', tmux_pane, '-p', '#{session_name}'])
+            window, _ = self.controller._run_tmux_command(
+                ['display-message', '-t', tmux_pane, '-p', '#{window_name}'])
+            pane_index, _ = self.controller._run_tmux_command(
+                ['display-message', '-t', tmux_pane, '-p', '#{pane_index}'])
+        else:
+            # Fallback if TMUX_PANE not set
+            session = self.controller.get_current_session()
+            window = self.controller.get_current_window()
+            pane_index = self.controller.get_current_pane_index()
+
         if session and window and pane_index:
             print(f"Current location: {session}:{window}.{pane_index}")
         else:


### PR DESCRIPTION
## Summary

Fixes #48 - tmux-cli operations were inconsistent about which pane/window to use as the reference point when running in local mode (inside tmux).

## Problem

When the user switches to a different tmux window while a tool (like Claude Code) is running:
- `get_current_window_id()` used `TMUX_PANE` → correct window (where tool is running)
- `status()` used `display-message -p` without `-t` → focused window (where user is looking)
- `list_panes()` used `get_current_window_id()` → correct window

This inconsistency caused:
- `status()` reporting wrong location
- Confusion about where panes were created
- Apparent "failures" when panes were actually created in the correct window

## Changes

1. **`status()`** - Now uses `TMUX_PANE` with `-t` flag, consistent with other methods
2. **`create_pane()`** - Added verification that returned pane ID actually exists, with fallback to find newly created pane by diffing before/after pane lists

## Testing

Tested on Raspberry Pi 5 running tmux 3.4:
- Verified panes spawn in correct window (where command originated)
- Verified `status()` reports correct location even when focused on different window
- Verified `send`, `capture`, and `kill` operations work correctly

## Test plan

- [ ] Run `tmux-cli launch "bash"` while focused on a different window
- [ ] Verify pane appears in Claude's window, not focused window
- [ ] Verify `tmux-cli status` reports Claude's location, not focused location

🤖 Generated with [Claude Code](https://claude.com/claude-code)