### PR TITLE
Fix #64: Listed in Awesome Codex CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ CLI tools, skills, agents, hooks, and plugins for enhancing productivity with Cl
 
 [![Documentation](https://img.shields.io/badge/%F0%9F%93%96-documentation-blue)](https://pchalasani.github.io/claude-code-tools/)
 [![aichat-search](https://img.shields.io/github/v/release/pchalasani/claude-code-tools?filter=rust-v*&label=aichat-search&color=orange)](https://github.com/pchalasani/claude-code-tools/releases?q=rust)
+[![Mentioned in Awesome Codex CLI](https://awesome.re/mentioned-badge.svg)](https://github.com/RoggeOhta/awesome-codex-cli)
 
 </div>
 


### PR DESCRIPTION
Closes #64

Adds the "Mentioned in Awesome Codex CLI" badge to `README.md` in response to the project being listed in the [Awesome Codex CLI](https://github.com/RoggeOhta/awesome-codex-cli) curated directory. The badge is inserted on line 12 of `README.md`, alongside the existing Documentation and aichat-search shields in the `<div>` badge block.

- `README.md`: added `[![Mentioned in Awesome Codex CLI](...)]` badge after the `aichat-search` release badge

Verified by confirming the badge URL (`https://awesome.re/mentioned-badge.svg`) renders correctly and the linked repo (`RoggeOhta/awesome-codex-cli`) includes this project in its listing.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*