### PR TITLE
fix(voice): raise marker trim cap and give model an explicit word budget

### DIFF
--- a/plugins/voice/hooks/stop_hook.py
+++ b/plugins/voice/hooks/stop_hook.py
@@ -22,7 +22,7 @@ from pathlib import Path
 # Add hooks directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent))
 
-from voice_common import MAX_SPOKEN_WORDS
+from voice_common import MAX_EXPLICIT_SUMMARY_WORDS, MAX_SPOKEN_WORDS
 
 PLUGIN_ROOT = Path(__file__).parent.parent
 
@@ -433,14 +433,12 @@ def main():
     # Get last assistant message
     last_assistant_msg = get_last_assistant_message(session_file)
 
-    # Flexible limit for explicit summaries (1.5x the strict limit)
-    flexible_limit = int(MAX_SPOKEN_WORDS * 1.5)
-
     # Strategy 1: Try to extract 📢 marker (instant!)
     if last_assistant_msg:
         marker_summary = extract_voice_marker(last_assistant_msg)
         if marker_summary:
-            summary = trim_to_words(marker_summary, flexible_limit)
+            # Safety cap: marker is prompted to be brief, but trim if it overshoots.
+            summary = trim_to_words(marker_summary, MAX_EXPLICIT_SUMMARY_WORDS)
 
     # Strategy 2: If no marker but response is short, speak directly
     if not summary and last_assistant_msg:
@@ -453,7 +451,7 @@ def main():
         if conversation:
             summary = summarize_with_claude(conversation, custom_prompt)
             if summary:
-                summary = trim_to_words(summary, flexible_limit)
+                summary = trim_to_words(summary, MAX_EXPLICIT_SUMMARY_WORDS)
                 used_headless = True
 
     # Strategy 4: Last resort - truncate last message
@@ -463,9 +461,6 @@ def main():
     if not summary:
         print(json.dumps({"decision": "approve"}))
         return
-
-    # No final truncation - trust explicit summaries (marker or headless Claude)
-    # Only Strategy 2 and 4 use raw text which is already bounded by MAX_SPOKEN_WORDS
 
     # Speak it
     speak_summary(session_id, summary, voice)

--- a/plugins/voice/hooks/voice_common.py
+++ b/plugins/voice/hooks/voice_common.py
@@ -6,8 +6,10 @@ Shared voice plugin utilities and constants.
 from pathlib import Path
 
 # Word limit for short response detection and fallback truncation.
-# This does NOT apply to explicitly generated summaries (📢 marker or headless Claude).
+# Explicit summaries (📢 marker or headless Claude) are allowed up to
+# MAX_SPOKEN_WORDS * 2 as a safety cap in case the model overshoots.
 MAX_SPOKEN_WORDS = 25
+MAX_EXPLICIT_SUMMARY_WORDS = MAX_SPOKEN_WORDS * 2
 
 
 def get_voice_config() -> tuple[bool, str, str, bool]:
@@ -89,7 +91,7 @@ def build_full_reminder(custom_prompt: str = "") -> str:
         f"- If ≤{MAX_SPOKEN_WORDS} words of natural speakable text, no summary needed\n"
         f"- If ≤{MAX_SPOKEN_WORDS} words but contains code/paths/technical output, "
         "ADD a 📢 summary\n"
-        "- If longer, end with: 📢 [brief spoken summary]\n\n"
+        f"- If longer, end with: 📢 [brief spoken summary, ≤{MAX_EXPLICIT_SUMMARY_WORDS} words]\n\n"
         "VOICE SUMMARY STYLE:\n"
         "- Match the user's tone - if they're casual or use colorful language, "
         "mirror that\n"
@@ -111,6 +113,7 @@ def build_full_reminder(custom_prompt: str = "") -> str:
 def build_short_reminder() -> str:
     """Build a brief voice reminder for PostToolUse hook."""
     return (
-        "[Voice feedback: when done, end with 📢 summary (max 25 words) "
-        "if response is >25 words or contains code/paths]"
+        f"[Voice feedback: when done, end with 📢 summary "
+        f"(≤{MAX_EXPLICIT_SUMMARY_WORDS} words) "
+        f"if response is >{MAX_SPOKEN_WORDS} words or contains code/paths]"
     )


### PR DESCRIPTION
## Summary

Fixes #76. The 📢 marker safety trim was firing at 37 words (`MAX_SPOKEN_WORDS * 1.5`) — below where the model typically lands when prompted for a "brief" summary — so well-behaved markers were being cut off mid-sentence with `"..."` appended.

The trim itself is intentional (safety net for runaway summaries), so the fix is to raise the cap and tell the model an explicit word budget so the trim only fires on actual overshoots.

## Changes

- New constant `MAX_EXPLICIT_SUMMARY_WORDS = MAX_SPOKEN_WORDS * 2` (= 50) in `voice_common.py`.
- `build_full_reminder` now tells the model `📢 [brief spoken summary, ≤50 words]` instead of just "brief spoken summary".
- `build_short_reminder` updated to reference the same ceiling.
- Strategy 1 (marker) and Strategy 3 (headless) in `stop_hook.py` now trim at `MAX_EXPLICIT_SUMMARY_WORDS` instead of the old `flexible_limit`.
- Removed the outdated "No final truncation — trust explicit summaries" comment, since the trim is deliberately a backstop, not a bug.

## Notes on the original issue

The reporter's proposed fix (remove the trim entirely) would let a runaway 200-word "summary" play in full, defeating the safety net. The real problems were:
1. The cap was too tight relative to what the model produces.
2. The reminder gave no explicit word budget, so the model had nothing to aim at.
3. The comment in the code falsely implied no trimming happened.

This PR addresses all three.

## Test plan

- [ ] 📢 marker of ~40 words: spoken in full (previously cut at word 37).
- [ ] 📢 marker of >50 words: trimmed at 50 with `...` (safety net still works).
- [ ] Headless fallback summary >50 words: trimmed at 50.
- [ ] Short responses (≤25 words, no marker): spoken directly, unchanged.

https://claude.ai/code/session_01DMaaHayvCT6xZS7xQ6TGMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMaaHayvCT6xZS7xQ6TGMw)_