### PR TITLE
refactor(agent-tunnel): extract platform-neutral chat_core behind ChatTransport

### DIFF
--- a/claude_code_tools/agent_tunnel/chat_core.py
+++ b/claude_code_tools/agent_tunnel/chat_core.py
@@ -1,0 +1,591 @@
+"""Platform-neutral routing + answer/ingest/deliver pipeline + reaper.
+
+``ChatCore`` owns every routing and policy decision for agent-tunnel's chat
+front-ends. A front-end adapter (``discord_bot``, ``slack_bot``) normalizes its
+platform events into :class:`~.chat_types.IncomingMessage`, implements
+:class:`~.chat_types.ChatTransport`, constructs ONE ``ChatCore``, schedules
+:meth:`ChatCore.run_reaper`, and forwards each accepted message via
+``await core.handle_message(msg)``. Because all policy lives here, the Discord
+and Slack front-ends are behavior-identical by construction.
+
+The bodies below are ports of the original ``discord_bot`` handlers with the
+``discord.*`` I/O replaced by ``ChatTransport`` calls, the conversation key read
+from ``dest.thread_key``, the leading-mention decision read from
+``msg.addressee``, the cooldown map keyed on the string principal id, and the
+numeric caps read from ``transport.limits``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from collections import defaultdict
+from pathlib import Path
+
+from .backends import (
+    Answer,
+    Backend,
+    BackendError,
+    backend_by_name,
+    backend_for_record,
+    effective_backend,
+)
+from .chat_types import (  # re-exported for adapters/tests via this module
+    Addressee,
+    AttachmentRef,
+    ChatDest,
+    ChatTransport,
+    IncomingMessage,
+    OutgoingFile,
+    Surface,
+    format_relayed_message,
+    is_close_command,
+    is_list_command,
+    split_chunks,
+    _safe_filename,
+    _unique_name,
+)
+from .config import TunnelConfig
+from .convert import CONVERTIBLE_EXTS, convert_attachment
+from .paths import attachment_preamble, uploads_dir_for
+from .registry import HANDLE_RE, Registry
+from .store import TunnelStore
+
+logger = logging.getLogger("agent_tunnel")
+
+REAP_INTERVAL_S = 300
+
+
+class ChatCore:
+    """Platform-neutral routing + answer/ingest/deliver pipeline + reaper.
+
+    ONE instance per running bot. The adapter builds
+    ``core = ChatCore(cfg, store, registry, transport)``, schedules
+    ``core.run_reaper()`` on its loop, and for each accepted, normalized event
+    awaits ``core.handle_message(msg)``.
+    """
+
+    def __init__(
+        self,
+        cfg: TunnelConfig,
+        store: TunnelStore,
+        registry: Registry,
+        transport: ChatTransport,
+    ) -> None:
+        """Keep references and create the per-run concurrency primitives."""
+        self.cfg = cfg
+        self.store = store
+        self.registry = registry
+        self.tx = transport
+        self._sem = asyncio.Semaphore(cfg.limits.max_concurrent)
+        self._locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+        self._last_ask: dict[str, float] = {}
+
+    async def handle_message(self, msg: IncomingMessage) -> None:
+        """Drop empty messages, then dispatch on the surface the adapter set."""
+        # An attachment-only message has empty text but still carries a file for
+        # the agent to read -- ``has_content`` keeps it.
+        if not msg.has_content:
+            return
+        if msg.surface is Surface.THREAD:
+            await self._on_thread(msg)
+        elif msg.surface is Surface.DM:
+            await self._on_direct(msg)
+        else:
+            await self._on_channel(msg)
+
+    # -- policy ----------------------------------------------------------------
+
+    def _allowed(self, msg: IncomingMessage) -> bool:
+        """True if this principal may ask (empty allowlists = anyone allowed)."""
+        uids, rids = self.cfg.principal_allowlists()
+        if not uids and not rids:
+            return True
+        if msg.author_id in uids:
+            return True
+        return bool(msg.author_role_ids & rids)
+
+    def _cooldown_ok(self, author_id: str) -> bool:
+        """True (and stamps now) unless this principal asked within the cooldown."""
+        now = time.time()
+        if now - self._last_ask.get(author_id, 0) < self.cfg.limits.per_user_cooldown_s:
+            return False
+        self._last_ask[author_id] = now
+        return True
+
+    # -- routing ---------------------------------------------------------------
+
+    async def _on_channel(self, msg: IncomingMessage) -> None:
+        """A message in a watched channel: try to open a handle thread."""
+        content = msg.text
+        if is_list_command(content):
+            if self._allowed(msg):
+                await self._list_handles(msg.dest)
+            return
+        token, _, remainder = content.partition(" ")
+        handle = token.strip().lower()
+        rec = self.registry.get(handle)
+        if rec is None:
+            # Only complain if it clearly looks like a handle attempt (before the
+            # allowlist gate, matching the shipped bot).
+            if HANDLE_RE.match(handle) and not remainder:
+                await self.tx.send_text(
+                    msg.dest,
+                    f"No live session for handle `{handle}`. "
+                    "Ask the owner to `>share` it.",
+                )
+            return
+        if not self._allowed(msg):
+            return
+
+        question = remainder.strip()
+        label = rec.label or rec.handle
+        # Lead with the handle (recognizable), then the question so multiple
+        # threads for the same handle stay distinguishable.
+        thread_name = (f"{label}: {question}" if question else label)[
+            : self.tx.limits.thread_title_max
+        ]
+        dest = await self.tx.open_thread(msg.dest, thread_name)
+        logger.info(
+            "Opened thread for handle %s (session %s) asked by %s",
+            rec.handle,
+            rec.session_id[:8],
+            msg.author_display,
+        )
+        self.store.bind(
+            dest.thread_key,
+            handle=rec.handle,
+            expert_session_id=rec.session_id,
+            project_dir=rec.cwd,
+            config_dir=rec.config_dir,
+            access=rec.access,
+            backend=self.cfg.backend,
+            asker=msg.author_display,
+        )
+        if question or msg.attachments:
+            await self._answer(dest, question, msg)
+        else:
+            await self.tx.send_text(
+                dest,
+                f"Connected to **{label}**. Ask your question here; "
+                "follow-ups stay in this thread.",
+            )
+
+    async def _on_thread(self, msg: IncomingMessage) -> None:
+        """A follow-up inside a bound thread."""
+        thread_key = msg.dest.thread_key
+        if self.store.get(thread_key) is None:
+            return
+        if not self._allowed(msg):
+            return
+        # A message that opens with @someone-else (or a broadcast/role) is
+        # teammates talking among themselves -- stay out silently. A leading
+        # @bot was already stripped by the adapter (Addressee.SELF). No mention
+        # = answer (in a thread you never need to address the bot).
+        if msg.addressee is Addressee.OTHER:
+            return
+        content = msg.text
+        if is_list_command(content):
+            await self._list_handles(msg.dest)
+            return
+        if is_close_command(content):
+            await self._close(msg.dest)
+            return
+        if not self._cooldown_ok(msg.author_id):
+            await self.tx.add_reaction(msg, "hourglass")
+            return
+        await self._answer(msg.dest, content, msg)
+
+    async def _on_direct(self, msg: IncomingMessage) -> None:
+        """DM handling: `<handle> ...` (re)binds; bare text follows up."""
+        thread_key = msg.dest.thread_key
+        content = msg.text
+        if is_list_command(content):
+            if self._allowed(msg):
+                await self._list_handles(msg.dest)
+            return
+        if is_close_command(content) and self.store.get(thread_key) is not None:
+            if self._allowed(msg):
+                await self._close(msg.dest)
+            return
+        token, _, remainder = content.partition(" ")
+        handle = token.strip().lower()
+        rec = self.registry.get(handle)
+        if rec is not None:
+            # Rebinding this DM starts a fresh thread; fully tear down any
+            # previous binding first so its uploads/outbox (and live tmux window)
+            # don't leak into the new handle's fork -- the upload dir is keyed
+            # only by the DM channel and would otherwise be reused across handles.
+            #
+            # Hold the thread lock around forget+bind so the rebind can't race a
+            # still-running turn on the OLD binding: that turn holds this same
+            # lock, and its trailing upsert() would otherwise attach the old fork
+            # to the new handle. The lock is released here before _answer
+            # re-acquires it below -- it is not reentrant -- so the new turn
+            # simply queues behind the old one.
+            async with self._locks[thread_key]:
+                existing = self.store.get(thread_key)
+                if existing is not None:
+                    await asyncio.to_thread(
+                        backend_for_record(
+                            self.cfg, self.store, existing
+                        ).forget,
+                        thread_key,
+                    )
+                self.store.bind(
+                    thread_key,
+                    handle=rec.handle,
+                    expert_session_id=rec.session_id,
+                    project_dir=rec.cwd,
+                    config_dir=rec.config_dir,
+                    access=rec.access,
+                    backend=self.cfg.backend,
+                    asker=msg.author_display,
+                )
+            content = remainder.strip()
+            if not content and not msg.attachments:
+                await self.tx.send_text(
+                    msg.dest, f"Connected to **{rec.label or rec.handle}**."
+                )
+                return
+        elif self.store.get(thread_key) is None:
+            await self.tx.send_text(
+                msg.dest, "Start with a handle, e.g. `pay-7Q2 your question`."
+            )
+            return
+        if not self._allowed(msg):
+            return
+        if not self._cooldown_ok(msg.author_id):
+            await self.tx.add_reaction(msg, "hourglass")
+            return
+        await self._answer(msg.dest, content, msg)
+
+    async def _list_handles(self, dest: ChatDest) -> None:
+        """Post the list of currently shared handles."""
+        recs = self.registry.active()
+        if not recs:
+            await self.tx.send_text(dest, "No sessions are shared right now.")
+            return
+        lines = ["**Available handles** — post `<handle> your question`:"]
+        for rec in recs:
+            proj = Path(rec.cwd).name
+            label = (
+                f" ({rec.label})"
+                if rec.label and rec.label != rec.handle
+                else ""
+            )
+            lines.append(f"• `{rec.handle}`{label} — {proj}")
+        # Single message (not paginated); the invariant list_truncate_len <=
+        # max_message_len keeps this within the no-re-chunk send_text contract.
+        limit = min(
+            self.tx.limits.list_truncate_len, self.tx.limits.max_message_len
+        )
+        await self.tx.send_text(dest, "\n".join(lines)[:limit])
+
+    async def _close(self, dest: ChatDest) -> None:
+        """Close a thread: tear down its fork and confirm."""
+        thread_key = dest.thread_key
+        try:
+            # Hold the thread lock so we don't delete a turn's upload/outbox dirs
+            # (or kill its window) while it is mid-answer.
+            async with self._locks[thread_key]:
+                rec = self.store.get(thread_key)
+                await asyncio.to_thread(
+                    backend_for_record(self.cfg, self.store, rec).forget,
+                    thread_key,
+                )
+        except Exception:
+            logger.exception("Error closing %s", thread_key)
+        logger.info("Closed thread %s on request", thread_key)
+        await self.tx.send_text(
+            dest,
+            "✅ Closed and cleaned up. Post the handle in the channel "
+            "to start a fresh thread anytime.",
+        )
+
+    # -- the turn --------------------------------------------------------------
+
+    async def _answer(
+        self, dest: ChatDest, question: str, msg: IncomingMessage
+    ) -> None:
+        """Run one turn in the thread's fork and deliver the answer + files."""
+        thread_key = dest.thread_key
+        sender = msg.author_display
+        attachments = msg.attachments
+        # Per-question log line so an unattended (esp. headless) daemon shows
+        # live activity + an audit trail of who-asked-what.
+        rec = self.store.get(thread_key)
+        handle = rec.handle if rec else "?"
+        # The per-message sender is more accurate than the bind-time asker for
+        # follow-ups by other people.
+        asker = sender or (rec.asker if rec else "?")
+        n_att = len(attachments or [])
+        logger.info(
+            "Q [%s] %s ← %s%s: %r",
+            thread_key,
+            handle,
+            asker,
+            f" +{n_att} file(s)" if n_att else "",
+            (question or "").replace("\n", " ")[:120],
+        )
+        lock = self._locks[thread_key]
+        if lock.locked():
+            await self.tx.send_text(
+                dest,
+                "⏳ Still working on the previous question here — "
+                "I'll take this one next.",
+            )
+        async with lock, self._sem:
+            # The thread may have been rebound (even to the same session, which
+            # resets the fork) or closed while this turn waited for the lock. A
+            # fresh bind stamps a new created_at, so compare the full binding
+            # identity (session + created_at) and don't answer a queued question
+            # against a binding it was not asked under.
+            current = self.store.get(thread_key)
+            if current is None or (
+                rec is not None
+                and (
+                    current.expert_session_id != rec.expert_session_id
+                    or current.created_at != rec.created_at
+                )
+            ):
+                await self.tx.send_text(
+                    dest,
+                    "↪️ This conversation was restarted before I got to "
+                    "your message — please resend it.",
+                )
+                return
+            start = time.time()
+            try:
+                async with self.tx.activity(dest):
+                    question = await self._ingest_attachments(
+                        dest, thread_key, question, attachments or ()
+                    )
+                    if not question.strip():
+                        await self.tx.send_text(
+                            dest,
+                            "⚠️ Nothing to act on — add a question, or a "
+                            "(smaller/readable) file.",
+                        )
+                        logger.info(
+                            "A [%s] %s: skipped (no usable content)",
+                            thread_key,
+                            handle,
+                        )
+                        return
+                    # Tell the fork who sent this (it can't see chat); the persona
+                    # explains the "<name> (via X) says:" convention.
+                    question = format_relayed_message(
+                        sender, question, self.cfg.platform
+                    )
+                    answer = await asyncio.to_thread(
+                        backend_for_record(self.cfg, self.store, rec).ask,
+                        thread_key,
+                        question,
+                    )
+            except BackendError as exc:
+                logger.warning(
+                    "A [%s] %s: error after %.1fs — %s",
+                    thread_key,
+                    handle,
+                    time.time() - start,
+                    str(exc)[:200],
+                )
+                await self.tx.send_text(
+                    dest, f"⚠️ {str(exc)[: self.tx.limits.max_error_len]}"
+                )
+                return
+            except Exception:
+                logger.exception(
+                    "A [%s] %s: unexpected backend failure",
+                    thread_key,
+                    handle,
+                )
+                await self.tx.send_text(
+                    dest,
+                    "⚠️ Unexpected error — the owner can check the "
+                    "agent-tunnel logs.",
+                )
+                return
+
+        deliverables = (
+            f", {len(answer.attachments)} deliverable(s)"
+            if answer.attachments
+            else ""
+        )
+        logger.info(
+            "A [%s] %s: %s in %.1fs, %d chars%s, fork %s",
+            thread_key,
+            handle,
+            "new" if answer.new_thread else "follow-up",
+            time.time() - start,
+            len(answer.text),
+            deliverables,
+            answer.fork_session_id[:8],
+        )
+        await self._deliver_answer(dest, answer.text)
+        await self._post_deliverables(dest, answer)
+
+    async def _deliver_answer(self, dest: ChatDest, text: str) -> None:
+        """Post the answer text: inline chunks, or a preview + answer.md if long."""
+        limit = self.tx.limits.max_message_len
+        if len(text) > self.cfg.limits.max_inline_chars:
+            preview = split_chunks(text, limit)[0]
+            await self.tx.send_files(
+                dest,
+                preview,
+                [OutgoingFile.from_bytes(text.encode("utf-8"), "answer.md")],
+            )
+        else:
+            for chunk in split_chunks(text, limit):
+                await self.tx.send_text(dest, chunk)
+
+    async def _ingest_attachments(
+        self,
+        dest: ChatDest,
+        thread_key: str,
+        question: str,
+        attachments: tuple[AttachmentRef, ...],
+    ) -> str:
+        """Download a colleague's attachments and point the fork at them.
+
+        Saves each (within size/count caps) into the thread's upload dir -- which
+        the backend exposes to the fork via ``--add-dir`` -- and prepends the
+        absolute paths to the question. Oversized or excess files are skipped
+        with a heads-up. Returns the (possibly preamble-prefixed) question.
+        """
+        attlist = list(attachments)
+        if not attlist:
+            return question
+        cap = int(self.cfg.limits.max_attachment_mb * 1024 * 1024)
+        limit = self.cfg.limits.max_attachments
+        # A unique per-turn subdir (plus per-turn dedup of basenames) keeps
+        # same-named files from silently overwriting each other.
+        turn_dir = (
+            uploads_dir_for(self.cfg.state_path.parent, thread_key)
+            / uuid.uuid4().hex[:8]
+        )
+        turn_dir.mkdir(parents=True, exist_ok=True)
+        saved: list[Path] = []
+        skipped: list[str] = []
+        unreadable: list[str] = []
+        used: set[str] = set()
+        for att in attlist[:limit]:
+            size = att.size or 0
+            if size > cap:
+                skipped.append(f"{att.filename} ({size / 1048576:.1f} MB)")
+                continue
+            target = turn_dir / _unique_name(_safe_filename(att.filename), used)
+            try:
+                await self.tx.download_attachment(att, target)
+            except Exception:
+                logger.exception("Download failed: %s", att.filename)
+                skipped.append(att.filename)
+                continue
+            # Office files the Read tool can't open: best-effort convert to a
+            # readable format. convert_attachment returns path=None when "off" or
+            # no converter handled it -- then mark unreadable rather than point
+            # the fork at a binary it can't Read.
+            ext = target.suffix.lower()
+            if ext in CONVERTIBLE_EXTS:
+                conv = await asyncio.to_thread(
+                    convert_attachment,
+                    target,
+                    turn_dir,
+                    self.cfg.attachments.convert,
+                    self.cfg.attachments.convert_command,
+                )
+                if conv.path is not None:
+                    saved.append(conv.path)
+                else:
+                    unreadable.append(att.filename)
+            else:
+                saved.append(target)
+        if len(attlist) > limit:
+            extra = len(attlist) - limit
+            skipped.append(f"+{extra} more (max {limit} per message)")
+        if skipped:
+            await self.tx.send_text(dest, "⚠️ Skipped: " + ", ".join(skipped))
+        if unreadable:
+            why = (
+                "Office conversion is turned off"
+                if self.cfg.attachments.convert == "off"
+                else "no converter is available"
+            )
+            await self.tx.send_text(
+                dest,
+                f"⚠️ Couldn't open {', '.join(unreadable)} here ({why}) "
+                "— attach a PDF or paste the text.",
+            )
+        return attachment_preamble(saved, question)
+
+    async def _post_deliverables(self, dest: ChatDest, answer: Answer) -> None:
+        """Post files the fork wrote to its outbox back to the conversation."""
+        files = list(getattr(answer, "attachments", None) or [])
+        if not files:
+            return
+        cap = int(self.cfg.limits.max_attachment_mb * 1024 * 1024)
+        batch_size = self.tx.limits.max_attachments_per_msg
+        sendable: list[Path] = []
+        skipped: list[str] = []
+        for path in files:
+            try:
+                size = path.stat().st_size
+            except OSError:
+                continue
+            if size > cap:
+                skipped.append(f"{path.name} ({size / 1048576:.1f} MB)")
+            else:
+                sendable.append(path)
+        for start in range(0, len(sendable), batch_size):
+            batch = sendable[start : start + batch_size]
+            caption = (
+                "📎 Deliverable(s) from the agent:"
+                if start == 0
+                else "📎 More deliverables:"
+            )
+            try:
+                await self.tx.send_files(
+                    dest, caption, [OutgoingFile.from_path(p) for p in batch]
+                )
+            except Exception:
+                logger.exception("Failed to post deliverables batch")
+        if skipped:
+            await self.tx.send_text(
+                dest,
+                "⚠️ Produced but too large to post (raise "
+                "limits.max_attachment_mb): " + ", ".join(skipped),
+            )
+
+    # -- reaper ----------------------------------------------------------------
+
+    async def run_reaper(self) -> None:
+        """Periodically reap idle backend resources (a backstop loop)."""
+        while True:
+            await asyncio.sleep(REAP_INTERVAL_S)
+            try:
+                reaped = await asyncio.to_thread(self._reap_all)
+                if reaped:
+                    logger.info("Reaped %d idle window(s)", reaped)
+            except Exception:
+                logger.exception("Reaper error")
+
+    def _reap_all(self) -> int:
+        """Reap idle windows across every backend present in the store.
+
+        The daemon defaults to headless, but records from earlier tmux runs still
+        own live windows; reaping only the configured backend would leak them.
+        ``reap_idle`` filters by its own backend name, so calling it once per
+        distinct record backend covers them all.
+        """
+        cache: dict[str, Backend] = {}
+        total = 0
+        names = {
+            effective_backend(r, self.cfg.backend)
+            for r in self.store.all_records()
+        }
+        for name in names:
+            total += backend_by_name(self.cfg, self.store, name, cache).reap_idle()
+        return total

