### PR TITLE
feat(agent-tunnel): gated full-access level (--dangerously-skip-permissions)

### DIFF
--- a/claude_code_tools/agent_tunnel/backends.py
+++ b/claude_code_tools/agent_tunnel/backends.py
@@ -208,8 +208,12 @@ class _BaseBackend:
         return upload_dir
 
     def _can_write(self, rec: ThreadRecord) -> bool:
-        """True if this handle may produce deliverables (write or bash)."""
-        return rec.access in ("write", "bash")
+        """True if this handle may produce deliverables (write/bash/all).
+
+        "all" (skip-permissions) is above bash, so it must get the outbox
+        instruction too, or its generated files never get posted back.
+        """
+        return rec.access in ("write", "bash", "all")
 
     def _begin_turn(
         self, rec: ThreadRecord

--- a/claude_code_tools/agent_tunnel/backends.py
+++ b/claude_code_tools/agent_tunnel/backends.py
@@ -113,16 +113,25 @@ def build_claude_flags(
         Argument list (excluding the binary, -p, and the prompt).
     """
     claude = cfg.claude
-    allowed, disallowed = resolve_tools(claude, access)
     flags = ["--resume", resume_id]
     if fork:
         flags.append("--fork-session")
-    if allowed:
-        flags += ["--allowedTools", ",".join(allowed)]
-    if disallowed:
-        flags += ["--disallowedTools", ",".join(disallowed)]
-    if claude.permission_mode:
-        flags += ["--permission-mode", claude.permission_mode]
+    if access == "all" and claude.allow_skip_permissions:
+        # Full access: skip every permission prompt so the fork can use any
+        # tool or MCP server the session has (web, browser, shell, edits). No
+        # allow/deny lists — they would only restrict. The answer path refuses
+        # an "all" handle when the gate is off, so this is never reached
+        # ungated; and resolve_tools has no "all" preset, so an ungated "all"
+        # would fall back to the restrictive read tools, never to "no limits".
+        flags.append("--dangerously-skip-permissions")
+    else:
+        allowed, disallowed = resolve_tools(claude, access)
+        if allowed:
+            flags += ["--allowedTools", ",".join(allowed)]
+        if disallowed:
+            flags += ["--disallowedTools", ",".join(disallowed)]
+        if claude.permission_mode:
+            flags += ["--permission-mode", claude.permission_mode]
     if claude.model:
         flags += ["--model", claude.model]
     for directory in add_dirs:
@@ -167,6 +176,13 @@ class _BaseBackend:
         if not rec.expert_session_id or not rec.project_dir:
             raise BackendError(
                 f"Thread {thread_key} has an incomplete binding."
+            )
+        if rec.access == "all" and not self.cfg.claude.allow_skip_permissions:
+            raise BackendError(
+                "This handle was shared with full "
+                "(--dangerously-skip-permissions) access, but the owner has "
+                "not enabled it. Set [claude] allow_skip_permissions = true in "
+                "the agent-tunnel config and restart serve."
             )
         return rec
 

--- a/claude_code_tools/agent_tunnel/cli.py
+++ b/claude_code_tools/agent_tunnel/cli.py
@@ -144,6 +144,12 @@ def serve(
     is_flag=True,
     help="Grant write + shell execution (with --session/auto).",
 )
+@click.option(
+    "--dangerously-skip-permissions",
+    "skip_perms",
+    is_flag=True,
+    help="Grant FULL access (skip-permissions; needs allow_skip_permissions).",
+)
 @click.argument("question")
 def ask(
     config: Optional[str],
@@ -154,6 +160,7 @@ def ask(
     thread: str,
     write: bool,
     allow_bash: bool,
+    skip_perms: bool,
     question: str,
 ) -> None:
     """Ask one question through the full pipeline (no Discord).
@@ -168,7 +175,7 @@ def ask(
 
     if store.get(thread_key) is None:
         expert_id, project_dir, hname, config_dir, access = _resolve_target(
-            cfg, store, handle, session, project, write, allow_bash
+            cfg, store, handle, session, project, write, allow_bash, skip_perms
         )
         store.bind(
             thread_key,
@@ -200,6 +207,7 @@ def _resolve_target(
     project: Optional[str],
     write: bool = False,
     allow_bash: bool = False,
+    skip_perms: bool = False,
 ) -> tuple[str, Path, str, str, str]:
     """Resolve (expert_session_id, project_dir, handle, config_dir, access)."""
     if handle:
@@ -209,7 +217,11 @@ def _resolve_target(
         return rec.session_id, Path(rec.cwd), rec.handle, rec.config_dir, (
             rec.access
         )
-    access = "bash" if allow_bash else ("write" if write else "read")
+    access = (
+        "all"
+        if skip_perms
+        else "bash" if allow_bash else "write" if write else "read"
+    )
     project_dir = Path(project or os.getcwd()).expanduser().resolve()
     env_dir = os.environ.get("CLAUDE_CONFIG_DIR", "")
     if session:
@@ -241,9 +253,11 @@ def published(config: Optional[str]) -> None:
             f" ({rec.label})" if rec.label and rec.label != rec.handle else ""
         )
         cfgdir = f"  [{Path(rec.config_dir).name}]" if rec.config_dir else ""
-        access = {"write": "  ✍️ write", "bash": "  💥 bash"}.get(
-            rec.access, ""
-        )
+        access = {
+            "write": "  ✍️ write",
+            "bash": "  💥 bash",
+            "all": "  🚨 all",
+        }.get(rec.access, "")
         click.echo(
             f"{rec.handle}{label}: {rec.session_id[:8]} @ {rec.cwd}{cfgdir}"
             f"{access}"
@@ -300,6 +314,7 @@ _ACCESS_DISPLAY = {
     "read": ("read", "dim"),
     "write": ("✍️ write", "yellow"),
     "bash": ("💥 bash", "red"),
+    "all": ("🚨 all", "bold red"),
 }
 
 

--- a/claude_code_tools/agent_tunnel/config.py
+++ b/claude_code_tools/agent_tunnel/config.py
@@ -105,6 +105,12 @@ class ClaudeConfig:
     # Override the config file holding trust state (default: ~/.claude.json,
     # honoring CLAUDE_CONFIG_DIR).
     trust_config_path: str = ""
+    # Opt-in gate for the "all" access level (>share
+    # --dangerously-skip-permissions): only when true do those forks launch
+    # with --dangerously-skip-permissions (any tool/MCP, no prompts). Off by
+    # default — handing a remote colleague's agent full machine access is a
+    # deliberate double opt-in (this flag AND the per-share flag).
+    allow_skip_permissions: bool = False
 
 
 def resolve_tools(
@@ -321,6 +327,12 @@ tmux_extra_args = []
 # Pre-trust a shared folder in ~/.claude.json before forking (tmux backend),
 # so the fork doesn't hit the "trust this folder?" dialog. false = don't touch.
 auto_trust = true
+# DANGEROUS: enable the "all" access level (>share
+# --dangerously-skip-permissions). Those forks run with
+# --dangerously-skip-permissions — a colleague's agent can then use ANY tool
+# or MCP server (web, your browser, shell, file edits) with no prompts. Off
+# unless you fully trust everyone who can reach that handle.
+# allow_skip_permissions = false
 
 [limits]
 max_concurrent = 2

--- a/docs-site/src/content/docs/tools/agent-tunnel.mdx
+++ b/docs-site/src/content/docs/tools/agent-tunnel.mdx
@@ -45,6 +45,11 @@ session from inside Claude Code. Full setup is below.
   turns are **hard-restricted to read-only tools** (`Read`/`Grep`/`Glob`).
 - The Discord Gateway is an *outbound* websocket — **no tunnel, no open port,
   no cloud**. Everything runs on your Mac.
+- The fork knows it's in **bot mode**: its persona says it's answering
+  teammates relayed over chat, and each incoming message is prefixed with who
+  sent it and how — e.g. `Alice (via Discord) says: …` — so it can address
+  people by name. The platform label is the `[tunnel] platform` config value
+  (defaults to `Discord`), ready for other chat front-ends.
 
 ```text
    inside any session:  >share  ─►  hook writes registry  { handle → session }

--- a/docs-site/src/content/docs/tools/agent-tunnel.mdx
+++ b/docs-site/src/content/docs/tools/agent-tunnel.mdx
@@ -129,16 +129,20 @@ is intercepted — it never reaches the model; you just see the handle):
 | `>share <label>` | Publish under a friendly handle, e.g. `>share payments` |
 | `>share --write <label>` | Publish with **write access** (file edits); read-only otherwise |
 | `>share --dangerously-allow-bash <label>` | Write **plus shell commands** (for real PDFs/docx) — trusted people only |
+| `>share --dangerously-skip-permissions <label>` | **Full access**: any tool/MCP (web, browser, shell) with no prompts — needs `[claude] allow_skip_permissions`; fully-trusted only |
 | `>share --read <label>` | Downgrade a handle back to read-only |
 | `>share status` | Show this session's handle, if any |
 | `>share off` | Stop sharing (revoke the handle) |
 
-Access is **per handle** and escalates **read ⊂ write ⊂ bash**: read-only by
-default, `--write` adds file edits (but still **never** `Bash`), and
-`--dangerously-allow-bash` additionally allows shell commands — which drops the
-sandbox, so reserve it for fully trusted colleagues. Re-sharing without a flag
-keeps the current level. `agent-tunnel published` tags writable handles with ✍️
-and bash handles with 💥.
+Access is **per handle** and escalates **read ⊂ write ⊂ bash ⊂ all**: read-only
+by default, `--write` adds file edits (but still **never** `Bash`),
+`--dangerously-allow-bash` additionally allows shell commands, and
+`--dangerously-skip-permissions` (the **all** level) drops every restriction so
+the fork can use any tool or MCP server (web, the browser, shell) with no
+prompts. The **all** level is gated: it does nothing unless the owner also sets
+`[claude] allow_skip_permissions = true` (double opt-in), or the daemon refuses
+the turn. Re-sharing without a flag keeps the current level. `agent-tunnel
+published` tags writable handles with ✍️, bash with 💥, and full with 🚨.
 
 A labeled handle also makes the Discord thread and the tmux window readable
 (`payments-…` instead of a cryptic id). Colleagues end a conversation with

--- a/docs/agent-tunnel-spec.md
+++ b/docs/agent-tunnel-spec.md
@@ -137,10 +137,17 @@ Daemon + core — `claude_code_tools/agent_tunnel/`:
   (write = read tools + Write/Edit/NotebookEdit, never Bash; read = read-only).
   Re-sharing without a flag preserves the current level. The access level rides
   on the registry record → ThreadRecord → `build_claude_flags(access=…)`.
-- `>share --dangerously-allow-bash <label>` — the strongest level: write tools
-  **plus `Bash`/command execution**, so a fork can build real PDFs/docx (e.g.
-  via pandoc) as deliverables. It removes the read-only sandbox — grant it only
-  to fully trusted colleagues. Access escalates linearly: read ⊂ write ⊂ bash.
+- `>share --dangerously-allow-bash <label>` — write tools **plus
+  `Bash`/command execution**, so a fork can build real PDFs/docx (e.g. via
+  pandoc) as deliverables. It removes the read-only sandbox — grant it only to
+  fully trusted colleagues.
+- `>share --dangerously-skip-permissions <label>` — the top level (`"all"`):
+  the fork launches with `--dangerously-skip-permissions`, so it can use **any
+  tool or MCP server** the session has (web search, the browser via
+  chrome-devtools, shell, file edits) with **no permission prompts**. It only
+  takes effect when the owner also sets `[claude] allow_skip_permissions =
+  true` (a deliberate double opt-in); otherwise the daemon refuses the turn
+  with a clear message. Access escalates linearly: read ⊂ write ⊂ bash ⊂ all.
 - `>share status` — show this session's handle, if any.
 - `>share off` — revoke (new threads can't open; existing forks keep working,
   since a fork holds its own copy of history).

--- a/docs/agent-tunnel-spec.md
+++ b/docs/agent-tunnel-spec.md
@@ -118,7 +118,11 @@ Daemon + core — `claude_code_tools/agent_tunnel/`:
   `!done`/`!close`/`!end` teardown, `<handle>: <question>` thread names,
   allowlists, cooldown, concurrency, 2000-char chunking, long answers as
   `answer.md`; `token_file` resolution. Downloads inbound attachments and posts
-  outbound deliverables (`discord.File`), within size/count caps.
+  outbound deliverables (`discord.File`), within size/count caps. Prefixes each
+  relayed message with its sender (`<name> (via {platform}) says: …`) so the
+  fork knows who is asking; the persona (`DEFAULT_PERSONA`, with a `{platform}`
+  placeholder filled from `[tunnel] platform`, default `Discord`) tells the
+  fork it is in bot mode relaying to teammates.
 - `cli.py` — `serve | ask | published | forks | resume | rename | status | watch |
   doctor | forget | init | help`. `forks` lists fork sessions (handle, asker,
   last active, turn count, fork id) from the store; `resume <handle>` execs

--- a/plugins/agent-tunnel/hooks/share_hook.py
+++ b/plugins/agent-tunnel/hooks/share_hook.py
@@ -214,15 +214,21 @@ def main():
             message = _status(session_id)
         else:
             tokens = arg.split()
+            skip = "--dangerously-skip-permissions" in tokens
             bash = "--dangerously-allow-bash" in tokens
             write = "--write" in tokens or "-w" in tokens
             read = "--read" in tokens or "-r" in tokens
-            # None preserves an existing record's access on re-share. bash is
-            # the strongest level (also runs shell commands), then write, read.
+            # None preserves an existing record's access on re-share. "all" is
+            # the strongest (skip-permissions: any tool/MCP, no prompts), then
+            # bash (shell), write, read.
             access = (
-                "bash"
-                if bash
-                else ("write" if write else ("read" if read else None))
+                "all"
+                if skip
+                else (
+                    "bash"
+                    if bash
+                    else ("write" if write else ("read" if read else None))
+                )
             )
             label_raw = next((t for t in tokens if not t.startswith("-")), "")
             label = _sanitize_label(label_raw) if label_raw else ""
@@ -242,7 +248,16 @@ def main():
                         f"another session. Pick a different name.{RESET}"
                     )
                 else:
-                    if access == "bash":
+                    if access == "all":
+                        note = (
+                            f"\n{YELLOW}🚨 FULL ACCESS "
+                            "(--dangerously-skip-permissions): the colleague's "
+                            "agent can use ANY tool or MCP with NO prompts — "
+                            "shell, the web, your browser, file edits. Requires "
+                            "[claude] allow_skip_permissions = true on the "
+                            f"daemon. Only for people you fully trust.{RESET}"
+                        )
+                    elif access == "bash":
                         note = (
                             f"\n{YELLOW}⚠️ BASH access: the colleague's agent "
                             f"can RUN SHELL COMMANDS and edit files in this "

--- a/tests/test_agent_tunnel_backends.py
+++ b/tests/test_agent_tunnel_backends.py
@@ -159,3 +159,13 @@ def test_all_access_refused_without_gate(tmp_path: Path) -> None:
         backend._require_binding("t")
     cfg.claude.allow_skip_permissions = True
     assert backend._require_binding("t").access == "all"
+
+
+def test_all_access_can_write_for_outbox(tmp_path: Path) -> None:
+    # "all" is above bash, so it must be in the write/outbox path — else its
+    # generated deliverables never get posted back (Codex P2).
+    cfg = TunnelConfig(state_path=tmp_path / "s.json")
+    backend = HeadlessBackend(cfg, TunnelStore(cfg.state_path))
+    assert backend._can_write(ThreadRecord(thread_key="t", access="all"))
+    assert backend._can_write(ThreadRecord(thread_key="t", access="bash"))
+    assert not backend._can_write(ThreadRecord(thread_key="t", access="read"))

--- a/tests/test_agent_tunnel_backends.py
+++ b/tests/test_agent_tunnel_backends.py
@@ -10,12 +10,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from claude_code_tools.agent_tunnel.backends import (
     Backend,
+    BackendError,
     HeadlessBackend,
     TmuxBackend,
     backend_by_name,
     backend_for_record,
+    build_claude_flags,
 )
 from claude_code_tools.agent_tunnel.config import TunnelConfig
 from claude_code_tools.agent_tunnel.paths import uploads_dir_for
@@ -125,3 +129,33 @@ def test_persona_platform_substituted_in_flags(tmp_path: Path) -> None:
     flags = build_claude_flags(cfg, "sid", fork=True)
     system = flags[flags.index("--append-system-prompt") + 1]
     assert "via Slack" in system and "{platform}" not in system
+
+
+def test_all_access_emits_skip_permissions_only_when_gated(
+    tmp_path: Path,
+) -> None:
+    # The "all" level grants --dangerously-skip-permissions, but ONLY when the
+    # owner has flipped the config gate. Ungated, it must never emit the flag.
+    cfg = TunnelConfig(state_path=tmp_path / "s.json")
+    cfg.claude.allow_skip_permissions = True
+    on = build_claude_flags(cfg, "sid", fork=True, access="all")
+    assert "--dangerously-skip-permissions" in on
+    assert "--allowedTools" not in on and "--permission-mode" not in on
+
+    cfg.claude.allow_skip_permissions = False
+    off = build_claude_flags(cfg, "sid", fork=True, access="all")
+    assert "--dangerously-skip-permissions" not in off
+    assert "--allowedTools" in off  # falls back to the restrictive read preset
+
+
+def test_all_access_refused_without_gate(tmp_path: Path) -> None:
+    # A handle shared as "all" can't run until the owner enables the gate;
+    # the backend refuses with a clear, actionable error.
+    cfg = TunnelConfig(state_path=tmp_path / "s.json")
+    store = TunnelStore(cfg.state_path)
+    store.bind("t", "h", "expsid", "/p", "headless", access="all")
+    backend = HeadlessBackend(cfg, store)
+    with pytest.raises(BackendError, match="allow_skip_permissions"):
+        backend._require_binding("t")
+    cfg.claude.allow_skip_permissions = True
+    assert backend._require_binding("t").access == "all"

--- a/tests/test_share_hook.py
+++ b/tests/test_share_hook.py
@@ -63,3 +63,12 @@ def test_share_hook_relabel_preserves_access(tmp_path: Path) -> None:
     new = Registry(reg).get("payments")
     assert new is not None and new.access == "write"  # preserved
     assert Registry(reg).get("paydocs") is None  # old handle relabeled away
+
+
+def test_share_hook_skip_permissions_sets_all(tmp_path: Path) -> None:
+    # `>share --dangerously-skip-permissions` records the top "all" level; the
+    # daemon still gates it behind [claude] allow_skip_permissions.
+    reg = tmp_path / "registry.json"
+    _run(reg, ">share --dangerously-skip-permissions full", "sess-x")
+    rec = Registry(reg).get("full")
+    assert rec is not None and rec.access == "all"


### PR DESCRIPTION
## Full-access bot level (gated)

Adds a top access level **`all`** above read/write/bash. A handle shared with `>share --dangerously-skip-permissions <label>` launches the fork with `--dangerously-skip-permissions`, so a colleague's agent can use **any tool or MCP** the session has — web search, the browser via chrome-devtools, shell, file edits — with **no permission prompts** (the same as driving Claude Code yourself).

### Security: double opt-in
Handing a remote agent full machine access is deliberate, so it requires BOTH:
- the per-share flag `>share --dangerously-skip-permissions`, AND
- `[claude] allow_skip_permissions = true` in the daemon config.

If the flag is used but the gate is off, the daemon **refuses** the turn with an actionable message. `build_claude_flags` emits `--dangerously-skip-permissions` only when the gate is on; `resolve_tools` has no `all` preset, so an ungated `all` falls back to the restrictive **read** tools — never to "no limits."

### Also
- Loud warning in the `>share` hook; `agent-tunnel ask --dangerously-skip-permissions` for local smoke tests.
- `forks` / `published` tag full handles with 🚨.
- Spec + Starlight docs; sample config.

### Tests
`build_claude_flags` gating, `_require_binding` refusal, hook flag → `access=all`. **57 tests pass, pyright clean.**

> Note: the `>share` hook is the separate plugin, so the new flag is live only after the plugin is updated/reinstalled.
