### PR TITLE
Fix mobile overflow on Starlight docs landing page and tables

### DIFF
--- a/docs-site/src/content/docs/getting-started/index.mdx
+++ b/docs-site/src/content/docs/getting-started/index.mdx
@@ -8,6 +8,10 @@ description: >-
 import { Steps } from "@astrojs/starlight/components";
 
 <style>{`
+  table {
+    display: block;
+    overflow-x: auto;
+  }
   table td:first-child,
   table th:first-child {
     white-space: nowrap;

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -13,7 +13,7 @@ hero:
       <img
         src="/claude-code-tools/assets/demo.gif"
         alt="claude-code-tools demo"
-        style="max-width:480px;border-radius:8px;"
+        style="width:100%;max-width:480px;border-radius:8px;"
       />
   actions:
     - text: Get Started

--- a/docs-site/src/content/docs/tools/aichat/resume.mdx
+++ b/docs-site/src/content/docs/tools/aichat/resume.mdx
@@ -5,6 +5,10 @@ title: "Resume"
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 <style>{`
+  table {
+    display: block;
+    overflow-x: auto;
+  }
   table td:first-child,
   table th:first-child {
     white-space: nowrap;


### PR DESCRIPTION
Add width:100% to the hero demo GIF so it scales down on viewports
narrower than 480px (e.g. iPhone). Also add overflow-x:auto to tables
on the getting-started and resume pages so white-space:nowrap columns
scroll horizontally instead of blowing out the page width.

https://claude.ai/code/session_01MVVkjhTs487EWjHjQWuUaJ