### PR TITLE
feat(agent-tunnel): live access upgrade/downgrade on running threads

### DIFF
--- a/claude_code_tools/agent_tunnel/backends.py
+++ b/claude_code_tools/agent_tunnel/backends.py
@@ -41,6 +41,7 @@ from .paths import (
     snapshot_dir,
     uploads_dir_for,
 )
+from .registry import Registry
 from .session import (
     extract_answer,
     list_session_files,
@@ -167,6 +168,26 @@ class _BaseBackend:
         self.cfg = cfg
         self.store = store
 
+    def _current_access(self, rec: ThreadRecord) -> str:
+        """The handle's *current* access level from the registry.
+
+        Re-read each turn so a live ``>share --write|--read|...`` re-share
+        upgrades/downgrades an already-running thread, not only new threads.
+        ``Registry.get`` hides a revoked/absent handle, so we fall back to the
+        thread's bound level — a revoked thread keeps working at its last-known
+        access (revoke semantics are out of scope here).
+        """
+        reg = Registry(self.cfg.registry_path).get(rec.handle)
+        return reg.access if (reg is not None and reg.access) else rec.access
+
+    def _on_access_changed(self, rec: ThreadRecord, old: str, new: str) -> None:
+        """Hook fired when a turn syncs the thread to a new access level.
+
+        Base no-op: HeadlessBackend re-reads ``rec.access`` on its next
+        ``claude -p`` automatically. TmuxBackend overrides this to drop the
+        warm window so the next turn cold-relaunches the fork with new flags.
+        """
+
     def _require_binding(self, thread_key: str) -> ThreadRecord:
         rec = self.store.get(thread_key)
         if rec is None:
@@ -177,6 +198,16 @@ class _BaseBackend:
             raise BackendError(
                 f"Thread {thread_key} has an incomplete binding."
             )
+        # Live access upgrade/downgrade: re-read the handle's current registry
+        # access so a `>share --write|--read|...` re-share takes effect on this
+        # already-running thread (same fork, context kept). Persisting it means
+        # the change fires `_on_access_changed` once, not on every later turn.
+        cur = self._current_access(rec)
+        if cur != rec.access:
+            old = rec.access
+            rec.access = cur
+            self.store.set_access(thread_key, cur)
+            self._on_access_changed(rec, old, cur)
         if rec.access == "all" and not self.cfg.claude.allow_skip_permissions:
             raise BackendError(
                 "This handle was shared with full "
@@ -359,6 +390,17 @@ class TmuxBackend(_BaseBackend):
         """Bind to the dedicated tmux session named in the config."""
         super().__init__(cfg, store)
         self.tmux = TmuxSession(cfg.tmux_session)
+
+    def _on_access_changed(self, rec: ThreadRecord, old: str, new: str) -> None:
+        """Kill the warm window so the next turn cold-relaunches the fork.
+
+        ``ask`` resumes the SAME fork (``--resume <fork>``), but
+        ``build_claude_flags`` only applies the new access flags on a cold
+        launch — a warm window keeps what it launched with. Killing the window
+        forces the next turn down the relaunch path, so the fork comes back
+        with the new tools, same fork id, full context retained.
+        """
+        self.tmux.kill_window(_window_name(rec.handle, rec.thread_key))
 
     def _launch(
         self,

--- a/claude_code_tools/agent_tunnel/store.py
+++ b/claude_code_tools/agent_tunnel/store.py
@@ -197,6 +197,24 @@ class TunnelStore:
                 self._save_locked()
             return renamed
 
+    def set_access(self, thread_key: str, access: str) -> Optional[ThreadRecord]:
+        """Set a bound thread's access level and persist it.
+
+        Lets the daemon propagate a live ``>share --write|--read|...`` re-share
+        onto an already-running thread: the backend re-reads the handle's
+        current registry access each turn and calls this to sync the stored
+        record. Mirrors ``rename_handle``'s reload/mutate/save shape. Returns
+        the updated record (a live reference), or None if the thread is no
+        longer bound.
+        """
+        with self._lock, file_lock(self.path):
+            self._reload_locked()
+            rec = self._records.get(thread_key)
+            if rec is not None:
+                rec.access = access
+                self._save_locked()
+            return rec
+
     def all_records(self) -> list[ThreadRecord]:
         """Return a fresh snapshot of all records (re-read under the lock)."""
         with self._lock, file_lock(self.path):

--- a/docs-site/src/content/docs/tools/agent-tunnel.mdx
+++ b/docs-site/src/content/docs/tools/agent-tunnel.mdx
@@ -149,6 +149,14 @@ prompts. The **all** level is gated: it does nothing unless the owner also sets
 the turn. Re-sharing without a flag keeps the current level. `agent-tunnel
 published` tags writable handles with ✍️, bash with 💥, and full with 🚨.
 
+Re-sharing **with** a level flag changes a **live** thread's access on its next
+message (same fork, full context kept), not just new threads: the daemon
+re-reads the handle's access each turn. So `>share --write payments` upgrades an
+in-flight read-only conversation, and `>share --read payments` pulls it back,
+with no need to close the thread (`!done`) and reopen it. Upgrading to **all**
+still honors the gate: without `allow_skip_permissions` the next turn is refused
+rather than silently granted.
+
 A labeled handle also makes the Discord thread and the tmux window readable
 (`payments-…` instead of a cryptic id). Colleagues end a conversation with
 `!done` in their thread; that tears the fork down immediately.

--- a/docs/agent-tunnel-spec.md
+++ b/docs/agent-tunnel-spec.md
@@ -139,8 +139,12 @@ Daemon + core — `claude_code_tools/agent_tunnel/`:
 - `>share <label>` — publish with a chosen handle (validated, deduped).
 - `>share --write <label>` / `>share --read <label>` — set per-handle access
   (write = read tools + Write/Edit/NotebookEdit, never Bash; read = read-only).
-  Re-sharing without a flag preserves the current level. The access level rides
-  on the registry record → ThreadRecord → `build_claude_flags(access=…)`.
+  Re-sharing without a flag preserves the current level; re-sharing **with** a
+  level flag changes an already-running thread on its next message (same fork,
+  context kept), because the daemon re-reads the handle's current registry
+  access each turn in `_require_binding` and syncs it onto the ThreadRecord
+  (`TunnelStore.set_access`). The access level rides on the registry record →
+  ThreadRecord → `build_claude_flags(access=…)`.
 - `>share --dangerously-allow-bash <label>` — write tools **plus
   `Bash`/command execution**, so a fork can build real PDFs/docx (e.g. via
   pandoc) as deliverables. It removes the read-only sandbox — grant it only to

--- a/tests/test_agent_tunnel_backends.py
+++ b/tests/test_agent_tunnel_backends.py
@@ -17,12 +17,14 @@ from claude_code_tools.agent_tunnel.backends import (
     BackendError,
     HeadlessBackend,
     TmuxBackend,
+    _BaseBackend,
     backend_by_name,
     backend_for_record,
     build_claude_flags,
 )
 from claude_code_tools.agent_tunnel.config import TunnelConfig
 from claude_code_tools.agent_tunnel.paths import uploads_dir_for
+from claude_code_tools.agent_tunnel.registry import PublishRecord, Registry
 from claude_code_tools.agent_tunnel.store import ThreadRecord, TunnelStore
 
 
@@ -169,3 +171,113 @@ def test_all_access_can_write_for_outbox(tmp_path: Path) -> None:
     assert backend._can_write(ThreadRecord(thread_key="t", access="all"))
     assert backend._can_write(ThreadRecord(thread_key="t", access="bash"))
     assert not backend._can_write(ThreadRecord(thread_key="t", access="read"))
+
+
+def test_require_binding_syncs_access_up_from_registry(tmp_path: Path) -> None:
+    # A live `>share --write <handle>` on an already-bound (read) thread must
+    # upgrade it on its next turn: _require_binding re-reads the handle's
+    # current registry access and persists it onto the stored record, so the
+    # turn's build_claude_flags(access=…) and follow-ups see the new level.
+    cfg = TunnelConfig(
+        state_path=tmp_path / "s.json", registry_path=tmp_path / "reg.json"
+    )
+    store = TunnelStore(cfg.state_path)
+    store.bind("t", "payments", "expsid", "/p", "headless", access="read")
+    Registry(cfg.registry_path).upsert(
+        PublishRecord(
+            handle="payments", session_id="expsid", cwd="/p", access="write"
+        )
+    )
+    rec = HeadlessBackend(cfg, store)._require_binding("t")
+    assert rec.access == "write"  # synced in-memory for this turn's flags
+    persisted = store.get("t")
+    assert persisted is not None and persisted.access == "write"
+
+
+def test_require_binding_syncs_access_down_from_registry(
+    tmp_path: Path,
+) -> None:
+    # A `>share --read <handle>` re-share downgrades a live write thread too,
+    # so an owner can pull back access mid-conversation.
+    cfg = TunnelConfig(
+        state_path=tmp_path / "s.json", registry_path=tmp_path / "reg.json"
+    )
+    store = TunnelStore(cfg.state_path)
+    store.bind("t", "payments", "expsid", "/p", "headless", access="write")
+    Registry(cfg.registry_path).upsert(
+        PublishRecord(
+            handle="payments", session_id="expsid", cwd="/p", access="read"
+        )
+    )
+    rec = HeadlessBackend(cfg, store)._require_binding("t")
+    assert rec.access == "read"
+    persisted = store.get("t")
+    assert persisted is not None and persisted.access == "read"
+
+
+def test_live_upgrade_to_all_respects_gate(tmp_path: Path) -> None:
+    # Upgrading a live thread to "all" (>share --dangerously-skip-permissions)
+    # still honors the gate: with allow_skip_permissions off the turn is
+    # refused (no silent grant) even though the level synced; once the owner
+    # enables the gate the same thread runs.
+    cfg = TunnelConfig(
+        state_path=tmp_path / "s.json", registry_path=tmp_path / "reg.json"
+    )
+    store = TunnelStore(cfg.state_path)
+    store.bind("t", "ops", "expsid", "/p", "headless", access="write")
+    Registry(cfg.registry_path).upsert(
+        PublishRecord(
+            handle="ops", session_id="expsid", cwd="/p", access="all"
+        )
+    )
+    backend = HeadlessBackend(cfg, store)
+    with pytest.raises(BackendError, match="allow_skip_permissions"):
+        backend._require_binding("t")
+    persisted = store.get("t")  # synced to "all" before the gate refusal
+    assert persisted is not None and persisted.access == "all"
+    cfg.claude.allow_skip_permissions = True
+    assert backend._require_binding("t").access == "all"  # now allowed
+
+
+def test_current_access_falls_back_when_handle_revoked(tmp_path: Path) -> None:
+    # Registry.get hides a revoked/absent handle, so a revoked thread keeps
+    # working at its bound level instead of breaking mid-conversation (revoke
+    # semantics are intentionally out of scope for the live-access sync).
+    cfg = TunnelConfig(
+        state_path=tmp_path / "s.json", registry_path=tmp_path / "reg.json"
+    )
+    store = TunnelStore(cfg.state_path)
+    store.bind("t", "gone", "expsid", "/p", "headless", access="write")
+    reg = Registry(cfg.registry_path)
+    reg.upsert(
+        PublishRecord(
+            handle="gone", session_id="expsid", cwd="/p", access="write"
+        )
+    )
+    reg.revoke("gone")
+    rec = HeadlessBackend(cfg, store)._require_binding("t")
+    assert rec.access == "write"  # bound level retained despite revoke
+
+
+def test_store_set_access_persists_and_noops_on_missing(
+    tmp_path: Path,
+) -> None:
+    # set_access is the persistence primitive behind the live upgrade: it
+    # writes through to disk for a bound thread and is a clean no-op (returns
+    # None) for an unknown thread key.
+    store = TunnelStore(tmp_path / "s.json")
+    store.bind("t", "h", "expsid", "/p", "headless", access="read")
+    updated = store.set_access("t", "bash")
+    assert updated is not None and updated.access == "bash"
+    persisted = store.get("t")  # persisted across a fresh read
+    assert persisted is not None and persisted.access == "bash"
+    assert store.set_access("missing", "write") is None  # unknown key: no-op
+
+
+def test_tmux_backend_overrides_access_changed_hook() -> None:
+    # The live-upgrade window-kill is the tmux backend's job; headless uses the
+    # base no-op (its next `claude -p` re-reads the access). Asserting the
+    # override is wired keeps the actual kill_window behavior — exercised in the
+    # live/manual tmux tier — from being silently dropped. No mock, no live tmux.
+    assert TmuxBackend._on_access_changed is not _BaseBackend._on_access_changed
+    assert HeadlessBackend._on_access_changed is _BaseBackend._on_access_changed

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
Make `>share --write|--read|--dangerously-allow-bash|--dangerously-skip-permissions <handle>`
change a **running** thread's access on its next message (same fork, full
context kept), not just new threads. Access was frozen at bind time before.

## How

- `_BaseBackend._current_access` re-reads the handle's live registry access
  each turn (falls back to the bound level for a revoked/absent handle, so a
  revoked thread keeps working).
- `_require_binding` syncs + persists it (`TunnelStore.set_access`) and fires
  `_on_access_changed` **before** the `all` gate check — a live upgrade to
  `all` with `allow_skip_permissions` off is refused, not silently granted.
- `TmuxBackend` overrides `_on_access_changed` to kill the warm window so the
  next turn cold-relaunches the same fork with new flags. HeadlessBackend (the
  default) needs nothing — its next `claude -p` already rebuilds its flags.

## Tests

6 new no-mock tests in `tests/test_agent_tunnel_backends.py` (sync up, sync
down, live `all` upgrade honoring the gate, revoked→bound fallback,
`set_access` persist/no-op, tmux hook override), verified to fail on the
pre-change source. Full suite: **55 passed**; Pyright clean.

## Docs

[`docs/agent-tunnel-spec.md`](https://github.com/pchalasani/claude-code-tools/blob/feat/agent-tunnel-live-access-upgrade/docs/agent-tunnel-spec.md)
(`>share` access semantics) and the Starlight page `agent-tunnel.mdx` updated.

## Notes

- `uv.lock`: `uv run` corrected the project's own version `1.12.0 → 1.13.0` to
  match the already-shipped `pyproject.toml` (stale-lock fix, orthogonal).
- No committed summary doc: `issues/`/`ai-chats/` are gitignored here and prior
  agent-tunnel PRs (#82–#84) kept the writeup in the PR body, so this follows
  that convention.
