### PR TITLE
fix(agent-tunnel): forks use the subscription login, not a stray API key

### DIFF
--- a/claude_code_tools/agent_tunnel/backends.py
+++ b/claude_code_tools/agent_tunnel/backends.py
@@ -56,6 +56,10 @@ from .trust import (
     trust_config_path_for,
 )
 
+# Auth env vars that override the claude.ai login; stripped from fork envs so
+# forks run under the session owner's subscription (see claude.unset_api_key).
+AUTH_OVERRIDE_VARS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+
 
 class BackendError(RuntimeError):
     """Answering a question failed; message is user-presentable."""
@@ -234,10 +238,15 @@ class _BaseBackend:
         return Path(rec.config_dir) if rec.config_dir else self.cfg.claude_home
 
     def _env(self, rec: ThreadRecord) -> dict[str, str]:
-        """Subprocess env with CLAUDE_CONFIG_DIR pinned to the session's dir."""
+        """Subprocess env: CLAUDE_CONFIG_DIR pinned to the session's dir, and
+        (by default) API-key auth stripped so the fork uses the owner's
+        claude.ai login rather than an API key."""
         env = dict(os.environ)
         if rec.config_dir:
             env["CLAUDE_CONFIG_DIR"] = rec.config_dir
+        if self.cfg.claude.unset_api_key:
+            for var in AUTH_OVERRIDE_VARS:
+                env.pop(var, None)
         return env
 
     def _state_dir(self) -> Path:
@@ -456,8 +465,14 @@ class TmuxBackend(_BaseBackend):
             # flag (which would make claude die at launch with "invalid
             # option"). Verified: `claude … -- "- text"` submits "- text".
             argv += ["--", initial_prompt]
+        prefix: list[str] = []
+        if self.cfg.claude.unset_api_key:
+            for var in AUTH_OVERRIDE_VARS:
+                prefix += ["-u", var]
         if config_dir:
-            argv = ["env", f"CLAUDE_CONFIG_DIR={config_dir}", *argv]
+            prefix.append(f"CLAUDE_CONFIG_DIR={config_dir}")
+        if prefix:
+            argv = ["env", *prefix, *argv]
         if self.cfg.claude.auto_trust:
             self._pretrust(project_dir, config_dir)
         self.tmux.kill_window(window)

--- a/claude_code_tools/agent_tunnel/config.py
+++ b/claude_code_tools/agent_tunnel/config.py
@@ -105,6 +105,12 @@ class ClaudeConfig:
     # Override the config file holding trust state (default: ~/.claude.json,
     # honoring CLAUDE_CONFIG_DIR).
     trust_config_path: str = ""
+    # Strip ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN from the fork's env so it
+    # authenticates with the session owner's claude.ai login (subscription),
+    # not an API key — otherwise a stray key set for the daemon makes forks
+    # use API billing (and can break: "connectors are disabled…"). Set false
+    # to let forks use whatever auth the daemon has.
+    unset_api_key: bool = True
     # Opt-in gate for the "all" access level (>share
     # --dangerously-skip-permissions): only when true do those forks launch
     # with --dangerously-skip-permissions (any tool/MCP, no prompts). Off by
@@ -327,6 +333,9 @@ tmux_extra_args = []
 # Pre-trust a shared folder in ~/.claude.json before forking (tmux backend),
 # so the fork doesn't hit the "trust this folder?" dialog. false = don't touch.
 auto_trust = true
+# Strip ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN from forks so they use your
+# claude.ai subscription login, not an API key. false = inherit the daemon's.
+unset_api_key = true
 # DANGEROUS: enable the "all" access level (>share
 # --dangerously-skip-permissions). Those forks run with
 # --dangerously-skip-permissions — a colleague's agent can then use ANY tool

--- a/tests/test_agent_tunnel.py
+++ b/tests/test_agent_tunnel.py
@@ -490,6 +490,26 @@ def test_resolve_token(tmp_path: Path, monkeypatch) -> None:
     assert resolve_token(cfg) == "env-token-999"  # env wins
 
 
+def test_env_strips_api_key(tmp_path: Path, monkeypatch) -> None:
+    from claude_code_tools.agent_tunnel.backends import HeadlessBackend
+    from claude_code_tools.agent_tunnel.store import ThreadRecord
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    cfg = TunnelConfig()
+    cfg.state_path = tmp_path / "state.json"
+    backend = HeadlessBackend(cfg, TunnelStore(cfg.state_path))
+    rec = ThreadRecord("t", config_dir=str(tmp_path))
+
+    # default: API key stripped so the fork uses the subscription login.
+    env = backend._env(rec)
+    assert "ANTHROPIC_API_KEY" not in env
+    assert env["CLAUDE_CONFIG_DIR"] == str(tmp_path)
+
+    # opt-out keeps it.
+    cfg.claude.unset_api_key = False
+    assert backend._env(rec)["ANTHROPIC_API_KEY"] == "sk-test"
+
+
 def test_build_claude_flags() -> None:
     cfg = TunnelConfig()
     flags = build_claude_flags(cfg, resume_id=SID_A, fork=True)

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.14.1"
+version = "1.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
## The bug

A tunneled fork **inherited the daemon's `ANTHROPIC_API_KEY`**, so `claude`
authenticated with the API key instead of the session owner's claude.ai login.
Two problems:

- **Wrong billing** — the tmux backend is meant to run on the owner's
  subscription, but the key silently switched it to API billing.
- **Hard failure** — observed live: a fork `exited 1` with
  `⚠ claude.ai connectors are disabled because ANTHROPIC_API_KEY or another
  auth source is set and takes precedence over your claude.ai login`.

## The fix

Strip `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` from fork environments so
forks use the owner's claude.ai login:

- **tmux** — the launch command becomes
  `env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN [CLAUDE_CONFIG_DIR=…] claude …`
- **headless** — `_env()` pops those vars.
- **Opt-out** — `[claude] unset_api_key = false` to inherit the daemon's auth
  (e.g. if you deliberately want API billing).

## Testing

- New `test_env_strips_api_key` (default strips; opt-out keeps).
- `pyright` clean, full agent-tunnel suite passes (42 tests).
- Verified `env -u ANTHROPIC_API_KEY …` strips the key while keeping
  `CLAUDE_CONFIG_DIR`.

## Note

Orthogonal to the in-flight #88 (`chat_core` refactor) and #89 (Slack adapter).
If either restructures the fork-launch/env code, this stripping needs to land
there too.
