### PR TITLE
chore(plugins): unify all plugin versions to 1.13.0

### DIFF
--- a/plugins/agent-tunnel/.claude-plugin/plugin.json
+++ b/plugins/agent-tunnel/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-tunnel",
-  "version": "0.1.0",
+  "version": "1.13.0",
   "description": "Publish the current Claude session via >share so teammates can ask it questions through the agent-tunnel Discord bot",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/aichat/.claude-plugin/plugin.json
+++ b/plugins/aichat/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aichat",
-  "version": "1.10.4",
+  "version": "1.13.0",
   "description": "Provides an agent, skill, hook, and slash command related to the `aichat` tool-set for searching and resuming CLI-agent sessions",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/langroid/.claude-plugin/plugin.json
+++ b/plugins/langroid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "langroid",
-  "version": "1.8.4",
+  "version": "1.13.0",
   "description": "Design patterns for the Langroid multi-agent LLM framework",
   "author": {
     "name": "Langroid"

--- a/plugins/msg/.claude-plugin/plugin.json
+++ b/plugins/msg/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "msg",
-  "version": "0.1.0",
+  "version": "1.13.0",
   "description": "Inter-agent communication for Claude Code and Codex CLI sessions via threads and messages",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/safety-hooks/.claude-plugin/plugin.json
+++ b/plugins/safety-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safety-hooks",
-  "version": "1.10.5",
+  "version": "1.13.0",
   "description": "Safety hooks to block or require user approval for dangerous commands (rm, git operations, .env access, file size limits)",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/tmux-cli/.claude-plugin/plugin.json
+++ b/plugins/tmux-cli/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tmux-cli",
-  "version": "1.8.4",
+  "version": "1.13.0",
   "description": "Provides tmux-cli skill, to allow Claude-Code to interact with CLI scripts or other code-agents in tmux panes, using the `tmux-cli` command",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/voice/.claude-plugin/plugin.json
+++ b/plugins/voice/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voice",
-  "version": "1.10.4",
+  "version": "1.13.0",
   "description": "Audio feedback when Claude Code agent completes tasks using pocket-tts",
   "author": {
     "name": "pchalasani"

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "1.8.4",
+  "version": "1.13.0",
   "description": "Workflow skills and agents: code-walk-thru, log-work, make-issue-spec, socratic-quiz skills; ui-tester agent for browser-based UI validation",
   "author": {
     "name": "Prasad Chalasani"


### PR DESCRIPTION
Unify the 8 marketplace plugins' `plugin.json` versions to **1.13.0** (matching the package release). They were scattered (`0.1.0`/`1.8.4`/`1.10.4`/`1.10.5`).

With versions bumped on each change going forward, refreshing installs becomes `claude plugin marketplace update cctools-plugins` + `claude plugin update <plugin>@cctools-plugins` (applied on restart) — no more clear-cache-and-reinstall dance. (`marketplace.json` top-level version left at `1.0.0` — say if you want that bumped too.)