### PR TITLE
Add CCHub - Claude Code desktop control panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ CLI tools, skills, agents, hooks, and plugins for enhancing productivity with Cl
 </div>
 
 ## [Full Documentation](https://pchalasani.github.io/claude-code-tools/)
+- [CCHub](https://github.com/Moresl/cchub) - A desktop control panel for the Claude Code / Codex / Gemini CLI ecosystem. Manage MCP servers, config profiles, agent skills, CLAUDE.md, hooks, and workflow templates from a single Tauri app (Windows / macOS / Linux).
 
 ## Install
 


### PR DESCRIPTION
## CCHub

[CCHub](https://github.com/Moresl/cchub) is an open-source (MIT) desktop control
panel for the Claude Code / Codex / Gemini CLI ecosystem. It is built with Tauri
2 + React + Rust, ships as a single ~20MB binary, and runs on Windows / macOS /
Linux.

### What it does

- **MCP marketplace** - browse, install, enable/disable MCP servers for multiple
  clients from one place
- **Config profiles** - manage multiple API endpoints / keys for Claude Code,
  Codex CLI, Gemini CLI, OpenCode, OpenClaw and hot-switch between them
- **Agent skills browser** - install / update / remove skills per CLI
- **Workflow templates, CLAUDE.md editor, hooks visualizer, security audit,
  Autopilot, i18n (EN / CN / JP)**

### Why it might fit this list

It is a real, released product (v1.4.0), with clean screenshots, a PROMOTION
page, and an active release pipeline. If you think it does not fit the scope of
this list, please close this PR and I will respect that — thanks either way for
the work on the list!