--- a/claude_code_tools/agent_tunnel/chat_types.py
+++ b/claude_code_tools/agent_tunnel/chat_types.py
@@ -1,0 +1,392 @@
+"""Platform-neutral seam between a chat front-end and the answer pipeline.
+
+``ChatCore`` (in ``chat_core.py``) owns ALL routing and policy and reaches the
+outside world only through :class:`ChatTransport` plus the normalized
+dataclasses defined here. A front-end supplies an adapter that drops bot/self
+events, normalizes each surviving event into an :class:`IncomingMessage`,
+implements :class:`ChatTransport`, builds one ``ChatCore``, schedules the
+reaper, and forwards each message via ``await core.handle_message(msg)``.
+
+No platform identifier ever appears in this module, and it imports only the
+standard library, so it loads without ``discord``/``slack_bolt`` installed.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, AsyncIterator, Optional, Protocol, Sequence, runtime_checkable
+
+# Kept as module constants because ``discord_bot`` re-exports them (and they are
+# the Discord defaults baked into ``TransportLimits``).
+DISCORD_MSG_LIMIT = 2000
+THREAD_NAME_MAX = 90
+
+
+@dataclass(frozen=True)
+class TransportLimits:
+    """Per-platform numeric caps the core honors when chunking/batching/truncating.
+
+    Declared once per adapter instance (read via ``ChatTransport.limits``). These
+    replace the hard-coded Discord constants (the 2000-char message limit, the
+    literal 10 attachments/message, the 90-char thread name, the 1500-char error
+    truncation, the 1900-char ``!list`` truncation). The defaults ARE Discord's,
+    so a Discord adapter that omits them reproduces the shipped bot exactly.
+
+    Invariant (enforced by the core): ``list_truncate_len <= max_message_len``.
+    ``_list_handles`` truncates to ``min(list_truncate_len, max_message_len)`` so
+    the "transport must not re-chunk ``send_text``" contract can never be broken.
+    """
+
+    max_message_len: int = 2000
+    max_attachments_per_msg: int = 10
+    thread_title_max: int = 90
+    max_error_len: int = 1500
+    list_truncate_len: int = 1900
+
+
+@dataclass(frozen=True)
+class OutgoingFile:
+    """A file the core asks the transport to post, by path OR by bytes.
+
+    Exactly one of ``data`` / ``path`` is set. Unifies the two Discord upload
+    cases: ``discord.File(BytesIO(bytes), filename=...)`` (the long-answer
+    ``answer.md``) and ``discord.File(path, filename=...)`` (a deliverable).
+
+    ``filename`` MUST carry the extension; on Slack the adapter also passes it as
+    ``title`` because Slack strips the extension from the filename alone.
+    """
+
+    filename: str
+    data: Optional[bytes] = None
+    path: Optional[Path] = None
+
+    @classmethod
+    def from_bytes(cls, data: bytes, filename: str) -> "OutgoingFile":
+        """A file delivered from in-memory ``data`` (e.g. ``answer.md``)."""
+        return cls(filename=filename, data=data)
+
+    @classmethod
+    def from_path(cls, path: Path) -> "OutgoingFile":
+        """A file delivered from an on-disk ``path`` (a fork deliverable)."""
+        return cls(filename=path.name, path=path)
+
+
+@asynccontextmanager
+async def noop_activity() -> AsyncIterator[None]:
+    """A do-nothing ``activity()`` for transports with no typing API (Slack)."""
+    yield
+
+
+class Surface(Enum):
+    """Which routing branch an inbound message belongs to.
+
+    The adapter classifies; the core routes on this. Replaces Discord's
+    ``isinstance(channel, Thread/DMChannel)`` and Slack's ``channel_type`` switch.
+    """
+
+    CHANNEL = "channel"  # watched channel, not in a thread (handle-opens-thread)
+    THREAD = "thread"    # follow-up inside an already-bound thread
+    DM = "dm"            # a direct message (Slack ``im`` AND ``mpim``)
+
+
+class Addressee(Enum):
+    """Who a message's *leading* mention addresses, if anyone.
+
+    The adapter computes the verdict from its own mention wire-format AND
+    pre-strips a SELF mention from :attr:`IncomingMessage.text`. The core never
+    parses mentions or compares ids -- it branches on this enum, and only on the
+    THREAD surface (CHANNEL uses the handle-token parse; DM is 1:1).
+    """
+
+    NONE = "none"    # no leading mention -> answer (in a thread)
+    SELF = "self"    # leading mention IS this bot -> (already stripped) answer
+    OTHER = "other"  # someone else / broadcast / role -> stay out, silent
+
+
+@dataclass(frozen=True)
+class AttachmentRef:
+    """One inbound file, normalized across platforms.
+
+    The core uses only ``filename`` / ``size`` (caps + safe naming) and hands the
+    whole ref back to :meth:`ChatTransport.download_attachment`. ``url`` /
+    ``_native`` are opaque to the core.
+
+    Discord adapter builds ``AttachmentRef(a.filename, getattr(a, "size", 0) or
+    0, _native=a)``. Slack adapter fills ``url`` (``url_private_download``) and
+    ``_native`` with the raw file dict.
+    """
+
+    filename: str
+    size: int            # bytes; 0 if the platform did not report a size
+    url: str = ""        # authenticated download URL (Slack); "" on Discord
+    _native: Any = None  # platform file object, for the adapter's downloader
+
+
+@dataclass(frozen=True)
+class ChatDest:
+    """A place the core sends replies to, with a stable conversation key.
+
+    Neutral replacement for the Discord ``dest`` threaded through
+    ``_answer``/``_list_handles``/``_close``. ``thread_key`` is THE universal
+    store/backend/uploads/locks key (the ``th:``/``dm:`` scheme), minted by the
+    adapter.
+
+    Attributes:
+        thread_key: Universal conversation key. Discord ``th:{thread.id}`` /
+            ``dm:{channel.id}``; Slack ``th:{channel}-{thread_ts}`` /
+            ``dm:{channel}``. For a CHANNEL dest (used by ``!list`` and as
+            ``open_thread``'s parent before a thread exists) this is "" and is
+            never used as a key.
+        surface: Which branch this dest serves.
+        channel_id: Normalized channel/conversation id (``str``); addresses Slack
+            sends. "" where unused on Discord.
+        thread_ts: Slack thread anchor. For a THREAD dest it is the parent ts; for
+            a CHANNEL parent dest passed to ``open_thread`` it carries the
+            triggering message's ts so the Slack transport can build
+            ``th:{channel}-{ts}`` and thread off it. "" on Discord.
+        _native: Platform send-target (Discord: the triggering message / thread).
+    """
+
+    thread_key: str
+    surface: Surface
+    channel_id: str = ""
+    thread_ts: str = ""
+    _native: Any = None
+
+
+@dataclass(frozen=True)
+class IncomingMessage:
+    """One inbound chat message, normalized to be wire-format-free.
+
+    Built by the adapter AFTER dropping bot/self events and AFTER resolving the
+    leading mention. Discord ids (``int``) and Slack ids (``str``) are both
+    normalized to ``str`` so allowlist/cooldown/principal logic is uniform.
+
+    Attributes:
+        text: Body, ``.strip()``-ed. For a THREAD message whose leading mention
+            was this bot, the adapter has ALSO stripped that mention. May be ""
+            when ``attachments`` is non-empty (attachment-only message).
+        dest: Where replies go (+ the conversation ``thread_key`` + ``surface``).
+            For a CHANNEL message this is the parent dest passed to
+            ``open_thread``; on Slack it carries ``thread_ts = ts``.
+        surface: CHANNEL / THREAD / DM.
+        author_id: Stable per-user principal id (``str``); keys cooldown +
+            allowlist.
+        author_display: Display name for logs and the ``<name> (via X) says:``
+            prefix. Falls back to ``author_id``.
+        author_role_ids: Principal's role/usergroup ids (``str``) for the
+            allowlist role check. Empty when unavailable.
+        addressee: Leading-mention verdict. Meaningful only on THREAD; CHANNEL and
+            DM leave it NONE.
+        attachments: Normalized inbound files (possibly empty).
+        channel_id: Normalized channel/conversation id.
+        ts: Platform message id/timestamp -- Slack ``ts`` (needed for reactions +
+            threading). Discord leaves "" (it reacts/threads via ``_native``).
+        _native: Raw platform message, used only by transport I/O targeting THIS
+            message (Discord ``add_reaction``).
+    """
+
+    text: str
+    dest: ChatDest
+    surface: Surface
+    author_id: str
+    author_display: str = ""
+    author_role_ids: frozenset[str] = frozenset()
+    addressee: Addressee = Addressee.NONE
+    attachments: tuple[AttachmentRef, ...] = ()
+    channel_id: str = ""
+    ts: str = ""
+    _native: Any = None
+
+    @property
+    def has_content(self) -> bool:
+        """True if there is text or at least one attachment (the empty-drop rule)."""
+        return bool(self.text) or bool(self.attachments)
+
+
+@runtime_checkable
+class ChatTransport(Protocol):
+    """Every chat I/O the answer pipeline needs, abstracted per platform.
+
+    ONE instance per running bot (NOT per turn): the core passes a
+    :class:`ChatDest` to every send, so one instance serves all destinations.
+    All methods are async except :meth:`activity` (which returns an async context
+    manager). Implementations must be safe to call concurrently for distinct
+    ``dest`` values; the core serializes per conversation, never globally.
+    """
+
+    @property
+    def limits(self) -> TransportLimits:
+        """Numeric caps the core honors (message length, batch size, ...)."""
+        ...
+
+    async def open_thread(self, parent: ChatDest, title: str) -> ChatDest:
+        """Open (or identify) the thread a conversation lives in.
+
+        Discord anchors a real sub-thread to the triggering message; Slack mints
+        no object and threads off the triggering ts. ``title`` is already
+        truncated by the core to ``limits.thread_title_max`` (ignored by Slack).
+        Returns the THREAD dest carrying the conversation ``thread_key``.
+        """
+        ...
+
+    async def send_text(self, dest: ChatDest, text: str) -> None:
+        """Post one plain-text message to ``dest``.
+
+        The core has already chunked to ``limits.max_message_len`` (one call per
+        chunk); the adapter MUST NOT re-chunk. The adapter applies platform
+        formatting fixups (Discord passes through; Slack escapes ``& < >`` then
+        translates markdown to mrkdwn before sending).
+        """
+        ...
+
+    async def send_files(
+        self, dest: ChatDest, caption: str, files: Sequence[OutgoingFile]
+    ) -> None:
+        """Post one message carrying ``caption`` plus one or more files.
+
+        The core has already filtered by the size cap and split into batches of at
+        most ``limits.max_attachments_per_msg``. ``caption`` is formatted by the
+        adapter exactly like :meth:`send_text`.
+        """
+        ...
+
+    async def download_attachment(
+        self, attachment: AttachmentRef, target: Path
+    ) -> None:
+        """Download one inbound attachment to local ``target`` (parent exists).
+
+        MUST raise on failure (the core catches it and marks the file skipped).
+        Discord saves via the file object; Slack GETs ``attachment.url`` with a
+        bearer header that survives the file-host redirect, and raises on an
+        HTML login-page response before writing bytes.
+        """
+        ...
+
+    async def add_reaction(self, message: IncomingMessage, emoji: str) -> None:
+        """React to ``message`` with the cooldown 'busy' signal. Best-effort.
+
+        The core passes the NEUTRAL name ``"hourglass"``; each adapter maps it to
+        a platform glyph/shortcode (Discord ``⏳``; Slack
+        ``hourglass_flowing_sand``).
+        """
+        ...
+
+    def activity(self, dest: ChatDest) -> AbstractAsyncContextManager[None]:
+        """An async context manager showing 'working' for its duration.
+
+        Discord uses the channel typing indicator; Slack has none, so it returns
+        :func:`noop_activity`. Non-async (returns a CM) so the core writes
+        ``async with transport.activity(dest):``.
+        """
+        ...
+
+
+def format_relayed_message(
+    sender: str, question: str, platform: str = "Discord"
+) -> str:
+    """Prefix a relayed chat message with its sender for the fork.
+
+    The daemon knows who sent each message; the forked Claude does not, so we
+    prepend ``<name> (via <platform>) says:``. The persona explains this
+    convention so Claude reads the prefix as the asker's identity. ``platform``
+    comes from config (``TunnelConfig.platform``).
+    """
+    who = sender.strip() or "A teammate"
+    return f"{who} (via {platform}) says:\n{question}"
+
+
+def resolve_token(env_name: str, file_path: str = "") -> str:
+    """Resolve a token: env var first, then an optional file (env wins).
+
+    Generalized from the original ``resolve_token(cfg)`` so both the Discord bot
+    token and the two Slack tokens share one resolver. An empty ``file_path``
+    skips the file read; the path is ``expanduser()``-ed and read only if it
+    exists.
+    """
+    token = os.environ.get(env_name, "").strip()
+    if not token and file_path:
+        path = Path(file_path).expanduser()
+        if path.exists():
+            token = path.read_text(encoding="utf-8").strip()
+    return token
+
+
+CLOSE_COMMANDS = {"!done", "!close", "!end"}
+LIST_COMMANDS = {"!list", "!handles"}
+
+
+def is_close_command(text: str) -> bool:
+    """True if a thread/DM message is a close-out command (e.g. !done)."""
+    return text.strip().lower() in CLOSE_COMMANDS
+
+
+def is_list_command(text: str) -> bool:
+    """True if a message asks for the list of shared handles (!list)."""
+    return text.strip().lower() in LIST_COMMANDS
+
+
+def _safe_filename(name: str) -> str:
+    """Basename of an uploaded file, stripped to safe chars (no traversal).
+
+    Long names are shortened but keep their extension -- downstream code decides
+    type/conversion from the suffix, so chopping `.docx` off the end would skip
+    conversion and hand the fork an unreadable path.
+    """
+    base = os.path.basename(name or "").strip() or "file"
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", base).strip("._") or "file"
+    if len(cleaned) <= 120:
+        return cleaned
+    ext = Path(cleaned).suffix
+    if 1 < len(ext) <= 12:  # plausible extension -- keep it, trim the stem
+        return cleaned[: -len(ext)][: 120 - len(ext)] + ext
+    return cleaned[:120]
+
+
+def _unique_name(name: str, used: set[str]) -> str:
+    """`name` unless already in `used`, else suffixed `-2`/`-3`/... before the
+    extension. Records the chosen name in `used`."""
+    if name not in used:
+        used.add(name)
+        return name
+    stem, dot, ext = name.partition(".")
+    i = 2
+    while f"{stem}-{i}{dot}{ext}" in used:
+        i += 1
+    chosen = f"{stem}-{i}{dot}{ext}"
+    used.add(chosen)
+    return chosen
+
+
+def split_chunks(text: str, limit: int = DISCORD_MSG_LIMIT) -> list[str]:
+    """Split text into <=limit chunks, preferring newline boundaries.
+
+    ``limit`` stays a defaulted keyword (2000) so the existing callers/tests and
+    the ``discord_bot`` re-export keep working; core callers pass
+    ``limit=transport.limits.max_message_len`` (Slack chunks to 4000).
+    """
+    if not text:
+        return []
+    chunks: list[str] = []
+    current = ""
+    for line in text.split("\n"):
+        while len(line) > limit:
+            head, line = line[:limit], line[limit:]
+            if current:
+                chunks.append(current)
+                current = ""
+            chunks.append(head)
+        candidate = f"{current}\n{line}" if current else line
+        if len(candidate) > limit:
+            chunks.append(current)
+            current = line
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+    return chunks

--- a/claude_code_tools/agent_tunnel/config.py
+++ b/claude_code_tools/agent_tunnel/config.py
@@ -182,6 +182,21 @@ class TunnelConfig:
     limits: LimitsConfig = field(default_factory=LimitsConfig)
     attachments: AttachmentsConfig = field(default_factory=AttachmentsConfig)
 
+    def principal_allowlists(self) -> tuple[set[str], set[str]]:
+        """(allowed user ids, allowed role ids) for the active front-end.
+
+        Front-end-neutral so ``ChatCore`` compares uniformly against
+        ``IncomingMessage.author_id`` / ``author_role_ids`` (both ``str``).
+        Discord ids are ints in config and are stringified here; empty sets mean
+        "anyone in a watched channel may ask". (Slack support is added with the
+        Slack front-end.)
+        """
+        d = self.discord
+        return (
+            {str(u) for u in d.allowed_user_ids},
+            {str(r) for r in d.allowed_role_ids},
+        )
+
 
 def _apply(dc: Any, data: dict[str, Any]) -> None:
     """Copy known keys from a TOML table onto a dataclass instance."""

--- a/claude_code_tools/agent_tunnel/discord_bot.py
+++ b/claude_code_tools/agent_tunnel/discord_bot.py
@@ -1,130 +1,65 @@
 """Discord front-end for agent-tunnel (handle-opens-a-thread model).
 
-Flow:
+This module is now a thin **adapter** over the platform-neutral
+:class:`~.chat_core.ChatCore`: it owns only the Discord wire-format. It drops
+bot messages, classifies each message into a :class:`~.chat_types.Surface`,
+normalizes it into an :class:`~.chat_types.IncomingMessage` (resolving the
+leading ``<@id>`` mention into an :class:`~.chat_types.Addressee` and stripping a
+leading self-mention), implements :class:`~.chat_types.ChatTransport` over
+``discord.py``, and forwards each message to the core. All routing/policy/
+pipeline logic lives in ``chat_core``.
 
-- A teammate posts ``<handle> [question]`` in a watched channel. If the
-  handle is live in the registry, the bot opens a public thread, binds that
-  thread to the published session, and answers (or posts a ready notice).
-- Subsequent messages *inside that thread* are follow-ups to the same fork —
-  no handle needed.
-- Each handle/thread = its own fork; different teammates and different
-  sessions never collide.
-
-Other bots are always ignored (no loops with a co-resident bot such as
-openclaw). ``discord`` is imported lazily so the rest of the package works
-without the dependency installed.
+``discord`` is imported lazily so the rest of the package (and the re-exported
+pure helpers below) work without the dependency installed.
 """
 
 from __future__ import annotations
 
-import asyncio
 import io
 import logging
-import os
 import re
-import time
-import uuid
-from collections import defaultdict
-from pathlib import Path
 from typing import Any, Optional
 
-from .backends import (
-    Answer,
-    Backend,
-    BackendError,
-    backend_by_name,
-    backend_for_record,
-    effective_backend,
+from .chat_core import ChatCore
+from .chat_types import (
+    DISCORD_MSG_LIMIT as DISCORD_MSG_LIMIT,
+    THREAD_NAME_MAX as THREAD_NAME_MAX,
+    Addressee,
+    AttachmentRef,
+    ChatDest,
+    ChatTransport,
+    IncomingMessage,
+    Surface,
+    TransportLimits,
+    format_relayed_message as format_relayed_message,
+    is_close_command as is_close_command,
+    is_list_command as is_list_command,
+    resolve_token as _resolve_token,
+    split_chunks as split_chunks,
+    _safe_filename as _safe_filename,
+    _unique_name as _unique_name,
 )
 from .config import TunnelConfig
-from .convert import CONVERTIBLE_EXTS, convert_attachment
-from .paths import attachment_preamble, uploads_dir_for
-from .registry import HANDLE_RE, Registry
+from .registry import Registry
 from .store import TunnelStore
 
 logger = logging.getLogger("agent_tunnel")
 
-DISCORD_MSG_LIMIT = 2000
-REAP_INTERVAL_S = 300
-THREAD_NAME_MAX = 90
-
-
-def format_relayed_message(
-    sender: str, question: str, platform: str = "Discord"
-) -> str:
-    """Prefix a relayed chat message with its sender for the fork.
-
-    The daemon knows who sent each message; the forked Claude does not, so we
-    prepend ``<name> (via <platform>) says:``. The persona explains this
-    convention so Claude reads the prefix as the asker's identity. ``platform``
-    comes from config (``TunnelConfig.platform``), so a future Slack bot just
-    passes ``"Slack"``.
-    """
-    who = sender.strip() or "A teammate"
-    return f"{who} (via {platform}) says:\n{question}"
-
 
 def resolve_token(cfg: TunnelConfig) -> str:
-    """Resolve the Discord bot token: env var first, then token_file."""
-    token = os.environ.get(cfg.discord.token_env, "").strip()
-    if not token and cfg.discord.token_file:
-        path = Path(cfg.discord.token_file).expanduser()
-        if path.exists():
-            token = path.read_text(encoding="utf-8").strip()
-    return token
+    """Resolve the Discord bot token: env var first, then token_file.
 
-
-CLOSE_COMMANDS = {"!done", "!close", "!end"}
-LIST_COMMANDS = {"!list", "!handles"}
-
-
-def is_close_command(text: str) -> bool:
-    """True if a thread/DM message is a close-out command (e.g. !done)."""
-    return text.strip().lower() in CLOSE_COMMANDS
-
-
-def is_list_command(text: str) -> bool:
-    """True if a message asks for the list of shared handles (!list)."""
-    return text.strip().lower() in LIST_COMMANDS
-
-
-def _safe_filename(name: str) -> str:
-    """Basename of an uploaded file, stripped to safe chars (no traversal).
-
-    Long names are shortened but keep their extension — downstream code decides
-    type/conversion from the suffix, so chopping `.docx` off the end would skip
-    conversion and hand the fork an unreadable path.
+    A thin wrapper over the generalized :func:`chat_types.resolve_token` so the
+    daemon/doctor and the existing test keep their one-argument call.
     """
-    base = os.path.basename(name or "").strip() or "file"
-    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", base).strip("._") or "file"
-    if len(cleaned) <= 120:
-        return cleaned
-    ext = Path(cleaned).suffix
-    if 1 < len(ext) <= 12:  # plausible extension — keep it, trim the stem
-        return cleaned[: -len(ext)][: 120 - len(ext)] + ext
-    return cleaned[:120]
-
-
-def _unique_name(name: str, used: set[str]) -> str:
-    """`name` unless already in `used`, else suffixed `-2`/`-3`/… before the
-    extension. Records the chosen name in `used`."""
-    if name not in used:
-        used.add(name)
-        return name
-    stem, dot, ext = name.partition(".")
-    i = 2
-    while f"{stem}-{i}{dot}{ext}" in used:
-        i += 1
-    chosen = f"{stem}-{i}{dot}{ext}"
-    used.add(chosen)
-    return chosen
+    return _resolve_token(cfg.discord.token_env, cfg.discord.token_file)
 
 
 def _leading_mention_id(content: str) -> Optional[int]:
     """The id of a *leading* Discord mention, or None if there isn't one.
 
-    Returns the user/role id of a leading ``<@id>`` (also ``<@!id>`` nickname
-    or ``<@&id>`` role) mention; ``-1`` for a leading ``@everyone``/``@here``
+    Returns the user/role id of a leading ``<@id>`` (also ``<@!id>`` nickname or
+    ``<@&id>`` role) mention; ``-1`` for a leading ``@everyone``/``@here``
     broadcast; ``None`` when the message doesn't start with a mention. Used in
     threads to silently skip messages addressed to someone other than the bot.
     """
@@ -135,28 +70,72 @@ def _leading_mention_id(content: str) -> Optional[int]:
     return int(match.group(1)) if match else None
 
 
-def split_chunks(text: str, limit: int = DISCORD_MSG_LIMIT) -> list[str]:
-    """Split text into <=limit chunks, preferring newline boundaries."""
-    if not text:
-        return []
-    chunks: list[str] = []
-    current = ""
-    for line in text.split("\n"):
-        while len(line) > limit:
-            head, line = line[:limit], line[limit:]
-            if current:
-                chunks.append(current)
-                current = ""
-            chunks.append(head)
-        candidate = f"{current}\n{line}" if current else line
-        if len(candidate) > limit:
-            chunks.append(current)
-            current = line
-        else:
-            current = candidate
-    if current:
-        chunks.append(current)
-    return chunks
+def _discord_target(native: Any) -> Any:
+    """The Discord object to ``.send``/``.typing`` on for a dest's native.
+
+    A channel/thread/DM channel is Messageable (has ``.send``) and is used
+    directly; a ``Message`` (carried by an incoming dest) routes through its
+    ``.channel`` (the watched channel, the thread, or the DM channel).
+    """
+    return native if hasattr(native, "send") else native.channel
+
+
+class DiscordTransport(ChatTransport):
+    """``ChatTransport`` over a live ``discord.py`` client/objects."""
+
+    def __init__(self, client: Any) -> None:
+        """Keep the client (its objects carry the real send targets)."""
+        self._client = client
+
+    @property
+    def limits(self) -> TransportLimits:
+        """Discord's caps (the defaults reproduce the shipped numbers)."""
+        return TransportLimits()
+
+    async def open_thread(self, parent: ChatDest, title: str) -> ChatDest:
+        """Open a public thread anchored to the triggering message."""
+        thread = await parent._native.create_thread(name=title)
+        return ChatDest(
+            thread_key=f"th:{thread.id}",
+            surface=Surface.THREAD,
+            channel_id=str(thread.id),
+            _native=thread,
+        )
+
+    async def send_text(self, dest: ChatDest, text: str) -> None:
+        """Send plain text (Discord renders markdown; no translation)."""
+        await _discord_target(dest._native).send(text)
+
+    async def send_files(
+        self, dest: ChatDest, caption: str, files: Any
+    ) -> None:
+        """Send ``caption`` plus one or more files in a single message."""
+        import discord
+
+        dfiles = [
+            discord.File(io.BytesIO(of.data), filename=of.filename)
+            if of.data is not None
+            else discord.File(str(of.path), filename=of.filename)
+            for of in files
+        ]
+        await _discord_target(dest._native).send(caption, files=dfiles)
+
+    async def download_attachment(
+        self, attachment: AttachmentRef, target: Any
+    ) -> None:
+        """Save an inbound Discord attachment to ``target``."""
+        await attachment._native.save(str(target))
+
+    async def add_reaction(
+        self, message: IncomingMessage, emoji: str
+    ) -> None:
+        """React to the triggering message (maps ``hourglass`` -> ⏳)."""
+        glyph = {"hourglass": "⏳"}.get(emoji, emoji)
+        await message._native.add_reaction(glyph)
+
+    def activity(self, dest: ChatDest) -> Any:
+        """The Discord typing indicator for the dest's channel/thread."""
+        return _discord_target(dest._native).typing()
 
 
 def run_bot(
@@ -186,43 +165,13 @@ def run_bot(
     intents = discord.Intents.default()
     intents.message_content = True
 
-    sem = asyncio.Semaphore(cfg.limits.max_concurrent)
-    locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
-    last_ask: dict[int, float] = {}
-
     class TunnelClient(discord.Client):
-        """Routes channel/thread/DM messages to the backend."""
+        """Normalizes Discord events and forwards them to the ChatCore."""
 
         async def setup_hook(self) -> None:
-            self.loop.create_task(self._reaper())
-
-        async def _reaper(self) -> None:
-            while True:
-                await asyncio.sleep(REAP_INTERVAL_S)
-                try:
-                    reaped = await asyncio.to_thread(self._reap_all)
-                    if reaped:
-                        logger.info("Reaped %d idle window(s)", reaped)
-                except Exception:
-                    logger.exception("Reaper error")
-
-        def _reap_all(self) -> int:
-            """Reap idle windows across every backend present in the store.
-
-            The daemon now defaults to headless, but records from earlier tmux
-            runs still own live windows; reaping only the configured backend
-            would leak them. ``reap_idle`` filters by its own backend name, so
-            calling it once per distinct record backend covers them all.
-            """
-            cache: dict[str, Backend] = {}
-            total = 0
-            names = {
-                effective_backend(r, cfg.backend)
-                for r in store.all_records()
-            }
-            for name in names:
-                total += backend_by_name(cfg, store, name, cache).reap_idle()
-            return total
+            self.tx = DiscordTransport(self)
+            self.core = ChatCore(cfg, store, registry, self.tx)
+            self.loop.create_task(self.core.run_reaper())
 
         async def on_ready(self) -> None:
             logger.info(
@@ -231,487 +180,67 @@ def run_bot(
                 cfg.discord.channel_ids,
             )
 
-        def _allowed(self, author: Any) -> bool:
-            uids = cfg.discord.allowed_user_ids
-            rids = set(cfg.discord.allowed_role_ids)
-            if not uids and not rids:
-                return True
-            if getattr(author, "id", None) in uids:
-                return True
-            roles = getattr(author, "roles", []) or []
-            return any(role.id in rids for role in roles)
-
-        def _cooldown_ok(self, user_id: int) -> bool:
-            now = time.time()
-            if now - last_ask.get(user_id, 0) < cfg.limits.per_user_cooldown_s:
-                return False
-            last_ask[user_id] = now
-            return True
-
-        async def on_message(self, message: discord.Message) -> None:
-            if message.author.bot:
+        async def on_message(self, m: discord.Message) -> None:
+            if m.author.bot:
                 return
-            content = (message.content or "").strip()
-            # An attachment-only message has empty content but still carries a
-            # file for the agent to read — don't drop it.
-            if not content and not message.attachments:
-                return
-            channel = message.channel
-
-            if isinstance(channel, discord.Thread):
-                await self._on_thread_message(message, channel, content)
-            elif isinstance(channel, discord.DMChannel):
-                if cfg.discord.respond_to_dms:
-                    await self._on_direct(message, content)
-            elif channel.id in cfg.discord.channel_ids:
-                await self._on_channel_message(message, content)
-
-        async def _on_channel_message(
-            self, message: discord.Message, content: str
-        ) -> None:
-            """A message in a watched channel: try to open a handle thread."""
-            if is_list_command(content):
-                if self._allowed(message.author):
-                    await self._list_handles(message.channel)
-                return
-            token, _, remainder = content.partition(" ")
-            handle = token.strip().lower()
-            rec = registry.get(handle)
-            if rec is None:
-                # Only complain if it clearly looks like a handle attempt.
-                if HANDLE_RE.match(handle) and not remainder:
-                    await message.reply(
-                        f"No live session for handle `{handle}`. "
-                        "Ask the owner to `>share` it."
-                    )
-                return
-            if not self._allowed(message.author):
-                return
-
-            question = remainder.strip()
-            label = rec.label or rec.handle
-            # Lead with the handle (recognizable), then the question so that
-            # multiple threads for the same handle stay distinguishable.
-            thread_name = (
-                f"{label}: {question}" if question else label
-            )[:THREAD_NAME_MAX]
-            thread = await message.create_thread(name=thread_name)
-            logger.info(
-                "Opened thread for handle %s (session %s) asked by %s",
-                rec.handle,
-                rec.session_id[:8],
-                message.author.display_name,
-            )
-            store.bind(
-                f"th:{thread.id}",
-                handle=rec.handle,
-                expert_session_id=rec.session_id,
-                project_dir=rec.cwd,
-                config_dir=rec.config_dir,
-                access=rec.access,
-                backend=cfg.backend,
-                asker=message.author.display_name,
-            )
-            if question or message.attachments:
-                await self._answer(
-                    thread,
-                    f"th:{thread.id}",
-                    question,
-                    message.attachments,
-                    sender=message.author.display_name,
-                )
+            ch = m.channel
+            if isinstance(ch, discord.Thread):
+                surface, key = Surface.THREAD, f"th:{ch.id}"
+            elif isinstance(ch, discord.DMChannel):
+                if not cfg.discord.respond_to_dms:
+                    return
+                surface, key = Surface.DM, f"dm:{ch.id}"
+            elif ch.id in cfg.discord.channel_ids:
+                surface, key = Surface.CHANNEL, ""
             else:
-                await thread.send(
-                    f"Connected to **{label}**. Ask your question here; "
-                    "follow-ups stay in this thread."
-                )
-
-        async def _on_thread_message(
-            self, message: discord.Message, thread: Any, content: str
-        ) -> None:
-            """A follow-up inside a bound thread."""
-            thread_key = f"th:{thread.id}"
-            if store.get(thread_key) is None:
                 return
-            if not self._allowed(message.author):
-                return
-            # A message that opens with @someone-else (or @everyone/@here/a
-            # role) is teammates talking among themselves — stay out silently.
-            # A leading @bot is fine: strip it and answer. No mention = answer
-            # (in a thread you never need to address the bot).
-            mention_id = _leading_mention_id(content)
-            if mention_id is not None:
-                if mention_id != getattr(self.user, "id", None):
-                    return
-                content = re.sub(r"^\s*<@[!&]?\d+>\s*", "", content)
-            if is_list_command(content):
-                await self._list_handles(thread)
-                return
-            if is_close_command(content):
-                await self._close(thread, thread_key)
-                return
-            if not self._cooldown_ok(message.author.id):
-                await message.add_reaction("⏳")
-                return
-            await self._answer(
-                thread,
-                thread_key,
-                content,
-                message.attachments,
-                sender=message.author.display_name,
+            await self.core.handle_message(
+                self._to_incoming(m, surface, key)
             )
 
-        async def _on_direct(
-            self, message: discord.Message, content: str
-        ) -> None:
-            """DM handling: `<handle> ...` (re)binds; bare text follows up."""
-            thread_key = f"dm:{message.channel.id}"
-            if is_list_command(content):
-                if self._allowed(message.author):
-                    await self._list_handles(message.channel)
-                return
-            if is_close_command(content) and store.get(thread_key) is not None:
-                if self._allowed(message.author):
-                    await self._close(message.channel, thread_key)
-                return
-            token, _, remainder = content.partition(" ")
-            handle = token.strip().lower()
-            rec = registry.get(handle)
-            if rec is not None:
-                # Rebinding this DM starts a fresh thread; fully tear down any
-                # previous binding first so its uploads/outbox (and live tmux
-                # window) don't leak into the new handle's fork — the upload
-                # dir is keyed only by the DM channel and would otherwise be
-                # reused across handles.
-                #
-                # Hold the thread lock around forget+bind so the rebind can't
-                # race a still-running turn on the OLD binding: that turn holds
-                # this same lock, and its trailing upsert() (which merges fork/
-                # window into whatever record now owns thread_key) would
-                # otherwise attach the old fork to the new handle. The lock is
-                # released here before _answer re-acquires it below — it is not
-                # reentrant — so the new turn simply queues behind the old one.
-                async with locks[thread_key]:
-                    existing = store.get(thread_key)
-                    if existing is not None:
-                        await asyncio.to_thread(
-                            backend_for_record(cfg, store, existing).forget,
-                            thread_key,
-                        )
-                    store.bind(
-                        thread_key,
-                        handle=rec.handle,
-                        expert_session_id=rec.session_id,
-                        project_dir=rec.cwd,
-                        config_dir=rec.config_dir,
-                        access=rec.access,
-                        backend=cfg.backend,
-                        asker=message.author.display_name,
-                    )
-                content = remainder.strip()
-                if not content and not message.attachments:
-                    await message.channel.send(
-                        f"Connected to **{rec.label or rec.handle}**."
-                    )
-                    return
-            elif store.get(thread_key) is None:
-                await message.channel.send(
-                    "Start with a handle, e.g. `pay-7Q2 your question`."
-                )
-                return
-            if not self._allowed(message.author):
-                return
-            if not self._cooldown_ok(message.author.id):
-                await message.add_reaction("⏳")
-                return
-            await self._answer(
-                message.channel,
-                thread_key,
-                content,
-                message.attachments,
-                sender=message.author.display_name,
-            )
-
-        async def _list_handles(self, dest: Any) -> None:
-            """Post the list of currently shared handles."""
-            recs = registry.active()
-            if not recs:
-                await dest.send("No sessions are shared right now.")
-                return
-            lines = ["**Available handles** — post `<handle> your question`:"]
-            for rec in recs:
-                proj = Path(rec.cwd).name
-                label = (
-                    f" ({rec.label})"
-                    if rec.label and rec.label != rec.handle
-                    else ""
-                )
-                lines.append(f"• `{rec.handle}`{label} — {proj}")
-            await dest.send("\n".join(lines)[:1900])
-
-        async def _close(self, dest: Any, thread_key: str) -> None:
-            """Close a thread: tear down its fork and confirm."""
-            try:
-                # Hold the thread lock so we don't delete a turn's upload/
-                # outbox dirs (or kill its window) while it is mid-answer.
-                async with locks[thread_key]:
-                    rec = store.get(thread_key)
-                    await asyncio.to_thread(
-                        backend_for_record(cfg, store, rec).forget, thread_key
-                    )
-            except Exception:
-                logger.exception("Error closing %s", thread_key)
-            logger.info("Closed thread %s on request", thread_key)
-            await dest.send(
-                "✅ Closed and cleaned up. Post the handle in the channel "
-                "to start a fresh thread anytime."
-            )
-
-        async def _answer(
-            self,
-            dest: Any,
-            thread_key: str,
-            question: str,
-            attachments: Any = None,
-            sender: str = "",
-        ) -> None:
-            # Per-question log line so an unattended (esp. headless) daemon
-            # shows live activity + an audit trail of who-asked-what.
-            rec = store.get(thread_key)
-            handle = rec.handle if rec else "?"
-            # The per-message sender (this message's author) is more accurate
-            # than the bind-time asker for follow-ups by other people.
-            asker = sender or (rec.asker if rec else "?")
-            n_att = len(attachments or [])
-            logger.info(
-                "Q [%s] %s ← %s%s: %r",
-                thread_key,
-                handle,
-                asker,
-                f" +{n_att} file(s)" if n_att else "",
-                (question or "").replace("\n", " ")[:120],
-            )
-            lock = locks[thread_key]
-            if lock.locked():
-                await dest.send(
-                    "⏳ Still working on the previous question here — "
-                    "I'll take this one next."
-                )
-            async with lock, sem:
-                # The thread may have been rebound (even to the same session,
-                # which resets the fork) or closed while this turn waited for
-                # the lock — e.g. a queued follow-up parked on the "still
-                # working" send above while a rebind jumped the lock queue. A
-                # fresh bind stamps a new created_at, so compare the full
-                # binding identity (session + created_at) and don't answer a
-                # queued question against a binding it was not asked under.
-                current = store.get(thread_key)
-                if current is None or (
-                    rec is not None
-                    and (
-                        current.expert_session_id != rec.expert_session_id
-                        or current.created_at != rec.created_at
-                    )
-                ):
-                    await dest.send(
-                        "↪️ This conversation was restarted before I got to "
-                        "your message — please resend it."
-                    )
-                    return
-                start = time.time()
-                try:
-                    async with dest.typing():
-                        question = await self._ingest_attachments(
-                            dest, thread_key, question, attachments or []
-                        )
-                        if not question.strip():
-                            await dest.send(
-                                "⚠️ Nothing to act on — add a question, or a "
-                                "(smaller/readable) file."
-                            )
-                            logger.info(
-                                "A [%s] %s: skipped (no usable content)",
-                                thread_key,
-                                handle,
-                            )
-                            return
-                        # Tell the fork who sent this (it can't see chat); the
-                        # persona explains the "<name> (via X) says:" convention.
-                        question = format_relayed_message(
-                            sender, question, cfg.platform
-                        )
-                        answer = await asyncio.to_thread(
-                            backend_for_record(cfg, store, rec).ask,
-                            thread_key,
-                            question,
-                        )
-                except BackendError as exc:
-                    logger.warning(
-                        "A [%s] %s: error after %.1fs — %s",
-                        thread_key,
-                        handle,
-                        time.time() - start,
-                        str(exc)[:200],
-                    )
-                    await dest.send(f"⚠️ {str(exc)[:1500]}")
-                    return
-                except Exception:
-                    logger.exception(
-                        "A [%s] %s: unexpected backend failure",
-                        thread_key,
-                        handle,
-                    )
-                    await dest.send(
-                        "⚠️ Unexpected error — the owner can check the "
-                        "agent-tunnel logs."
-                    )
-                    return
-
-            deliverables = (
-                f", {len(answer.attachments)} deliverable(s)"
-                if answer.attachments
-                else ""
-            )
-            logger.info(
-                "A [%s] %s: %s in %.1fs, %d chars%s, fork %s",
-                thread_key,
-                handle,
-                "new" if answer.new_thread else "follow-up",
-                time.time() - start,
-                len(answer.text),
-                deliverables,
-                answer.fork_session_id[:8],
-            )
-            text = answer.text
-            if len(text) > cfg.limits.max_inline_chars:
-                preview = split_chunks(text)[0]
-                file = discord.File(
-                    io.BytesIO(text.encode("utf-8")), filename="answer.md"
-                )
-                await dest.send(preview, file=file)
-            else:
-                for chunk in split_chunks(text):
-                    await dest.send(chunk)
-            await self._post_deliverables(dest, answer)
-
-        async def _ingest_attachments(
-            self,
-            dest: Any,
-            thread_key: str,
-            question: str,
-            attachments: Any,
-        ) -> str:
-            """Download a colleague's attachments and point the fork at them.
-
-            Saves each (within size/count caps) into the thread's upload dir —
-            which the backend exposes to the fork via ``--add-dir`` — and
-            prepends the absolute paths to the question. Oversized or excess
-            files are skipped with a heads-up. Returns the (possibly
-            preamble-prefixed) question.
-            """
-            if not attachments:
-                return question
-            cap = int(cfg.limits.max_attachment_mb * 1024 * 1024)
-            limit = cfg.limits.max_attachments
-            # A unique per-turn subdir (plus per-turn dedup of basenames) keeps
-            # same-named files — two `report.pdf` in one message, or one reused
-            # across turns — from silently overwriting each other.
-            turn_dir = (
-                uploads_dir_for(cfg.state_path.parent, thread_key)
-                / uuid.uuid4().hex[:8]
-            )
-            turn_dir.mkdir(parents=True, exist_ok=True)
-            saved: list[Path] = []
-            skipped: list[str] = []
-            unreadable: list[str] = []
-            used: set[str] = set()
-            for att in list(attachments)[:limit]:
-                size = getattr(att, "size", 0) or 0
-                if size > cap:
-                    skipped.append(f"{att.filename} ({size / 1048576:.1f} MB)")
-                    continue
-                target = turn_dir / _unique_name(
-                    _safe_filename(att.filename), used
-                )
-                try:
-                    await att.save(str(target))
-                except Exception:
-                    logger.exception("Download failed: %s", att.filename)
-                    skipped.append(att.filename)
-                    continue
-                # Office files the Read tool can't open: best-effort convert to
-                # a readable format (PDF/Markdown/text). convert_attachment
-                # returns path=None when conversion is "off" or no converter
-                # handled it — then mark the file unreadable rather than point
-                # the fork at a binary original it can't Read.
-                ext = target.suffix.lower()
-                if ext in CONVERTIBLE_EXTS:
-                    conv = await asyncio.to_thread(
-                        convert_attachment,
-                        target,
-                        turn_dir,
-                        cfg.attachments.convert,
-                        cfg.attachments.convert_command,
-                    )
-                    if conv.path is not None:
-                        saved.append(conv.path)
+        def _to_incoming(
+            self, m: discord.Message, surface: Surface, key: str
+        ) -> IncomingMessage:
+            """Normalize a Discord message into a neutral IncomingMessage."""
+            content = (m.content or "").strip()
+            addressee, text = Addressee.NONE, content
+            # In a thread, a leading mention of someone else means teammates are
+            # talking among themselves; a leading @bot is stripped and answered.
+            if surface is Surface.THREAD:
+                mid = _leading_mention_id(content)
+                if mid is not None:
+                    if mid != getattr(self.user, "id", None):
+                        addressee = Addressee.OTHER
                     else:
-                        unreadable.append(att.filename)
-                else:
-                    saved.append(target)
-            if len(list(attachments)) > limit:
-                extra = len(list(attachments)) - limit
-                skipped.append(f"+{extra} more (max {limit} per message)")
-            if skipped:
-                await dest.send("⚠️ Skipped: " + ", ".join(skipped))
-            if unreadable:
-                why = (
-                    "Office conversion is turned off"
-                    if cfg.attachments.convert == "off"
-                    else "no converter is available"
-                )
-                await dest.send(
-                    f"⚠️ Couldn't open {', '.join(unreadable)} here ({why}) "
-                    "— attach a PDF or paste the text."
-                )
-            return attachment_preamble(saved, question)
-
-        async def _post_deliverables(self, dest: Any, answer: Answer) -> None:
-            """Post files the fork wrote to its outbox back to the thread."""
-            files = list(getattr(answer, "attachments", None) or [])
-            if not files:
-                return
-            cap = int(cfg.limits.max_attachment_mb * 1024 * 1024)
-            sendable: list[Path] = []
-            skipped: list[str] = []
-            for path in files:
-                try:
-                    size = path.stat().st_size
-                except OSError:
-                    continue
-                if size > cap:
-                    skipped.append(f"{path.name} ({size / 1048576:.1f} MB)")
-                else:
-                    sendable.append(path)
-            # Discord caps a single message at 10 attachments.
-            for start in range(0, len(sendable), 10):
-                batch = sendable[start : start + 10]
-                dfiles = [
-                    discord.File(str(p), filename=p.name) for p in batch
-                ]
-                caption = (
-                    "📎 Deliverable(s) from the agent:"
-                    if start == 0
-                    else "📎 More deliverables:"
-                )
-                try:
-                    await dest.send(caption, files=dfiles)
-                except Exception:
-                    logger.exception("Failed to post deliverables batch")
-            if skipped:
-                await dest.send(
-                    "⚠️ Produced but too large to post (raise "
-                    "limits.max_attachment_mb): " + ", ".join(skipped)
-                )
+                        addressee = Addressee.SELF
+                        text = re.sub(r"^\s*<@[!&]?\d+>\s*", "", content)
+            ch = m.channel
+            # _native is the Message; the transport routes sends through
+            # message.channel and anchors open_thread to the message.
+            dest = ChatDest(
+                thread_key=key,
+                surface=surface,
+                channel_id=str(ch.id),
+                _native=m,
+            )
+            return IncomingMessage(
+                text=text,
+                dest=dest,
+                surface=surface,
+                author_id=str(m.author.id),
+                author_display=m.author.display_name,
+                author_role_ids=frozenset(
+                    str(r.id) for r in getattr(m.author, "roles", []) or []
+                ),
+                addressee=addressee,
+                attachments=tuple(
+                    AttachmentRef(
+                        a.filename, getattr(a, "size", 0) or 0, _native=a
+                    )
+                    for a in m.attachments
+                ),
+                channel_id=str(ch.id),
+                _native=m,
+            )
 
     TunnelClient(intents=intents).run(token, log_handler=None)

--- a/tests/test_chat_core.py
+++ b/tests/test_chat_core.py
@@ -1,0 +1,510 @@
+"""Behavior tests for the platform-neutral ChatCore (routing + pipeline).
+
+The existing ``test_discord_bot.py`` / ``test_agent_tunnel.py`` only cover the
+pure helpers; these drive the EXTRACTED routing/answer pipeline end-to-end
+through a real in-memory ``FakeTransport`` (records every chat I/O, opens
+deterministic thread dests, no network) and a real ``FakeBackend`` (a canned
+``Answer``, captured questions) injected by redirecting the
+``chat_core.backend_for_record`` lookup. Real ``TunnelConfig``/``TunnelStore``/
+``Registry`` pinned to ``tmp_path`` so nothing touches a live daemon's state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from claude_code_tools.agent_tunnel import chat_core
+from claude_code_tools.agent_tunnel.backends import (
+    Answer,
+    BackendError,
+    HeadlessBackend,
+)
+from claude_code_tools.agent_tunnel.chat_core import ChatCore
+from claude_code_tools.agent_tunnel.chat_types import (
+    Addressee,
+    AttachmentRef,
+    ChatDest,
+    IncomingMessage,
+    OutgoingFile,
+    Surface,
+    TransportLimits,
+    noop_activity,
+    split_chunks,
+)
+from claude_code_tools.agent_tunnel.config import TunnelConfig
+from claude_code_tools.agent_tunnel.registry import PublishRecord, Registry
+from claude_code_tools.agent_tunnel.store import TunnelStore
+
+
+class FakeTransport:
+    """In-memory ChatTransport: records calls, mints deterministic threads."""
+
+    def __init__(self, limits: TransportLimits | None = None) -> None:
+        self._limits = limits or TransportLimits()
+        self.texts: list[tuple[str, str]] = []
+        self.files: list[tuple[str, str, list[OutgoingFile]]] = []
+        self.reactions: list[tuple[str, str]] = []
+        self.opened: list[tuple[str, str]] = []
+        self.downloads: list[tuple[AttachmentRef, Path]] = []
+        self.fail_download = False
+        self.fail_send_files = False
+        self._seq = 0
+
+    @property
+    def limits(self) -> TransportLimits:
+        return self._limits
+
+    async def open_thread(self, parent: ChatDest, title: str) -> ChatDest:
+        self._seq += 1
+        self.opened.append((parent.thread_key, title))
+        return ChatDest(
+            thread_key=f"th:fake{self._seq}",
+            surface=Surface.THREAD,
+            channel_id=parent.channel_id,
+        )
+
+    async def send_text(self, dest: ChatDest, text: str) -> None:
+        self.texts.append((dest.thread_key, text))
+
+    async def send_files(self, dest, caption, files) -> None:
+        if self.fail_send_files:
+            raise RuntimeError("send boom")
+        self.files.append((dest.thread_key, caption, list(files)))
+
+    async def download_attachment(
+        self, attachment: AttachmentRef, target: Path
+    ) -> None:
+        self.downloads.append((attachment, target))
+        if self.fail_download:
+            raise RuntimeError("download boom")
+        target.write_bytes(b"FAKE")
+
+    async def add_reaction(self, message: IncomingMessage, emoji: str) -> None:
+        self.reactions.append((message.author_id, emoji))
+
+    def activity(self, dest: ChatDest):
+        return noop_activity()
+
+
+class FakeBackend:
+    """Real Backend implementation with a canned Answer + captured questions."""
+
+    def __init__(self, answer=None, error=None, store=None):
+        self.questions: list[tuple[str, str]] = []
+        self.forgotten: list[str] = []
+        self._answer = answer
+        self._error = error
+        self._store = store
+
+    def ask(self, thread_key: str, question: str) -> Answer:
+        self.questions.append((thread_key, question))
+        if self._error is not None:
+            raise self._error
+        return self._answer or Answer(
+            text="ok", fork_session_id="fork1234", new_thread=True
+        )
+
+    def forget(self, thread_key: str) -> None:
+        # The real backend.forget removes the store binding (+ cleans dirs); mirror
+        # the removal so DM rebind's forget-then-bind isn't a no-op.
+        self.forgotten.append(thread_key)
+        if self._store is not None:
+            self._store.remove(thread_key)
+
+    def reap_idle(self) -> int:
+        return 0
+
+
+def _core(tmp_path: Path):
+    """A ChatCore wired to a FakeTransport + tmp-pinned store/registry."""
+    cfg = TunnelConfig(
+        state_path=tmp_path / "state.json",
+        registry_path=tmp_path / "registry.json",
+    )
+    store = TunnelStore(cfg.state_path)
+    registry = Registry(cfg.registry_path)
+    tx = FakeTransport()
+    return ChatCore(cfg, store, registry, tx), tx, store, registry, cfg
+
+
+def _msg(
+    surface: Surface = Surface.CHANNEL,
+    text: str = "",
+    thread_key: str = "",
+    channel_id: str = "C1",
+    author_id: str = "U1",
+    author_display: str = "Alice",
+    author_role_ids=frozenset(),
+    addressee: Addressee = Addressee.NONE,
+    attachments=(),
+) -> IncomingMessage:
+    dest = ChatDest(
+        thread_key=thread_key, surface=surface, channel_id=channel_id
+    )
+    return IncomingMessage(
+        text=text,
+        dest=dest,
+        surface=surface,
+        author_id=author_id,
+        author_display=author_display,
+        author_role_ids=author_role_ids,
+        addressee=addressee,
+        attachments=tuple(attachments),
+        channel_id=channel_id,
+    )
+
+
+def _use_backend(monkeypatch, fake: FakeBackend) -> None:
+    monkeypatch.setattr(
+        chat_core, "backend_for_record", lambda *a, **k: fake
+    )
+
+
+def _seed(registry: Registry, tmp_path: Path, handle="pay", access="read") -> None:
+    registry.upsert(
+        PublishRecord(
+            handle=handle, session_id="S1", cwd=str(tmp_path), access=access
+        )
+    )
+
+
+# -- helpers / policy ---------------------------------------------------------
+
+
+def test_split_chunks_default_and_limit() -> None:
+    assert split_chunks("") == []
+    assert split_chunks("hello") == ["hello"]
+    chunks = split_chunks("x" * 130, 50)
+    assert all(len(c) <= 50 for c in chunks) and "".join(chunks) == "x" * 130
+
+
+def test_allowed_open_user_role_and_denied(tmp_path: Path) -> None:
+    core, _, _, _, cfg = _core(tmp_path)
+    # empty allowlists -> anyone
+    assert core._allowed(_msg(author_id="U1")) is True
+    # int Discord ids are stringified -> "123" matches author_id="123"
+    cfg.discord.allowed_user_ids = [123]
+    assert core._allowed(_msg(author_id="123")) is True
+    assert core._allowed(_msg(author_id="999")) is False
+    # role/usergroup match
+    cfg.discord.allowed_user_ids = []
+    cfg.discord.allowed_role_ids = [9]
+    assert core._allowed(_msg(author_role_ids=frozenset({"9"}))) is True
+    assert core._allowed(_msg(author_role_ids=frozenset({"8"}))) is False
+
+
+def test_cooldown_blocks_allows_after_and_per_principal(
+    tmp_path: Path, monkeypatch
+) -> None:
+    core, *_ = _core(tmp_path)
+    core.cfg.limits.per_user_cooldown_s = 100
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(chat_core.time, "time", lambda: clock["t"])
+    assert core._cooldown_ok("U1") is True
+    assert core._cooldown_ok("U1") is False  # within cooldown
+    assert core._cooldown_ok("U2") is True   # different principal
+    clock["t"] = 1101.0
+    assert core._cooldown_ok("U1") is True   # cooldown elapsed
+
+
+def test_deliver_answer_inline_chunked_and_as_file(tmp_path: Path) -> None:
+    core, tx, *_ = _core(tmp_path)
+    tx._limits = TransportLimits(max_message_len=50)
+    core.cfg.limits.max_inline_chars = 80
+    asyncio.run(core._deliver_answer(_dest("th:1"), "y" * 70))  # <=80 -> inline
+    assert tx.texts and all(len(t) <= 50 for _, t in tx.texts)  # chunked to 50
+    assert "".join(t for _, t in tx.texts) == "y" * 70
+    tx.texts.clear()
+    long = "z" * 200  # > max_inline_chars -> one file + preview caption
+    asyncio.run(core._deliver_answer(_dest("th:1"), long))
+    assert not tx.texts and len(tx.files) == 1
+    _, caption, files = tx.files[0]
+    assert len(files) == 1 and files[0].filename == "answer.md"
+    assert files[0].data is not None and files[0].data.decode() == long
+    assert caption == long[:50]
+
+
+def _dest(key: str, surface: Surface = Surface.THREAD) -> ChatDest:
+    return ChatDest(thread_key=key, surface=surface, channel_id="C1")
+
+
+def test_thread_key_scheme_is_opaque(tmp_path: Path, monkeypatch) -> None:
+    # Discord th:NNN and a Slack-style th:C-ts both round-trip through the store.
+    core, tx, store, registry, _ = _core(tmp_path)
+    core.cfg.limits.per_user_cooldown_s = 0  # both turns by the same author
+    fake = FakeBackend()
+    _use_backend(monkeypatch, fake)
+    for key in ("th:fakeA", "th:C123-1700000000.0001"):
+        store.bind(key, "pay", "S1", str(tmp_path), "headless")
+        asyncio.run(core._on_thread(_msg(Surface.THREAD, "hi", thread_key=key)))
+    assert {k for k, _ in fake.questions} == {"th:fakeA", "th:C123-1700000000.0001"}
+
+
+def test_thread_addressee_other_silent_self_and_none_answer(
+    tmp_path: Path, monkeypatch
+) -> None:
+    core, tx, store, registry, _ = _core(tmp_path)
+    core.cfg.limits.per_user_cooldown_s = 0  # SELF + NONE turns by one author
+    fake = FakeBackend()
+    _use_backend(monkeypatch, fake)
+    store.bind("th:1", "pay", "S1", str(tmp_path), "headless")
+    asyncio.run(
+        core._on_thread(_msg(Surface.THREAD, "x", thread_key="th:1",
+                             addressee=Addressee.OTHER))
+    )
+    assert not fake.questions  # addressed to someone else -> silent
+    asyncio.run(
+        core._on_thread(_msg(Surface.THREAD, "real q", thread_key="th:1",
+                             addressee=Addressee.SELF))
+    )
+    asyncio.run(
+        core._on_thread(_msg(Surface.THREAD, "another", thread_key="th:1",
+                             addressee=Addressee.NONE))
+    )
+    assert len(fake.questions) == 2  # SELF + NONE both answer
+
+
+# -- routing: channel open ----------------------------------------------------
+
+
+def test_channel_open_binds_answers_and_relay_prefix(
+    tmp_path: Path, monkeypatch
+) -> None:
+    core, tx, store, registry, cfg = _core(tmp_path)
+    fake = FakeBackend()
+    _use_backend(monkeypatch, fake)
+    _seed(registry, tmp_path)
+    asyncio.run(
+        core.handle_message(_msg(text="pay how does refresh work?"))
+    )
+    assert tx.opened == [("", "pay: how does refresh work?")]
+    assert store.get("th:fake1") is not None
+    # answer delivered on the new thread; relay prefix names the sender+platform
+    assert any(k == "th:fake1" for k, _ in tx.texts)
+    assert fake.questions[0][1].startswith("Alice (via Discord) says:")
+
+
+def test_channel_handle_only_posts_ready_notice(
+    tmp_path: Path, monkeypatch
+) -> None:
+    core, tx, store, registry, _ = _core(tmp_path)
+    fake = FakeBackend()
+    _use_backend(monkeypatch, fake)
+    _seed(registry, tmp_path)
+    asyncio.run(core.handle_message(_msg(text="pay")))
+    assert not fake.questions  # no question -> no ask
+    assert any("Connected to **pay**" in t for _, t in tx.texts)
+
+
+def test_unknown_handle_complains_before_allowlist(
+    tmp_path: Path, monkeypatch
+) -> None:
+    core, tx, store, registry, cfg = _core(tmp_path)
+    fake = FakeBackend()
+    _use_backend(monkeypatch, fake)
+    cfg.discord.allowed_user_ids = [999]  # would DENY author U1 (id "1")
+    asyncio.run(core.handle_message(_msg(text="nope", author_id="1")))
+    assert any("No live session for handle `nope`" in t for _, t in tx.texts)
+    tx.texts.clear()
+    # but a handle-looking token WITH a question stays silent
+    asyncio.run(core.handle_message(_msg(text="nope please help", author_id="1")))
+    assert not tx.texts
+
+
+# -- routing: thread follow-up ------------------------------------------------
+
+
+def test_thread_followup_answers_then_cooldown_reacts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    core, tx, store, registry, cfg = _core(tmp_path)
+    cfg.limits.per_user_cooldown_s = 100
+    fake = FakeBackend()
+    _use_backend(monkeypatch, fake)
+    store.bind("th:1", "pay", "S1", str(tmp_path), "headless")
+    asyncio.run(core._on_thread(_msg(Surface.THREAD, "q1", thread_key="th:1")))
+    assert len(fake.questions) == 1
+    asyncio.run(core._on_thread(_msg(Surface.THREAD, "q2", thread_key="th:1")))
+    assert len(fake.questions) == 1  # cooled down -> no second ask
+    assert tx.reactions == [("U1", "hourglass")]
+
+
+# -- pipeline: attachments + deliverables -------------------------------------
+
+
+def test_attachments_ingested_and_oversize_skipped(
+    tmp_path: Path, monkeypatch
+) -> None:
+    core, tx, store, registry, cfg = _core(tmp_path)
+    fake = FakeBackend()
+    _use_backend(monkeypatch, fake)
+    store.bind("th:1", "pay", "S1", str(tmp_path), "headless")
+    big = int(cfg.limits.max_attachment_mb * 1024 * 1024) + 1
+    atts = (AttachmentRef("a.txt", 4), AttachmentRef("huge.bin", big))
+    asyncio.run(
+        core._on_thread(_msg(Surface.THREAD, "see file", thread_key="th:1",
+                             attachments=atts))
+    )
+    assert [a.filename for a, _ in tx.downloads] == ["a.txt"]  # huge not fetched
+    assert "a.txt" in fake.questions[0][1]  # preamble path handed to the fork
+    assert any("⚠️ Skipped:" in t and "huge.bin" in t for _, t in tx.texts)
+
+
+def test_attachment_download_failure_skipped(tmp_path: Path, monkeypatch) -> None:
+    core, tx, store, registry, _ = _core(tmp_path)
+    tx.fail_download = True
+    fake = FakeBackend()
+    _use_backend(monkeypatch, fake)
+    store.bind("th:1", "pay", "S1", str(tmp_path), "headless")
+    asyncio.run(
+        core._on_thread(_msg(Surface.THREAD, "q", thread_key="th:1",
+                             attachments=(AttachmentRef("a.txt", 4),)))
+    )
+    assert any("⚠️ Skipped:" in t and "a.txt" in t for _, t in tx.texts)
+
+
+def test_attachment_only_empty_after_ingest(tmp_path: Path, monkeypatch) -> None:
+    # text="" + a file whose ingest yields no usable content path still ingests;
+    # if the question is empty after ingest with no saved files -> "nothing".
+    core, tx, store, registry, _ = _core(tmp_path)
+    tx.fail_download = True  # the lone file is skipped -> nothing usable
+    fake = FakeBackend()
+    _use_backend(monkeypatch, fake)
+    store.bind("th:1", "pay", "S1", str(tmp_path), "headless")
+    asyncio.run(
+        core._on_thread(_msg(Surface.THREAD, "", thread_key="th:1",
+                             attachments=(AttachmentRef("a.txt", 4),)))
+    )
+    assert not fake.questions
+    assert any("Nothing to act on" in t for _, t in tx.texts)
+
+
+def test_deliverables_posted_in_batches(tmp_path: Path, monkeypatch) -> None:
+    core, tx, store, registry, _ = _core(tmp_path)
+    tx._limits = TransportLimits(max_attachments_per_msg=10)
+    outs = []
+    for i in range(11):
+        p = tmp_path / f"out{i}.txt"
+        p.write_text("x")
+        outs.append(p)
+    fake = FakeBackend(
+        Answer(text="done", fork_session_id="f1", new_thread=False, attachments=outs)
+    )
+    _use_backend(monkeypatch, fake)
+    store.bind("th:1", "pay", "S1", str(tmp_path), "headless")
+    asyncio.run(core._on_thread(_msg(Surface.THREAD, "make files", thread_key="th:1")))
+    captions = [c for _, c, _ in tx.files]
+    assert "📎 Deliverable(s) from the agent:" in captions
+    assert "📎 More deliverables:" in captions  # 11 files -> two batches
+
+
+def test_deliverables_send_failure_swallowed(tmp_path: Path, monkeypatch) -> None:
+    core, tx, store, registry, _ = _core(tmp_path)
+    tx.fail_send_files = True
+    p = tmp_path / "out.txt"
+    p.write_text("x")
+    fake = FakeBackend(
+        Answer(text="done", fork_session_id="f1", new_thread=False, attachments=[p])
+    )
+    _use_backend(monkeypatch, fake)
+    store.bind("th:1", "pay", "S1", str(tmp_path), "headless")
+    # must not raise even though send_files blows up
+    asyncio.run(core._on_thread(_msg(Surface.THREAD, "q", thread_key="th:1")))
+
+
+# -- pipeline: error paths + stale binding ------------------------------------
+
+
+def test_backend_error_truncated(tmp_path: Path, monkeypatch) -> None:
+    core, tx, store, registry, _ = _core(tmp_path)
+    fake = FakeBackend(error=BackendError("x" * 5000))
+    _use_backend(monkeypatch, fake)
+    store.bind("th:1", "pay", "S1", str(tmp_path), "headless")
+    asyncio.run(core._on_thread(_msg(Surface.THREAD, "q", thread_key="th:1")))
+    warn = [t for _, t in tx.texts if t.startswith("⚠️ ")][0]
+    # "⚠️ " prefix + the error sliced to max_error_len
+    assert len(warn) == len("⚠️ ") + core.tx.limits.max_error_len
+    assert warn.endswith("x" * 10)
+
+
+def test_unexpected_error_releases_lock(tmp_path: Path, monkeypatch) -> None:
+    core, tx, store, registry, _ = _core(tmp_path)
+    fake = FakeBackend(error=ValueError("kaboom"))
+    _use_backend(monkeypatch, fake)
+    store.bind("th:1", "pay", "S1", str(tmp_path), "headless")
+    asyncio.run(core._on_thread(_msg(Surface.THREAD, "q", thread_key="th:1")))
+    assert any("Unexpected error" in t for _, t in tx.texts)
+    assert not core._locks["th:1"].locked()  # lock released for the next turn
+
+
+def test_stale_binding_guard(tmp_path: Path, monkeypatch) -> None:
+    core, tx, store, registry, _ = _core(tmp_path)
+    fake = FakeBackend()
+    _use_backend(monkeypatch, fake)
+    store.bind("th:1", "pay", "S1", str(tmp_path), "headless")
+
+    # Force _answer to read rec=S1, then park on the per-thread lock; rebind to a
+    # different session before releasing -> the in-lock re-read sees S2, so the
+    # queued question is refused instead of answered against the wrong binding.
+    async def drive():
+        lock = core._locks["th:1"]
+        await lock.acquire()
+        msg = _msg(Surface.THREAD, "q", thread_key="th:1")
+        task = asyncio.create_task(core._answer(msg.dest, "q", msg))
+        await asyncio.sleep(0)  # let _answer read S1 and block on the lock
+        store.remove("th:1")
+        store.bind("th:1", "pay", "S2", str(tmp_path), "headless")
+        lock.release()
+        await task
+
+    asyncio.run(drive())
+    assert not fake.questions
+    assert any("was restarted" in t for _, t in tx.texts)
+
+
+# -- DM rebind ----------------------------------------------------------------
+
+
+def _dm_msg(text: str) -> IncomingMessage:
+    return _msg(
+        text=text, surface=Surface.DM, thread_key="dm:D1", channel_id="D1"
+    )
+
+
+def test_dm_rebind_then_followup(tmp_path: Path, monkeypatch) -> None:
+    core, tx, store, registry, _ = _core(tmp_path)
+    core.cfg.limits.per_user_cooldown_s = 0
+    fake = FakeBackend(store=store)  # forget removes the binding (real behavior)
+    _use_backend(monkeypatch, fake)
+    registry.upsert(PublishRecord(handle="pay", session_id="S1", cwd=str(tmp_path)))
+    registry.upsert(PublishRecord(handle="ops", session_id="S2", cwd=str(tmp_path)))
+    asyncio.run(core.handle_message(_dm_msg("pay first q")))
+    bound = store.get("dm:D1")
+    assert bound is not None and bound.expert_session_id == "S1"
+    asyncio.run(core.handle_message(_dm_msg("more")))  # bare follow-up
+    asyncio.run(core.handle_message(_dm_msg("ops")))   # rebind to a new session
+    assert "dm:D1" in fake.forgotten  # old binding torn down on rebind
+    rebound = store.get("dm:D1")
+    assert rebound is not None and rebound.expert_session_id == "S2"
+
+
+# -- cross-feature: live-access collision guard (Slack dm: key) ---------------
+
+
+def test_access_collision_slack_dm_key(tmp_path: Path) -> None:
+    # A Slack DM bound under the sentinel handle "cli" (session A) must NOT be
+    # escalated by an unrelated >share cli for a different session — the guard
+    # keys on session_id == expert_session_id (mirrors the backends test).
+    cfg = TunnelConfig(
+        state_path=tmp_path / "s.json", registry_path=tmp_path / "reg.json"
+    )
+    store = TunnelStore(cfg.state_path)
+    store.bind("dm:C9", "cli", "session-A", "/p", "headless", access="read")
+    Registry(cfg.registry_path).upsert(
+        PublishRecord(
+            handle="cli", session_id="session-B", cwd="/p", access="write"
+        )
+    )
+    rec = HeadlessBackend(cfg, store)._require_binding("dm:C9")
+    assert rec.access == "read"


### PR DESCRIPTION
Foundational refactor that pulls agent-tunnel's chat routing + answer pipeline
out of `discord_bot.py` into a **platform-neutral core** behind a `ChatTransport`
Protocol, so a second front-end (**Slack — next PR**) reuses 100% of the
routing/policy/pipeline. **Zero behavior change to Discord.**

## What moved

- **`chat_types.py`** (new) — `ChatTransport` Protocol + neutral value objects
  (`IncomingMessage`, `ChatDest`, `AttachmentRef`, `OutgoingFile`,
  `TransportLimits`, `Surface`, `Addressee`) + the pure helpers
  (`format_relayed_message`, `split_chunks`, `is_*_command`, `_safe_filename`,
  `_unique_name`, `resolve_token`), moved verbatim.
- **`chat_core.py`** (new) — `ChatCore`: every routing branch (channel/thread/DM),
  allowlist/cooldown/concurrency, the answer/ingest/deliver pipeline, and the
  reaper — ported from `discord_bot` with `discord.*` I/O replaced by
  `ChatTransport` calls.
- **`discord_bot.py`** — now a thin adapter (**717 → 246 lines**): drop bot msgs,
  classify into a `Surface`, normalize into an `IncomingMessage` (resolving
  `<@id>` → `Addressee`, stripping a leading self-mention), and `DiscordTransport`.
  Re-exports the moved helpers so existing imports/tests are unchanged.
- **`config.py`** — `principal_allowlists()` (front-end-neutral allowlist;
  extended for Slack in the next PR).

## Verification

- **Parity:** the existing `test_discord_bot` / `test_agent_tunnel` (helpers +
  re-exports) and `test_agent_tunnel_backends` suites stay green.
- **New:** `test_chat_core.py` — 20 behavior tests driving the extracted
  routing/pipeline through a fake transport + fake backend (channel-open → bind →
  answer + relay prefix, handle-only notice, unknown-handle-before-allowlist,
  follow-ups + cooldown, attachments ingest/skip/download-fail/empty, deliverable
  batching, `BackendError` truncation, unexpected-error lock release, the
  stale-binding race, DM rebind, and the Slack-`dm:` access-collision guard).
- **Full suite: 79 passed**; Pyright 0 errors; all files <1000 lines.

The design + the upcoming Slack adapter are specified in a spec doc that lands
with PR2.

Note: this only changes on-disk code — a running `agent-tunnel serve` keeps its
loaded code until restarted.
