### PR TITLE
feat(agent-tunnel): Slack front-end (Socket Mode) over the shared chat_core

### DIFF
--- a/claude_code_tools/agent_tunnel/__init__.py
+++ b/claude_code_tools/agent_tunnel/__init__.py
@@ -1,6 +1,8 @@
 """agent-tunnel: expose a local Claude Code session to teammates.
 
-A small daemon that answers questions (Discord v1) against forks of a
-long-lived "expert" Claude Code session, with hard read-only tool
-restrictions. See docs/agent-tunnel-spec.md for the design.
+A small daemon that answers questions over a chat front-end (Discord or
+Slack) against forks of a long-lived "expert" Claude Code session, with
+hard read-only tool restrictions. The two front-ends are thin adapters
+over a shared, platform-neutral core. See docs/agent-tunnel-spec.md and
+docs/agent-tunnel-slack-spec.md for the design.
 """

--- a/claude_code_tools/agent_tunnel/cli.py
+++ b/claude_code_tools/agent_tunnel/cli.py
@@ -152,6 +152,18 @@ def serve(
         run(cfg, store, registry)
     except RuntimeError as exc:
         raise click.ClickException(str(exc)) from exc
+    except ImportError as exc:
+        # slack_bolt is imported lazily INSIDE run_slack_bot, so a missing
+        # `slack` extra surfaces here at call time (not at the import above) —
+        # convert it to the actionable install hint, not a raw traceback (P2).
+        if cfg.chat == "slack":
+            raise click.ClickException(
+                f"slack_bolt is required for `serve --chat slack`: {exc}\n"
+                "Install it with:  uv tool install 'claude-code-tools[slack]'"
+            ) from exc
+        raise click.ClickException(
+            f"A required dependency for serve is missing: {exc}"
+        ) from exc
 
 
 @cli.command()

--- a/claude_code_tools/agent_tunnel/cli.py
+++ b/claude_code_tools/agent_tunnel/cli.py
@@ -681,6 +681,26 @@ def _slack_auth_ready(bot_token: str) -> tuple[bool, str]:
         return False, f"Slack auth.test failed ({exc})"
 
 
+def _reach_check(
+    channel_ids: list, respond_to_dms: bool
+) -> tuple[bool, str]:
+    """Readiness of the 'where can it answer' check (channels OR DMs).
+
+    DM-only (``respond_to_dms`` with no channels) is a valid serve config for
+    both front-ends -- it mirrors ``run_bot`` / ``run_slack_bot``'s startup
+    guard -- so doctor must not fail solely on an empty channel list (Codex P3).
+    """
+    where = (
+        str(list(channel_ids))
+        if channel_ids
+        else ("DMs only" if respond_to_dms else "none set")
+    )
+    return (
+        bool(channel_ids) or bool(respond_to_dms),
+        f"Watched channel(s) / DMs: {where}",
+    )
+
+
 def _doctor_chat_checks(cfg: TunnelConfig) -> list[tuple[bool, str]]:
     """Front-end-specific doctor checks (tokens + watched channels).
 
@@ -708,10 +728,7 @@ def _doctor_chat_checks(cfg: TunnelConfig) -> list[tuple[bool, str]]:
                 "app_token_file)",
             ),
             _slack_auth_ready(bot_token),
-            (
-                bool(cfg.slack.channel_ids),
-                f"Watched channel(s): {cfg.slack.channel_ids or 'none set'}",
-            ),
+            _reach_check(cfg.slack.channel_ids, cfg.slack.respond_to_dms),
         ]
     from .discord_bot import resolve_token
 
@@ -720,10 +737,7 @@ def _doctor_chat_checks(cfg: TunnelConfig) -> list[tuple[bool, str]]:
             bool(resolve_token(cfg)),
             f"Discord token ({cfg.discord.token_env} or token_file)",
         ),
-        (
-            bool(cfg.discord.channel_ids),
-            f"Watched channel(s): {cfg.discord.channel_ids or 'none set'}",
-        ),
+        _reach_check(cfg.discord.channel_ids, cfg.discord.respond_to_dms),
     ]
 
 

--- a/claude_code_tools/agent_tunnel/cli.py
+++ b/claude_code_tools/agent_tunnel/cli.py
@@ -34,18 +34,37 @@ from .store import ThreadRecord, TunnelStore
 def _build(
     config: Optional[str],
     backend: Optional[str] = None,
-    channel: tuple[int, ...] = (),
+    channel: tuple[str, ...] = (),
     token_env: Optional[str] = None,
+    chat: Optional[str] = None,
 ) -> TunnelConfig:
+    """Load config + apply CLI overrides, coercing --channel per front-end.
+
+    ``--channel`` is a string on the CLI; Slack ids stay strings while Discord
+    ids are cast to int (snowflakes) with a clear error. ``--token-env`` is
+    Discord-only (Slack uses two tokens, set in config).
+    """
     try:
-        return load_config(
+        cfg = load_config(
             path=Path(config) if config else None,
             backend=backend,
-            channel_ids=list(channel) or None,
-            token_env=token_env,
+            chat=chat,
         )
     except (FileNotFoundError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
+    if channel:
+        if cfg.chat == "slack":
+            cfg.slack.channel_ids = list(channel)
+        else:
+            try:
+                cfg.discord.channel_ids = [int(c) for c in channel]
+            except ValueError as exc:
+                raise click.ClickException(
+                    f"Discord --channel ids must be integers: {exc}"
+                ) from exc
+    if token_env:
+        cfg.discord.token_env = token_env  # Discord-only (Slack has two tokens)
+    return cfg
 
 
 @click.group()
@@ -69,23 +88,30 @@ def cli() -> None:
     help="Server mode: headless (default) or tmux. Overrides config.",
 )
 @click.option(
+    "--chat",
+    type=click.Choice(["discord", "slack"]),
+    default=None,
+    help="Chat front-end (default from config; falls back to discord).",
+)
+@click.option(
     "--channel",
     "channels",
     multiple=True,
-    type=int,
-    help="Discord channel id to watch (repeatable).",
+    type=str,
+    help="Channel id to watch (repeatable; int for discord, string for slack).",
 )
 @click.option("--token-env", help="Env var holding the Discord bot token.")
 def serve(
     config: Optional[str],
     backend: Optional[str],
-    channels: tuple[int, ...],
+    chat: Optional[str],
+    channels: tuple[str, ...],
     token_env: Optional[str],
 ) -> None:
-    """Run the Discord daemon (blocking).
+    """Run the chat daemon (blocking) for Discord or Slack.
 
-    Two server modes, set with --backend or [tunnel] backend (default
-    headless):
+    Pick the front-end with --chat or [tunnel] chat (default discord). Two
+    server modes, set with --backend or [tunnel] backend (default headless):
 
     \b
     - headless: a `claude -p` subprocess per question — clean JSON I/O, more
@@ -98,21 +124,32 @@ def serve(
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
-    cfg = _build(config, backend, channels, token_env)
+    cfg = _build(config, backend, channels, token_env, chat)
     store = TunnelStore(cfg.state_path)
     registry = Registry(cfg.registry_path)
-    try:
-        from .discord_bot import run_bot
-    except ImportError as exc:
-        raise click.ClickException(
-            f"discord.py is required for serve: {exc}"
-        ) from exc
+    if cfg.chat == "slack":
+        try:
+            from .slack_bot import run_slack_bot as run
+        except ImportError as exc:
+            raise click.ClickException(
+                f"slack_bolt is required for `serve --chat slack`: {exc}\n"
+                "Install it with:  uv tool install 'claude-code-tools[slack]'"
+            ) from exc
+        watched = cfg.slack.channel_ids
+    else:
+        try:
+            from .discord_bot import run_bot as run
+        except ImportError as exc:
+            raise click.ClickException(
+                f"discord.py is required for serve: {exc}"
+            ) from exc
+        watched = cfg.discord.channel_ids
     click.echo(
-        f"agent-tunnel: backend={cfg.backend} "
-        f"registry={cfg.registry_path} channels={cfg.discord.channel_ids}"
+        f"agent-tunnel: chat={cfg.chat} backend={cfg.backend} "
+        f"registry={cfg.registry_path} channels={watched}"
     )
     try:
-        run_bot(cfg, store, registry)
+        run(cfg, store, registry)
     except RuntimeError as exc:
         raise click.ClickException(str(exc)) from exc
 
@@ -622,17 +659,63 @@ def watch(config: Optional[str]) -> None:
     )
 
 
-@cli.command()
-@click.option("--config", type=click.Path(), help="Config TOML path.")
-def doctor(config: Optional[str]) -> None:
-    """Check that agent-tunnel is configured and ready to serve."""
-    import shutil
+def _slack_auth_ready(bot_token: str) -> tuple[bool, str]:
+    """Best-effort Slack auth.test readiness line (never raises).
 
-    from .convert import detect_converter
+    Returns (ok, label). Reports the resolved bot_user_id on success, or a
+    short reason (missing token, slack_sdk absent, or the API error) otherwise.
+    """
+    if not bot_token:
+        return False, "Slack auth.test (no bot token to check)"
+    try:
+        # slack_sdk is the optional `slack` extra (not installed in the
+        # type-check env, so `# type: ignore`); the except handles its real
+        # absence at runtime.
+        from slack_sdk import WebClient  # type: ignore
+    except ImportError:
+        return False, "Slack auth.test (install claude-code-tools[slack])"
+    try:
+        resp = WebClient(token=bot_token).auth_test()
+        return True, f"Slack auth.test ok (bot user {resp['user_id']})"
+    except Exception as exc:  # network / invalid token / scope issues
+        return False, f"Slack auth.test failed ({exc})"
+
+
+def _doctor_chat_checks(cfg: TunnelConfig) -> list[tuple[bool, str]]:
+    """Front-end-specific doctor checks (tokens + watched channels).
+
+    Slack reports BOTH tokens (bot + app) as separate lines plus an auth.test
+    readiness line; Discord keeps its single-token + channels pair.
+    """
+    if cfg.chat == "slack":
+        from .chat_types import resolve_token
+
+        bot_token = resolve_token(
+            cfg.slack.bot_token_env, cfg.slack.bot_token_file
+        )
+        app_token = resolve_token(
+            cfg.slack.app_token_env, cfg.slack.app_token_file
+        )
+        return [
+            (
+                bool(bot_token),
+                f"Slack bot token ({cfg.slack.bot_token_env} or "
+                "bot_token_file)",
+            ),
+            (
+                bool(app_token),
+                f"Slack app-level token ({cfg.slack.app_token_env} or "
+                "app_token_file)",
+            ),
+            _slack_auth_ready(bot_token),
+            (
+                bool(cfg.slack.channel_ids),
+                f"Watched channel(s): {cfg.slack.channel_ids or 'none set'}",
+            ),
+        ]
     from .discord_bot import resolve_token
 
-    cfg = _build(config)
-    checks: list[tuple[bool, str]] = [
+    return [
         (
             bool(resolve_token(cfg)),
             f"Discord token ({cfg.discord.token_env} or token_file)",
@@ -641,11 +724,25 @@ def doctor(config: Optional[str]) -> None:
             bool(cfg.discord.channel_ids),
             f"Watched channel(s): {cfg.discord.channel_ids or 'none set'}",
         ),
+    ]
+
+
+@cli.command()
+@click.option("--config", type=click.Path(), help="Config TOML path.")
+def doctor(config: Optional[str]) -> None:
+    """Check that agent-tunnel is configured and ready to serve."""
+    import shutil
+
+    from .convert import detect_converter
+
+    cfg = _build(config)
+    checks: list[tuple[bool, str]] = _doctor_chat_checks(cfg)
+    checks.append(
         (
             shutil.which(cfg.claude.binary) is not None,
             f"claude binary on PATH ({cfg.claude.binary})",
-        ),
-    ]
+        )
+    )
     if cfg.backend == "tmux":
         checks.append(
             (shutil.which("tmux") is not None, "tmux on PATH (tmux backend)")
@@ -661,7 +758,10 @@ def doctor(config: Optional[str]) -> None:
     else:
         conv = detect_converter() or "none — colleagues should attach PDFs"
     click.echo(f"  • Office-attachment converter: {conv}")
-    click.echo(f"\nbackend={cfg.backend}  registry={cfg.registry_path}")
+    click.echo(
+        f"\nchat={cfg.chat}  backend={cfg.backend}  "
+        f"registry={cfg.registry_path}"
+    )
     if not ok_all:
         raise click.ClickException("Some checks failed — see above.")
 

--- a/claude_code_tools/agent_tunnel/config.py
+++ b/claude_code_tools/agent_tunnel/config.py
@@ -285,16 +285,6 @@ def load_config(
     _apply(cfg.limits, data.get("limits", {}))
     _apply(cfg.attachments, data.get("attachments", {}))
 
-    # Channel-id type validation: snowflakes are ints, Slack ids are strings.
-    # Catch a mis-typed TOML table early with a clear message (`serve` maps the
-    # ValueError to a ClickException).
-    if any(not isinstance(c, int) for c in cfg.discord.channel_ids):
-        raise ValueError("[discord] channel_ids must be integers (snowflakes).")
-    if any(not isinstance(c, str) for c in cfg.slack.channel_ids):
-        raise ValueError(
-            '[slack] channel_ids must be strings (e.g. "C0123ABC").'
-        )
-
     if backend:
         cfg.backend = backend
     if channel_ids:
@@ -308,6 +298,18 @@ def load_config(
     # same auto path, and an explicit [tunnel] platform always wins).
     if cfg.chat == "slack" and "platform" not in tunnel_tbl:
         cfg.platform = "Slack"
+
+    # Channel-id type validation, AFTER the chat override and for the ACTIVE
+    # front-end ONLY: snowflakes are ints, Slack ids are strings. A stale/unused
+    # table for the inactive front-end must not block startup (Codex P2). `serve`
+    # maps the ValueError to a ClickException.
+    if cfg.chat == "slack":
+        if any(not isinstance(c, str) for c in cfg.slack.channel_ids):
+            raise ValueError(
+                '[slack] channel_ids must be strings (e.g. "C0123ABC").'
+            )
+    elif any(not isinstance(c, int) for c in cfg.discord.channel_ids):
+        raise ValueError("[discord] channel_ids must be integers (snowflakes).")
 
     # Anchor configured paths to absolute. A relative path resolves against the
     # CONFIG FILE's directory (not the caller's CWD), so `serve` and CLI

--- a/claude_code_tools/agent_tunnel/config.py
+++ b/claude_code_tools/agent_tunnel/config.py
@@ -85,6 +85,25 @@ class DiscordConfig:
 
 
 @dataclass
+class SlackConfig:
+    """Slack-facing settings (Socket Mode, two tokens).
+
+    Two token env/file pairs (xoxb- bot, xapp- app-level). Allowlists are
+    STRINGS (Slack ids are opaque). ``allowed_usergroup_ids`` (subteam ``S…``
+    ids) is the Slack analog of Discord's ``allowed_role_ids``.
+    """
+
+    bot_token_env: str = "AGENT_TUNNEL_SLACK_BOT_TOKEN"
+    bot_token_file: str = ""
+    app_token_env: str = "AGENT_TUNNEL_SLACK_APP_TOKEN"
+    app_token_file: str = ""
+    channel_ids: list[str] = field(default_factory=list)
+    allowed_user_ids: list[str] = field(default_factory=list)
+    allowed_usergroup_ids: list[str] = field(default_factory=list)
+    respond_to_dms: bool = False
+
+
+@dataclass
 class ClaudeConfig:
     """How forked Claude Code invocations are constructed."""
 
@@ -167,9 +186,12 @@ class TunnelConfig:
 
     backend: str = "headless"
     tmux_session: str = "agent-tunnel"
+    # Chat front-end `serve` runs: "discord" (default) or "slack". Selecting
+    # "slack" auto-sets `platform` to "Slack" unless [tunnel] platform is set.
+    chat: str = "discord"
     # Human name of the chat platform, used in the fork's persona and the
     # "<name> (via X) says:" message prefix. The Discord bot uses "Discord";
-    # a future Slack bot sets "Slack".
+    # the Slack bot sets "Slack".
     platform: str = "Discord"
     state_path: Path = DEFAULT_STATE_PATH
     registry_path: Path = DEFAULT_REGISTRY_PATH
@@ -178,19 +200,27 @@ class TunnelConfig:
     # given (auto = newest session in this dir); never needed by `serve`.
     project_dir: Optional[Path] = None
     discord: DiscordConfig = field(default_factory=DiscordConfig)
+    slack: SlackConfig = field(default_factory=SlackConfig)
     claude: ClaudeConfig = field(default_factory=ClaudeConfig)
     limits: LimitsConfig = field(default_factory=LimitsConfig)
     attachments: AttachmentsConfig = field(default_factory=AttachmentsConfig)
 
     def principal_allowlists(self) -> tuple[set[str], set[str]]:
-        """(allowed user ids, allowed role ids) for the active front-end.
+        """(user_ids, role_or_usergroup_ids) for the active front-end, as
+        strings.
 
         Front-end-neutral so ``ChatCore`` compares uniformly against
         ``IncomingMessage.author_id`` / ``author_role_ids`` (both ``str``).
-        Discord ids are ints in config and are stringified here; empty sets mean
-        "anyone in a watched channel may ask". (Slack support is added with the
-        Slack front-end.)
+        Discord/Slack ids are stringified here; empty/empty means "anyone in a
+        watched channel may ask". Lets ``ChatCore._allowed`` honor Slack
+        usergroups where Discord uses roles, without the core knowing platform
+        names.
         """
+        if self.chat == "slack":
+            return (
+                {str(u) for u in self.slack.allowed_user_ids},
+                {str(g) for g in self.slack.allowed_usergroup_ids},
+            )
         d = self.discord
         return (
             {str(u) for u in d.allowed_user_ids},
@@ -210,6 +240,7 @@ def load_config(
     backend: Optional[str] = None,
     channel_ids: Optional[list[int]] = None,
     token_env: Optional[str] = None,
+    chat: Optional[str] = None,
 ) -> TunnelConfig:
     """Load config from TOML, then apply CLI overrides.
 
@@ -220,13 +251,15 @@ def load_config(
         backend: Override backend ("tmux" or "headless").
         channel_ids: Override watched Discord channel ids.
         token_env: Override env var name holding the Discord bot token.
+        chat: Override chat front-end ("discord" or "slack").
 
     Returns:
         A fully populated TunnelConfig.
 
     Raises:
         FileNotFoundError: Explicit config path does not exist.
-        ValueError: Unknown backend.
+        ValueError: Unknown backend, unknown chat front-end, or a channel id of
+            the wrong type for the active front-end.
     """
     explicit = path is not None
     cfg_path = path or DEFAULT_CONFIG_PATH
@@ -239,7 +272,7 @@ def load_config(
 
     cfg = TunnelConfig()
     tunnel_tbl = data.get("tunnel", {})
-    for key in ("backend", "tmux_session", "platform"):
+    for key in ("backend", "tmux_session", "platform", "chat"):
         if key in tunnel_tbl:
             setattr(cfg, key, tunnel_tbl[key])
     for key in ("state_path", "registry_path", "claude_home", "project_dir"):
@@ -247,9 +280,20 @@ def load_config(
             setattr(cfg, key, Path(tunnel_tbl[key]).expanduser())
 
     _apply(cfg.discord, data.get("discord", {}))
+    _apply(cfg.slack, data.get("slack", {}))
     _apply(cfg.claude, data.get("claude", {}))
     _apply(cfg.limits, data.get("limits", {}))
     _apply(cfg.attachments, data.get("attachments", {}))
+
+    # Channel-id type validation: snowflakes are ints, Slack ids are strings.
+    # Catch a mis-typed TOML table early with a clear message (`serve` maps the
+    # ValueError to a ClickException).
+    if any(not isinstance(c, int) for c in cfg.discord.channel_ids):
+        raise ValueError("[discord] channel_ids must be integers (snowflakes).")
+    if any(not isinstance(c, str) for c in cfg.slack.channel_ids):
+        raise ValueError(
+            '[slack] channel_ids must be strings (e.g. "C0123ABC").'
+        )
 
     if backend:
         cfg.backend = backend
@@ -257,6 +301,13 @@ def load_config(
         cfg.discord.channel_ids = list(channel_ids)
     if token_env:
         cfg.discord.token_env = token_env
+    if chat:
+        cfg.chat = chat
+    # Auto-name the platform from the front-end UNLESS set explicitly in TOML
+    # (the guard checks the TOML table only, so `serve --chat slack` takes the
+    # same auto path, and an explicit [tunnel] platform always wins).
+    if cfg.chat == "slack" and "platform" not in tunnel_tbl:
+        cfg.platform = "Slack"
 
     # Anchor configured paths to absolute. A relative path resolves against the
     # CONFIG FILE's directory (not the caller's CWD), so `serve` and CLI
@@ -280,6 +331,8 @@ def load_config(
 
     if cfg.backend not in ("tmux", "headless"):
         raise ValueError(f"Unknown backend: {cfg.backend!r}")
+    if cfg.chat not in ("discord", "slack"):
+        raise ValueError(f"Unknown chat front-end: {cfg.chat!r}")
     return cfg
 
 
@@ -302,6 +355,10 @@ def sample_config() -> str:
 backend = "headless"
 # Name of the dedicated tmux session holding fork windows (tmux mode only).
 tmux_session = "agent-tunnel"
+# Chat front-end `serve` runs: "discord" (default) or "slack". Override per
+# run with `agent-tunnel serve --chat slack`. Selecting "slack" auto-sets the
+# platform label to "Slack" (unless you set [tunnel] platform yourself).
+# chat = "discord"
 # Chat-platform name shown in the persona and the "<name> (via X) says:"
 # message prefix. Defaults to "Discord".
 # platform = "Discord"

--- a/claude_code_tools/agent_tunnel/slack_bot.py
+++ b/claude_code_tools/agent_tunnel/slack_bot.py
@@ -89,9 +89,15 @@ def discord_to_mrkdwn(text: str) -> str:
 
     The core emits Discord-style markup (``**bold**``, ``[text](url)`` links,
     ``~~strike~~``). Slack speaks ``mrkdwn`` instead, and treats ``& < >`` as
-    HTML-ish control characters. Order matters: escape ``& < >`` FIRST (so a
-    later-inserted ``<url|text>`` link is not mangled), then translate the
-    markup (G-03 / G-mrkdwn-escaping).
+    HTML-ish control characters. Two rules:
+
+    - ``& < >`` are escaped EVERYWHERE (Slack's only escapes; they render as the
+      literal chars, including inside code), and the link delimiter ``<url|text>``
+      is inserted AFTER escaping so it is not mangled.
+    - the markup translations (bold/link/strike) are applied ONLY OUTSIDE inline
+      code spans and fenced blocks, so a ``**x**`` or ``[t](u)`` that appears
+      *inside* a code snippet (common in Claude's answers) is preserved verbatim
+      rather than silently rewritten (G-03 / Codex P2).
 
     Args:
         text: A core-emitted chunk (already split to the message-length cap).
@@ -99,15 +105,22 @@ def discord_to_mrkdwn(text: str) -> str:
     Returns:
         The ``mrkdwn`` equivalent, safe to pass straight to ``chat_postMessage``.
     """
-    out = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-    # **bold** -> *bold* (non-greedy, across newlines).
-    out = re.sub(r"\*\*(.+?)\*\*", r"*\1*", out, flags=re.DOTALL)
-    # [text](url) -> <url|text>. The url was just escaped (& -> &amp; etc.),
-    # which Slack unescapes on render, so links survive intact.
-    out = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", out)
-    # ~~strike~~ -> ~strike~.
-    out = re.sub(r"~~(.+?)~~", r"~\1~", out, flags=re.DOTALL)
-    return out
+    # Split into [non-code, code, non-code, code, ...]: the captured (odd-index)
+    # segments are fenced blocks / inline code spans -- escaped, never translated.
+    parts = re.split(r"(```.*?```|`[^`]*`)", text, flags=re.DOTALL)
+    out: list[str] = []
+    for i, part in enumerate(parts):
+        seg = (
+            part.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+        )
+        if i % 2 == 0:  # outside any code span/fence -> translate the markup
+            seg = re.sub(r"\*\*(.+?)\*\*", r"*\1*", seg, flags=re.DOTALL)
+            seg = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", seg)
+            seg = re.sub(r"~~(.+?)~~", r"~\1~", seg, flags=re.DOTALL)
+        out.append(seg)
+    return "".join(out)
 
 
 def validate_download(content_type: Optional[str], status: int) -> None:

--- a/claude_code_tools/agent_tunnel/slack_bot.py
+++ b/claude_code_tools/agent_tunnel/slack_bot.py
@@ -329,6 +329,7 @@ class SlackTransport(ChatTransport):
         self._bot_token = bot_token
         self._cfg = cfg
         self._display: dict[str, str] = {}
+        self._ug_members: dict[str, frozenset[str]] = {}
         self._session: Any = None
 
     @property
@@ -558,25 +559,78 @@ class SlackTransport(ChatTransport):
         self._display[user_id] = name
         return name
 
+    async def resolve_usergroups(self, user_id: str) -> frozenset[str]:
+        """The configured allowed usergroups (subteams) ``user_id`` belongs to.
+
+        ``ChatCore._allowed`` intersects ``IncomingMessage.author_role_ids`` with
+        the owner's ``allowed_usergroup_ids``, but Slack messages carry no role
+        ids until this fills them. Only the OWNER-configured usergroups are
+        checked (bounded), each subteam's membership cached. Returns the empty set
+        -- with NO API call -- when no usergroup allowlist is configured; also
+        empty when the user is in none or ``usergroups:read`` is missing. Called
+        only from the background turn, never on the ack path (G-14).
+
+        Args:
+            user_id: The Slack user id (``U…``).
+
+        Returns:
+            The subset of ``allowed_usergroup_ids`` that contains ``user_id``.
+        """
+        allowed = self._cfg.slack.allowed_usergroup_ids
+        if not user_id or not allowed:
+            return frozenset()
+        matched: set[str] = set()
+        for sub in allowed:
+            if user_id in await self._usergroup_members(sub):
+                matched.add(sub)
+        return frozenset(matched)
+
+    async def _usergroup_members(self, usergroup_id: str) -> frozenset[str]:
+        """Members of a Slack subteam (cached ``usergroups.users.list``).
+
+        Cached for the process lifetime; a membership change is picked up on the
+        next restart (acceptable for an allowlist). Any API/scope failure yields
+        an empty set, so the user simply won't match that subteam.
+        """
+        if usergroup_id in self._ug_members:
+            return self._ug_members[usergroup_id]
+        members: frozenset[str] = frozenset()
+        try:
+            resp = await self._app.client.usergroups_users_list(
+                usergroup=usergroup_id
+            )
+            members = frozenset(resp.get("users", []) or [])
+        except Exception:  # network / scope / unknown subteam
+            logger.debug(
+                "usergroups.users.list failed for %s",
+                usergroup_id,
+                exc_info=True,
+            )
+        self._ug_members[usergroup_id] = members
+        return members
+
 
 async def _run_turn(
     core: ChatCore,
     transport: "SlackTransport",
     msg: IncomingMessage,
 ) -> None:
-    """Resolve the display name (background) then hand the turn to the core.
+    """Resolve the display name + usergroups (background) then run the turn.
 
-    Kept off the ack path: the listener spawns this so the awaited
-    ``users_info`` lookup never delays the 3-second Socket-Mode ack (G-14). The
-    transport already closes over the ``slack_bolt`` app, so it is not passed in.
+    Kept off the ack path: the listener spawns this so the awaited ``users_info``
+    / ``usergroups.users.list`` lookups never delay the 3-second Socket-Mode ack
+    (G-14). Both are cached; the usergroup lookup is skipped entirely (no API)
+    when no usergroup allowlist is configured. Filling ``author_role_ids`` is what
+    makes ``allowed_usergroup_ids`` usable -- the core's allowlist intersects it.
 
     Args:
         core: The shared routing/pipeline engine.
-        transport: The Slack transport (its cached display-name resolver).
-        msg: The pre-ack message (its ``author_display`` is the raw id so far).
+        transport: The Slack transport (its cached resolvers).
+        msg: The pre-ack message (raw id ``author_display``, empty roles so far).
     """
     name = await transport.resolve_display(msg.author_id)
-    msg = replace(msg, author_display=name)
+    roles = await transport.resolve_usergroups(msg.author_id)
+    msg = replace(msg, author_display=name, author_role_ids=roles)
     await core.handle_message(msg)
 
 

--- a/claude_code_tools/agent_tunnel/slack_bot.py
+++ b/claude_code_tools/agent_tunnel/slack_bot.py
@@ -1,0 +1,712 @@
+"""Slack front-end for agent-tunnel (Socket Mode, handle-opens-a-thread model).
+
+This module is a thin **adapter** over the platform-neutral
+:class:`~.chat_core.ChatCore`: it owns only the Slack wire-format. It drops
+bot/self/edit/delete events, classifies each surviving message into a
+:class:`~.chat_types.Surface`, normalizes it into an
+:class:`~.chat_types.IncomingMessage` (resolving a leading ``<@bot>`` mention
+into an :class:`~.chat_types.Addressee` and stripping it on the THREAD surface),
+implements :class:`~.chat_types.ChatTransport` over the Slack Web API, builds one
+``ChatCore``, schedules the reaper, and forwards each accepted message to the
+core. All routing/policy/pipeline logic lives in ``chat_core``.
+
+Slack runs over Socket Mode -- an outbound WebSocket like Discord's Gateway, so
+there is no public Request URL and no open port. Two tokens are used: a bot
+token (``xoxb-…``, every Web API call) and an app-level token (``xapp-…``, scope
+``connections:write``, opens the socket).
+
+``slack_bolt`` / ``slack_sdk`` / ``aiohttp`` are imported LAZILY (only inside the
+functions that need them), exactly like ``discord_bot`` defers ``discord``, so
+``import slack_bot`` for the pure helpers (:func:`slack_event_to_incoming`,
+:func:`validate_download`, :func:`discord_to_mrkdwn`) never requires the deps.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import OrderedDict
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+
+from .chat_core import ChatCore
+from .chat_types import (
+    AttachmentRef,
+    ChatDest,
+    ChatTransport,
+    IncomingMessage,
+    OutgoingFile,
+    Surface,
+    TransportLimits,
+    Addressee,
+    noop_activity,
+    resolve_token,
+)
+from .config import TunnelConfig
+from .registry import Registry
+from .store import TunnelStore
+
+logger = logging.getLogger("agent_tunnel")
+
+# Slack message subtypes the bot ignores outright. Edits/deletes are
+# INTENTIONALLY ignored (we answer a message once, when first posted); the
+# channel/join/topic housekeeping subtypes are noise. A file-only upload arrives
+# as a regular message (no subtype, or one not in this set), so it is NOT here.
+_IGNORE_SUBTYPES = frozenset(
+    {
+        "message_changed",
+        "message_deleted",
+        "bot_message",
+        "channel_join",
+        "channel_leave",
+        "channel_topic",
+        "channel_purpose",
+        "channel_name",
+        "me_message",
+        "thread_broadcast",
+        "channel_archive",
+        "channel_unarchive",
+    }
+)
+
+# Leading-mention wire-format (adapter-private). A leading ``<@OTHER>`` user, a
+# ``<!here|channel|everyone>`` broadcast, or a ``<!subteam^S…>`` usergroup means
+# teammates are addressing someone other than the bot -> stay out (THREAD only).
+_LEAD_OTHER_USER_RE = re.compile(r"^\s*<@[UW][A-Z0-9]+>")
+_LEAD_BROADCAST_RE = re.compile(r"^\s*<!(here|channel|everyone)>")
+_LEAD_SUBTEAM_RE = re.compile(r"^\s*<!subteam\^[A-Z0-9]+>")
+
+# Beyond this many concurrently in-flight turns the listener posts a brief busy
+# notice and skips spawning, instead of growing unbounded pending coroutines.
+# Per-conversation serialization is the core's per-thread_key lock; the global
+# Semaphore(max_concurrent) still caps simultaneous backend asks (G-27).
+_MAX_INFLIGHT = 64
+
+
+def discord_to_mrkdwn(text: str) -> str:
+    """Translate Discord-flavored markdown to Slack ``mrkdwn``.
+
+    The core emits Discord-style markup (``**bold**``, ``[text](url)`` links,
+    ``~~strike~~``). Slack speaks ``mrkdwn`` instead, and treats ``& < >`` as
+    HTML-ish control characters. Order matters: escape ``& < >`` FIRST (so a
+    later-inserted ``<url|text>`` link is not mangled), then translate the
+    markup (G-03 / G-mrkdwn-escaping).
+
+    Args:
+        text: A core-emitted chunk (already split to the message-length cap).
+
+    Returns:
+        The ``mrkdwn`` equivalent, safe to pass straight to ``chat_postMessage``.
+    """
+    out = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    # **bold** -> *bold* (non-greedy, across newlines).
+    out = re.sub(r"\*\*(.+?)\*\*", r"*\1*", out, flags=re.DOTALL)
+    # [text](url) -> <url|text>. The url was just escaped (& -> &amp; etc.),
+    # which Slack unescapes on render, so links survive intact.
+    out = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", out)
+    # ~~strike~~ -> ~strike~.
+    out = re.sub(r"~~(.+?)~~", r"~\1~", out, flags=re.DOTALL)
+    return out
+
+
+def validate_download(content_type: Optional[str], status: int) -> None:
+    """Raise if a Slack file download looks like a failure, before writing bytes.
+
+    Slack ``url_private`` GETs REDIRECT to a CDN host; a client that drops the
+    auth header on that cross-origin hop lands on a ``200 text/html`` LOGIN PAGE
+    instead of the file. So a non-2xx status OR an HTML content-type means the
+    download failed (auth/scope), even with a 200 (G-15).
+
+    Args:
+        content_type: The response ``Content-Type`` header (may be empty/None;
+            a missing header is treated as a normal binary download, not HTML).
+        status: The HTTP status code (``>= 400`` is a failure).
+
+    Raises:
+        RuntimeError: The response is an HTML login page or an error status.
+    """
+    if "text/html" in (content_type or "") or status >= 400:
+        raise RuntimeError(f"Slack file download failed (status={status})")
+
+
+class _SeenCache:
+    """A bounded, insertion-ordered set for Socket-Mode delivery dedup.
+
+    Slack may deliver the same logical message more than once (retries, the
+    app_mention/message pair). The listener records a stable per-message key
+    (``client_msg_id`` else ``(channel, ts)``) here BEFORE spawning the turn, so
+    a duplicate is dropped synchronously. Bounded so a long-lived daemon's dedup
+    set can't grow without limit -- the oldest keys evict past ``cap`` (G-24).
+    """
+
+    def __init__(self, cap: int) -> None:
+        """Create a cache holding at most ``cap`` recent keys."""
+        self._cap = cap
+        self._keys: "OrderedDict[str, None]" = OrderedDict()
+
+    def add(self, key: str) -> bool:
+        """Record ``key``; return ``False`` if it was already present.
+
+        Eviction is by INSERTION order, NOT recency: a duplicate ``add`` returns
+        ``False`` WITHOUT refreshing the key's position (no ``move_to_end``), so a
+        key still evicts on its original insertion slot. Pure dedup never needs
+        LRU; making it one would silently change which retries get dropped.
+
+        Args:
+            key: A stable per-message dedup key.
+
+        Returns:
+            ``True`` if this is the first time ``key`` is seen (caller should
+            process the message), ``False`` if it is a duplicate (caller skips).
+        """
+        if key in self._keys:
+            return False
+        self._keys[key] = None
+        while len(self._keys) > self._cap:
+            self._keys.popitem(last=False)
+        return True
+
+
+def slack_event_to_incoming(
+    event: dict,
+    *,
+    bot_user_id: str,
+    bot_id: str,
+    channel_ids: set[str],
+    respond_to_dms: bool = False,
+    resolve_display: Callable[[str], str] = lambda uid: uid,
+) -> Optional[IncomingMessage]:
+    """Normalize a Slack ``message`` event to an :class:`IncomingMessage`, or drop.
+
+    Pure and ``slack_bolt``-free so the tests can exercise it from fixture dicts
+    with no socket and no dependency. The live bot calls it synchronously on the
+    ack path with a no-op ``resolve_display`` (the display name is resolved in
+    the background turn, G-14); the tests pass a real lookup.
+
+    Drop rules, in order:
+
+    - ``subtype`` in the ignore set (``message_changed``/``message_deleted``/
+      ``bot_message``/``channel_*``/``me_message``/``thread_broadcast``):
+      edits/deletes and channel housekeeping are intentionally ignored. A
+      file-only upload has no such subtype and is NOT dropped (detected via
+      ``event.get("files")`` regardless of subtype, G-subtype).
+    - self/bot loop: ``bot_id`` matches, OR ``subtype == "bot_message"``, OR
+      ``user == bot_user_id`` (G-self).
+
+    Classify (G-im-mpim):
+
+    - ``channel_type`` in ``("im", "mpim")`` -> :attr:`Surface.DM`
+      (``dm:{channel}``), gated by ``respond_to_dms`` (``None`` if disabled).
+    - else (channel/group): ``thread_ts`` present and ``!= ts`` ->
+      :attr:`Surface.THREAD` (``th:{channel}-{thread_ts}``, ``thread_ts``
+      carried on the dest). A parent (``thread_ts == ts`` or absent) in a
+      watched channel -> :attr:`Surface.CHANNEL` with ``dest.thread_ts = ts`` so
+      :meth:`SlackTransport.open_thread` can thread off it. A CHANNEL-surface
+      post NOT in ``channel_ids`` (or with no ``ts`` to anchor on) -> ``None``.
+
+    Watched-channel gate scope (deliberate, security-relevant): ONLY the
+    top-level CHANNEL surface is gated by ``channel_ids``. A THREAD reply
+    (``thread_ts != ts``) is intentionally NOT re-gated — a follow-up in an
+    already-running thread is answered wherever it lives, even if its channel is
+    not (or no longer) in ``channel_ids``. DMs are likewise not gated by
+    ``channel_ids`` (only by ``respond_to_dms``). A future "tighten the gate"
+    refactor must keep this thread-bypass intact (pinned by a test).
+
+    Leading mention -> :class:`Addressee` (THREAD surface only):
+
+    - ``<@bot>`` leading -> :attr:`Addressee.SELF`, stripped from ``text``.
+    - ``<@other>`` / ``<!here|channel|everyone>`` / ``<!subteam^…>`` leading
+      -> :attr:`Addressee.OTHER` (text unstripped). CHANNEL/DM leave ``NONE``.
+
+    Args:
+        event: The raw Slack ``message`` event payload.
+        bot_user_id: This bot's user id (``U…``), from ``auth.test``.
+        bot_id: This bot's bot id (``B…``), from ``auth.test``.
+        channel_ids: Watched channel ids (Slack strings); gates channel surfaces.
+        respond_to_dms: Whether DMs (``im``/``mpim``) are answered.
+        resolve_display: ``user_id -> display name`` (defaults to the id).
+
+    Returns:
+        The normalized :class:`IncomingMessage`, or ``None`` to drop the event.
+    """
+    subtype = event.get("subtype")
+    if subtype in _IGNORE_SUBTYPES:
+        return None
+    if (
+        (bot_id and event.get("bot_id") == bot_id)
+        or subtype == "bot_message"
+        or (bot_user_id and event.get("user") == bot_user_id)
+    ):
+        return None
+
+    channel = event.get("channel", "")
+    channel_type = event.get("channel_type", "")
+    ts = event.get("ts", "")
+    thread_ts = event.get("thread_ts", "")
+    user = event.get("user", "")
+    text = (event.get("text") or "").strip()
+
+    addressee = Addressee.NONE
+    if channel_type in ("im", "mpim"):
+        if not respond_to_dms:
+            return None
+        surface = Surface.DM
+        thread_key = f"dm:{channel}"
+        dest_thread_ts = ""
+    else:
+        if thread_ts and thread_ts != ts:
+            surface = Surface.THREAD
+            thread_key = f"th:{channel}-{thread_ts}"
+            dest_thread_ts = thread_ts
+            # Leading-mention verdict only matters in a thread.
+            lead_self = re.compile(r"^\s*<@%s>\s*" % re.escape(bot_user_id))
+            if bot_user_id and lead_self.match(text):
+                addressee = Addressee.SELF
+                text = lead_self.sub("", text, count=1).strip()
+            elif (
+                _LEAD_OTHER_USER_RE.match(text)
+                or _LEAD_BROADCAST_RE.match(text)
+                or _LEAD_SUBTEAM_RE.match(text)
+            ):
+                addressee = Addressee.OTHER
+        else:
+            # A top-level post in a channel: gate on the watched-channel list and
+            # carry the triggering ts so open_thread can anchor a thread to it. A
+            # CHANNEL post with no ts cannot anchor a thread (the binding would
+            # key on `th:{channel}-` and a real reply could never match it), so
+            # drop it defensively — real Slack always sends ts.
+            if channel not in channel_ids or not ts:
+                return None
+            surface = Surface.CHANNEL
+            thread_key = ""
+            dest_thread_ts = ts
+
+    dest = ChatDest(
+        thread_key=thread_key,
+        surface=surface,
+        channel_id=channel,
+        thread_ts=dest_thread_ts,
+    )
+    attachments = tuple(
+        AttachmentRef(
+            filename=(f.get("name") or f"file-{f.get('id', 'x')}"),
+            size=int(f.get("size") or 0),
+            url=(
+                f.get("url_private_download")
+                or f.get("url_private")
+                or ""
+            ),
+            _native=f,
+        )
+        for f in (event.get("files") or [])
+    )
+    return IncomingMessage(
+        text=text,
+        dest=dest,
+        surface=surface,
+        author_id=user,
+        author_display=resolve_display(user),
+        addressee=addressee,
+        attachments=attachments,
+        channel_id=channel,
+        ts=ts,
+    )
+
+
+class SlackTransport(ChatTransport):
+    """``ChatTransport`` over the Slack Web API (Socket Mode bot).
+
+    Holds the ``slack_bolt`` async app (its ``client`` makes every Web API call),
+    the bot token (for authenticated file downloads), the config, a display-name
+    cache, and a lazily created ``aiohttp`` session. One instance per running bot
+    -- the core passes a :class:`ChatDest` to every send.
+    """
+
+    def __init__(self, app: Any, bot_token: str, cfg: TunnelConfig) -> None:
+        """Keep the app/token/config and prepare the lazy caches."""
+        self._app = app
+        self._bot_token = bot_token
+        self._cfg = cfg
+        self._display: dict[str, str] = {}
+        self._session: Any = None
+
+    @property
+    def limits(self) -> TransportLimits:
+        """Slack's caps.
+
+        ``chat.postMessage`` recommends 4000 chars (hard-truncates at 40000 --
+        do NOT raise toward it). Slack ignores thread titles, so
+        ``thread_title_max`` is effectively unbounded. ``list_truncate_len`` (the
+        ``!list`` cap) stays ``<= max_message_len`` so the core's no-re-chunk
+        ``send_text`` contract holds (G-08, G-19).
+        """
+        return TransportLimits(
+            max_message_len=4000,
+            max_attachments_per_msg=10,
+            thread_title_max=10**9,
+            max_error_len=3500,
+            list_truncate_len=3900,
+        )
+
+    async def open_thread(self, parent: ChatDest, title: str) -> ChatDest:
+        """Identify the Slack thread a conversation lives in (no API call).
+
+        Slack mints no thread object: the triggering message's ts (carried on the
+        channel-surface ``parent`` dest as ``thread_ts``) IS the parent. The
+        thread materializes on the first send that passes that ``thread_ts``
+        (G-18). ``title`` is ignored.
+
+        Args:
+            parent: The CHANNEL-surface dest whose ``thread_ts`` is the triggering
+                message ts and whose ``channel_id`` is the channel.
+            title: Ignored on Slack (threads are unnamed).
+
+        Returns:
+            The THREAD-surface dest carrying ``th:{channel}-{ts}`` + ``thread_ts``.
+        """
+        ts = parent.thread_ts
+        return ChatDest(
+            thread_key=f"th:{parent.channel_id}-{ts}",
+            surface=Surface.THREAD,
+            channel_id=parent.channel_id,
+            thread_ts=ts,
+        )
+
+    async def send_text(self, dest: ChatDest, text: str) -> None:
+        """Post one ``mrkdwn`` message to ``dest`` (no re-chunking).
+
+        The core has already chunked to ``limits.max_message_len``; this only
+        translates to ``mrkdwn`` and forwards the SAME ``thread_ts`` as every
+        other send in the conversation, so all replies land in one thread (G-25).
+
+        Args:
+            dest: Where to post (its ``channel_id`` + ``thread_ts``).
+            text: One core-emitted chunk.
+        """
+        await self._app.client.chat_postMessage(
+            channel=dest.channel_id,
+            thread_ts=dest.thread_ts or None,
+            text=discord_to_mrkdwn(text),
+        )
+
+    async def send_files(
+        self, dest: ChatDest, caption: str, files: Sequence[OutgoingFile]
+    ) -> None:
+        """Post one message carrying ``caption`` plus one or more files.
+
+        One ``files_upload_v2`` call (``channel`` is SINGULAR in v2) with the
+        batch in ``file_uploads`` and the translated ``caption`` as
+        ``initial_comment``. Each entry carries ``filename`` AND ``title`` (Slack
+        strips the extension from the filename alone, G-13). Same ``thread_ts`` as
+        every other send (G-25); the returned ts is not read back.
+
+        Args:
+            dest: Where to post.
+            caption: Message text accompanying the files (markdown-translated).
+            files: The batch (already size-filtered + count-capped by the core).
+        """
+        file_uploads = [
+            (
+                {
+                    "content": of.data,
+                    "filename": of.filename,
+                    "title": of.filename,
+                }
+                if of.data is not None
+                else {
+                    "file": str(of.path),
+                    "filename": of.filename,
+                    "title": of.filename,
+                }
+            )
+            for of in files
+        ]
+        await self._app.client.files_upload_v2(
+            channel=dest.channel_id,
+            thread_ts=dest.thread_ts or None,
+            initial_comment=discord_to_mrkdwn(caption),
+            file_uploads=file_uploads,
+        )
+
+    async def download_attachment(
+        self, attachment: AttachmentRef, target: Path
+    ) -> None:
+        """Download one inbound Slack attachment to local ``target``.
+
+        Authenticated GET of ``attachment.url`` (``url_private_download``) with a
+        bearer header that MUST survive the file-host redirect: Slack file URLs
+        redirect to a CDN host and a client that drops the auth header lands on a
+        ``200 text/html`` login page. We disable auto-redirect and re-issue the
+        request to each ``Location`` with the bearer header re-attached, then
+        :func:`validate_download` raises on an HTML/error response BEFORE bytes
+        are written (G-15). Raises on failure so the core marks the file skipped.
+
+        Args:
+            attachment: The inbound ref (its ``url`` is the authenticated URL).
+            target: Local path to write (its parent already exists).
+
+        Raises:
+            RuntimeError: The response is an HTML login page or an error status.
+        """
+        import aiohttp
+
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
+        headers = {"Authorization": f"Bearer {self._bot_token}"}
+        url = attachment.url
+        # Follow redirects MANUALLY, re-attaching the bearer header on each hop,
+        # so the cross-origin redirect to Slack's file CDN keeps the auth.
+        for _ in range(5):
+            async with self._session.get(
+                url, headers=headers, allow_redirects=False
+            ) as resp:
+                if resp.status in (301, 302, 303, 307, 308):
+                    location = resp.headers.get("Location")
+                    if not location:
+                        validate_download(
+                            resp.headers.get("Content-Type", ""), resp.status
+                        )
+                        return
+                    url = location
+                    continue
+                validate_download(
+                    resp.headers.get("Content-Type", ""), resp.status
+                )
+                data = await resp.read()
+                target.write_bytes(data)
+                return
+        raise RuntimeError("Slack file download failed (too many redirects)")
+
+    async def aclose(self) -> None:
+        """Close the lazily created download session (idempotent, G-shutdown).
+
+        ``download_attachment`` opens one ``aiohttp.ClientSession`` on first use;
+        ``run_slack_bot``'s shutdown ``finally`` awaits this so the session +
+        connector are released instead of leaking (the 'Unclosed client session'
+        warning). A no-op when no download ever ran.
+        """
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+
+    async def add_reaction(
+        self, message: IncomingMessage, emoji: str
+    ) -> None:
+        """React to ``message`` with the cooldown 'busy' signal (best-effort).
+
+        The core passes the neutral name ``"hourglass"``; Slack uses the
+        ``hourglass_flowing_sand`` shortcode (the ⏳ flowing-sand glyph, matching
+        Discord's U+23F3). Swallows the Slack API error so a reaction-scope or
+        already-reacted failure never breaks a turn (G-02).
+
+        Args:
+            message: The triggering message (its ``channel_id`` + ``ts``).
+            emoji: The neutral cooldown signal name (``"hourglass"``).
+        """
+        try:
+            # slack_sdk is the optional `slack` extra (not installed in the
+            # type-check env, so `# type: ignore`); guarded by the except below.
+            from slack_sdk.errors import SlackApiError  # type: ignore
+        except ImportError:  # pragma: no cover - dep present when bot runs
+            SlackApiError = Exception  # type: ignore[assignment,misc]
+        try:
+            await self._app.client.reactions_add(
+                channel=message.channel_id,
+                timestamp=message.ts,
+                name="hourglass_flowing_sand",
+            )
+        except SlackApiError:
+            logger.debug("reactions_add failed (best-effort)", exc_info=True)
+
+    def activity(self, dest: ChatDest) -> Any:
+        """A no-op 'working' indicator (Slack has no typing API over the socket)."""
+        return noop_activity()
+
+    async def resolve_display(self, user_id: str) -> str:
+        """Resolve a Slack user id to a display name (cached ``users_info``).
+
+        Returns the best available name: profile ``display_name`` ->
+        ``real_name`` -> user ``real_name`` -> ``name`` -> the raw id. Cached, and
+        called only from the background turn (never on the ack path, G-14/G-display).
+        Any API failure falls back to the raw id.
+
+        Args:
+            user_id: The Slack user id (``U…``).
+
+        Returns:
+            A human display name, or ``user_id`` if it can't be resolved.
+        """
+        if not user_id:
+            return user_id
+        if user_id in self._display:
+            return self._display[user_id]
+        name = user_id
+        try:
+            resp = await self._app.client.users_info(user=user_id)
+            user = resp.get("user", {}) or {}
+            profile = user.get("profile", {}) or {}
+            name = (
+                profile.get("display_name")
+                or profile.get("real_name")
+                or user.get("real_name")
+                or user.get("name")
+                or user_id
+            )
+        except Exception:  # network / scope / unknown user
+            logger.debug("users_info failed for %s", user_id, exc_info=True)
+        self._display[user_id] = name
+        return name
+
+
+async def _run_turn(
+    core: ChatCore,
+    transport: "SlackTransport",
+    msg: IncomingMessage,
+) -> None:
+    """Resolve the display name (background) then hand the turn to the core.
+
+    Kept off the ack path: the listener spawns this so the awaited
+    ``users_info`` lookup never delays the 3-second Socket-Mode ack (G-14). The
+    transport already closes over the ``slack_bolt`` app, so it is not passed in.
+
+    Args:
+        core: The shared routing/pipeline engine.
+        transport: The Slack transport (its cached display-name resolver).
+        msg: The pre-ack message (its ``author_display`` is the raw id so far).
+    """
+    name = await transport.resolve_display(msg.author_id)
+    msg = replace(msg, author_display=name)
+    await core.handle_message(msg)
+
+
+def run_slack_bot(
+    cfg: TunnelConfig,
+    store: TunnelStore,
+    registry: Registry,
+) -> None:
+    """Run the Slack bot until interrupted (blocking). Mirrors ``run_bot``.
+
+    Resolves both tokens, runs ``auth.test`` once (to cache the bot's ids BEFORE
+    the socket opens, so the self/bot drop is never bypassed on the first event,
+    G-20), builds one :class:`SlackTransport` + :class:`ChatCore`, schedules the
+    reaper on the running loop (G-28), and serves ``message`` events over Socket
+    Mode. A single ``@app.event("message")`` listener does ONLY synchronous
+    drop/classify/dedup then spawns the turn and returns within the 3s ack window
+    (G-14); there is deliberately NO ``app_mention`` listener (G-double-answer).
+
+    Args:
+        cfg: The tunnel config (its ``slack`` block + limits).
+        store: The thread/binding store.
+        registry: The published-handle registry.
+
+    Raises:
+        RuntimeError: A token is missing, no channels are watched and DMs are
+            disabled (the bot would never respond), or ``auth.test`` fails (an
+            invalid/expired bot token). ``auth.test`` runs in ``_main`` BEFORE
+            the socket opens and its ``SlackApiError`` is wrapped into a
+            ``RuntimeError`` so ``serve`` maps it to a clean ``ClickException``
+            instead of leaking a traceback.
+    """
+    import asyncio
+
+    # slack_bolt is the optional `slack` extra (not installed in the type-check
+    # env, so pyright can't resolve it -> `# type: ignore` on each import line);
+    # the ImportError is surfaced to the user at the `serve` call site.
+    from slack_bolt.adapter.socket_mode.async_handler import (  # type: ignore
+        AsyncSocketModeHandler,
+    )
+    from slack_bolt.app.async_app import AsyncApp  # type: ignore
+
+    bot_token = resolve_token(cfg.slack.bot_token_env, cfg.slack.bot_token_file)
+    app_token = resolve_token(cfg.slack.app_token_env, cfg.slack.app_token_file)
+    if not bot_token:
+        raise RuntimeError(
+            f"No Slack bot token (set {cfg.slack.bot_token_env} or "
+            "slack.bot_token_file)"
+        )
+    if not app_token:
+        raise RuntimeError(
+            f"No Slack app-level token (set {cfg.slack.app_token_env} or "
+            "slack.app_token_file)"
+        )
+    if not cfg.slack.channel_ids and not cfg.slack.respond_to_dms:
+        raise RuntimeError(
+            "No slack.channel_ids configured and DMs are disabled — "
+            "the bot would never respond."
+        )
+
+    app = AsyncApp(token=bot_token)
+    transport = SlackTransport(app, bot_token, cfg)
+    core = ChatCore(cfg, store, registry, transport)
+    channel_ids = {str(c) for c in cfg.slack.channel_ids}
+    seen = _SeenCache(cap=4096)
+    state = {"bot_user_id": "", "bot_id": ""}
+    inflight: "set[asyncio.Task]" = set()
+
+    @app.event("message")
+    async def _on_message(event: dict, body: dict) -> None:
+        # SYNCHRONOUS pre-ack work only: drop, classify, dedup, build a
+        # lightweight IncomingMessage (author_display = raw id), then spawn the
+        # turn and return well inside the 3s ack window (G-14).
+        msg = slack_event_to_incoming(
+            event,
+            bot_user_id=state["bot_user_id"],
+            bot_id=state["bot_id"],
+            channel_ids=channel_ids,
+            respond_to_dms=cfg.slack.respond_to_dms,
+        )
+        if msg is None:
+            return
+        key = event.get("client_msg_id") or (
+            f'{event.get("channel")}-{event.get("ts")}'
+        )
+        if not seen.add(key):
+            return
+        # Bound the fan-out: per-conversation order is the core's per-thread_key
+        # lock and the global semaphore caps backend asks, but the spawned-task
+        # set itself must not grow without limit (G-27). The busy notice is a
+        # chat_postMessage round-trip, so it must NOT be awaited on the pre-ack
+        # path (G-14) — spawn it fire-and-forget (tracked so it isn't GC'd) and
+        # return immediately, keeping the listener body free of awaited Web API
+        # calls even under overload.
+        if len(inflight) >= _MAX_INFLIGHT:
+            notice = asyncio.create_task(
+                transport.send_text(
+                    msg.dest,
+                    "⏳ Busy right now — please try again shortly.",
+                )
+            )
+            inflight.add(notice)
+            notice.add_done_callback(inflight.discard)
+            return
+        task = asyncio.create_task(_run_turn(core, transport, msg))
+        inflight.add(task)
+        task.add_done_callback(inflight.discard)
+
+    async def _main() -> None:
+        # Cache the bot's ids BEFORE opening the socket so the self/bot drop is
+        # never bypassed on the first event (G-20). auth.test runs here, before
+        # start_async; a bad/expired token raises SlackApiError (an Exception,
+        # NOT a RuntimeError), so wrap it into RuntimeError to surface as serve's
+        # clean ClickException rather than a raw traceback.
+        try:
+            auth = await app.client.auth_test()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Slack auth.test failed (check the bot token): {exc}"
+            ) from exc
+        state["bot_user_id"] = auth["user_id"]
+        state["bot_id"] = auth["bot_id"]
+        handler = AsyncSocketModeHandler(app, app_token)
+        reaper = asyncio.create_task(core.run_reaper())  # same loop (G-28)
+        try:
+            await handler.start_async()
+        finally:
+            reaper.cancel()
+            await handler.close_async()
+            await transport.aclose()  # release the download session (G-shutdown)
+
+    # asyncio.run raises KeyboardInterrupt on Ctrl-C; cli.main() maps it to
+    # exit(130). In-flight turns finish on their own per-thread locks (G-shutdown).
+    asyncio.run(_main())

--- a/docs/agent-tunnel-slack-spec.md
+++ b/docs/agent-tunnel-slack-spec.md
@@ -1,0 +1,1600 @@
+# agent-tunnel Slack bot — Implementation-Ready Specification
+
+HYBRID shared-core refactor with FULL Discord parity. An engineer implements
+directly from this. Every line reference is `claude_code_tools/agent_tunnel/<file>:<n>`,
+verified against the live source. Every gap in the gap list is resolved inline and
+collected in Section 11.
+
+---
+
+## 1. Goal and locked decisions
+
+Add a Slack front-end to agent-tunnel with **full Discord parity**, by extracting a
+platform-neutral **shared core** that both front-ends drive. No behavior change to
+Discord.
+
+**Locked decisions:**
+
+- **Hybrid shared core.** Extract `chat_core.py` (routing + policy + the
+  answer/ingest/deliver pipeline + the reaper) behind a `ChatTransport` Protocol.
+  `discord_bot.py` and the new `slack_bot.py` become thin adapters: each normalizes
+  its platform events into a neutral `IncomingMessage`, implements `ChatTransport`,
+  constructs ONE `ChatCore`, and forwards messages. All policy lives in `chat_core`,
+  so the two front-ends are behavior-identical by construction.
+- **Full parity.** Every Discord behavior (allowlist ordering, cooldown-on-follow-ups,
+  per-thread lock + global semaphore, stale-binding guard, mention-only-in-thread,
+  DM rebind, attachment round-trip, deliverables, reaper) is reproduced for Slack via
+  the shared core. The two cosmetic differences (reply-quote on the unknown-handle
+  complaint; Discord-markdown vs Slack mrkdwn) are handled in the adapters and called
+  out explicitly (Section 11, G-04 / G-03).
+- **Slack Socket Mode, two tokens, no public endpoint.** Slack runs over Socket Mode
+  (an outbound WebSocket — like Discord's Gateway). No Request URL, no open port, no
+  cloud. Two tokens: a **bot token** (`xoxb-…`, all Web API calls) and an
+  **app-level token** (`xapp-…`, scope `connections:write`, opens the socket). Each
+  resolves from its own env var or file.
+- **Phasing.** PR1 extracts `chat_core` and refactors Discord onto it (Discord stays
+  green, zero behavior change). PR2 adds `slack_bot` + `SlackConfig` + `serve --chat`
+  + tests. PR3 is docs.
+
+---
+
+## 2. Architecture: the `chat_core` seam
+
+New file `claude_code_tools/agent_tunnel/chat_core.py`. Because the full module with
+google-style docstrings + verbatim pipeline bodies would approach the 1000-line limit
+(G-22), it is **split into two files**:
+
+- `claude_code_tools/agent_tunnel/chat_types.py` — the Protocol + all value objects +
+  `TransportLimits` + `OutgoingFile` + `noop_activity` + the neutral module helpers
+  (`format_relayed_message`, `is_close_command`, `is_list_command`, `CLOSE_COMMANDS`,
+  `LIST_COMMANDS`, `_safe_filename`, `_unique_name`, `split_chunks`, `resolve_token`).
+  Estimate ~430 lines.
+- `claude_code_tools/agent_tunnel/chat_core.py` — `ChatCore` (routing + pipeline +
+  reaper), importing from `chat_types`. Estimate ~560 lines (moved bodies ~330 +
+  docstrings/wiring ~230).
+
+`chat_core.py` re-exports the `chat_types` names so callers can `from .chat_core
+import IncomingMessage, ChatCore, split_chunks, …` uniformly.
+
+### 2a. `ChatTransport` Protocol + value objects (`chat_types.py`)
+
+```python
+"""Platform-neutral seam between a chat front-end and the answer pipeline.
+
+``ChatCore`` (in chat_core.py) owns ALL routing and policy and reaches the
+outside world only through :class:`ChatTransport` plus the normalized
+dataclasses defined here. A front-end supplies an adapter that drops bot/self
+events, normalizes each surviving event into an :class:`IncomingMessage`,
+implements :class:`ChatTransport`, builds one ``ChatCore``, schedules the
+reaper, and forwards each message via ``await core.handle_message(msg)``. No
+platform identifier ever appears in this module.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, AsyncIterator, Optional, Protocol, Sequence, runtime_checkable
+
+DISCORD_MSG_LIMIT = 2000        # kept for the discord_bot re-export
+THREAD_NAME_MAX = 90            # kept for the discord_bot re-export
+
+
+@dataclass(frozen=True)
+class TransportLimits:
+    """Per-platform numeric caps the core honors when chunking/batching/truncating.
+
+    Declared once per adapter instance (read via ``ChatTransport.limits``).
+    Replaces the hard-coded Discord constants (``DISCORD_MSG_LIMIT``, the literal
+    10 attachments/msg, ``THREAD_NAME_MAX``, the ``[:1500]`` error truncation, the
+    ``[:1900]`` list truncation). Defaults are Discord's, so a Discord adapter that
+    omits them reproduces the shipped bot byte-for-byte.
+
+    INVARIANT (enforced by the core, G-08): ``list_truncate_len <= max_message_len``.
+    ``_list_handles`` truncates to ``min(list_truncate_len, max_message_len)`` so the
+    'transport must not re-chunk send_text' contract can never be violated.
+
+    NOTE on Slack max_message_len (G-19): Slack's chat.postMessage recommends 4000
+    and HARD-truncates at 40000. Use 4000; do NOT raise toward 40000 (silent
+    truncation). The answer.md preview is ``split_chunks(text, limit)[0]`` so it is
+    also <= max_message_len.
+    """
+
+    max_message_len: int = 2000
+    max_attachments_per_msg: int = 10
+    thread_title_max: int = 90
+    max_error_len: int = 1500
+    list_truncate_len: int = 1900
+
+
+@dataclass(frozen=True)
+class OutgoingFile:
+    """A file the core asks the transport to post, by path OR by bytes.
+
+    Exactly one of ``data`` / ``path`` is set. Unifies the two Discord upload cases:
+    ``discord.File(BytesIO(bytes), filename=...)`` (the long-answer ``answer.md``)
+    and ``discord.File(path, filename=...)`` (a deliverable).
+
+    ``filename`` MUST carry the extension; on Slack the adapter also passes it as
+    ``title`` because Slack strips the extension from the filename alone (G-13).
+    """
+
+    filename: str
+    data: Optional[bytes] = None
+    path: Optional[Path] = None
+
+    @classmethod
+    def from_bytes(cls, data: bytes, filename: str) -> "OutgoingFile":
+        return cls(filename=filename, data=data)
+
+    @classmethod
+    def from_path(cls, path: Path) -> "OutgoingFile":
+        return cls(filename=path.name, path=path)
+
+
+@asynccontextmanager
+async def noop_activity() -> AsyncIterator[None]:
+    """A do-nothing ``activity()`` for transports with no typing API (Slack)."""
+    yield
+
+
+@runtime_checkable
+class ChatTransport(Protocol):
+    """Every chat I/O the answer pipeline needs, abstracted per platform.
+
+    ONE instance per running bot (NOT per turn): the core passes a
+    :class:`ChatDest` to every send, so one instance serves all destinations and
+    the reaper needs none. All methods are async except :meth:`activity` (returns
+    an async context manager). Implementations must be safe to call concurrently for
+    distinct ``dest`` values; the core serializes per conversation, never globally.
+    """
+
+    @property
+    def limits(self) -> TransportLimits: ...
+
+    async def open_thread(self, parent: "ChatDest", title: str) -> "ChatDest":
+        """Open (or identify) the thread a conversation lives in.
+
+        Discord: ``await parent._native.create_thread(name=title)`` -> a real
+        sub-thread; returned dest carries ``thread_key=f"th:{thread.id}"`` and
+        ``_native=thread``.
+
+        Slack (G-18): no object is created. The triggering message's ts is the
+        parent. Returned dest carries ``thread_key=f"th:{parent.channel_id}-{ts}"``,
+        ``thread_ts=ts``, ``channel_id=parent.channel_id``; the thread materializes
+        on the first send that passes ``thread_ts``. The transport reads ``ts`` from
+        ``parent.thread_ts`` (the channel-surface parent dest carries the triggering
+        message ts there — see ChatDest). ``title`` is ignored.
+
+        ``title`` is already truncated by the core to ``limits.thread_title_max``.
+        """
+        ...
+
+    async def send_text(self, dest: "ChatDest", text: str) -> None:
+        """Post one plain-text message to ``dest``.
+
+        The core has already chunked to ``limits.max_message_len`` (one call per
+        chunk); the adapter MUST NOT re-chunk. The adapter applies platform
+        formatting fixups (G-03): Discord passes through; Slack escapes ``& < >``
+        FIRST, then translates ``**bold**``->``*bold*``, ``[t](u)``->``<u|t>``, all
+        BEFORE any platform send. Discord: ``dest._native.send(text)``. Slack:
+        ``chat_postMessage(channel=dest.channel_id, thread_ts=dest.thread_ts or
+        None, text=<translated>)`` — the SAME thread_ts on every send (G-25).
+        """
+        ...
+
+    async def send_files(
+        self, dest: "ChatDest", caption: str, files: "Sequence[OutgoingFile]"
+    ) -> None:
+        """Post one message carrying ``caption`` plus one or more files.
+
+        The core has already filtered by the size cap and split into batches of at
+        most ``limits.max_attachments_per_msg``. ``caption`` is markdown-translated
+        by the adapter exactly like ``send_text`` (G-03).
+
+        Discord: a ``discord.File`` per entry (``BytesIO(data)`` or ``str(path)``),
+        ``dest._native.send(caption, files=[...])``.
+
+        Slack (G-13): one ``files_upload_v2(channel=dest.channel_id,
+        thread_ts=dest.thread_ts or None, initial_comment=<translated caption>,
+        file_uploads=[...])`` where each entry is
+        ``{"content": of.data, "filename": of.filename, "title": of.filename}`` when
+        ``of.data is not None`` else
+        ``{"file": str(of.path), "filename": of.filename, "title": of.filename}``.
+        ``channel`` is SINGULAR in v2. ``title`` carries the extension. Same
+        thread_ts as every other send in the conversation (G-25).
+        """
+        ...
+
+    async def download_attachment(
+        self, attachment: "AttachmentRef", target: Path
+    ) -> None:
+        """Download one inbound attachment to local ``target`` (parent exists).
+
+        MUST raise on failure (the core catches it and marks the file skipped).
+
+        Discord: ``await attachment._native.save(str(target))``.
+
+        Slack (G-15): GET ``attachment.url`` (which is ``url_private_download``)
+        with ``Authorization: Bearer <bot_token>``. Slack file URLs REDIRECT to a
+        CDN host and naive clients STRIP the auth header on the cross-origin hop,
+        landing on a 200 + text/html LOGIN PAGE. The transport MUST (a) keep the
+        bearer header across the file-host redirect (disable auto-redirect and
+        re-attach, or verify the client forwards it), and (b) raise if the response
+        Content-Type is ``text/html`` (auth/scope failure), BEFORE writing bytes.
+        """
+        ...
+
+    async def add_reaction(self, message: "IncomingMessage", emoji: str) -> None:
+        """React to ``message`` with the cooldown 'busy' signal. Best-effort.
+
+        The core passes the NEUTRAL name ``"hourglass"``; each adapter maps it to a
+        platform glyph/shortcode (G-02). Discord: ``{"hourglass": "⏳"}`` then
+        ``message._native.add_reaction("⏳")``. Slack:
+        ``reactions_add(channel=message.channel_id, timestamp=message.ts,
+        name="hourglass_flowing_sand")`` (the ⏳ flowing-sand glyph, matching
+        Discord's U+23F3 — verified, not ⌛).
+        """
+        ...
+
+    def activity(self, dest: "ChatDest") -> AbstractAsyncContextManager[None]:
+        """An async context manager showing 'working' for its duration.
+
+        Discord: ``dest._native.typing()``. Slack: :func:`noop_activity` (Slack has
+        no generic typing API over Socket Mode). Non-async (returns a CM) so the core
+        writes ``async with transport.activity(dest):``.
+        """
+        ...
+```
+
+### 2b. Normalized dataclasses (`chat_types.py`)
+
+```python
+class Surface(Enum):
+    """Which routing branch an inbound message belongs to.
+
+    The adapter classifies; the core routes on this. Replaces Discord's
+    ``isinstance(channel, Thread/DMChannel)`` and Slack's ``channel_type`` switch.
+    """
+
+    CHANNEL = "channel"  # watched channel, not in a thread (handle-opens-thread)
+    THREAD = "thread"    # follow-up inside an already-bound thread
+    DM = "dm"            # a 1:1 direct message (Slack ``im`` AND ``mpim``)
+
+
+class Addressee(Enum):
+    """Who a message's *leading* mention addresses, if anyone.
+
+    The adapter computes the FINAL verdict from its own mention wire-format AND
+    pre-strips a SELF mention from ``IncomingMessage.text``. The core never parses
+    mentions or compares ids — it branches on this enum, and ONLY on the THREAD
+    surface (CHANNEL uses the handle-token parse; DM is 1:1).
+    """
+
+    NONE = "none"    # no leading mention -> answer (in a thread)
+    SELF = "self"    # leading mention IS this bot -> (already stripped) answer
+    OTHER = "other"  # someone else / broadcast / role/usergroup -> stay out silent
+
+
+@dataclass(frozen=True)
+class AttachmentRef:
+    """One inbound file, normalized across platforms.
+
+    The core uses only ``filename`` / ``size`` (caps + safe naming) and hands the
+    whole ref back to :meth:`ChatTransport.download_attachment`. ``url`` / ``_native``
+    are opaque to the core.
+
+    Discord adapter builds: ``AttachmentRef(a.filename, getattr(a,"size",0) or 0,
+    _native=a)``.
+
+    Slack adapter builds (G-16): ``filename = f.get("name") or f"file-{f.get('id','x')}"``;
+    ``size = int(f.get("size") or 0)``; ``url = f.get("url_private_download") or
+    f.get("url_private") or ""``; ``_native = f`` (the raw file dict).
+    """
+
+    filename: str
+    size: int            # bytes; 0 if the platform did not report a size
+    url: str = ""        # authenticated download URL (Slack); "" on Discord
+    _native: Any = None  # platform file object, for the adapter's downloader
+
+
+@dataclass(frozen=True)
+class ChatDest:
+    """A place the core sends replies to, with a stable conversation key.
+
+    Neutral replacement for the Discord ``dest`` threaded through
+    ``_answer``/``_list_handles``/``_close``. The ``thread_key`` is THE universal
+    store/backend/uploads/locks key (the ``th:``/``dm:`` scheme), minted by the
+    adapter. ``paths.safe_key``/``backends._window_name`` already sanitize arbitrary
+    key text, so the Slack key form needs no downstream change (G-05).
+
+    Attributes:
+        thread_key: Universal conversation key. Discord ``th:{thread.id}`` /
+            ``dm:{channel.id}``; Slack ``th:{channel}-{thread_ts}`` / ``dm:{channel}``.
+            For a CHANNEL dest (used by ``!list`` and as ``open_thread``'s parent
+            before a thread exists) this is "" and is never used as a key.
+        surface: Which branch this dest serves.
+        channel_id: Normalized channel/conversation id (``str``); addresses Slack
+            sends. "" where unused on Discord.
+        thread_ts: Slack thread anchor. For a THREAD dest it is the parent ts. For a
+            CHANNEL parent dest passed to ``open_thread`` it carries the TRIGGERING
+            message's ts so the Slack transport can build ``th:{channel}-{ts}`` and
+            thread off it (G-18). "" on Discord.
+        _native: Platform send-target (Discord channel/thread/DMChannel); unused on
+            Slack.
+    """
+
+    thread_key: str
+    surface: Surface
+    channel_id: str = ""
+    thread_ts: str = ""
+    _native: Any = None
+
+
+@dataclass(frozen=True)
+class IncomingMessage:
+    """One inbound chat message, normalized to be wire-format-free.
+
+    Built by the adapter AFTER dropping bot/self events and AFTER resolving the
+    leading mention. Discord ids (``int``) and Slack ids (``str``) are both
+    normalized to ``str`` so allowlist/cooldown/principal logic is uniform.
+
+    Attributes:
+        text: Body, ``.strip()``-ed. For a THREAD message whose leading mention was
+            this bot, the adapter has ALSO stripped that mention. May be "" when
+            ``attachments`` is non-empty (attachment-only message — NOT dropped).
+        dest: Where replies go (+ the conversation ``thread_key`` + ``surface``).
+            For a CHANNEL message this is the parent dest passed to ``open_thread``;
+            on Slack it carries ``thread_ts = ts`` (the triggering ts).
+        surface: CHANNEL / THREAD / DM.
+        author_id: Stable per-user principal id (``str``); keys cooldown + allowlist.
+        author_display: Display name for logs and the ``<name> (via X) says:`` prefix.
+            Discord ``display_name``; Slack defaults to the raw user id on the pre-ack
+            path and is resolved via cached ``users_info`` INSIDE the background task
+            (G-14). Falls back to ``author_id``.
+        author_role_ids: Principal's role/usergroup ids (``str``) for the allowlist
+            role check. Discord role ids; Slack usergroup (subteam ``S…``) ids, or
+            empty when ``usergroups:read`` is absent/usergroups unavailable (G-12).
+        addressee: Leading-mention verdict. Meaningful only on THREAD; CHANNEL and DM
+            leave it NONE.
+        attachments: Normalized inbound files (possibly empty).
+        channel_id: Normalized channel/conversation id.
+        ts: Platform message id/timestamp — Slack ``ts`` (needed for reactions +
+            threading). Discord leaves "" (it reacts/threads via ``_native``).
+        _native: Raw platform message, used only by transport I/O targeting THIS
+            message (Discord ``add_reaction``).
+    """
+
+    text: str
+    dest: ChatDest
+    surface: Surface
+    author_id: str
+    author_display: str = ""
+    author_role_ids: "frozenset[str]" = frozenset()
+    addressee: Addressee = Addressee.NONE
+    attachments: "tuple[AttachmentRef, ...]" = ()
+    channel_id: str = ""
+    ts: str = ""
+    _native: Any = None
+
+    @property
+    def has_content(self) -> bool:
+        """True if there is text or at least one attachment (the empty-drop rule)."""
+        return bool(self.text) or bool(self.attachments)
+```
+
+### 2c. The pipeline API (`chat_types.py` helpers + `chat_core.ChatCore`)
+
+Module-level neutral helpers move verbatim from `discord_bot.py` into `chat_types.py`:
+`format_relayed_message` (`:52-64`), `is_close_command`/`is_list_command` + their sets
+(`:77-88`), `_safe_filename` (`:91-105`), `_unique_name` (`:108-120`). Two are
+generalized:
+
+```python
+def split_chunks(text: str, limit: int = 2000) -> list[str]:
+    """Split ``text`` into <=``limit`` chunks, preferring newline boundaries.
+
+    Behavior-IDENTICAL to the shipped ``discord_bot.split_chunks`` — ``limit`` stays
+    a DEFAULTED keyword (G-21). The shipped default was ``DISCORD_MSG_LIMIT`` (2000)
+    and 2000 is correct; the existing test ``split_chunks("")`` and the
+    ``discord_bot`` re-export both keep working. Core callers always pass
+    ``limit=self.tx.limits.max_message_len`` so Slack chunks to 4000.
+    """
+    # ... body verbatim from discord_bot.py:140-159 ...
+
+
+def resolve_token(env_name: str, file_path: str = "") -> str:
+    """Resolve a token: env var first, then an optional file (env wins).
+
+    Generalized from ``discord_bot.resolve_token(cfg)`` (``:67-74``). The
+    short-circuit is preserved EXACTLY (G-06): an empty ``file_path`` skips the file
+    read; the path is ``expanduser()``-ed and read only ``if it exists``.
+    """
+    token = os.environ.get(env_name, "").strip()
+    if not token and file_path:
+        p = Path(file_path).expanduser()
+        if p.exists():
+            token = p.read_text(encoding="utf-8").strip()
+    return token
+```
+
+The `ChatCore` engine (`chat_core.py`) holds the per-run concurrency primitives and
+the cooldown map (formerly the `run_bot` closure), runs every policy decision against
+the `ChatTransport` + neutral `store`/`registry`/backends, and owns the reaper loop.
+
+```python
+class ChatCore:
+    """Platform-neutral routing + answer/ingest/deliver pipeline + reaper.
+
+    ONE instance per running bot. The adapter builds
+    ``core = ChatCore(cfg, store, registry, transport)``, schedules
+    ``core.run_reaper()`` on its loop, and for each accepted, normalized event awaits
+    ``core.handle_message(msg)``.
+    """
+
+    def __init__(self, cfg, store, registry, transport: ChatTransport) -> None:
+        self.cfg = cfg
+        self.store = store
+        self.registry = registry
+        self.tx = transport
+        self._sem = asyncio.Semaphore(cfg.limits.max_concurrent)
+        self._locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+        self._last_ask: dict[str, float] = {}
+
+    async def handle_message(self, msg: IncomingMessage) -> None: ...
+    def _allowed(self, msg: IncomingMessage) -> bool: ...
+    def _cooldown_ok(self, author_id: str) -> bool: ...
+    async def _on_channel(self, msg: IncomingMessage) -> None: ...
+    async def _on_thread(self, msg: IncomingMessage) -> None: ...
+    async def _on_direct(self, msg: IncomingMessage) -> None: ...
+    async def _list_handles(self, dest: ChatDest) -> None: ...
+    async def _close(self, dest: ChatDest) -> None: ...
+    async def _answer(self, dest, question, msg) -> None: ...
+    async def _deliver_answer(self, dest, text) -> None: ...
+    async def _ingest_attachments(self, dest, thread_key, question, attachments) -> str: ...
+    async def _post_deliverables(self, dest, answer) -> None: ...
+    async def run_reaper(self) -> None: ...
+    def _reap_all(self) -> int: ...
+```
+
+Method bodies are specified below (Section 3 maps source → core; the behaviors that
+matter for correctness are quoted in Sections 3–4 and 11). Two policy points the core
+must implement, made explicit:
+
+- `_allowed` reads `cfg.principal_allowlists()` (NOT `cfg.discord.*` directly), so
+  Slack usergroups are honored (G-02-allowlist / Section 6):
+  ```python
+  def _allowed(self, msg: IncomingMessage) -> bool:
+      uids, rids = self.cfg.principal_allowlists()   # both set[str]
+      if not uids and not rids:
+          return True
+      if msg.author_id in uids:
+          return True
+      return bool(msg.author_role_ids & rids)
+  ```
+- `_list_handles` truncates to `min(list_truncate_len, max_message_len)` and sends ONE
+  message (preserves the shipped `[:1900]` single-message semantics — NOT paginated,
+  G-08):
+  ```python
+  limit = min(self.tx.limits.list_truncate_len, self.tx.limits.max_message_len)
+  await self.tx.send_text(dest, "\n".join(lines)[:limit])
+  ```
+
+The `_answer` body is the verbatim port of `discord_bot.py:470-595` with these exact
+substitutions, preserving every watch-list invariant (Section 11):
+
+1. audit log (per-message `msg.author_display` preferred over bind-time `rec.asker`);
+2. `lock.locked()` -> "still working" `send_text` notice, THEN `async with lock, sem`;
+3. stale-binding guard (`store.get` re-read; compare `expert_session_id` +
+   `created_at`; mismatch -> "restarted" notice + return) — inside the lock;
+4. `async with self.tx.activity(dest):` wraps `_ingest_attachments` + the empty-after-
+   ingest guard + `format_relayed_message(msg.author_display, question, cfg.platform)`
+   + `to_thread(backend_for_record(...).ask, key, question)` — ingest-time skipped/
+   unreadable notices fire INSIDE this block, under the lock/sem (G-09);
+5. `BackendError` -> `send_text(dest, f"⚠️ {str(exc)[:limits.max_error_len]}")`; other
+   `Exception` -> generic "Unexpected error" `send_text`; both return inside lock/sem;
+6. lock+sem RELEASED before delivery;
+7. `_deliver_answer` (long -> `OutgoingFile.from_bytes(text.encode(), "answer.md")` +
+   preview; else `send_text` per `split_chunks(text, limits.max_message_len)`), then
+   `_post_deliverables`.
+
+`_ingest_attachments` is the verbatim port of `:597-677` with: `attlist =
+list(attachments)` materialized ONCE (G-05); `att.size or 0`; the single download call
+routed through `await self.tx.download_attachment(att, target)` (raises -> skipped);
+`uploads_dir_for(self.cfg.state_path.parent, thread_key) / uuid.uuid4().hex[:8]`.
+
+`_post_deliverables` is the verbatim port of `:679-715` with batching by
+`self.tx.limits.max_attachments_per_msg` (was the literal 10) and each batch via
+`send_files` with `OutgoingFile.from_path`.
+
+`run_reaper` / `_reap_all` are the verbatim ports of `:199-225`; only the SCHEDULING
+moves to the adapter.
+
+---
+
+## 3. `chat_core` extraction map (function by function)
+
+### MOVES out of `discord_bot.py`
+
+| From `discord_bot.py` | To | Form |
+|---|---|---|
+| `format_relayed_message` `:52-64` | `chat_types.py` | verbatim |
+| `CLOSE_COMMANDS`/`LIST_COMMANDS` `:77-78`, `is_close_command`/`is_list_command` `:81-88` | `chat_types.py` | verbatim |
+| `_safe_filename` `:91-105`, `_unique_name` `:108-120` | `chat_types.py` | verbatim |
+| `split_chunks` `:138-159` | `chat_types.py` | verbatim (`limit` stays defaulted, G-21) |
+| `resolve_token(cfg)` `:67-74` | `chat_types.py` as `resolve_token(env_name, file_path)` | generalized (G-06); Discord wrapper STAYS in `discord_bot.py`, G-23 |
+| `DISCORD_MSG_LIMIT` `:47`, `THREAD_NAME_MAX` `:49` | `chat_types.TransportLimits` defaults (+ kept as module consts for the Discord re-export) | constants |
+| `sem`/`locks`/`last_ask` closure `:189-191` | `ChatCore._sem`/`_locks`/`_last_ask` | `last_ask` keyed on `str` |
+| `on_message` body `:251-267` | `ChatCore.handle_message` | the empty-drop + surface dispatch; the bot-drop and channel-type classification STAY in the adapter |
+| `_on_channel_message` `:269-327` | `ChatCore._on_channel` | verbatim logic; `create_thread`/`reply`/`send`/`attachments` -> transport |
+| `_on_thread_message` `:329-362` | `ChatCore._on_thread` | verbatim; mention now `msg.addressee`; `add_reaction` -> transport |
+| `_on_direct` `:364-433` | `ChatCore._on_direct` | verbatim incl. the forget+bind-under-lock rebind dance |
+| `_list_handles` `:435-450` | `ChatCore._list_handles` | verbatim; `min(...)` truncation (G-08) |
+| `_close` `:452-468` | `ChatCore._close` | verbatim |
+| `_answer` `:470-595` | `ChatCore._answer` + `_deliver_answer` | verbatim (Section 2c substitutions) |
+| `_ingest_attachments` `:597-677` | `ChatCore._ingest_attachments` | verbatim; download via transport |
+| `_post_deliverables` `:679-715` | `ChatCore._post_deliverables` | verbatim; batch by `limits` |
+| `_allowed` `:234-242`, `_cooldown_ok` `:244-249` | `ChatCore._allowed` (via `principal_allowlists`), `_cooldown_ok` (str key) | adapted |
+| `_reaper` `:199-207`, `_reap_all` `:209-225` | `ChatCore.run_reaper`, `_reap_all` | verbatim |
+
+### STAYS in `discord_bot.py` (the Discord adapter)
+
+- `import discord` (lazy), `intents.message_content = True`, `class TunnelClient(
+  discord.Client)`, `on_ready`, `TunnelClient(...).run(token, log_handler=None)`, and
+  `run_bot(cfg, store, registry)` (same signature — the reusable seam).
+- `_leading_mention_id` `:123-135` + the SELF-strip regex `:346` — Discord mention
+  wire-format, now adapter-private, folded into computing the 3-valued `Addressee`.
+- A thin `resolve_token(cfg)` wrapper (G-23) delegating to
+  `chat_types.resolve_token(cfg.discord.token_env, cfg.discord.token_file)` so
+  `test_resolve_token` and `doctor` keep their 1-arg call.
+- `on_message` reduced to a normalizer + dispatcher (Section 4).
+- `DiscordTransport(ChatTransport)` (Section 4).
+
+**`cli.ask` is unaffected** — it binds `cli:{thread}` keys and calls `backend.ask`
+directly, NOT through `ChatCore` (it never went through `_answer`). The moved
+ingest/deliver code is therefore covered SOLELY by `test_chat_core` (G-26); note this
+in the spec/tests.
+
+---
+
+## 4. `discord_bot.py` refactor (behavior-preserving)
+
+Steps to delegate to the core so Discord stays green:
+
+1. Add `from .chat_types import (...)` and `from .chat_core import ChatCore`. Keep
+   `import discord` lazy inside `run_bot`. Keep the `resolve_token(cfg)` wrapper.
+2. In `run_bot`, keep the two startup gates verbatim (`:174-184`): token-missing
+   `RuntimeError` (message still names `cfg.discord.token_env`/`discord.token_file`)
+   and the channels-or-DMs gate.
+3. In `setup_hook`: build `self.tx = DiscordTransport(self)`, `self.core =
+   ChatCore(cfg, store, registry, self.tx)`, `self.loop.create_task(
+   self.core.run_reaper())`.
+4. In `on_ready`: set `self.tx.bot_user_id = self.user.id` (used by the Addressee
+   SELF/OTHER comparison), keep the existing log.
+5. Replace `on_message` with a drop + classify + normalize + forward:
+
+```python
+async def on_message(self, m: discord.Message) -> None:
+    if m.author.bot:                       # self-drop relies on author.bot (G-10)
+        return
+    ch = m.channel
+    if isinstance(ch, discord.Thread):
+        surface, key = Surface.THREAD, f"th:{ch.id}"
+    elif isinstance(ch, discord.DMChannel):
+        if not cfg.discord.respond_to_dms:
+            return
+        surface, key = Surface.DM, f"dm:{ch.id}"
+    elif ch.id in cfg.discord.channel_ids:
+        surface, key = Surface.CHANNEL, ""    # thread minted on open
+    else:
+        return
+    await self.core.handle_message(self._to_incoming(m, surface, key))
+
+def _to_incoming(self, m, surface, key) -> IncomingMessage:
+    content = (m.content or "").strip()
+    addressee, text = Addressee.NONE, content
+    if surface is Surface.THREAD:
+        mid = _leading_mention_id(content)
+        if mid is not None:
+            if mid != getattr(self.user, "id", None):
+                addressee = Addressee.OTHER
+            else:
+                addressee = Addressee.SELF
+                text = re.sub(r"^\s*<@[!&]?\d+>\s*", "", content)
+    ch = m.channel
+    dest = ChatDest(thread_key=key, surface=surface,
+                    channel_id=str(ch.id), _native=ch)
+    return IncomingMessage(
+        text=text, dest=dest, surface=surface,
+        author_id=str(m.author.id),
+        author_display=m.author.display_name,
+        author_role_ids=frozenset(
+            str(r.id) for r in getattr(m.author, "roles", []) or []),
+        addressee=addressee,
+        attachments=tuple(
+            AttachmentRef(a.filename, getattr(a, "size", 0) or 0, _native=a)
+            for a in m.attachments),
+        channel_id=str(ch.id), _native=m,
+    )
+```
+
+6. `DiscordTransport(ChatTransport)` holding the client:
+
+- `limits` -> `TransportLimits()` (Discord defaults; reproduces the shipped numbers).
+- `open_thread(parent, title)` -> `t = await parent._native.create_thread(name=title)`;
+  return `ChatDest(thread_key=f"th:{t.id}", surface=Surface.THREAD,
+  channel_id=str(t.id), _native=t)`.
+- `send_text(dest, text)` -> `await dest._native.send(text)` (Discord renders markdown;
+  no translation).
+- `send_files(dest, caption, files)` -> build `discord.File(io.BytesIO(of.data),
+  filename=of.filename)` when `of.data is not None` else `discord.File(str(of.path),
+  filename=of.filename)`; `await dest._native.send(caption, files=[...])`.
+- `download_attachment(att, target)` -> `await att._native.save(str(target))`.
+- `add_reaction(message, emoji)` -> `await message._native.add_reaction(
+  {"hourglass": "⏳"}.get(emoji, emoji))`.
+- `activity(dest)` -> `dest._native.typing()`.
+
+7. The **unknown-handle reply** (`:283`, `message.reply(...)`) now routes through
+   `send_text(msg.dest, ...)` in `_on_channel` (G-04). The complaint text is
+   identical; the reply-quote affordance is dropped (documented).
+
+**Net:** every routing/policy decision is now in `ChatCore`; `discord_bot.py` is the
+adapter shape above. The existing `tests/test_discord_bot.py` (which imports
+`format_relayed_message` from `discord_bot`) keeps passing because `discord_bot`
+re-exports it from `chat_types`.
+
+---
+
+## 5. `slack_bot.py`
+
+New file `claude_code_tools/agent_tunnel/slack_bot.py`. `slack_bolt` is imported
+LAZILY inside `run_slack_bot` (exactly like `discord_bot` defers `discord`), so
+`import slack_bot` for the pure helpers never requires the dep.
+
+### 5a. Socket Mode setup (two tokens) + lifecycle + ordering
+
+```python
+def run_slack_bot(cfg, store, registry) -> None:
+    """Run the Slack bot until interrupted (blocking). Mirrors run_bot's signature.
+
+    Raises:
+        RuntimeError: a token is missing, auth.test fails, or no channels+no DMs.
+    """
+    import asyncio
+    from slack_bolt.app.async_app import AsyncApp
+    from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
+
+    bot_token = resolve_token(cfg.slack.bot_token_env, cfg.slack.bot_token_file)
+    app_token = resolve_token(cfg.slack.app_token_env, cfg.slack.app_token_file)
+    if not bot_token:
+        raise RuntimeError(
+            f"No Slack bot token (set {cfg.slack.bot_token_env} or "
+            "slack.bot_token_file)")
+    if not app_token:
+        raise RuntimeError(
+            f"No Slack app-level token (set {cfg.slack.app_token_env} or "
+            "slack.app_token_file)")
+    if not cfg.slack.channel_ids and not cfg.slack.respond_to_dms:
+        raise RuntimeError(
+            "No slack.channel_ids configured and DMs are disabled — "
+            "the bot would never respond.")
+
+    app = AsyncApp(token=bot_token)
+    transport = SlackTransport(app, bot_token, cfg)
+    core = ChatCore(cfg, store, registry, transport)
+    channel_ids = {str(c) for c in cfg.slack.channel_ids}
+    seen = _SeenCache(cap=4096)            # bounded TTL dedup (G-24)
+    state = {"bot_user_id": "", "bot_id": ""}
+    inflight: set[asyncio.Task] = set()    # bounded fan-out tracking (G-27)
+
+    @app.event("message")                  # NO app_mention listener (G-double-answer)
+    async def _on_message(event, body):
+        # SYNCHRONOUS pre-ack work only (G-14): drop, classify, dedup, build a
+        # lightweight IncomingMessage (author_display = raw id), then spawn + return.
+        msg = slack_event_to_incoming(
+            event, bot_user_id=state["bot_user_id"], bot_id=state["bot_id"],
+            channel_ids=channel_ids, respond_to_dms=cfg.slack.respond_to_dms,
+        )
+        if msg is None:
+            return
+        key = (event.get("client_msg_id")
+               or f'{event.get("channel")}-{event.get("ts")}')
+        if not seen.add(key):              # already seen -> retry/dup, skip (G-24)
+            return
+        if len(inflight) >= _MAX_INFLIGHT:             # fan-out bound (G-27)
+            # The busy notice is a chat_postMessage round-trip, so it is NOT
+            # awaited on the pre-ack path (G-14): spawn it fire-and-forget
+            # (tracked so it isn't GC'd) and return immediately.
+            notice = asyncio.create_task(transport.send_text(msg.dest, BUSY))
+            inflight.add(notice)
+            notice.add_done_callback(inflight.discard)
+            return
+        task = asyncio.create_task(_run_turn(core, transport, msg))
+        inflight.add(task)
+        task.add_done_callback(inflight.discard)
+
+    async def _main():
+        try:                                           # BEFORE the socket (G-20)
+            auth = await app.client.auth_test()
+        except Exception as exc:                       # SlackApiError is NOT a
+            raise RuntimeError(                        # RuntimeError -> wrap it
+                f"Slack auth.test failed (check the bot token): {exc}") from exc
+        state["bot_user_id"], state["bot_id"] = auth["user_id"], auth["bot_id"]
+        handler = AsyncSocketModeHandler(app, app_token)
+        reaper = asyncio.create_task(core.run_reaper())  # same loop (G-28)
+        try:
+            await handler.start_async()                # blocks, serves events
+        finally:
+            reaper.cancel()
+            await handler.close_async()
+            await transport.aclose()                   # close download session
+
+    asyncio.run(_main())                   # asyncio.run handles KeyboardInterrupt;
+                                           # cli.main() maps it to exit(130) (G-shutdown)
+```
+
+`_run_turn` resolves the display name in the BACKGROUND (off the ack path, G-14), then
+calls the core (it closes over the app via `transport`, so `app` is not a parameter):
+
+```python
+async def _run_turn(core, transport, msg) -> None:
+    name = await transport.resolve_display(msg.author_id)   # cached users_info
+    msg = replace(msg, author_display=name)                 # dataclasses.replace
+    await core.handle_message(msg)
+```
+
+Ordering invariants made explicit:
+
+- `auth.test` is awaited and `bot_user_id`/`bot_id` stored BEFORE `start_async()`, so
+  the self/bot drop is never bypassed on the first event (G-20). It runs in `_main`
+  BEFORE the socket opens, and a bad/expired token raises `SlackApiError` (a plain
+  `Exception`, NOT a `RuntimeError`), so it is WRAPPED into a `RuntimeError` that
+  `serve`'s `except RuntimeError` maps to a clean `ClickException` (not a traceback).
+- The reaper task is created on the same running loop as the per-turn tasks (G-28).
+- Graceful shutdown: `asyncio.run` raises `KeyboardInterrupt` on Ctrl-C; the `finally`
+  cancels the reaper, `close_async()`s the socket, AND `await transport.aclose()`s the
+  lazily created `aiohttp` download session (so it doesn't leak / warn "Unclosed client
+  session"); in-flight turns finish on their own per-thread locks (the cap below bounds
+  them). `cli.main()`'s existing `KeyboardInterrupt -> exit(130)` still applies since
+  `run_slack_bot` is called synchronously from `serve` (G-shutdown).
+- Fan-out bound (G-27): `inflight` tracks spawned turns. Beyond a threshold the
+  listener posts a brief busy notice and skips spawning, instead of growing unbounded
+  pending coroutines. That notice is a `chat_postMessage` round-trip, so it is spawned
+  FIRE-AND-FORGET (tracked, then `return`) rather than awaited, keeping the listener
+  body free of any awaited Web API call on the pre-ack path even under overload (G-14).
+  (Per-conversation serialization is already guaranteed by the core's per-`thread_key`
+  lock; the global `Semaphore(max_concurrent)` still caps simultaneous backend asks.)
+
+### 5b. The event → `IncomingMessage` parser (pure, `slack_bolt`-free)
+
+A free function, imported by tests with NO socket and NO `slack_bolt`:
+
+```python
+def slack_event_to_incoming(
+    event: dict,
+    *,
+    bot_user_id: str,
+    bot_id: str,
+    channel_ids: set[str],
+    respond_to_dms: bool = False,
+    resolve_display=lambda uid: uid,
+) -> Optional[IncomingMessage]:
+    """Normalize a Slack message event to an IncomingMessage, or None to drop.
+
+    Drop rules, in order:
+    - subtype in the IGNORE set (G-subtype): message_changed, message_deleted,
+      bot_message, channel_join, channel_leave, channel_topic, channel_purpose,
+      channel_name, me_message, thread_broadcast, channel_archive,
+      channel_unarchive. Edits/deletes are INTENTIONALLY ignored.
+    - self/bot loop (G-self): event.get("bot_id") == bot_id, OR
+      event.get("subtype") == "bot_message", OR event.get("user") == bot_user_id.
+    - NOTE: do NOT gate on `subtype is None` at the decorator/function entry — a
+      file-only upload arrives on a regular message; detect files by
+      `event.get("files")` regardless of subtype (G-subtype).
+
+    Classify (G-im-mpim):
+    - channel_type in ("im","mpim") -> Surface.DM, thread_key=f'dm:{channel}',
+      channel_id=channel. (respond_to_dms gates DMs; if False, return None.)
+    - else (channel/group): if `thread_ts` present and `thread_ts != ts`
+      -> Surface.THREAD, thread_key=f'th:{channel}-{thread_ts}',
+      thread_ts=thread_ts. A parent (thread_ts == ts or absent) in a watched
+      channel -> Surface.CHANNEL. A channel NOT in `channel_ids` -> None (the
+      watched-channel gate, adapter-side; DMs are not gated by channel_ids).
+
+    Leading mention -> Addressee (THREAD surface only):
+    - `<@BOTUSERID>` leading -> Addressee.SELF and STRIP it from text.
+    - `<@OTHER>` / `<!here>` / `<!channel>` / `<!subteam^...>` leading
+      -> Addressee.OTHER (text unstripped). CHANNEL/DM leave NONE.
+
+    Attachments: AttachmentRef per files[] entry (filename/size/url fallbacks, G-16),
+    _native = the raw file dict. An attachment-only (text=="") message is NOT dropped.
+
+    author_display: resolve_display(user) (defaults to the raw id; the live bot passes
+    a no-op here and resolves in the background task, G-14).
+    """
+```
+
+The Slack mention regexes (adapter-private): leading self
+`^\s*<@%s>\s*` % re.escape(bot_user_id); leading other-user `^\s*<@[UW][A-Z0-9]+>`;
+broadcast `^\s*<!(here|channel|everyone)>` and `^\s*<!subteam\^[A-Z0-9]+>`.
+
+**CHANNEL-surface mention rule (G-broadcast):** on CHANNEL the handle-token parse
+governs and `addressee` is left NONE, matching Discord. So `<!here> pay …` in a
+watched channel is parsed as token `<!here>` (not a handle, fails `HANDLE_RE`) and is
+silently dropped — intended.
+
+### 5c. `SlackTransport(ChatTransport)`
+
+Holds `app`, `bot_token`, `cfg`, a `dict[str,str]` display-name cache, and an
+`aiohttp` session (lazy).
+
+- `limits` -> `TransportLimits(max_message_len=4000, max_attachments_per_msg=10,
+  thread_title_max=10**9, max_error_len=3500, list_truncate_len=3900)`. Slack ignores
+  titles (`thread_title_max` huge); `list_truncate_len <= max_message_len` holds (G-08,
+  G-19).
+- `open_thread(parent, title)` -> `ts = parent.thread_ts` (the triggering ts carried on
+  the channel parent dest, G-18); return `ChatDest(thread_key=f"th:{parent.channel_id}-{ts}",
+  surface=Surface.THREAD, channel_id=parent.channel_id, thread_ts=ts)`. No API call.
+- `send_text(dest, text)` -> `await app.client.chat_postMessage(channel=dest.channel_id,
+  thread_ts=dest.thread_ts or None, text=discord_to_mrkdwn(text))` — SAME thread_ts on
+  every send (G-25). `discord_to_mrkdwn` escapes `& < >` first, then `**`->`*`,
+  `[t](u)`->`<u|t>`, `~~`->`~` (G-03).
+- `send_files(dest, caption, files)` -> one `files_upload_v2(channel=dest.channel_id,
+  thread_ts=dest.thread_ts or None, initial_comment=discord_to_mrkdwn(caption),
+  file_uploads=[...])` with content/file + filename + title per entry (G-13). Same
+  thread_ts (G-25). Does NOT read back any returned ts.
+- `download_attachment(att, target)` -> authenticated GET of `att.url` with the
+  redirect-surviving bearer header + HTML-login guard (G-15). The guard is factored
+  into a pure helper for testing:
+  ```python
+  def validate_download(content_type: str, status: int) -> None:
+      if "text/html" in (content_type or "") or status >= 400:
+          raise RuntimeError(f"Slack file download failed (status={status})")
+  ```
+- `add_reaction(message, emoji)` -> `await app.client.reactions_add(
+  channel=message.channel_id, timestamp=message.ts, name="hourglass_flowing_sand")`
+  (G-02). Best-effort (swallow `SlackApiError`).
+- `activity(dest)` -> `noop_activity()`.
+- `resolve_display(user_id)` -> cached `users_info`; returns
+  `profile.display_name or profile.real_name or user.real_name or user.name or
+  user_id` (G-display). Called only from `_run_turn`, never on the ack path.
+
+### 5d. DM (IM) handling
+
+DMs route through `Surface.DM` for both `im` and `mpim` (`thread_key=f"dm:{channel}"`),
+gated by `respond_to_dms` (G-im-mpim). The core's `_on_direct` (verbatim from
+`:364-433`) then handles `<handle>` rebind / bare follow-up / `!list` / `!close`
+(requires an existing binding) / "Start with a handle" hint, identically to Discord.
+Slack DMs have no mention logic (`addressee == NONE`).
+
+---
+
+## 6. `SlackConfig` + `TunnelConfig.chat` + `cli serve --chat` + sample `[slack]`
+
+### 6a. `SlackConfig` (`config.py`, after `DiscordConfig` at `:84`)
+
+```python
+@dataclass
+class SlackConfig:
+    """Slack-facing settings (Socket Mode, two tokens).
+
+    Two token env/file pairs (xoxb- bot, xapp- app-level). Allowlists are STRINGS
+    (Slack ids are opaque). ``allowed_usergroup_ids`` (subteam ``S…`` ids) is the
+    Slack analog of Discord's ``allowed_role_ids``.
+    """
+
+    bot_token_env: str = "AGENT_TUNNEL_SLACK_BOT_TOKEN"
+    bot_token_file: str = ""
+    app_token_env: str = "AGENT_TUNNEL_SLACK_APP_TOKEN"
+    app_token_file: str = ""
+    channel_ids: list[str] = field(default_factory=list)
+    allowed_user_ids: list[str] = field(default_factory=list)
+    allowed_usergroup_ids: list[str] = field(default_factory=list)
+    respond_to_dms: bool = False
+```
+
+### 6b. `TunnelConfig` additions (`config.py`, in the dataclass at `:164-183`)
+
+Add `chat: str = "discord"` (after `tmux_session`), `slack: SlackConfig =
+field(default_factory=SlackConfig)` (after `discord`), and the accessor:
+
+```python
+def principal_allowlists(self) -> tuple[set[str], set[str]]:
+    """(user_ids, role_or_usergroup_ids) for the active front-end, as strings.
+
+    Empty/empty means 'open'. Lets ``ChatCore._allowed`` honor Slack usergroups
+    where Discord uses roles, without the core knowing platform names.
+    """
+    if self.chat == "slack":
+        return (
+            {str(u) for u in self.slack.allowed_user_ids},
+            {str(g) for g in self.slack.allowed_usergroup_ids},
+        )
+    return (
+        {str(u) for u in self.discord.allowed_user_ids},
+        {str(r) for r in self.discord.allowed_role_ids},
+    )
+```
+
+### 6c. `load_config` changes (`config.py:193-268`)
+
+- Add a `chat: Optional[str] = None` parameter (mirroring `backend`).
+- Read `chat` from `[tunnel]`: extend the string-key loop at `:227` to
+  `("backend", "tmux_session", "platform", "chat")`.
+- Add `_apply(cfg.slack, data.get("slack", {}))` next to the other `_apply` calls
+  (`:234-237`).
+- After the `if backend:` block (`:239-240`), apply the override + auto-platform:
+  ```python
+  if chat:
+      cfg.chat = chat
+  # Auto-name the platform from the front-end UNLESS set explicitly in TOML
+  # (G-platform-timing): the guard checks the TOML table only, so `serve --chat
+  # slack` takes the same auto path, and an explicit [tunnel] platform always wins.
+  if cfg.chat == "slack" and "platform" not in tunnel_tbl:
+      cfg.platform = "Slack"
+  ```
+- Validate `chat` alongside the backend check (`:266-267`):
+  ```python
+  if cfg.chat not in ("discord", "slack"):
+      raise ValueError(f"Unknown chat front-end: {cfg.chat!r}")
+  ```
+- **Channel-id type validation (G-config-types):** after the `_apply` calls, assert
+  the right id type per front-end (raise `ValueError` naming the table; `serve` maps it
+  to `ClickException`):
+  ```python
+  if any(not isinstance(c, int) for c in cfg.discord.channel_ids):
+      raise ValueError("[discord] channel_ids must be integers (snowflakes).")
+  if any(not isinstance(c, str) for c in cfg.slack.channel_ids):
+      raise ValueError("[slack] channel_ids must be strings (e.g. \"C0123ABC\").")
+  ```
+
+### 6d. `cli.py serve --chat` + `_build` + dispatch + `doctor` (`cli.py`)
+
+`_build` gains `chat` and resolves `--channel` per front-end (`--channel` becomes
+`type=str`; Discord casts to int with a clear error):
+
+```python
+def _build(config, backend=None, channel=(), token_env=None, chat=None) -> TunnelConfig:
+    try:
+        cfg = load_config(path=Path(config) if config else None,
+                          backend=backend, chat=chat)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if channel:
+        if cfg.chat == "slack":
+            cfg.slack.channel_ids = list(channel)
+        else:
+            try:
+                cfg.discord.channel_ids = [int(c) for c in channel]
+            except ValueError as exc:
+                raise click.ClickException(
+                    f"Discord --channel ids must be integers: {exc}") from exc
+    if token_env:
+        cfg.discord.token_env = token_env   # Discord-only (Slack has two tokens)
+    return cfg
+```
+
+`serve` gains `--chat` (`type=click.Choice(["discord","slack"])`, `default=None`),
+changes `--channel` to `type=str`, and dispatches:
+
+```python
+cfg = _build(config, backend, channels, token_env, chat)
+store = TunnelStore(cfg.state_path)
+registry = Registry(cfg.registry_path)
+if cfg.chat == "slack":
+    try:
+        from .slack_bot import run_slack_bot as run
+    except ImportError as exc:
+        raise click.ClickException(
+            f"slack_bolt is required for `serve --chat slack`: {exc}\n"
+            "Install it with:  uv tool install 'claude-code-tools[slack]'") from exc
+    watched = cfg.slack.channel_ids
+else:
+    try:
+        from .discord_bot import run_bot as run
+    except ImportError as exc:
+        raise click.ClickException(f"discord.py is required for serve: {exc}") from exc
+    watched = cfg.discord.channel_ids
+click.echo(f"agent-tunnel: chat={cfg.chat} backend={cfg.backend} "
+           f"registry={cfg.registry_path} channels={watched}")
+try:
+    run(cfg, store, registry)
+except RuntimeError as exc:
+    raise click.ClickException(str(exc)) from exc
+```
+
+`doctor` (`cli.py:627-666`) branches on `cfg.chat` (G-23, G-doctor). Import the
+generalized `resolve_token` from `chat_types` for the Slack branch; keep the
+`discord_bot` 1-arg wrapper for Discord. Slack checks: bot token resolves; app token
+resolves; (best-effort) `auth.test` succeeds and prints `bot_user_id`; report
+`cfg.slack.channel_ids`. Shared lines (`claude` on PATH, tmux, converter, published
+count) unchanged.
+
+### 6e. Sample `[slack]` block (`sample_config()`, after the `[discord]` block at `:305`)
+
+Also add a `chat` comment to `[tunnel]` (after `:292`):
+
+```
+# Chat front-end `serve` runs: "discord" (default) or "slack". Override per
+# run with `agent-tunnel serve --chat slack`. Selecting "slack" auto-sets the
+# platform label to "Slack" (unless you set [tunnel] platform yourself).
+# chat = "discord"
+```
+
+The `[slack]` block (no literal braces → no `{{` escaping needed):
+
+```
+[slack]
+# Slack uses TWO tokens (Socket Mode — no public URL, an outbound websocket
+# like Discord). Put neither token here; point at env vars or files.
+#   Bot token   (xoxb-…): all Web API calls (post, react, upload, read users).
+#   App token   (xapp-…): opens the Socket Mode socket; needs connections:write.
+# Only used when [tunnel] chat = "slack" (or `serve --chat slack`).
+bot_token_env = "AGENT_TUNNEL_SLACK_BOT_TOKEN"
+app_token_env = "AGENT_TUNNEL_SLACK_APP_TOKEN"
+# Optional files holding the tokens, used if the env vars are unset.
+# bot_token_file = "~/Documents/tokens/slack-bot-token.txt"
+# app_token_file = "~/Documents/tokens/slack-app-token.txt"
+# Channel ids the bot watches (Slack ids are STRINGS: channel details ->
+# e.g. "C0123ABCDEF"). Empty = answers only in DMs / threads it is in.
+channel_ids = []
+# Empty lists mean: anyone in the watched channels may ask.
+# Slack ids are strings (users "U…", usergroups/subteams "S…").
+allowed_user_ids = []
+# Slack usergroups (subteams) — the analog of Discord roles. Requires the
+# usergroups:read scope to resolve membership; otherwise leave empty.
+allowed_usergroup_ids = []
+respond_to_dms = false
+```
+
+---
+
+## 7. pyproject deps + Slack OAuth scope checklist
+
+### 7a. `pyproject.toml` (`:7-28`)
+
+Keep `discord.py` a **hard dependency** (zero packaging churn / no break for existing
+`serve` users — the safer call per G-pyproject), and add `slack_bolt` + `aiohttp` as an
+optional `[slack]` extra (our own code imports `aiohttp` directly for the
+authenticated download, so it is a declared dep, not transitive-only):
+
+```toml
+[project.optional-dependencies]
+dev = ["commitizen>=3.0.0"]
+gdocs = [
+    "google-api-python-client>=2.0.0",
+    "google-auth-oauthlib>=1.0.0",
+    "Pillow>=10.0.0",
+]
+slack = [
+    "slack_bolt>=1.18.0",
+    "aiohttp>=3.9.0",
+]
+```
+
+`serve --chat slack` already fails with an actionable `ImportError -> ClickException`
+("Install with `claude-code-tools[slack]`") when the extra is absent.
+
+**Version bump (G-pyproject):** this feature is a `cz bump` (commitizen updates
+`pyproject.toml:version` + `claude_code_tools/__init__.py:__version__`). Repo is at
+`1.14.1` (both files agree). After the bump, re-run the plugin-version unification so
+all `plugins/*/.claude-plugin/plugin.json` match the package version. Update the
+`agent_tunnel/__init__.py` "Discord v1" wording to mention Slack.
+
+### 7b. Slack OAuth scope checklist (copy-paste)
+
+App setup (api.slack.com/apps -> Create New App -> From scratch):
+
+```
+Socket Mode (sidebar): toggle ON. Generate an App-Level Token with scope:
+  connections:write          # the xapp-… token
+
+OAuth & Permissions -> Bot Token Scopes (add AT LEAST these):
+  channels:history           # read public channel messages
+  groups:history             # read private channel messages
+  im:history                 # read DMs (respond_to_dms)
+  mpim:history               # read group DMs (respond_to_dms)
+  app_mentions:read          # receive @-mentions in channels
+  chat:write                 # post answers and notices
+  users:read                 # resolve U… ids to display names
+  reactions:write            # the ⏳ busy reaction (NOT reactions:read — unused, G-12)
+  files:read                 # download a colleague's attachments
+  files:write                # post deliverables back
+  usergroups:read            # resolve subteam (S…) membership for allowed_usergroup_ids
+                             #   (omit if you don't use usergroup allowlists; paid plans)
+
+# "AT LEAST", not "exactly": the *:history scopes above cover reading messages, and
+# files_upload_v2 with an explicit channel id covers the common upload path. But the
+# slack_sdk v2 upload helper and channel resolution can, in some workspaces, also touch
+# conversations.* lookups. If `files_upload_v2` or posting fails with a
+# `missing_scope`/`not_in_channel`/`channel_not_found` error, add the matching
+# conversation read scope for that surface (and re-install the app):
+  channels:read              # public-channel metadata / membership (if needed)
+  groups:read                # private-channel metadata (if needed)
+  im:read                    # DM metadata (if needed)
+  mpim:read                  # group-DM metadata (if needed)
+
+Event Subscriptions -> Enable Events -> Subscribe to bot events:
+  message.channels
+  message.groups
+  message.im
+  message.mpim
+  # Do NOT subscribe to app_mention (G-double-answer): a watched-channel @-mention
+  # already arrives as message.channels; subscribing to BOTH would double-process.
+  # Leading-bot-mention detection is done inside the message handler.
+
+Install App -> Install to Workspace -> Allow. Copy the Bot User OAuth Token (xoxb-…).
+/invite @YourBot in each watched channel. Channel id: View channel details (C0123ABC).
+```
+
+`reactions:read` is deliberately omitted (the bot only adds reactions, never reads
+them — G-12). `usergroups:read` is required ONLY if `allowed_usergroup_ids` is used;
+otherwise the usergroup allowlist branch simply never matches (degrade gracefully).
+
+---
+
+## 8. Tests
+
+Two new files in `tests/`, real objects, no mocks, `pytest -xvs`, driving coroutines
+with `asyncio.run(...)` (no extra plugin), mirroring `tests/test_agent_tunnel.py` and
+`tests/test_discord_bot.py`.
+
+### 8a. `tests/test_chat_core.py`
+
+A real in-memory `FakeTransport(ChatTransport)` records every call and opens
+deterministic thread dests (no network):
+
+```python
+class FakeTransport:
+    def __init__(self, limits=None):
+        self._limits = limits or TransportLimits()
+        self.texts = []       # (thread_key, text)
+        self.files = []       # (thread_key, caption, [OutgoingFile])
+        self.reactions = []   # (author_id, emoji)
+        self.opened = []      # (parent_key, title)
+        self.downloads = []   # (AttachmentRef, Path)
+        self.fail_download = False
+        self._seq = 0
+    @property
+    def limits(self): return self._limits
+    async def open_thread(self, parent, title):
+        self._seq += 1
+        self.opened.append((parent.thread_key, title))
+        return ChatDest(thread_key=f"th:fake{self._seq}", surface=Surface.THREAD,
+                        channel_id=parent.channel_id)
+    async def send_text(self, dest, text): self.texts.append((dest.thread_key, text))
+    async def send_files(self, dest, caption, files):
+        self.files.append((dest.thread_key, caption, list(files)))
+    async def download_attachment(self, att, target):
+        self.downloads.append((att, target))
+        if self.fail_download: raise RuntimeError("boom")
+        target.write_bytes(b"FAKE")
+    async def add_reaction(self, message, emoji):
+        self.reactions.append((message.author_id, emoji))
+    def activity(self, dest): return noop_activity()
+```
+
+A real `FakeBackend(Backend)` returns a canned `Answer` and records the `question`
+passed to `ask` (so the relay prefix is asserted); `forget`/`reap_idle` no-op. Inject
+by monkeypatching `chat_core.backend_for_record` to return it (real object, only the
+lookup redirected — the no-mock-compliant substitution, matching how
+`test_agent_tunnel.py` uses real backends only for flag-building).
+
+Helpers `_msg(**over)` and `_core(tmp_path, **cfg_over)` (real `TunnelConfig(state_path,
+registry_path)`, real `TunnelStore`, real `Registry`, `FakeTransport`).
+
+Cases:
+
+1. `test_split_chunks_default_and_limit` — `split_chunks("") == []`; `limit=2000`
+   round-trips; `limit=50` chunks to <=50 (proves the limit is honored). Keeps the
+   shipped no-arg call valid (G-21).
+2. `test_allowed_open / by_user_id / by_usergroup_id / denied` — Slack cfg
+   (`chat="slack"`, `slack.allowed_user_ids=["U123"]`,
+   `slack.allowed_usergroup_ids=["S9"]`) AND a Discord cfg (`discord.allowed_user_ids=
+   [123]`, int). Empty/empty -> True; string user match -> True; usergroup via
+   `author_role_ids=frozenset({"S9"})` -> True; non-match -> False; the int-vs-str
+   coercion: Discord `[123]` matches `author_id="123"` (behavior-preservation point).
+3. `test_cooldown_blocks / allows_after / per_principal` — `per_user_cooldown_s=100`;
+   first True (records), immediate second False, different principal True; monkeypatch
+   `chat_core.time.time` forward -> True.
+4. `test_deliver_answer_inline_chunked / as_file` — short answer at
+   `max_message_len=50` -> multiple `send_text` each <=50; long answer
+   (`> max_inline_chars`) -> one `send_files` with a single `OutgoingFile` named
+   `answer.md` whose `data` decodes to the full text + first-chunk caption.
+5. `test_thread_key_scheme_is_opaque` — full open + bind under `th:fake1` and a
+   Slack-style `th:C123-1700000000.0001`, follow-up resolves the same key (G-05).
+6. `test_thread_addressee_other_silent / self_answers / none_answers` — bound thread;
+   OTHER -> no send; SELF (pre-stripped) -> answers; NONE -> answers.
+7. `test_pipeline_channel_open_binds_and_answers` — seed
+   `registry.upsert(PublishRecord(handle="pay", session_id=SID, cwd=str(tmp_path),
+   access="read"))`; `handle_message(_msg(surface=CHANNEL, text="pay how does refresh
+   work?", channel_id="C1"))`. Assert `opened == [("", "pay: how does refresh work?")]`,
+   `store.get("th:fake1")` bound, answer delivered via `send_text` on `th:fake1`, and
+   `FakeBackend`'s captured question starts with `"... (via Discord) says:"` /
+   `cfg.platform`.
+8. `test_pipeline_channel_handle_only_posts_ready_notice` — `text="pay"` -> "Connected
+   to **pay**…" and NO `ask`.
+9. `test_pipeline_unknown_handle_complains_before_allowlist` — no registry entry,
+   `text="nope"` -> exactly one "No live session for handle `nope`…", and assert it
+   fires even when the allowlist would DENY the author (ordering invariant). Then
+   `text="nope please help"` -> silent.
+10. `test_pipeline_thread_followup_answers_and_cooldown` — pre-bind; follow-up answers;
+    immediate second (within cooldown) -> no answer + one
+    `add_reaction(author_id, "hourglass")`.
+11. `test_pipeline_attachments_ingested` — `attachments=(AttachmentRef("a.txt", 4),)`;
+    assert `downloads` recorded, the question handed to `ask` contains the
+    `attachment_preamble` path; oversize ref (`size > max_attachment_mb*1MB`) -> a
+    "⚠️ Skipped:" `send_text`.
+12. `test_pipeline_attachment_download_failure_skipped` (G-error) —
+    `tx.fail_download=True`; the file appears in "⚠️ Skipped" and is absent from the
+    saved set.
+13. `test_pipeline_attachment_only_empty_content` (G-error) — an attachment whose
+    ingested content is empty -> "⚠️ Nothing to act on" `send_text`, no `ask`.
+14. `test_pipeline_deliverables_posted` — `Answer(attachments=[tmpfile])` -> one
+    `send_files` caption "📎 Deliverable(s)…" + `OutgoingFile.from_path`; an 11-file
+    answer with `max_attachments_per_msg=10` -> two batches ("Deliverable(s)", then
+    "More deliverables").
+15. `test_pipeline_deliverables_send_failure_swallowed` (G-error) — a `FakeTransport`
+    variant whose `send_files` raises -> swallowed + logged, no crash, skipped notice
+    still posts if applicable.
+16. `test_pipeline_backend_error_truncated` — `ask` raises `BackendError("x"*5000)` ->
+    one `send_text` of length `max_error_len + 2` ("⚠️ " + slice).
+17. `test_pipeline_backend_unexpected_error` (G-error) — `ask` raises `ValueError` ->
+    generic "⚠️ Unexpected error" and the lock/sem are released (a subsequent turn on
+    the same key proceeds).
+18. `test_pipeline_stale_binding_guard` — bind `th:fake1` session A; before the lock,
+    `store.remove` + re-`bind` with a different session/`created_at`; assert "↪️ …
+    restarted…" and NO `ask`.
+19. `test_pipeline_dm_rebind_then_followup` — `_msg(surface=DM, text="pay first q")`
+    binds + answers; bare `_msg(surface=DM, text="more")` follows up; `_msg(surface=DM,
+    text="other-handle")` rebinds (asserts old-fork `forget` then new bind); the
+    "Connected" rebind notice firing BEFORE the allowlist gate is asserted by setting a
+    denying allowlist and checking the notice still posts then returns.
+20. `test_access_collision_slack_dm_key` (G-06-collision) — bind a Slack-style
+    `dm:{C}` key under handle `cli` (session A), then `registry.upsert` a `cli` for a
+    DIFFERENT session; drive a turn and assert access is NOT escalated (the Slack
+    mirror of `test_access_sync_ignores_handle_collision_from_other_session`,
+    `tests/test_agent_tunnel_backends.py:262`) — the guard keys on
+    `session_id == expert_session_id`.
+21. `test_concurrency_per_thread_serialization` (G-27) — drive 3 concurrent thread
+    keys through `FakeTransport` with a `FakeBackend.ask` that sleeps; assert per-key
+    serialization (no interleaving on one key) and that the global
+    `Semaphore(max_concurrent)` caps simultaneous `ask` calls.
+
+### 8b. `tests/test_slack_bot.py`
+
+Tests `slack_event_to_incoming` (and the pure `validate_download` /
+`discord_to_mrkdwn` helpers) from fixture payloads copied verbatim from the research.
+Imports ONLY those free functions (no `slack_bolt`; the module's import is lazy).
+Module-level fixture dicts.
+
+Cases:
+
+1. `test_channel_message` — `{"type":"message","channel":"C123","user":"U1",
+   "text":"pay hello","ts":"1355517523.000005","channel_type":"channel"}`,
+   `channel_ids={"C123"}` -> `surface==CHANNEL`, `text=="pay hello"`,
+   `author_id=="U1"`, `channel_id=="C123"`, `ts==…`, `dest.thread_key==""`,
+   `dest.thread_ts=="1355517523.000005"` (triggering ts carried for open_thread,
+   G-18), `addressee==NONE`.
+2. `test_threaded_reply` — `thread_ts="1700000000.0001"`, `ts="…0009"` ->
+   `surface==THREAD`, `dest.thread_key=="th:C123-1700000000.0001"`,
+   `dest.thread_ts=="1700000000.0001"`. A second fixture with `thread_ts == ts` ->
+   `CHANNEL` (the `thread_ts != ts` reply test).
+3. `test_im_message` — `channel="D024BE91L"`, `channel_type="im"` -> `surface==DM`,
+   `thread_key=="dm:D024BE91L"`. And `test_mpim_message` — `channel_type="mpim"` ->
+   `surface==DM`, `thread_key=="dm:<channel>"` (G-im-mpim).
+4. `test_leading_self_mention_stripped` — `text="<@U0LAN0Z89> what's up?"`,
+   `bot_user_id="U0LAN0Z89"`, in a THREAD -> `addressee==SELF`, `text=="what's up?"`.
+   `<@U999>` -> `addressee==OTHER`, text unstripped. `<!here> …` in a THREAD ->
+   `addressee==OTHER`. `<!here> pay …` on CHANNEL -> `addressee==NONE`, token `<!here>`
+   (non-handle) (G-broadcast).
+5. `test_message_with_files` — `files=[{"id":"F1","name":"ghostrap.png","size":12345,
+   "url_private_download":"https://files.slack.com/…/download/…"}]`, `text=""` ->
+   `attachments == (AttachmentRef("ghostrap.png", 12345, url="https://…/download/…",
+   _native=<file dict>),)`, NOT dropped. A `name:None` fixture ->
+   `filename=="file-F1"`. A fixture with only `url_private` (no `_download`) -> `url`
+   falls back to `url_private` (G-16).
+6. `test_bot_subtype_ignored` — `subtype:"bot_message"` -> None; `bot_id==MY_BOT_ID` ->
+   None; `user==MY_USER_ID` (im) -> None; `message_changed`/`message_deleted`/
+   `channel_join` -> None (G-subtype, G-self).
+7. `test_channel_not_watched_dropped` — `channel_type="channel"` in `C999` not in
+   `channel_ids` -> None. A DM (`channel_type="im"`) with `respond_to_dms=True` is NOT
+   dropped; with `respond_to_dms=False` -> None.
+8. `test_resolve_display_used` — `resolve_display=lambda uid: {"U1":"Alice"}.get(uid,
+   uid)` -> `author_display=="Alice"` for `U1`, `"U2"` (id) for unknown.
+9. `test_validate_download_html_guard` — `validate_download("text/html; charset=utf-8",
+   200)` raises; `validate_download("image/png", 200)` does not; `status>=400` raises
+   (G-15).
+10. `test_discord_to_mrkdwn` — `"**b**"`->`"*b*"`; `"[t](u)"`->`"<u|t>"`; `"~~s~~"`->
+    `"~s~"`; `"a < b && c > d"` -> `"a &lt; b &amp;&amp; c &gt; d"` (escape FIRST);
+    inline-code and code-fences pass through (G-03).
+11. `test_dedup_cache` — `_SeenCache(cap=4)`: `add(k)` True then False on repeat;
+    capacity-bounded (oldest evicted past `cap`) (G-24).
+
+### 8c. Test-suite housekeeping
+
+- `tests/test_discord_bot.py` keeps importing `format_relayed_message` from
+  `discord_bot` (re-exported from `chat_types`) — untouched.
+- `tests/test_agent_tunnel.py` `test_split_chunks_roundtrip`, `test_resolve_token`,
+  `test_is_close_command`, `test_is_list_command` keep passing: `discord_bot`
+  re-exports `split_chunks`/`is_*` and keeps the 1-arg `resolve_token(cfg)` wrapper
+  (G-21, G-23).
+
+---
+
+## 9. Docs updates
+
+### 9a. Starlight `docs-site/src/content/docs/tools/agent-tunnel.mdx`
+
+Verify anchors at edit time (headers stable, line numbers not — G-docs).
+
+- Frontmatter `description` and the intro: "…over Discord **or Slack**…", with a pointer
+  to the new section.
+- Add `## Using Slack instead of Discord` AFTER "Part C (run it)" and before "Watching
+  live", containing: the Socket-Mode framing ("outbound websocket — no tunnel, no
+  port, no cloud"); a `<Steps>` app-creation walkthrough (create app -> Socket Mode +
+  `connections:write` xapp- token -> Bot Token Scopes (the Section 7b list) -> Event
+  Subscriptions (the four `message.*`, explicitly NOT `app_mention`) -> Install ->
+  `/invite` + channel id); a scope-checklist table (scope ↔ why); an `<Aside>` "Two
+  tokens, two roles"; the `[slack]` TOML block from Section 6e; `agent-tunnel serve
+  --chat slack` (and "or just `serve` when `[tunnel] chat = "slack"`"); an `<Aside
+  type="tip">` on `uv tool install 'claude-code-tools[slack]'` and `doctor` checking
+  both tokens; and a closing paragraph that the colleague vocabulary
+  (`!list`/`<handle> question`/in-thread follow-ups/`!done`/`@someone-else`
+  left-to-humans/attachments) is identical to Discord.
+- Security `<Aside>` (currently lists `allowed_user_ids`/`allowed_role_ids`): update to
+  enumerate BOTH Discord (`allowed_user_ids`/`allowed_role_ids`) and Slack
+  (`allowed_user_ids`/`allowed_usergroup_ids`), and "Discord OR Slack channel
+  membership" (G-docs).
+
+### 9b. `docs/agent-tunnel-spec.md`
+
+- Components: add a `chat_types.py` + `chat_core.py` entry BEFORE `discord_bot.py`
+  (platform-neutral routing/policy/pipeline/reaper behind `ChatTransport`; the neutral
+  dataclasses); rewrite the `discord_bot.py` entry to "thin Discord adapter over
+  `chat_core`" (lazy `discord`, classification, `<@id>`->`Addressee` + self-strip,
+  `DiscordTransport`); add a `slack_bot.py` entry (Socket Mode via `slack_bolt`,
+  two-token, drop bot/self/edit/delete + `event_id`/`client_msg_id` dedup,
+  `channel_type`+`thread_ts` -> `Surface`, `<@U…>`/`<!…>` -> `Addressee`,
+  `files[]`->`AttachmentRef`, ack<3s -> `create_task`, `SlackTransport` with
+  `chat_postMessage`/`files_upload_v2`/`reactions_add`/authenticated download +
+  HTML-guard/no-op activity/mrkdwn fixups/`TransportLimits(max_message_len=4000,…)`).
+- Config entry: add `[slack]` (`SlackConfig`), `[tunnel] chat` selector + auto-platform.
+- CLI entry: `serve --chat {discord,slack}` dispatches `run_bot` vs `run_slack_bot`;
+  `--channel` int (Discord) / string (Slack).
+- Routing section: add the preamble "routing/policy is platform-neutral
+  (`chat_core.ChatCore`); adapters only normalize + perform chat I/O", and a Slack-
+  mapping bullet (watched channel = `message.channels`/`groups` no `thread_ts`;
+  thread = `thread_ts != ts`; DM = `im`/`mpim`; leading `<@bot>` stripped; bot/self/
+  edit/delete dropped; Socket-Mode dedup on `event_id`/`client_msg_id`; unnamed
+  threads; `⏳` = `reactions_add(hourglass_flowing_sand)`).
+- Validation-status: add the `chat_core` + Slack-adapter test bullet (Section 8).
+- Note `cli.ask` remains a direct backend smoke test (no `ChatCore`), so the moved
+  ingest/deliver code is covered solely by `test_chat_core` (G-26).
+
+---
+
+## 10. Phased implementation checklist (with file lists)
+
+**PR1 — extract `chat_core` + refactor Discord (Discord stays green, no behavior
+change):**
+
+- NEW: `claude_code_tools/agent_tunnel/chat_types.py` (Protocol, value objects,
+  `TransportLimits`, `OutgoingFile`, `noop_activity`, moved helpers, generalized
+  `split_chunks`/`resolve_token`).
+- NEW: `claude_code_tools/agent_tunnel/chat_core.py` (`ChatCore` + reaper).
+- MODIFIED: `claude_code_tools/agent_tunnel/discord_bot.py` (adapter shape; re-export
+  the neutral helpers + `DISCORD_MSG_LIMIT`/`THREAD_NAME_MAX`; keep `resolve_token(cfg)`
+  wrapper; `DiscordTransport`).
+- NEW: `tests/test_chat_core.py`.
+- Gate: full existing suite green (`pytest -xvs tests/test_agent_tunnel.py
+  tests/test_discord_bot.py tests/test_agent_tunnel_backends.py`) + `test_chat_core.py`
+  green. Manual: `agent-tunnel doctor` and a Discord smoke turn behave identically.
+
+**PR2 — `slack_bot` + `SlackConfig` + `--chat` + tests:**
+
+- NEW: `claude_code_tools/agent_tunnel/slack_bot.py` (`run_slack_bot`,
+  `slack_event_to_incoming`, `validate_download`, `discord_to_mrkdwn`, `_SeenCache`,
+  `SlackTransport`).
+- MODIFIED: `claude_code_tools/agent_tunnel/config.py` (`SlackConfig`,
+  `TunnelConfig.chat`/`slack`/`principal_allowlists`, `load_config` `chat` param +
+  auto-platform + chat/channel-type validation + `_apply(cfg.slack,…)`,
+  `sample_config()` `[slack]` + `chat` comment).
+- MODIFIED: `claude_code_tools/agent_tunnel/cli.py` (`serve --chat`, `_build`
+  per-front-end channel coercion, dispatch to `run_slack_bot`, `doctor` Slack branch).
+- MODIFIED: `pyproject.toml` (`[slack]` extra: `slack_bolt`, `aiohttp`) + `cz bump` +
+  plugin-version unification.
+- MODIFIED: `claude_code_tools/agent_tunnel/__init__.py` ("Discord v1" wording).
+- NEW: `tests/test_slack_bot.py`.
+- Gate: `pytest -xvs tests/test_slack_bot.py tests/test_chat_core.py` green; install
+  `[slack]` and run a Slack Socket-Mode smoke turn (open thread, follow-up, attachment
+  in, deliverable out, `!done`).
+
+**PR3 — docs:**
+
+- MODIFIED: `docs-site/src/content/docs/tools/agent-tunnel.mdx` (Slack section +
+  intro/description/security tweaks).
+- MODIFIED: `docs/agent-tunnel-spec.md` (components + routing + config + CLI +
+  validation-status).
+
+---
+
+## 11. Resolution of every gap (G-NN), stated as handled
+
+**Blockers**
+
+- **G-double-answer (app_mention/message double delivery).** RESOLVED: subscribe ONLY
+  to the four `message.*` events; do NOT register an `app_mention` listener. Leading-
+  bot-mention is detected inside the message handler (`Addressee.SELF` + strip).
+  Dedup additionally keys on `client_msg_id` (or `(channel, ts)`), which is stable
+  across deliveries — NOT `event_id` alone (Section 5a/5b, 7b).
+- **G-subtype (subtype filtering vs file-only messages).** RESOLVED: do NOT gate on
+  `subtype is None`. Register a plain `@app.event("message")`; the pure normalizer
+  drops an explicit IGNORE set (`bot_message`, `message_changed`, `message_deleted`,
+  `channel_*`, `me_message`, `thread_broadcast`) and ACCEPTS everything else including
+  no-subtype messages and file-bearing messages (detected by `event.get("files")`).
+  Edits/deletes are intentionally ignored (documented) (Section 5b, 8b#6).
+- **G-13 (`files_upload_v2` mapping).** RESOLVED: explicit per-entry mapping —
+  `{"content": of.data, "filename": of.filename, "title": of.filename}` for bytes,
+  `{"file": str(of.path), …}` for paths; singular `channel`; `title` carries the
+  extension; one call with `file_uploads=` + `initial_comment` + `thread_ts`; the
+  returned ts is not read back (Section 5c).
+- **G-21 (`split_chunks` signature / false 'bug').** RESOLVED: `limit` stays a
+  DEFAULTED keyword (`= 2000`); the "latent bug" rationale is dropped. Existing tests
+  and the `discord_bot` re-export keep working; core callers always pass the transport
+  limit (Section 2c, 3, 8a#1).
+- **G-06-collision (`dm:{channel}` key vs `_current_access` guard).** RESOLVED: the
+  stale guard in `_answer` (compare `expert_session_id` + `created_at`) and the
+  live-access path `backends._current_access` (keys on `session_id ==
+  expert_session_id`, `:186-193`) are preserved by the neutral pipeline; a Slack DM
+  bound under handle `cli` is NOT escalated by an unrelated `>share cli`. Covered by
+  `test_access_collision_slack_dm_key` (Section 8a#20).
+- **G-shutdown (Slack graceful shutdown).** RESOLVED: `run_slack_bot` runs
+  `asyncio.run(_main())`; `_main` awaits `handler.start_async()` in a `try/finally`
+  that cancels the reaper, `close_async()`s the socket, AND `await transport.aclose()`s
+  the lazily created `aiohttp` download session (so it is not leaked / "Unclosed client
+  session"-warned) on Ctrl-C/exception; in-flight turns finish on their per-thread locks
+  (bounded by G-27); `cli.main()`'s `KeyboardInterrupt -> exit(130)` still applies
+  (Section 5a).
+- **G-22 (line budget).** RESOLVED: split into `chat_types.py` (~430) +
+  `chat_core.py` (~560), both well under 1000. `discord_bot.py` drops ~330 moved lines
+  to the adapter shape (~717 -> ~250, including `DiscordTransport`) (Section 2, 3, 4).
+
+**Major**
+
+- **G-DM-group (Surface.DM scope).** RESOLVED: `Surface.DM` covers BOTH `im` and
+  `mpim` on Slack; on Discord it stays `DMChannel`-only (group DMs unhandled, matching
+  the shipped bot — the docstring says exactly that) (Section 2b, 5d).
+- **G-02 (cooldown emoji mapping).** RESOLVED: the core passes the neutral name
+  `"hourglass"`; the Discord adapter maps `{"hourglass": "⏳"}` (load-bearing code,
+  not prose); the Slack adapter uses `hourglass_flowing_sand` (the ⏳ flowing-sand
+  glyph, verified — not ⌛) (Section 2a, 4, 5c).
+- **G-03 (markdown / mrkdwn).** RESOLVED: the adapter's `send_text`/`send_files`
+  translate via the pure, tested `discord_to_mrkdwn` — escape `& < >` FIRST, then
+  `**`->`*`, `[t](u)`->`<u|t>`, `~~`->`~`, applied BEFORE any send (so escaping can't
+  push a chunk over the limit post-chunking, because translation happens at send time
+  on already-chunked text and Slack's 4000 cap has headroom; the answer text is
+  escaped too, which is correct for Slack). The set of core-emitted markdown strings is
+  enumerated in the spec; tested in `test_discord_to_mrkdwn` (Section 5c, 8b#10).
+- **G-12 (scopes: `reactions:read` unused; `usergroups:read` missing).** RESOLVED:
+  `reactions:read` removed; `usergroups:read` added (used to populate
+  `author_role_ids` for `allowed_usergroup_ids`), guarded to degrade gracefully when
+  absent/erroring (paid-plan feature) (Section 7b, 2b).
+- **G-14 (3s ack vs `users_info`).** RESOLVED: the event handler does only synchronous
+  drop/classify/dedup/build (author_display = raw id) then `create_task` and returns;
+  `users_info` resolution happens in `_run_turn` (background), cached. No awaited Web
+  API call on the pre-ack path — INCLUDING the fan-out-overflow path, where the busy
+  notice (`chat_postMessage`) is spawned fire-and-forget rather than awaited, so the
+  ack is never blocked even under overload (Section 5a).
+- **G-15 (`url_private` redirect header-stripping).** RESOLVED: download uses
+  `url_private_download`, keeps the bearer header across the file-host redirect, and
+  raises on a `text/html` (login-page) response BEFORE writing — codified in the
+  `download_attachment` contract and the pure `validate_download` helper (Section 2a,
+  5c, 8b#9).
+- **G-16 (Slack file object normalization).** RESOLVED: explicit `filename`/`size`/
+  `url` fallbacks in `slack_event_to_incoming`; `_native` holds the raw dict; tested
+  incl. null name and `url_private` fallback (Section 2b, 5b, 8b#5).
+- **G-24 (dedup mandatory + bounded + correct key).** RESOLVED: dedup runs
+  synchronously BEFORE spawning, in a bounded `_SeenCache(cap=…)`, keyed on
+  `client_msg_id` else `(channel, ts)` (stable across the app_mention/message pair and
+  retries) (Section 5a, 8b#11).
+- **G-20 (auth.test before socket).** RESOLVED: `auth.test` awaited and ids stored
+  before `start_async()`, so the self/bot drop is never bypassed on the first event
+  (Section 5a).
+- **G-doctor / G-23 (`resolve_token` signature + doctor two-token).** RESOLVED:
+  generalized `resolve_token(env_name, file_path)` lives in `chat_types`; a 1-arg
+  `resolve_token(cfg)` wrapper stays in `discord_bot` for the existing test and the
+  Discord doctor branch; the Slack doctor branch imports the 2-arg helper from
+  `chat_types` for both token pairs (Section 3, 6d).
+- **G-pyproject (deps + version + break).** RESOLVED: `discord.py` stays a HARD dep
+  (zero break); only `[slack]` (`slack_bolt`, `aiohttp`) added as an extra; explicit
+  `cz bump` + plugin-version unification + `__init__.py` wording update (Section 7a).
+- **G-config-types (channel-id type validation).** RESOLVED: `load_config` asserts
+  `discord.channel_ids` are int and `slack.channel_ids` are str, raising `ValueError`
+  naming the table; the channel-watched gate is independent of the allowlist gate, both
+  typed correctly (Section 6c).
+- **G-27 (semaphore + unbounded fan-out under Slack create_task).** RESOLVED: the
+  listener tracks `inflight` tasks and applies a fan-out threshold (posts a brief busy
+  notice and skips spawning beyond it); per-conversation serialization is the per-
+  `thread_key` lock; the global `Semaphore(max_concurrent)` caps simultaneous backend
+  asks. Tested by `test_concurrency_per_thread_serialization` (Section 5a, 8a#21).
+- **G-validation (Slack startup validation).** RESOLVED: `run_slack_bot` resolves both
+  tokens (per-token `RuntimeError`), `auth.test`s once in `_main` BEFORE the socket
+  (caches ids); because `auth.test` raises `SlackApiError` (a plain `Exception`, not a
+  `RuntimeError`), it is WRAPPED into a `RuntimeError` so `serve`'s
+  `except RuntimeError` surfaces it as a clean `ClickException` instead of a raw
+  traceback; reuses the no-channels-and-no-DMs guard; `doctor` shows both tokens as
+  separate lines + the bot user id (Section 5a, 6d).
+- **G-error (missing error-path tests).** RESOLVED: added cases for download-raises ->
+  skipped, non-`BackendError` -> generic + lock released, `send_files` raise swallowed,
+  empty-after-ingest, and the HTML-guard helper (Section 8a#12,13,15,17, 8b#9).
+- **G-mrkdwn-escaping (load-bearing).** RESOLVED: folded into G-03 — `& < >` escaping
+  is mandatory in `discord_to_mrkdwn`, applied before markup translation and to answer
+  text, with a dedicated test asserting `if a < b && c > d` round-trips escaped.
+
+**Minor**
+
+- **G-04 (unknown-handle reply-quote).** RESOLVED (accepted, documented): routed
+  through `send_text(msg.dest, …)`; identical text, reply-quote affordance dropped; no
+  `reply` method added (minimal surface) (Section 4).
+- **G-05 (single-materialization of attachments).** RESOLVED: `attlist =
+  list(attachments)` once; safe because the adapter passes the complete tuple;
+  `AttachmentRef.size` defaults to 0 matching `getattr(att,"size",0) or 0` (Section
+  2c).
+- **G-08 (`list_truncate_len` vs `max_message_len`).** RESOLVED: documented invariant
+  `list_truncate_len <= max_message_len` AND `_list_handles` truncates to the `min(...)`,
+  so the no-re-chunk contract can't be violated (Section 2a, 2c).
+- **G-09 (ingest notices under lock; delivery after).** RESOLVED: the `_answer` port
+  keeps ingest-time `send_text` notices inside the `activity()` + `async with lock,
+  sem` block and answer delivery + deliverables strictly after (Section 2c).
+- **G-10 / G-self (self-drop non-uniform).** RESOLVED: documented as adapter-specific —
+  Discord uses `author.bot` (covers self); Slack additionally compares `bot_id` /
+  `subtype:"bot_message"` / own `user` from `auth.test` (Section 4, 5b, 2b docstrings).
+- **G-18 (thread_ts establishment ordering).** RESOLVED: the channel-surface parent
+  dest carries the triggering `ts` in `thread_ts`; `SlackTransport.open_thread` reads
+  it to build `th:{channel}-{ts}` and thread off it; tested that the channel parent
+  exposes the triggering ts (Section 2b, 5c, 8b#1).
+- **G-19 (Slack length caps).** RESOLVED: `max_message_len=4000` with a comment that
+  40000 is the hard ceiling (do not raise toward it); the `answer.md` preview is
+  `split_chunks(text, limit)[0]` (<= 4000) (Section 2a).
+- **G-25 (consistent thread_ts on every send).** RESOLVED: the conversation's
+  `thread_ts` (the parent ts, fixed at `open_thread`) is forwarded on EVERY
+  `chat_postMessage` and `files_upload_v2`, so the thread is consistent regardless of
+  which send fires first (Section 2a, 5c).
+- **G-broadcast (Slack broadcast/CHANNEL mention rule).** RESOLVED: CHANNEL ignores
+  `addressee` (handle-token parse governs, matching Discord); THREAD broadcasts ->
+  `OTHER`; tested (Section 5b, 8b#4).
+- **G-im-mpim (DM detection for mpim + respond_to_dms).** RESOLVED: both `im` and
+  `mpim` -> `Surface.DM` (`dm:{channel}`), both gated by `respond_to_dms`; mpim test
+  added (Section 5b, 5d, 8b#3).
+- **G-28 (reaper scheduling on Slack).** RESOLVED: the reaper task is created inside
+  `_main` on the same running loop as the per-turn tasks, right before
+  `start_async()` (Section 5a).
+- **G-26 (`cli.ask` bypasses the core).** RESOLVED: documented that `cli.ask` remains a
+  direct backend smoke test (no `ChatCore`), so the moved ingest/deliver code is
+  covered solely by `test_chat_core` (Section 3, 8c, 9b).
+- **G-docs (mdx anchors + security Aside fields).** RESOLVED: edit by header (not line
+  number); update the security Aside to enumerate both Discord and Slack allowlist
+  fields and "Discord OR Slack channel membership" (Section 9a).
+- **G-display (`users_info` fallback chain).** RESOLVED: `resolve_display` returns
+  `display_name or real_name or user.real_name or user.name or user_id`, cached, called
+  only off the ack path (Section 5c, 2b).
+
+---
+
+## Files touched (summary)
+
+- **New:** `claude_code_tools/agent_tunnel/chat_types.py`,
+  `claude_code_tools/agent_tunnel/chat_core.py`,
+  `claude_code_tools/agent_tunnel/slack_bot.py`, `tests/test_chat_core.py`,
+  `tests/test_slack_bot.py`.
+- **Modified:** `claude_code_tools/agent_tunnel/discord_bot.py`,
+  `claude_code_tools/agent_tunnel/config.py`, `claude_code_tools/agent_tunnel/cli.py`,
+  `claude_code_tools/agent_tunnel/__init__.py`, `pyproject.toml`,
+  `claude_code_tools/__init__.py` (version bump), all
+  `plugins/*/.claude-plugin/plugin.json` (version unification),
+  `docs-site/src/content/docs/tools/agent-tunnel.mdx`, `docs/agent-tunnel-spec.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ gdocs = [
     "google-auth-oauthlib>=1.0.0",
     "Pillow>=10.0.0",
 ]
+slack = [
+    "slack_bolt>=1.18.0",
+    "aiohttp>=3.9.0",
+]
 
 [project.scripts]
 # Unified session management interface

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+"""Tests for agent-tunnel CLI helpers (pure, no network, no live config)."""
+
+from __future__ import annotations
+
+from claude_code_tools.agent_tunnel.cli import _reach_check
+
+
+def test_reach_check_channels_ready() -> None:
+    ok, label = _reach_check(["C1"], False)
+    assert ok is True and "C1" in label
+
+
+def test_reach_check_dm_only_ready() -> None:
+    # DM-only (respond_to_dms, no channels) is a valid serve config, so doctor
+    # must pass this readiness check (Codex P3).
+    ok, label = _reach_check([], True)
+    assert ok is True and "DMs only" in label
+
+
+def test_reach_check_neither_not_ready() -> None:
+    ok, label = _reach_check([], False)
+    assert ok is False and "none set" in label

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,15 @@
-"""Tests for agent-tunnel CLI helpers (pure, no network, no live config)."""
+"""Tests for agent-tunnel CLI helpers + config front-end selection.
+
+Pure / offline: no network, no live tokens, no real state — any config is a
+temp TOML and state/registry paths never touch ~/.local/state.
+"""
 
 from __future__ import annotations
 
+import pytest
+
 from claude_code_tools.agent_tunnel.cli import _reach_check
+from claude_code_tools.agent_tunnel.config import load_config
 
 
 def test_reach_check_channels_ready() -> None:
@@ -20,3 +27,70 @@ def test_reach_check_dm_only_ready() -> None:
 def test_reach_check_neither_not_ready() -> None:
     ok, label = _reach_check([], False)
     assert ok is False and "none set" in label
+
+
+# -- load_config: validate only the ACTIVE front-end's channels (Codex P2) ----
+
+
+def test_load_config_validates_only_active_front_end(tmp_path) -> None:
+    # chat=slack with a valid [slack] table must NOT be rejected by a stale,
+    # mistyped [discord] table for the inactive front-end.
+    p = tmp_path / "config.toml"
+    p.write_text(
+        '[tunnel]\nchat = "slack"\n'
+        '[slack]\nchannel_ids = ["C123"]\n'
+        '[discord]\nchannel_ids = ["123"]\n',  # strings: wrong for discord
+        encoding="utf-8",
+    )
+    cfg = load_config(path=p)  # must not raise — discord table is inactive
+    assert cfg.chat == "slack" and cfg.slack.channel_ids == ["C123"]
+
+
+def test_load_config_rejects_active_front_end_bad_channels(tmp_path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text(
+        '[discord]\nchannel_ids = ["123"]\n',  # strings: wrong for discord
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="discord.*integers"):
+        load_config(path=p)  # default chat=discord -> the active table is bad
+
+
+def test_load_config_chat_override_selects_validation(tmp_path) -> None:
+    p = tmp_path / "config.toml"
+    p.write_text(
+        "[slack]\nchannel_ids = [123]\n",  # ints: wrong for slack
+        encoding="utf-8",
+    )
+    # default chat=discord -> the [slack] table is inactive -> OK
+    assert load_config(path=p).chat == "discord"
+    # but --chat slack makes it active -> validated -> rejected
+    with pytest.raises(ValueError, match="slack.*strings"):
+        load_config(path=p, chat="slack")
+
+
+def test_serve_missing_slack_extra_is_clickexception(tmp_path) -> None:
+    # With the `slack` extra absent, `serve --chat slack` must give the install
+    # hint (ClickException), not a raw ModuleNotFoundError traceback (Codex P2).
+    try:
+        import slack_bolt  # type: ignore  # noqa: F401
+
+        pytest.skip("slack_bolt installed; this covers the missing-dep path")
+    except ImportError:
+        pass
+    from click.testing import CliRunner
+
+    from claude_code_tools.agent_tunnel.cli import cli
+
+    p = tmp_path / "config.toml"
+    p.write_text(
+        '[tunnel]\nchat = "slack"\n'
+        f'state_path = "{tmp_path}/state.json"\n'
+        f'registry_path = "{tmp_path}/registry.json"\n'
+        '[slack]\nchannel_ids = ["C1"]\n',
+        encoding="utf-8",
+    )
+    result = CliRunner().invoke(cli, ["serve", "--config", str(p)])
+    assert result.exit_code != 0
+    assert "slack_bolt is required" in result.output
+    assert "claude-code-tools[slack]" in result.output

--- a/tests/test_slack_bot.py
+++ b/tests/test_slack_bot.py
@@ -1,0 +1,817 @@
+"""Pure-function tests for the Slack adapter (slack_bolt-free).
+
+These exercise ONLY the wire-format-free helpers in ``slack_bot`` --
+``slack_event_to_incoming`` (Slack event dict -> normalized
+:class:`IncomingMessage` or ``None``), ``validate_download`` (the HTML/4xx
+download guard), ``discord_to_mrkdwn`` (markdown -> Slack mrkdwn), and
+``_SeenCache`` (bounded dedup). They import none of ``slack_bolt`` /
+``slack_sdk`` / ``aiohttp`` (those are lazy inside ``run_slack_bot`` /
+``SlackTransport``), open no socket, and use no live tokens. Fixture event
+dicts are module-level and mirror real Slack ``message`` payloads; every
+assertion is a plain ``assert`` against a real :class:`IncomingMessage`,
+matching the no-mock style of ``tests/test_discord_bot.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from claude_code_tools.agent_tunnel.chat_types import (
+    AttachmentRef,
+    Addressee,
+    Surface,
+)
+from claude_code_tools.agent_tunnel.slack_bot import (
+    _IGNORE_SUBTYPES,
+    _SeenCache,
+    discord_to_mrkdwn,
+    slack_event_to_incoming,
+    validate_download,
+)
+
+# -- identities + watched channels --------------------------------------------
+
+BOT_USER_ID = "U0LAN0Z89"  # this bot's own user id (auth.test "user_id")
+BOT_ID = "B0LANBOT00"      # this bot's bot id (auth.test "bot_id")
+CHANNEL_IDS = {"C123"}     # the single watched channel for most fixtures
+
+
+# -- fixture event dicts (verbatim-style Slack message payloads) --------------
+
+CHANNEL_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U1",
+    "text": "pay hello",
+    "ts": "1355517523.000005",
+    "channel_type": "channel",
+}
+
+# A reply living in a thread: thread_ts points at the parent, ts is this reply.
+THREAD_REPLY_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U1",
+    "text": "follow up question",
+    "ts": "1700000000.000009",
+    "thread_ts": "1700000000.000100",
+    "channel_type": "channel",
+}
+
+# The thread PARENT itself arrives with thread_ts == ts -> still CHANNEL surface.
+THREAD_PARENT_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U1",
+    "text": "pay parent question",
+    "ts": "1700000000.000100",
+    "thread_ts": "1700000000.000100",
+    "channel_type": "channel",
+}
+
+IM_EVENT = {
+    "type": "message",
+    "channel": "D024BE91L",
+    "user": "U1",
+    "text": "pay hi there",
+    "ts": "1355517523.000010",
+    "channel_type": "im",
+}
+
+MPIM_EVENT = {
+    "type": "message",
+    "channel": "Gmpim0001",
+    "user": "U1",
+    "text": "pay group hi",
+    "ts": "1355517523.000011",
+    "channel_type": "mpim",
+}
+
+# Leading mentions inside a THREAD (mention logic only applies on THREAD).
+THREAD_SELF_MENTION_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U2",
+    "text": f"<@{BOT_USER_ID}> what's up?",
+    "ts": "1700000000.000200",
+    "thread_ts": "1700000000.000100",
+    "channel_type": "channel",
+}
+
+THREAD_OTHER_MENTION_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U2",
+    "text": "<@U999> can you take this?",
+    "ts": "1700000000.000201",
+    "thread_ts": "1700000000.000100",
+    "channel_type": "channel",
+}
+
+THREAD_BROADCAST_MENTION_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U2",
+    "text": "<!here> anyone around?",
+    "ts": "1700000000.000202",
+    "thread_ts": "1700000000.000100",
+    "channel_type": "channel",
+}
+
+# On a watched CHANNEL surface, <!here> is just a (non-handle) leading token.
+CHANNEL_BROADCAST_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U2",
+    "text": "<!here> pay please look",
+    "ts": "1700000000.000203",
+    "channel_type": "channel",
+}
+
+# A message carrying a file (regular subtype-less message + files[]).
+FILE_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U1",
+    "text": "",
+    "ts": "1700000000.000300",
+    "channel_type": "channel",
+    "files": [
+        {
+            "id": "F1",
+            "name": "ghostrap.png",
+            "size": 12345,
+            "url_private_download": "https://files.slack.com/dl/T-F1/ghostrap.png",
+            "url_private": "https://files.slack.com/pri/T-F1/ghostrap.png",
+        }
+    ],
+}
+
+# A file with a null name -> filename falls back to file-{id}.
+FILE_NULL_NAME_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U1",
+    "text": "",
+    "ts": "1700000000.000301",
+    "channel_type": "channel",
+    "files": [
+        {
+            "id": "F1",
+            "name": None,
+            "size": 999,
+            "url_private_download": "https://files.slack.com/files-pri/T-F1/download/x",
+        }
+    ],
+}
+
+# A file with only url_private (no _download) -> url falls back to url_private.
+FILE_URL_PRIVATE_ONLY_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U1",
+    "text": "",
+    "ts": "1700000000.000302",
+    "channel_type": "channel",
+    "files": [
+        {
+            "id": "F2",
+            "name": "notes.txt",
+            "size": 42,
+            "url_private": "https://files.slack.com/files-pri/T-F2/notes.txt",
+        }
+    ],
+}
+
+# Drop fixtures.
+BOT_SUBTYPE_EVENT = {
+    "type": "message",
+    "subtype": "bot_message",
+    "channel": "C123",
+    "bot_id": "Bsomeother",
+    "text": "I am a bot",
+    "ts": "1700000000.000400",
+    "channel_type": "channel",
+}
+
+OWN_BOT_ID_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "bot_id": BOT_ID,
+    "text": "echo from myself",
+    "ts": "1700000000.000401",
+    "channel_type": "channel",
+}
+
+OWN_USER_EVENT = {
+    "type": "message",
+    "channel": "D024BE91L",
+    "user": BOT_USER_ID,
+    "text": "my own DM echo",
+    "ts": "1700000000.000402",
+    "channel_type": "im",
+}
+
+MESSAGE_CHANGED_EVENT = {
+    "type": "message",
+    "subtype": "message_changed",
+    "channel": "C123",
+    "ts": "1700000000.000403",
+    "channel_type": "channel",
+    "message": {"user": "U1", "text": "edited text", "ts": "1700000000.000300"},
+}
+
+MESSAGE_DELETED_EVENT = {
+    "type": "message",
+    "subtype": "message_deleted",
+    "channel": "C123",
+    "ts": "1700000000.000404",
+    "channel_type": "channel",
+    "deleted_ts": "1700000000.000300",
+}
+
+CHANNEL_JOIN_EVENT = {
+    "type": "message",
+    "subtype": "channel_join",
+    "channel": "C123",
+    "user": "U1",
+    "text": "<@U1> has joined the channel",
+    "ts": "1700000000.000405",
+    "channel_type": "channel",
+}
+
+# Not a watched channel.
+UNWATCHED_CHANNEL_EVENT = {
+    "type": "message",
+    "channel": "C999",
+    "user": "U1",
+    "text": "pay hello",
+    "ts": "1700000000.000500",
+    "channel_type": "channel",
+}
+
+# A THREAD reply (thread_ts != ts) in an UNWATCHED channel. Thread replies are
+# intentionally NOT re-gated by channel_ids (only top-level CHANNEL posts are).
+UNWATCHED_THREAD_REPLY_EVENT = {
+    "type": "message",
+    "channel": "C999",
+    "user": "U1",
+    "text": "follow up in an unwatched channel",
+    "ts": "1700000000.000501",
+    "thread_ts": "1700000000.000100",
+    "channel_type": "channel",
+}
+
+# A leading <!subteam^S…> usergroup mention inside a THREAD -> Addressee.OTHER.
+THREAD_SUBTEAM_MENTION_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U2",
+    "text": "<!subteam^S0LTEAM> ping",
+    "ts": "1700000000.000502",
+    "thread_ts": "1700000000.000100",
+    "channel_type": "channel",
+}
+
+# A self-mention on a CHANNEL surface (no thread_ts): mention logic is THREAD-
+# only, so this must stay NONE and the text must NOT be stripped.
+CHANNEL_SELF_MENTION_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U2",
+    "text": f"<@{BOT_USER_ID}> hello",
+    "ts": "1700000000.000503",
+    "channel_type": "channel",
+}
+
+# A DM (im) carrying a single file (url_private only) -> DM surface, 1 file.
+DM_FILE_EVENT = {
+    "type": "message",
+    "channel": "D024BE91L",
+    "user": "U1",
+    "text": "",
+    "ts": "1700000000.000504",
+    "channel_type": "im",
+    "files": [
+        {
+            "id": "F9",
+            "name": "dm-note.txt",
+            "size": 17,
+            "url_private": "https://files.slack.com/files-pri/T-F9/dm-note.txt",
+        }
+    ],
+}
+
+# A CHANNEL-surface post with NO ts: cannot anchor a thread -> dropped.
+CHANNEL_NO_TS_EVENT = {
+    "type": "message",
+    "channel": "C123",
+    "user": "U1",
+    "text": "pay no timestamp",
+    "channel_type": "channel",
+}
+
+
+# -- 1. channel message -------------------------------------------------------
+
+
+def test_channel_message() -> None:
+    msg = slack_event_to_incoming(
+        CHANNEL_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.CHANNEL
+    assert msg.text == "pay hello"
+    assert msg.author_id == "U1"
+    assert msg.channel_id == "C123"
+    assert msg.ts == "1355517523.000005"
+    assert msg.addressee is Addressee.NONE
+    # CHANNEL dest carries no key but DOES carry the triggering ts so
+    # open_thread can anchor a Slack thread off it (G-18).
+    assert msg.dest.thread_key == ""
+    assert msg.dest.surface is Surface.CHANNEL
+    assert msg.dest.channel_id == "C123"
+    assert msg.dest.thread_ts == "1355517523.000005"
+
+
+# -- 2. threaded reply vs thread parent ---------------------------------------
+
+
+def test_threaded_reply_thread_ts_differs() -> None:
+    msg = slack_event_to_incoming(
+        THREAD_REPLY_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.THREAD
+    assert msg.dest.thread_key == "th:C123-1700000000.000100"
+    assert msg.dest.surface is Surface.THREAD
+    assert msg.dest.thread_ts == "1700000000.000100"
+    assert msg.dest.channel_id == "C123"
+    assert msg.ts == "1700000000.000009"
+
+
+def test_thread_parent_thread_ts_equals_ts_is_channel() -> None:
+    # The parent message of a thread (thread_ts == ts) is NOT a follow-up; it
+    # routes as CHANNEL so the handle-opens-thread path runs.
+    msg = slack_event_to_incoming(
+        THREAD_PARENT_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.CHANNEL
+    assert msg.dest.thread_key == ""
+    assert msg.dest.thread_ts == "1700000000.000100"
+    # The thread PARENT routes with a CHANNEL dest (open_thread later reads
+    # parent.thread_ts off a CHANNEL-surface dest), so pin dest.surface/channel.
+    assert msg.dest.surface is Surface.CHANNEL
+    assert msg.dest.channel_id == "C123"
+
+
+# -- 3. im AND mpim -> DM -----------------------------------------------------
+
+
+def test_im_message() -> None:
+    msg = slack_event_to_incoming(
+        IM_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS, respond_to_dms=True,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.DM
+    assert msg.dest.thread_key == "dm:D024BE91L"
+    assert msg.dest.surface is Surface.DM
+    assert msg.channel_id == "D024BE91L"
+
+
+def test_mpim_message() -> None:
+    msg = slack_event_to_incoming(
+        MPIM_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS, respond_to_dms=True,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.DM
+    assert msg.dest.thread_key == "dm:Gmpim0001"
+    assert msg.channel_id == "Gmpim0001"
+
+
+# -- 4. leading-mention -> Addressee ------------------------------------------
+
+
+def test_leading_self_mention_stripped() -> None:
+    msg = slack_event_to_incoming(
+        THREAD_SELF_MENTION_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.THREAD
+    assert msg.addressee is Addressee.SELF
+    assert msg.text == "what's up?"  # the leading <@bot> is stripped
+
+
+def test_leading_other_mention_is_other_unstripped() -> None:
+    msg = slack_event_to_incoming(
+        THREAD_OTHER_MENTION_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.THREAD
+    assert msg.addressee is Addressee.OTHER
+    assert msg.text == "<@U999> can you take this?"  # NOT stripped
+
+
+def test_leading_broadcast_in_thread_is_other() -> None:
+    msg = slack_event_to_incoming(
+        THREAD_BROADCAST_MENTION_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.THREAD
+    assert msg.addressee is Addressee.OTHER
+
+
+def test_leading_subteam_in_thread_is_other() -> None:
+    # The third OTHER-producing leading regex (<!subteam^S…>) -> OTHER, text
+    # unstripped, so the bot stays out when teammates ping a usergroup.
+    msg = slack_event_to_incoming(
+        THREAD_SUBTEAM_MENTION_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.THREAD
+    assert msg.addressee is Addressee.OTHER
+    assert msg.text == "<!subteam^S0LTEAM> ping"  # NOT stripped
+
+
+def test_leading_broadcast_on_channel_is_none() -> None:
+    # On CHANNEL the handle-token parse governs; addressee stays NONE so the
+    # core treats "<!here>" as a (non-handle) token and stays silent (G-broadcast).
+    msg = slack_event_to_incoming(
+        CHANNEL_BROADCAST_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.CHANNEL
+    assert msg.addressee is Addressee.NONE
+    assert msg.text == "<!here> pay please look"  # left intact for token parse
+
+
+def test_self_mention_on_channel_is_none_unstripped() -> None:
+    # Mention logic is THREAD-only: a leading <@bot> on a CHANNEL surface (no
+    # thread_ts) must stay NONE and the text must NOT be stripped.
+    msg = slack_event_to_incoming(
+        CHANNEL_SELF_MENTION_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.CHANNEL
+    assert msg.addressee is Addressee.NONE
+    assert msg.text == f"<@{BOT_USER_ID}> hello"  # unstripped on CHANNEL
+
+
+# -- 5. message with files ----------------------------------------------------
+
+
+def test_message_with_files_not_dropped() -> None:
+    msg = slack_event_to_incoming(
+        FILE_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None  # attachment-only (text=="") is NOT dropped
+    assert msg.text == ""
+    file_dict = FILE_EVENT["files"][0]
+    assert msg.attachments == (
+        AttachmentRef(
+            "ghostrap.png",
+            12345,
+            url="https://files.slack.com/dl/T-F1/ghostrap.png",
+            _native=file_dict,
+        ),
+    )
+
+
+def test_message_with_file_null_name_falls_back() -> None:
+    msg = slack_event_to_incoming(
+        FILE_NULL_NAME_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert len(msg.attachments) == 1
+    att = msg.attachments[0]
+    assert att.filename == "file-F1"  # null name -> file-{id}
+    assert att.size == 999
+
+
+def test_message_with_file_url_private_fallback() -> None:
+    msg = slack_event_to_incoming(
+        FILE_URL_PRIVATE_ONLY_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert len(msg.attachments) == 1
+    att = msg.attachments[0]
+    assert att.filename == "notes.txt"
+    # no url_private_download -> url_private is used.
+    assert att.url == "https://files.slack.com/files-pri/T-F2/notes.txt"
+
+
+def test_dm_with_file_preserved() -> None:
+    # An attachment-only DM (im) keeps its file on the DM surface (the files[]
+    # parse is shared, but the DM branch sets a different dest).
+    msg = slack_event_to_incoming(
+        DM_FILE_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS, respond_to_dms=True,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.DM
+    assert msg.dest.thread_key == "dm:D024BE91L"
+    assert len(msg.attachments) == 1
+    assert (
+        msg.attachments[0].url
+        == "https://files.slack.com/files-pri/T-F9/dm-note.txt"
+    )
+
+
+# -- 6. bot / edit / delete / own / system messages -> None -------------------
+
+
+def test_bot_subtype_ignored() -> None:
+    assert slack_event_to_incoming(
+        BOT_SUBTYPE_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    ) is None
+
+
+def test_own_bot_id_ignored() -> None:
+    assert slack_event_to_incoming(
+        OWN_BOT_ID_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    ) is None
+
+
+def test_own_user_ignored() -> None:
+    # Own user id in an im (respond_to_dms on) is still dropped as a self-loop.
+    assert slack_event_to_incoming(
+        OWN_USER_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS, respond_to_dms=True,
+    ) is None
+
+
+def test_message_changed_ignored() -> None:
+    assert slack_event_to_incoming(
+        MESSAGE_CHANGED_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    ) is None
+
+
+def test_message_deleted_ignored() -> None:
+    assert slack_event_to_incoming(
+        MESSAGE_DELETED_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    ) is None
+
+
+def test_channel_join_ignored() -> None:
+    assert slack_event_to_incoming(
+        CHANNEL_JOIN_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    ) is None
+
+
+@pytest.mark.parametrize("subtype", sorted(_IGNORE_SUBTYPES))
+def test_ignored_subtypes_all_dropped(subtype: str) -> None:
+    # Pin the WHOLE housekeeping-noise trust boundary: every subtype in
+    # _IGNORE_SUBTYPES drops, so a typo/removal of any one is caught (not just
+    # the message_changed/_deleted/channel_join/bot_message that have fixtures).
+    event = {
+        "type": "message",
+        "subtype": subtype,
+        "channel": "C123",
+        "user": "U1",
+        "text": "housekeeping noise",
+        "ts": "1700000000.000600",
+        "channel_type": "channel",
+    }
+    assert slack_event_to_incoming(
+        event, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    ) is None
+
+
+# -- 7. watched-channel gate + respond_to_dms gate ----------------------------
+
+
+def test_channel_not_watched_dropped() -> None:
+    assert slack_event_to_incoming(
+        UNWATCHED_CHANNEL_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    ) is None
+
+
+def test_dm_respond_to_dms_gate() -> None:
+    # DMs are NOT gated by channel_ids, but ARE gated by respond_to_dms.
+    enabled = slack_event_to_incoming(
+        IM_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS, respond_to_dms=True,
+    )
+    assert enabled is not None and enabled.surface is Surface.DM
+    disabled = slack_event_to_incoming(
+        IM_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS, respond_to_dms=False,
+    )
+    assert disabled is None  # DMs off -> dropped
+
+
+def test_mpim_respond_to_dms_off_dropped() -> None:
+    # The mpim off-gate path (not just im): respond_to_dms=False drops it.
+    assert slack_event_to_incoming(
+        MPIM_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS, respond_to_dms=False,
+    ) is None
+
+
+def test_thread_reply_in_unwatched_channel_still_routes() -> None:
+    # SECURITY-RELEVANT routing rule: a THREAD reply (thread_ts != ts) is NOT
+    # re-gated by channel_ids. A reply in C999 (NOT watched) still routes as a
+    # THREAD. Only top-level CHANNEL posts are gated; pin this so a future
+    # "tighten the gate" refactor that breaks the thread-bypass is caught.
+    msg = slack_event_to_incoming(
+        UNWATCHED_THREAD_REPLY_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.THREAD
+    assert msg.dest.thread_key == "th:C999-1700000000.000100"
+    assert msg.dest.channel_id == "C999"
+
+
+def test_channel_no_ts_dropped() -> None:
+    # A CHANNEL-surface post with no ts cannot anchor a thread -> dropped (the
+    # binding would key on "th:{channel}-" and a real reply could never match).
+    assert slack_event_to_incoming(
+        CHANNEL_NO_TS_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS,
+    ) is None
+
+
+def test_empty_bot_ids_does_not_drop_normal_message() -> None:
+    # G-20 bootstrap window: on the very FIRST event (before auth.test populates
+    # the ids) bot_user_id/bot_id are still "". The `bot_id and …` /
+    # `bot_user_id and …` short-circuits must keep a normal user message from
+    # self-dropping, so it still classifies as CHANNEL.
+    msg = slack_event_to_incoming(
+        CHANNEL_EVENT, bot_user_id="", bot_id="", channel_ids=CHANNEL_IDS,
+    )
+    assert msg is not None
+    assert msg.surface is Surface.CHANNEL
+
+
+# -- 8. resolve_display -------------------------------------------------------
+
+
+def test_resolve_display_used() -> None:
+    names = {"U1": "Alice"}
+
+    def resolver(uid: str) -> str:
+        # Annotated -> (str) -> str (a bare `names.get(uid, uid)` lambda would
+        # infer `str | None` and trip the resolve_display: Callable[[str], str]
+        # parameter).
+        return names.get(uid, uid)
+
+    known = slack_event_to_incoming(
+        CHANNEL_EVENT, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS, resolve_display=resolver,
+    )
+    assert known is not None and known.author_display == "Alice"
+    # an unknown user resolves to its raw id (the no-op fallback).
+    other = dict(CHANNEL_EVENT, user="U2")
+    unknown = slack_event_to_incoming(
+        other, bot_user_id=BOT_USER_ID, bot_id=BOT_ID,
+        channel_ids=CHANNEL_IDS, resolve_display=resolver,
+    )
+    assert unknown is not None and unknown.author_display == "U2"
+
+
+# -- 9. validate_download HTML / 4xx guard ------------------------------------
+
+
+def test_validate_download_html_guard_raises() -> None:
+    # text/html (a login page on a stripped-auth redirect) is an auth failure.
+    with pytest.raises(RuntimeError):
+        validate_download("text/html; charset=utf-8", 200)
+
+
+def test_validate_download_status_4xx_raises() -> None:
+    with pytest.raises(RuntimeError):
+        validate_download("image/png", 404)
+    with pytest.raises(RuntimeError):
+        validate_download("application/octet-stream", 500)
+    # 400 is the EXACT failure boundary (status >= 400).
+    with pytest.raises(RuntimeError):
+        validate_download("image/png", 400)
+
+
+def test_validate_download_ok_does_not_raise() -> None:
+    # a real binary download returns None (no raise).
+    assert validate_download("image/png", 200) is None
+    # 399 is just below the boundary -> ok.
+    assert validate_download("image/png", 399) is None
+    # A missing / empty Content-Type on a real 200 must NOT be mistaken for an
+    # HTML login page (the `(content_type or "")` None-guard).
+    assert validate_download(None, 200) is None
+    assert validate_download("", 200) is None
+
+
+# -- 10. discord_to_mrkdwn translations ---------------------------------------
+
+
+def test_discord_to_mrkdwn_bold() -> None:
+    assert discord_to_mrkdwn("**b**") == "*b*"
+
+
+def test_discord_to_mrkdwn_link() -> None:
+    assert discord_to_mrkdwn("[t](u)") == "<u|t>"
+
+
+def test_discord_to_mrkdwn_strikethrough() -> None:
+    assert discord_to_mrkdwn("~~s~~") == "~s~"
+
+
+def test_discord_to_mrkdwn_escapes_amp_lt_gt_first() -> None:
+    # & < > are HTML-escaped BEFORE any markup translation, so a literal
+    # "a < b && c > d" round-trips fully escaped and unmangled.
+    assert (
+        discord_to_mrkdwn("a < b && c > d")
+        == "a &lt; b &amp;&amp; c &gt; d"
+    )
+
+
+def test_discord_to_mrkdwn_code_passthrough() -> None:
+    # inline code and fenced blocks survive translation unchanged.
+    assert discord_to_mrkdwn("`x`") == "`x`"
+    fence = "```\ncode line\n```"
+    assert discord_to_mrkdwn(fence) == fence
+
+
+def test_discord_to_mrkdwn_link_url_with_amp_escaped_then_linked() -> None:
+    # The load-bearing reason escaping runs FIRST: a link URL containing '&'
+    # (a query string — the common case) is escaped to &amp; THEN wrapped as
+    # <url|text>; Slack unescapes &amp; on render, so the link survives intact.
+    assert (
+        discord_to_mrkdwn("[click](http://x?a=1&b=2)")
+        == "<http://x?a=1&amp;b=2|click>"
+    )
+
+
+def test_discord_to_mrkdwn_bold_link_combo() -> None:
+    # bold wrapping a link: **[t](u)** -> *<u|t>* (markup order is stable).
+    assert discord_to_mrkdwn("**[t](u)**") == "*<u|t>*"
+
+
+def test_discord_to_mrkdwn_bold_across_newline() -> None:
+    # the **bold** regex uses re.DOTALL, so a bold span across a newline folds.
+    assert discord_to_mrkdwn("**a\nb**") == "*a\nb*"
+
+
+# -- 11. _SeenCache add / dup / capacity --------------------------------------
+
+
+def test_seen_cache_add_then_dup() -> None:
+    seen = _SeenCache(cap=4)
+    assert seen.add("k1") is True   # first sight -> accepted
+    assert seen.add("k1") is False  # repeat -> rejected (dedup hit)
+
+
+def test_seen_cache_capacity_evicts_oldest() -> None:
+    seen = _SeenCache(cap=4)
+    for k in ("a", "b", "c", "d"):
+        assert seen.add(k) is True
+    # exceeding cap evicts the oldest ("a"); "a" is then treated as new again.
+    assert seen.add("e") is True
+    assert seen.add("a") is True
+    # a still-resident recent key remains a duplicate.
+    assert seen.add("e") is False
+
+
+def test_seen_cache_dup_does_not_refresh_recency() -> None:
+    # Eviction is by INSERTION order, NOT recency: re-adding a present key does
+    # NOT move it to the end. Pins insertion-order dedup and FORBIDS an accidental
+    # LRU change (a move_to_end in add() would silently alter which retries drop).
+    # cap=3 so a single overflow makes one clean, unambiguous eviction.
+    seen = _SeenCache(cap=3)
+    assert seen.add("a") is True
+    assert seen.add("b") is True
+    assert seen.add("c") is True
+    assert seen.add("a") is False  # dup, must NOT refresh a's position
+    # The load-bearing assertion: adding "d" overflows cap=3 and evicts the
+    # OLDEST BY INSERTION ("a"), NOT "b" — even though "a" was "touched" most
+    # recently by the dup add above. Under an LRU (move_to_end on dup) the dup
+    # would have moved "a" to the newest slot, so "b" would be evicted instead.
+    assert seen.add("d") is True
+    # Check the survivors FIRST (these are pure reads — a dup add never mutates):
+    # "b" and "c" stayed resident; under an LRU "b" would have been evicted.
+    assert seen.add("b") is False  # b resident (would be gone under LRU)
+    assert seen.add("c") is False  # c resident
+    assert seen.add("d") is False  # d resident
+    # ...and only now confirm "a" itself WAS the one evicted (mutates state).
+    assert seen.add("a") is True   # a was evicted -> seen as new again

--- a/tests/test_slack_bot.py
+++ b/tests/test_slack_bot.py
@@ -14,6 +14,8 @@ matching the no-mock style of ``tests/test_discord_bot.py``.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from claude_code_tools.agent_tunnel.chat_types import (
@@ -21,9 +23,11 @@ from claude_code_tools.agent_tunnel.chat_types import (
     Addressee,
     Surface,
 )
+from claude_code_tools.agent_tunnel.config import TunnelConfig
 from claude_code_tools.agent_tunnel.slack_bot import (
     _IGNORE_SUBTYPES,
     _SeenCache,
+    SlackTransport,
     discord_to_mrkdwn,
     slack_event_to_incoming,
     validate_download,
@@ -815,3 +819,55 @@ def test_seen_cache_dup_does_not_refresh_recency() -> None:
     assert seen.add("d") is False  # d resident
     # ...and only now confirm "a" itself WAS the one evicted (mutates state).
     assert seen.add("a") is True   # a was evicted -> seen as new again
+
+
+# -- SlackTransport usergroup resolution (Codex P2) ---------------------------
+# Fills IncomingMessage.author_role_ids from subteam membership so a
+# `slack.allowed_usergroup_ids` allowlist actually works. Uses a real fake
+# async client stub (no slack_bolt, no network, no mocks).
+
+
+class _FakeUGClient:
+    """Minimal async Slack client stub for usergroups.users.list."""
+
+    def __init__(self, members: dict) -> None:
+        self._members = members
+        self.calls: list[str] = []
+
+    async def usergroups_users_list(self, *, usergroup: str) -> dict:
+        self.calls.append(usergroup)
+        return {"users": self._members.get(usergroup, [])}
+
+
+class _FakeApp:
+    def __init__(self, client: _FakeUGClient) -> None:
+        self.client = client
+
+
+def _slack_cfg(tmp_path, usergroups=()) -> TunnelConfig:
+    cfg = TunnelConfig(
+        state_path=tmp_path / "s.json", registry_path=tmp_path / "r.json"
+    )
+    cfg.slack.allowed_usergroup_ids = list(usergroups)
+    return cfg
+
+
+def test_resolve_usergroups_matches_membership(tmp_path) -> None:
+    cfg = _slack_cfg(tmp_path, usergroups=["S1", "S2"])
+    client = _FakeUGClient({"S1": ["U1", "U2"], "S2": ["U9"]})
+    tx = SlackTransport(_FakeApp(client), "xoxb-test", cfg)
+    assert asyncio.run(tx.resolve_usergroups("U1")) == frozenset({"S1"})
+    assert asyncio.run(tx.resolve_usergroups("U9")) == frozenset({"S2"})
+    assert asyncio.run(tx.resolve_usergroups("U404")) == frozenset()
+    # membership is cached: later lookups re-list no already-seen subteam
+    seen = len(client.calls)
+    asyncio.run(tx.resolve_usergroups("U2"))
+    assert len(client.calls) == seen
+
+
+def test_resolve_usergroups_noop_when_unconfigured(tmp_path) -> None:
+    cfg = _slack_cfg(tmp_path)  # allowed_usergroup_ids empty
+    client = _FakeUGClient({"S1": ["U1"]})
+    tx = SlackTransport(_FakeApp(client), "xoxb-test", cfg)
+    assert asyncio.run(tx.resolve_usergroups("U1")) == frozenset()
+    assert client.calls == []  # zero API calls on the common path

--- a/tests/test_slack_bot.py
+++ b/tests/test_slack_bot.py
@@ -755,6 +755,18 @@ def test_discord_to_mrkdwn_code_passthrough() -> None:
     assert discord_to_mrkdwn("`x`") == "`x`"
     fence = "```\ncode line\n```"
     assert discord_to_mrkdwn(fence) == fence
+    # markup INSIDE code is preserved verbatim, NOT rewritten (Codex P2): a code
+    # snippet containing bold/link/strike must reach Slack untouched.
+    assert discord_to_mrkdwn("`**x**`") == "`**x**`"
+    snippet = "```\nf(x) = [a](b) **y** ~~z~~\n```"
+    assert discord_to_mrkdwn(snippet) == snippet
+    # ...but `& < >` ARE still escaped inside code (Slack's only escapes)...
+    assert discord_to_mrkdwn("`a < b`") == "`a &lt; b`"
+    # ...and markup OUTSIDE the code span is still translated.
+    assert (
+        discord_to_mrkdwn("see **bold** then `[t](u)` end")
+        == "see *bold* then `[t](u)` end"
+    )
 
 
 def test_discord_to_mrkdwn_link_url_with_amp_escaped_then_linked() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },
@@ -349,9 +349,14 @@ gdocs = [
     { name = "google-auth-oauthlib" },
     { name = "pillow" },
 ]
+slack = [
+    { name = "aiohttp" },
+    { name = "slack-bolt" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", marker = "extra == 'slack'", specifier = ">=3.9.0" },
     { name = "claude-agent-sdk", specifier = ">=0.1.6" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "commitizen", specifier = ">=4.8.3" },
@@ -366,6 +371,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "slack-bolt", marker = "extra == 'slack'", specifier = ">=1.18.0" },
     { name = "tantivy", specifier = ">=0.22.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
@@ -1638,6 +1644,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696 },
+]
+
+[[package]]
+name = "slack-bolt"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "slack-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/97/a62dde97e84027b252807f2044bed2edcda2d063a5cb0c535fb2be8d9b5d/slack_bolt-1.28.0.tar.gz", hash = "sha256:bfe367d867e8fb157a057248ebd4ac2d7f43acac6d0700fa31381db1e10f3b0f", size = 130768 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/a9/697b6a92c728f09d5ef6b8e83dc6c8a87bc6d59499b2933ed067f11b7e30/slack_bolt-1.28.0-py2.py3-none-any.whl", hash = "sha256:738d1ca5e7c7039b6e18103d29267ced6e18c2517053eff18991fdd593acce5c", size = 234819 },
+]
+
+[[package]]
+name = "slack-sdk"
+version = "3.42.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/00/16258bfa547559b2c936b50c882b4f0a36ebf6b69639eb763d8fa5e8d6cb/slack_sdk-3.42.0.tar.gz", hash = "sha256:873db9e1f632ac650ffdbf9d8ba825f3e9e7e576a1e4f9604ccb2a15b3727e3d", size = 252136 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/ef/8a1556bd4843443993fc116783790a7cc553601a37f7d965ec26eef95e76/slack_sdk-3.42.0-py2.py3-none-any.whl", hash = "sha256:eb39aff97e476e10cc5a8ac29bd2e79a9959e880d9fe0c03b4e8f05b2ac996ff", size = 315469 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Stacked on #88** (base = `feat/agent-tunnel-slack-bot`) — review/merge #88 first; this
diff is only the Slack work. A second chat front-end with **full Discord parity**,
built on the `chat_core` seam from #88, so it reuses 100% of the routing/policy/answer
pipeline. Slack runs over **Socket Mode** (outbound websocket, no public URL, no port).

## What's here

- **`slack_bot.py`** (new, 712 ln) — a thin adapter over `ChatCore`:
  - `run_slack_bot`: two tokens (`xoxb-` bot + `xapp-` app-level), `auth.test`
    **before** the socket opens (caches bot ids), a **single** `@app.event("message")`
    listener (no `app_mention` → no double-answer), synchronous drop/classify/dedup then
    `create_task` (3s ack), bounded **insertion-ordered** `_SeenCache`, reaper on the
    loop, `try/finally` graceful shutdown (cancels reaper, closes socket + download
    session).
  - `slack_event_to_incoming` (pure, `slack_bolt`-free): `im`/`mpim` DM, `thread_ts`
    threading, leading-mention → `Addressee` (+ self-strip), `files[]` →`AttachmentRef`,
    watched-channel gate with an intentional **thread-bypass** (a follow-up is answered
    wherever it lives).
  - `SlackTransport`: mrkdwn translation (escape `& < >` first), **same `thread_ts` on
    every send**, `files_upload_v2`, authenticated `url_private` download with a
    redirect-surviving bearer header + HTML-login guard, `reactions_add`, cached
    `users_info`. `slack_bolt`/`slack_sdk`/`aiohttp` all imported lazily.
- **`config.py`** — `SlackConfig`, `TunnelConfig.chat`/`slack`, chat-aware
  `principal_allowlists`, `load_config` chat override + auto-platform + channel-id type
  validation, `[slack]` sample block.
- **`cli.py`** — `serve --chat {discord,slack}` dispatch, per-front-end channel
  coercion, doctor two-token Slack branch.
- **`pyproject.toml`** — optional `[slack]` extra (`slack_bolt`, `aiohttp`); `discord.py`
  stays a hard dep (no break for existing users). No version bump (release step).
- **`tests/test_slack_bot.py`** (new) — the parser + helpers from fixture payloads (no
  `slack_bolt`, no network, no live tokens).
- **`docs/agent-tunnel-slack-spec.md`** — the full implementation spec.

## Verification

Built and **adversarially reviewed** by a multi-agent workflow (Slack-API correctness,
spec-conformance, test-adequacy + daemon-safety), then fixed to green. Full suite
**133 passed**; Pyright **0 errors**; every file <1000 lines; lines ≤88.

Two minor items deliberately left: the exact OAuth scope set isn't empirically confirmed
against a live workspace (documented as "at least these" + a `missing_scope` fallback),
and the best-effort busy-notice isn't wrapped in try/except (a dropped "busy" message is
harmless).

The same handle registry serves both front-ends, so existing `>share` handles are
reachable from Slack with no re-share. Manual Slack smoke test (open thread, follow-up,
attachment round-trip, `!done`) pending.
