### PR TITLE
fix: extend shell operator splitting to cover pipe and background

### DIFF
--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -135,12 +135,12 @@ def expand_command_aliases(command: str) -> str:
 
     # Find the operators and their positions to preserve them
     # This regex captures the operators as well as the commands
-    parts = re.split(r'(\s*(?:&&|\|\||;)\s*)', command)
+    parts = re.split(r'(\s*(?:&&|\|\||[;&|])\s*)', command)
 
     result = []
     for part in parts:
         # Check if this part is an operator
-        if re.match(r'\s*(?:&&|\|\||;)\s*', part):
+        if re.match(r'\s*(?:&&|\|\||[;&|])\s*', part):
             result.append(part)
         elif part.strip():
             # It's a command, expand its alias
@@ -155,7 +155,7 @@ def extract_subcommands(command: str) -> list[str]:
     """
     Split compound bash command into individual subcommands.
 
-    Splits on &&, ||, and ; operators.
+    Splits on &&, ||, ;, | (pipe), and & (background) operators.
 
     Args:
         command: A bash command string, possibly compound.
@@ -169,5 +169,5 @@ def extract_subcommands(command: str) -> list[str]:
     """
     if not command:
         return []
-    subcommands = re.split(r'\s*(?:&&|\|\||;)\s*', command)
+    subcommands = re.split(r'\s*(?:&&|\|\||[;&|])\s*', command)
     return [cmd.strip() for cmd in subcommands if cmd.strip()]

--- a/plugins/safety-hooks/hooks/rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/rm_block_hook.py
@@ -1,19 +1,39 @@
 #!/usr/bin/env python3
+import os
 import re
+import sys
+
+# Add plugin hooks directory to Python path for local imports
+PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
+if PLUGIN_ROOT:
+    hooks_dir = os.path.join(PLUGIN_ROOT, 'hooks')
+    if hooks_dir not in sys.path:
+        sys.path.insert(0, hooks_dir)
+
+from command_utils import extract_subcommands
 
 def check_rm_command(command):
     """
     Check if a command contains rm that should be blocked.
+    Handles compound commands (e.g., "cd /path && rm foo").
     Returns tuple: (should_block: bool, reason: str or None)
     """
+    for subcmd in extract_subcommands(command):
+        should_block, reason = _check_single_rm(subcmd)
+        if should_block:
+            return True, reason
+    return False, None
+
+
+def _check_single_rm(command):
+    """Check a single command (no shell chaining) for rm."""
     # Normalize the command
     normalized_cmd = ' '.join(command.strip().split())
-    
+
     # Check if it's an rm command
     # This catches: rm, /bin/rm, /usr/bin/rm, etc.
-    # Also simpler check: if the command starts with rm or contains rm after common separators
-    if (normalized_cmd.startswith("rm ") or normalized_cmd == "rm" or 
-        re.search(r'(^|[;&|]\s*)(/\S*/)?rm\b', normalized_cmd)):
+    if (normalized_cmd.startswith("rm ") or normalized_cmd == "rm" or
+        re.search(r'^(/\S*/)?rm\b', normalized_cmd)):
         reason_text = (
             "Instead of using 'rm':\n "
             "- MOVE files using `mv` to the TRASH directory in the CURRENT folder (create it if needed), \n"
@@ -25,7 +45,7 @@ def check_rm_command(command):
             "```"
         )
         return True, reason_text
-    
+
     return False, None
 
 


### PR DESCRIPTION
## Problem

`extract_subcommands()` in `command_utils.py` only splits on `&&`, `||`, and `;`. Commands chained with `|` (pipe) or `&` (background) stay as a single string, so the dangerous subcommand sits at a non-zero position and bypasses pattern matching in downstream hooks.

Additionally, `rm_block_hook.py` doesn't use `extract_subcommands()` at all — it still uses the old `startswith`/regex approach, making it vulnerable to all chaining operators.

## Fix

1. **`command_utils.py`**: Update both `extract_subcommands()` and `expand_command_aliases()` regex from `(?:&&|\|\||;)` to `(?:&&|\|\||[;&|])`. Two-character operators match first via left-to-right alternation; the `[;&|]` character class catches single `&`, `;`, and `|`.

2. **`rm_block_hook.py`**: Refactor to use `extract_subcommands()` like the other hooks, checking each subcommand independently.

## Files changed

- `plugins/safety-hooks/hooks/command_utils.py`
- `plugins/safety-hooks/hooks/rm_block_hook.py`

## Test plan

- [x] Verified commands chained with `|` are now blocked
- [x] Verified commands chained with `&` (background) are now blocked
- [x] Verified `&&`, `||`, `;` chaining still blocked
- [x] Verified direct (non-chained) commands still blocked
- [x] Verified safe commands still pass through
