### PR TITLE
fix(agent-tunnel): handle/thread lifecycle — reclaim revoked names, revoke CLI, forget --handle

### DIFF
--- a/claude_code_tools/agent_tunnel/cli.py
+++ b/claude_code_tools/agent_tunnel/cli.py
@@ -588,6 +588,24 @@ def rename(old: str, new: str, config: Optional[str]) -> None:
 
 
 @cli.command()
+@click.argument("handle")
+@click.option("--config", type=click.Path(), help="Config TOML path.")
+def revoke(handle: str, config: Optional[str]) -> None:
+    """Revoke (unpublish) a shared HANDLE from outside its session.
+
+    The in-session ``>share off`` only works from the owning Claude session;
+    this releases a handle whose session is gone, so the name can be reused.
+    Existing bound forks keep working (a fork holds its own copy of history);
+    new threads can't open on it until it is re-shared.
+    """
+    cfg = _build(config)
+    if Registry(cfg.registry_path).revoke(handle):
+        click.echo(f"Revoked handle '{handle.strip().lower()}'.")
+    else:
+        raise click.ClickException(f"No handle '{handle}' in the registry.")
+
+
+@cli.command()
 @click.option("--config", type=click.Path(), help="Config TOML path.")
 def watch(config: Optional[str]) -> None:
     """Attach to the private tmux server to watch live fork sessions.
@@ -693,15 +711,24 @@ def status(config: Optional[str]) -> None:
 @click.option(
     "--backend", type=click.Choice(["tmux", "headless"]), default=None
 )
-@click.option("--thread", help="Thread key to forget.")
+@click.option("--thread", help="Thread key to forget (one thread).")
+@click.option(
+    "--handle",
+    help="Forget ALL threads of this handle (every fork it spawned).",
+)
 @click.option("--all", "forget_all", is_flag=True, help="Forget everything.")
 def forget(
     config: Optional[str],
     backend: Optional[str],
     thread: Optional[str],
+    handle: Optional[str],
     forget_all: bool,
 ) -> None:
     """Drop thread mappings (and kill their tmux windows).
+
+    Pick exactly one target: ``--thread <key>`` (one thread), ``--handle
+    <name>`` (every thread/fork that handle spawned — a handle opened in several
+    Discord threads shows several rows in ``forks``), or ``--all``.
 
     Known limitation: this runs in a separate process from the daemon, so it
     does not coordinate with an in-flight turn. Running it while the daemon is
