### PR TITLE
docs: add sasy-guard card + page (docs site + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ Click a card to jump to that feature, or
 <img src="assets/card-session-repair.svg" alt="session repair" width="200"/>
 </a>
 </td>
+<td align="center">
+<a href="https://pchalasani.github.io/claude-code-tools/tools/sasy-guard/">
+<img src="assets/card-sasy-guard.svg" alt="sasy-guard" width="200"/>
+</a>
+</td>
 </tr>
 </table>
 

--- a/assets/card-sasy-guard.svg
+++ b/assets/card-sasy-guard.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <defs>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#181235"/>
+      <stop offset="100%" style="stop-color:#0b0818"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="100" rx="8" fill="url(#bg)"/>
+  <text x="100" y="37" font-family="monospace" font-size="24" font-weight="bold" fill="#a78bfa" text-anchor="middle" filter="url(#glow)">sasy-guard</text>
+  <text x="100" y="60" font-family="monospace" font-size="14" fill="#c4b5fd" text-anchor="middle">Compiled-policy</text>
+  <text x="100" y="75" font-family="monospace" font-size="14" fill="#c4b5fd" text-anchor="middle">agent guard</text>
+</svg>

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -85,6 +85,7 @@ export default defineConfig({
             { label: "Status Line", slug: "tools/statusline" },
             { label: "vault", slug: "tools/vault" },
             { label: "env-safe", slug: "tools/env-safe" },
+            { label: "sasy-guard", slug: "tools/sasy-guard" },
             { label: "agent-tunnel", slug: "tools/agent-tunnel" },
           ],
         },

--- a/docs-site/public/assets/card-sasy-guard.svg
+++ b/docs-site/public/assets/card-sasy-guard.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <defs>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#181235"/>
+      <stop offset="100%" style="stop-color:#0b0818"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="100" rx="8" fill="url(#bg)"/>
+  <text x="100" y="37" font-family="monospace" font-size="24" font-weight="bold" fill="#a78bfa" text-anchor="middle" filter="url(#glow)">sasy-guard</text>
+  <text x="100" y="60" font-family="monospace" font-size="14" fill="#c4b5fd" text-anchor="middle">Compiled-policy</text>
+  <text x="100" y="75" font-family="monospace" font-size="14" fill="#c4b5fd" text-anchor="middle">agent guard</text>
+</svg>

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -114,6 +114,10 @@ hero:
     <img src="/claude-code-tools/assets/card-env-safe.svg"
          alt="env-safe" />
   </a>
+  <a href="/claude-code-tools/tools/sasy-guard/">
+    <img src="/claude-code-tools/assets/card-sasy-guard.svg"
+         alt="sasy-guard" />
+  </a>
   <a href="/claude-code-tools/plugins-detail/safety-hooks/">
     <img src="/claude-code-tools/assets/card-safety.svg"
          alt="safety hooks" />

--- a/docs-site/src/content/docs/tools/sasy-guard.mdx
+++ b/docs-site/src/content/docs/tools/sasy-guard.mdx
@@ -1,0 +1,37 @@
+---
+title: "sasy-guard — Policy-compiled security for Claude Code"
+description: >
+  A deterministic security guard for Claude Code, built on
+  policy-compiler ideas: compiled Datalog rules reasoning over a
+  dependency graph rebuilt from the session.
+---
+
+`sasy-guard` is a security guard for Claude Code, built on
+**policy-compiler** ideas. It compiles your policy into **Soufflé
+Datalog** rules and reasons over a **dependency graph rebuilt from the
+whole session**, so every tool call is judged by a fast, deterministic
+engine running outside the model.
+
+That catches multi-step attacks a single-command check misses: a secret
+that is read and later leaves the machine, a `git push` with no clean
+secret scan, a large unreviewed change about to ship.
+
+## Install
+
+```bash
+# install the runtime
+uv tool install sasy-guard
+sasy-guard install
+
+# add the plugin (per project)
+claude plugin marketplace add sasy-labs/sasy-demo
+claude plugin install sasy-guard
+```
+
+:::note[Full docs and setup]
+This page is the short version. For full setup, the rule-by-rule
+breakdown, and live demos, see the SASY docs:
+
+- **[Enforce policy on Claude Code (setup)](https://sasy-demo.pages.dev/claude-code/)**
+- **[Why sasy-guard, not your own hooks?](https://sasy-demo.pages.dev/why-sasy-guard/)**
+:::


### PR DESCRIPTION
## Summary
Adds **sasy-guard** to the claude-code-tools docs.

- New `docs-site/src/content/docs/tools/sasy-guard.mdx` — short page: a policy-compiler security guard for Claude Code (compiled Soufflé Datalog rules reasoning over a session dependency graph, enforced deterministically), with basic install and links to the SASY demo **setup** and **why-sasy-guard** pages for full details.
- New `assets/card-sasy-guard.svg` — card matching the existing style.
- Card added to the Starlight landing grid (`index.mdx`) and the README card grid.
- Sidebar entry under **Tools** (`astro.config.mjs`).