### PR TITLE
fix(agent-tunnel): only sync live access from the bound session (Codex P2)

### DIFF
--- a/claude_code_tools/agent_tunnel/backends.py
+++ b/claude_code_tools/agent_tunnel/backends.py
@@ -173,12 +173,24 @@ class _BaseBackend:
 
         Re-read each turn so a live ``>share --write|--read|...`` re-share
         upgrades/downgrades an already-running thread, not only new threads.
-        ``Registry.get`` hides a revoked/absent handle, so we fall back to the
-        thread's bound level — a revoked thread keeps working at its last-known
-        access (revoke semantics are out of scope here).
+
+        Honored only when the registry record is the SAME session this thread
+        was bound to (``session_id == expert_session_id``); otherwise we keep
+        the stored level. This stops a handle-name collision from hijacking
+        access: the CLI direct path binds threads under the sentinel handle
+        ``cli``, which is also a valid ``>share`` label, so an unrelated
+        ``>share --write cli`` (a different session) must NOT escalate them.
+        A revoked/absent handle is hidden by ``Registry.get`` and likewise
+        falls back to the bound level (a revoked thread keeps working).
         """
         reg = Registry(self.cfg.registry_path).get(rec.handle)
-        return reg.access if (reg is not None and reg.access) else rec.access
+        if (
+            reg is not None
+            and reg.access
+            and reg.session_id == rec.expert_session_id
+        ):
+            return reg.access
+        return rec.access
 
     def _on_access_changed(self, rec: ThreadRecord, old: str, new: str) -> None:
         """Hook fired when a turn syncs the thread to a new access level.

--- a/docs/agent-tunnel-spec.md
+++ b/docs/agent-tunnel-spec.md
@@ -143,8 +143,11 @@ Daemon + core — `claude_code_tools/agent_tunnel/`:
   level flag changes an already-running thread on its next message (same fork,
   context kept), because the daemon re-reads the handle's current registry
   access each turn in `_require_binding` and syncs it onto the ThreadRecord
-  (`TunnelStore.set_access`). The access level rides on the registry record →
-  ThreadRecord → `build_claude_flags(access=…)`.
+  (`TunnelStore.set_access`) — but only when the registry record is still the
+  same bound session (`session_id == expert_session_id`), so a handle-name
+  collision (e.g. the `cli` direct-path sentinel) can't hijack a thread's
+  access. The access level rides on the registry record → ThreadRecord →
+  `build_claude_flags(access=…)`.
 - `>share --dangerously-allow-bash <label>` — write tools **plus
   `Bash`/command execution**, so a fork can build real PDFs/docx (e.g. via
   pandoc) as deliverables. It removes the read-only sandbox — grant it only to

--- a/tests/test_agent_tunnel_backends.py
+++ b/tests/test_agent_tunnel_backends.py
@@ -259,6 +259,29 @@ def test_current_access_falls_back_when_handle_revoked(tmp_path: Path) -> None:
     assert rec.access == "write"  # bound level retained despite revoke
 
 
+def test_access_sync_ignores_handle_collision_from_other_session(
+    tmp_path: Path,
+) -> None:
+    # Guard (Codex P2): sync access only from the registry record bound to THIS
+    # thread's session. The CLI direct path binds threads under the sentinel
+    # handle "cli"; an unrelated `>share --write cli` (a different session) must
+    # NOT escalate them — match on session_id, else keep the stored level.
+    cfg = TunnelConfig(
+        state_path=tmp_path / "s.json", registry_path=tmp_path / "reg.json"
+    )
+    store = TunnelStore(cfg.state_path)
+    store.bind("t", "cli", "session-A", "/p", "headless", access="read")
+    Registry(cfg.registry_path).upsert(
+        PublishRecord(
+            handle="cli", session_id="session-B", cwd="/other", access="write"
+        )
+    )
+    rec = HeadlessBackend(cfg, store)._require_binding("t")
+    assert rec.access == "read"  # not hijacked by a same-name other session
+    persisted = store.get("t")
+    assert persisted is not None and persisted.access == "read"
+
+
 def test_store_set_access_persists_and_noops_on_missing(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Follow-up to #86 — resolves the Codex P2 raised in review ([3429934533](https://github.com/pchalasani/claude-code-tools/pull/86#discussion_r3429934533), [3430172642](https://github.com/pchalasani/claude-code-tools/pull/86#discussion_r3430172642)).

## Problem

`_BaseBackend._current_access` adopted the registry level for **any** active record with the same handle, without checking it is the session this thread was bound from. The CLI direct path (`agent-tunnel ask --session/auto`) binds threads under the pseudo-handle `cli`, which is also a valid `>share` label — so an unrelated `>share --write|--dangerously-allow-bash|--dangerously-skip-permissions cli` published for a *different* session would override those threads' access on every ask (broaden tools, or refuse on `all`).

## Fix

Sync only when the registry record is the same bound session:

```python
reg = Registry(self.cfg.registry_path).get(rec.handle)
if (
    reg is not None
    and reg.access
    and reg.session_id == rec.expert_session_id
):
    return reg.access
return rec.access
```

Revoked/absent handles still fall back to the bound level (unchanged). Legitimate same-session re-shares (e.g. live-upgrading a real handle) keep working — their `session_id` matches.

## Tests

`test_access_sync_ignores_handle_collision_from_other_session` — binds `cli`→`session-A`, publishes `cli`→`session-B` as `write`, asserts the thread stays `read`. Verified to fail on pre-fix code (returned `write`). Full suite: **56 passed**; Pyright clean. Spec note updated.