@@ -711,12 +738,17 @@ def forget(
     in-thread, or run ``forget`` when the thread is idle; fully closing this
     would need a cross-process per-turn lock.
     """
-    if bool(thread) == forget_all:
-        raise click.ClickException("Use exactly one of --thread or --all.")
+    if sum(bool(x) for x in (thread, handle, forget_all)) != 1:
+        raise click.ClickException(
+            "Use exactly one of --thread, --handle, or --all."
+        )
     cfg = _build(config, backend)
     store = TunnelStore(cfg.state_path)
     if forget_all:
         keys = [r.thread_key for r in store.all_records()]
+    elif handle:
+        h = handle.strip().lower()
+        keys = [r.thread_key for r in store.all_records() if r.handle == h]
     else:
         keys = [thread] if thread else []
     cache: dict[str, Backend] = {}
@@ -725,7 +757,9 @@ def forget(
         backend_for_record(cfg, store, rec, cache).forget(key)
         click.echo(f"Forgot {key}")
     if not keys:
-        click.echo("Nothing to forget.")
+        click.echo(
+            f"No threads for handle '{handle}'." if handle else "Nothing to forget."
+        )
 
 
 @cli.command()

--- a/plugins/agent-tunnel/hooks/share_hook.py
+++ b/plugins/agent-tunnel/hooks/share_hook.py
@@ -106,7 +106,14 @@ def _publish(session_id, cwd, transcript_path, config_dir, access, label):
             if label:
                 handle = label
                 taken = records.get(handle)
-                if taken and taken.get("session_id") != session_id:
+                # A revoked handle is free for anyone to reclaim (matches
+                # Registry.rename); only a LIVE handle owned by a different
+                # session is a real collision.
+                if (
+                    taken
+                    and not taken.get("revoked")
+                    and taken.get("session_id") != session_id
+                ):
                     return None, handle  # collision
                 if existing and existing != handle:
                     records.pop(existing, None)
@@ -119,10 +126,14 @@ def _publish(session_id, cwd, transcript_path, config_dir, access, label):
                     and records[handle].get("session_id") != session_id
                 ):
                     handle += "x"
-            # No prior (fresh share, or re-share of a revoked handle) → fall
-            # back to whatever sits under the resolved handle.
+            # No prior captured from THIS session above. Inherit the preserved
+            # fields (access/label/created_at) only from a record this session
+            # already owns (a genuine re-share); a revoked handle reclaimed by a
+            # DIFFERENT session is a fresh publish and must NOT inherit the old
+            # owner's access/label/created_at.
             if prior is None:
-                prior = records.get(handle, {})
+                under = records.get(handle, {})
+                prior = under if under.get("session_id") == session_id else {}
             records[handle] = {
                 "handle": handle,
                 "session_id": session_id,

--- a/tests/test_cli_lifecycle.py
+++ b/tests/test_cli_lifecycle.py
@@ -1,0 +1,62 @@
+"""agent-tunnel CLI handle/thread lifecycle: `revoke` + `forget --handle`.
+
+Offline: CliRunner with a temp config whose registry/state paths are pinned to
+tmp_path — no network, no daemon, no real ~/.local/state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from claude_code_tools.agent_tunnel.cli import cli
+from claude_code_tools.agent_tunnel.registry import PublishRecord, Registry
+from claude_code_tools.agent_tunnel.store import TunnelStore
+
+
+def _cfg(tmp_path: Path) -> Path:
+    """A temp config.toml pinning registry/state to tmp_path."""
+    p = tmp_path / "config.toml"
+    p.write_text(
+        f'[tunnel]\nregistry_path = "{tmp_path}/registry.json"\n'
+        f'state_path = "{tmp_path}/state.json"\n',
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_revoke_cli_unpublishes_handle(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    reg = tmp_path / "registry.json"
+    Registry(reg).upsert(PublishRecord(handle="pay", session_id="S1", cwd="/p"))
+    r = CliRunner().invoke(cli, ["revoke", "pay", "--config", str(cfg)])
+    assert r.exit_code == 0, r.output
+    assert Registry(reg).get("pay") is None  # hidden after revoke
+    # unknown handle -> clean ClickException
+    r2 = CliRunner().invoke(cli, ["revoke", "nope", "--config", str(cfg)])
+    assert r2.exit_code != 0 and "nope" in r2.output
+
+
+def test_forget_handle_drops_all_threads_of_handle(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    state = tmp_path / "state.json"
+    store = TunnelStore(state)
+    store.bind("th:1", "pay", "S1", "/p", "headless")
+    store.bind("th:2", "pay", "S1", "/p", "headless")
+    store.bind("th:3", "ops", "S2", "/p", "headless")
+    r = CliRunner().invoke(
+        cli, ["forget", "--handle", "pay", "--config", str(cfg)]
+    )
+    assert r.exit_code == 0, r.output
+    s = TunnelStore(state)
+    assert s.get("th:1") is None and s.get("th:2") is None  # both pay threads
+    assert s.get("th:3") is not None  # ops thread untouched
+
+
+def test_forget_requires_exactly_one_target(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    r = CliRunner().invoke(
+        cli, ["forget", "--handle", "pay", "--all", "--config", str(cfg)]
+    )
+    assert r.exit_code != 0 and "exactly one" in r.output

--- a/tests/test_share_hook.py
+++ b/tests/test_share_hook.py
@@ -72,3 +72,26 @@ def test_share_hook_skip_permissions_sets_all(tmp_path: Path) -> None:
     _run(reg, ">share --dangerously-skip-permissions full", "sess-x")
     rec = Registry(reg).get("full")
     assert rec is not None and rec.access == "all"
+
+
+def test_revoked_handle_reclaimable_by_other_session(tmp_path: Path) -> None:
+    # Bug A: a revoked handle must be reclaimable by a DIFFERENT session, and the
+    # reclaim is a FRESH publish — it must NOT inherit the old owner's access.
+    reg = tmp_path / "registry.json"
+    _run(reg, ">share --dangerously-skip-permissions bigbang", "sess-1")
+    rec1 = Registry(reg).get("bigbang")
+    assert rec1 is not None and rec1.access == "all"
+    assert Registry(reg).revoke("bigbang")  # owner released it
+    _run(reg, ">share bigbang", "sess-2")  # different session, no flag
+    rec2 = Registry(reg).get("bigbang")
+    assert rec2 is not None and rec2.session_id == "sess-2"  # reclaimed
+    assert rec2.access == "read"  # fresh default, NOT the old "all"
+
+
+def test_live_handle_still_collides_across_sessions(tmp_path: Path) -> None:
+    # A LIVE (non-revoked) handle owned by another session stays off-limits.
+    reg = tmp_path / "registry.json"
+    _run(reg, ">share payments", "sess-1")
+    _run(reg, ">share payments", "sess-2")  # collision -> hook leaves it alone
+    rec = Registry(reg).get("payments")
+    assert rec is not None and rec.session_id == "sess-1"  # unchanged


### PR DESCRIPTION
Fixes the three handle/thread lifecycle gaps from #90 (hit while trying to reuse a published handle name).

## Changes

- **A — reclaim revoked names.** `>share <label>`'s collision check (`share_hook._publish`) now **skips revoked records** (matching `Registry.rename`), so a name freed via `>share off` / `revoke` can be reclaimed by another session. A cross-session reclaim is a **fresh publish** — it no longer inherits the old owner's `access`/`label`/`created_at` (previously a no-flag reshare could silently inherit `all`).
- **B — `agent-tunnel revoke <handle>`.** Release a publish from **outside** its session (the in-session `>share off` is keyed to the owning session, so a gone session left the name stuck forever). Existing bound forks keep working; new threads can't open until it's re-shared.
- **C — `forget --handle <name>`.** Drop **all** threads of a handle at once. A handle opened in several Discord threads shows several `th:` rows in `forks`; previously you had to `forget --thread` each key or `--all`.

## Tests (all green; Pyright clean)

- `test_share_hook.py` (real-subprocess hook): revoked handle reclaimable by another session as a *fresh* publish; a *live* handle owned by another session still collides.
- `test_cli_lifecycle.py` (offline CliRunner, tmp-pinned): `revoke` unpublishes (+ clean error on unknown handle); `forget --handle` drops only that handle's threads; `forget` rejects multiple targets.

## Going live
- **A** is the `>share` **plugin hook** → needs a plugin reinstall (`claude plugin update` / `ops cctools-*`) to take effect.
- **B/C** are in the **package** → need an `agent-tunnel` reinstall.

`!done`/closing the last thread does **not** auto-unpublish — that's deliberate (a publish can have many threads; the owner controls its lifecycle). The new `revoke` is the release path.

Closes #90.
