### PR TITLE
feat(voice): support CC_VOICE env var for one-off voice override

### DIFF
--- a/plugins/voice/README.md
+++ b/plugins/voice/README.md
@@ -128,8 +128,11 @@ You can use the `say` script directly from the command line:
 
 ### Environment Variables
 
+- `CC_VOICE`: Voice to use (overrides `~/.claude/voice.local.md`; `--voice` CLI flag still wins)
 - `TTS_HOST`: TTS server host (default: `localhost`)
 - `TTS_PORT`: TTS server port (default: `8000`)
+
+Voice resolution order: `--voice <name>` flag → `CC_VOICE` env var → config file `voice:` field.
 
 ## Disabling
 

--- a/plugins/voice/scripts/say
+++ b/plugins/voice/scripts/say
@@ -36,6 +36,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --help, -h         Show this help message"
             echo ""
             echo "Environment variables:"
+            echo "  CC_VOICE           Voice to use (overrides config file; --voice still wins)"
             echo "  TTS_HOST           TTS server host (default: localhost)"
             echo "  TTS_PORT           TTS server port (default: 8000)"
             exit 0
@@ -55,6 +56,11 @@ if [[ -z "$TEXT" ]]; then
     exit 1
 fi
 
+# Apply CC_VOICE env var if --voice was not specified
+if [[ -z "$VOICE" && -n "$CC_VOICE" ]]; then
+    VOICE="$CC_VOICE"
+fi
+
 # Check config file for voice and enabled status
 CONFIG_FILE="$HOME/.claude/voice.local.md"
 if [[ -f "$CONFIG_FILE" ]]; then
@@ -64,7 +70,7 @@ if [[ -f "$CONFIG_FILE" ]]; then
     if [[ "$ENABLED" == "false" ]]; then
         exit 0
     fi
-    # Extract voice if not specified via --voice
+    # Extract voice if not specified via --voice or CC_VOICE
     if [[ -z "$VOICE" ]]; then
         VOICE=$(sed -n '/^---$/,/^---$/p' "$CONFIG_FILE" | grep "^voice:" | sed 's/voice:[[:space:]]*//')
     fi


### PR DESCRIPTION
## Summary
- Adds `CC_VOICE` environment variable to `plugins/voice/scripts/say` so the voice can be set per-process without mutating `~/.claude/voice.local.md`.
- `--voice` CLI flag still takes precedence over `CC_VOICE`, which takes precedence over the config file.
- Documents the new env var in `--help` output and `plugins/voice/README.md`.

## Motivation
Multi-agent setups want a distinct voice per agent so the user can tell speakers apart by ear. The config file is a single global value, and threading `--voice` through every call site is awkward. Setting `CC_VOICE` once in the agent's env (e.g. via the launcher, a wrapper script, or a hook that exports it before the agent runs) gives each concurrent agent its own voice with no shared-state contention.

## Test plan
- [x] `CC_VOICE=eponine ./scripts/say "test"` plays in eponine voice
- [x] `./scripts/say --voice alba "test"` still wins when both `--voice` and `CC_VOICE` are set
- [x] With neither flag nor env var set, the config file value is still used
- [x] `./scripts/say --help` lists `CC_VOICE`

vibe coded with care