### PR TITLE
Add durable Codex dynamic workflow plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "cctools-codex-plugins",
+  "interface": {
+    "displayName": "CCTools Codex Plugins"
+  },
+  "plugins": [
+    {
+      "name": "dynamic-workflow",
+      "source": {
+        "source": "local",
+        "path": "./plugins/dynamic-workflow"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,7 @@ hooks/settings.json
 node_modules/
 package-lock.json
 !docs-site/package-lock.json
+!plugins/dynamic-workflow/package-lock.json
 
 # Backup files
 *.backup*

--- a/README.md
+++ b/README.md
@@ -40,13 +40,30 @@ separate Rust binary:
   [Releases](https://github.com/pchalasani/claude-code-tools/releases)
   (look for `rust-v*`)
 
-Install the Claude Code
-[plugins](https://pchalasani.github.io/claude-code-tools/getting-started/plugins/)
-for hooks, skills, and agents:
+Install the Claude Code workflow plugin:
 
 ```bash
 claude plugin marketplace add pchalasani/claude-code-tools
+claude plugin install workflow@cctools-plugins
 ```
+
+Install the equivalent dynamic workflow plugin for Codex:
+
+```bash
+codex plugin marketplace add pchalasani/claude-code-tools
+codex plugin add dynamic-workflow@cctools-codex-plugins
+```
+
+The Codex plugin installs independently: it does not require the Python
+`claude-code-tools` package or an npm install. Node.js 20 or newer only needs to
+be available to execute the plugin's bundled workflow runner.
+
+See the
+[Claude → Codex migration guide][claude-to-codex-guide]
+for usage and workflow-porting instructions.
+
+[claude-to-codex-guide]:
+  https://pchalasani.github.io/claude-code-tools/guides/claude-to-codex/
 
 ---
 
@@ -148,6 +165,11 @@ Click a card to jump to that feature, or
 <td align="center">
 <a href="https://pchalasani.github.io/claude-code-tools/tools/sasy-guard/">
 <img src="assets/card-sasy-guard.svg" alt="sasy-guard" width="200"/>
+</a>
+</td>
+<td align="center">
+<a href="https://pchalasani.github.io/claude-code-tools/guides/claude-to-codex/">
+<img src="assets/card-claude-to-codex.svg" alt="Claude to Codex" width="200"/>
 </a>
 </td>
 </tr>

--- a/assets/card-claude-to-codex.svg
+++ b/assets/card-claude-to-codex.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100"
+     viewBox="0 0 200 100">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#211046"/>
+      <stop offset="52%" stop-color="#10294a"/>
+      <stop offset="100%" stop-color="#083d3a"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="200" height="100" rx="8" fill="url(#bg)"/>
+  <rect x="1" y="1" width="198" height="98" rx="7" fill="none"
+        stroke="#5eead4" stroke-opacity="0.32"/>
+  <text x="100" y="36" font-family="monospace" font-size="20"
+        font-weight="bold" fill="#f8fafc" text-anchor="middle"
+        filter="url(#glow)">Claude → Codex</text>
+  <text x="100" y="63" font-family="monospace" font-size="12"
+        fill="#cbd5e1" text-anchor="middle">switch from Claude</text>
+  <text x="100" y="80" font-family="monospace" font-size="12"
+        fill="#cbd5e1" text-anchor="middle">to Codex</text>
+</svg>

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -102,6 +102,10 @@ export default defineConfig({
               slug: "plugins-detail/workflow",
             },
             {
+              label: "Dynamic Workflow",
+              slug: "plugins-detail/dynamic-workflow",
+            },
+            {
               label: "Langroid",
               slug: "plugins-detail/langroid",
             },
@@ -131,6 +135,10 @@ export default defineConfig({
         {
           label: "Guides",
           items: [
+            {
+              label: "Claude → Codex",
+              slug: "guides/claude-to-codex",
+            },
             {
               label: "Zsh Setup",
               slug: "guides/zsh-setup",

--- a/docs-site/public/assets/card-claude-to-codex.svg
+++ b/docs-site/public/assets/card-claude-to-codex.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100"
+     viewBox="0 0 200 100">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#211046"/>
+      <stop offset="52%" stop-color="#10294a"/>
+      <stop offset="100%" stop-color="#083d3a"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="200" height="100" rx="8" fill="url(#bg)"/>
+  <rect x="1" y="1" width="198" height="98" rx="7" fill="none"
+        stroke="#5eead4" stroke-opacity="0.32"/>
+  <text x="100" y="36" font-family="monospace" font-size="20"
+        font-weight="bold" fill="#f8fafc" text-anchor="middle"
+        filter="url(#glow)">Claude → Codex</text>
+  <text x="100" y="63" font-family="monospace" font-size="12"
+        fill="#cbd5e1" text-anchor="middle">switch from Claude</text>
+  <text x="100" y="80" font-family="monospace" font-size="12"
+        fill="#cbd5e1" text-anchor="middle">to Codex</text>
+</svg>

--- a/docs-site/src/content/docs/getting-started/plugins.mdx
+++ b/docs-site/src/content/docs/getting-started/plugins.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Plugins"
 description: >-
-  Claude Code plugin installation and details
-  for hooks, skills, agents, and safety guards.
+  Plugin installation and details for Codex and Claude Code.
 ---
 
 import { Steps, Badge } from "@astrojs/starlight/components";
@@ -14,7 +13,7 @@ import { Steps, Badge } from "@astrojs/starlight/components";
   }
 `}</style>
 
-This repo provides plugins for the
+This repo provides plugins for Codex and for the
 [Claude Code marketplace](https://code.claude.com/docs/en/discover-plugins).
 
 ## Plugin Overview
@@ -28,8 +27,26 @@ This repo provides plugins for the
 | `langroid` | Design patterns for the [Langroid](https://github.com/langroid/langroid) framework |
 | `voice` | Spoken audio summaries |
 | `agent-tunnel` | `>share` a live session so teammates can ask it questions over Discord |
+| `dynamic-workflow` | Durable JavaScript orchestration for headless Codex agents |
 
-## Installation
+## Codex Plugin Installation
+
+Install the dynamic workflow plugin from the Codex marketplace in this repo:
+
+```bash
+codex plugin marketplace add pchalasani/claude-code-tools
+codex plugin add dynamic-workflow@cctools-codex-plugins
+```
+
+This Codex plugin does not require `uv tool install claude-code-tools` or an
+`npm install`. It includes the skill and compiled runner; Node.js 20 or newer
+only needs to be available to execute the runner.
+
+See the
+[Dynamic Workflow detail page](/claude-code-tools/plugins-detail/dynamic-workflow/)
+for its JavaScript API, state model, and safety boundaries.
+
+## Claude Code Plugin Installation
 
 <Steps>
 

--- a/docs-site/src/content/docs/guides/claude-to-codex/index.mdx
+++ b/docs-site/src/content/docs/guides/claude-to-codex/index.mdx
@@ -1,0 +1,129 @@
+---
+title: "Claude → Codex"
+description: >-
+  Switch from Claude to Codex without giving up dynamic agent workflows.
+---
+
+import {
+  Aside,
+  Card,
+  CardGrid,
+  Steps,
+} from "@astrojs/starlight/components";
+
+Moving from Claude Code to Codex should not mean giving up the workflows you
+already rely on. This is the migration hub for translating those workflows to
+Codex-native tools, beginning with dynamic workflows.
+
+## Dynamic workflows
+
+A dynamic workflow is a small JavaScript program that coordinates agents at
+runtime. JavaScript owns predictable control flow—fan-out, fan-in, loops,
+branches, and aggregation—while agents own reasoning and tool use.
+
+Claude Code provides this pattern through its
+[dynamic workflows](https://code.claude.com/docs/en/workflows). The
+`dynamic-workflow` plugin in this repository provides equivalent orchestration
+for Codex through an installable skill and a durable JavaScript runtime.
+
+<CardGrid>
+  <Card title="What carries over">
+    You can still create and run dynamic workflows that coordinate multiple
+    agents and adapt as the work progresses.
+  </Card>
+  <Card title="What changes">
+    Claude Code's interactive `/workflows` command does not carry over to Codex.
+  </Card>
+</CardGrid>
+
+## Install in Codex
+
+<Aside type="note" title="No claude-code-tools or npm install needed">
+  Do **not** run `uv tool install claude-code-tools` for this feature. That
+  installs the repository's separate Python CLI and is not a prerequisite for
+  the Codex plugin. The plugin already contains the skill and a compiled
+  JavaScript runner, so there is no `npm install` step either. Node.js 20 or
+  newer must merely be available because it executes that bundled runner.
+</Aside>
+
+<Steps>
+
+1. **Add this repository as a Codex marketplace**
+
+   Codex accepts GitHub [`owner/repo` marketplace sources][codex-marketplace]:
+
+   ```bash
+   codex plugin marketplace add pchalasani/claude-code-tools
+   ```
+
+2. **Install the dynamic workflow plugin**
+
+   ```bash
+   codex plugin add dynamic-workflow@cctools-codex-plugins
+   ```
+
+   This is the complete installation. There is no separate Python package,
+   skill-installation step, MCP server, API key, or npm package to configure.
+
+3. **Start a new Codex thread**
+
+   A new thread ensures Codex discovers the newly installed skill.
+
+</Steps>
+
+## Run your first workflow
+
+Mention the skill explicitly when you want guaranteed activation:
+
+```text
+$dynamic-workflow Create a read-only workflow that discovers every API route,
+audits at most 30 routes with four workers, and synthesizes the findings.
+Show me the workflow and its agent cap before launching it.
+```
+
+Codex can also select the skill implicitly when you casually ask for a dynamic
+workflow, but the `$dynamic-workflow` mention removes any ambiguity.
+
+The skill will:
+
+- create a reviewable JavaScript workflow under `.codex/workflows/`
+- validate it before execution
+- explain its worker count, concurrency, permissions, and likely cost
+- ask before launching newly generated workflow code
+- preserve completed steps so a failed or paused run can resume
+- enforce reviewed agent, runtime, fan-out, prompt, and result limits
+- terminate runaway workflow JavaScript and worker process trees
+
+## Port an existing workflow
+
+Point the skill at the existing script and ask it to port and review it:
+
+```text
+$dynamic-workflow Port .claude/workflows/audit-routes.js to Codex. Preserve its
+fan-out and structured results, add explicit bounds, and do not launch it yet.
+```
+
+The script-body format is intentionally familiar, but this is not a universal
+drop-in compatibility layer. Imported modules and direct Node.js filesystem or
+shell access are unavailable inside workflow code; delegate that work to Codex
+agents instead.
+
+<Aside type="caution" title="Review before launch">
+  Generated workflow JavaScript is a capability boundary, not a hardened
+  hostile-code sandbox. Review the script, agent cap, deadline, context-heavy
+  fan-in, and requested write permissions before approving execution.
+</Aside>
+
+## Durable controls and reference
+
+Runs support status inspection, logs, pause, resume, and cancellation. The
+skill handles those commands for ordinary use, while the
+[Dynamic Workflow plugin reference](/claude-code-tools/plugins-detail/dynamic-workflow/)
+documents the JavaScript API, direct CLI, cache model, and safety boundaries.
+
+This migration hub will grow to cover project instructions, skills and command
+surfaces, and session-continuity strategies as more Codex equivalents are added
+to the repository.
+
+[codex-marketplace]:
+  https://developers.openai.com/codex/build-plugins#add-a-marketplace-from-the-cli

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -90,6 +90,10 @@ hero:
 </p>
 
 <div class="retro-grid">
+  <a href="/claude-code-tools/guides/claude-to-codex/">
+    <img src="/claude-code-tools/assets/card-claude-to-codex.svg"
+         alt="Claude to Codex" />
+  </a>
   <a href="/claude-code-tools/tools/aichat/">
     <img src="/claude-code-tools/assets/card-aichat.svg"
          alt="aichat" />

--- a/docs-site/src/content/docs/plugins-detail/dynamic-workflow.mdx
+++ b/docs-site/src/content/docs/plugins-detail/dynamic-workflow.mdx
@@ -1,0 +1,144 @@
+---
+title: "Dynamic Workflow Plugin"
+description: >-
+  Durable JavaScript orchestration for parallel headless Codex workers.
+---
+
+The `dynamic-workflow` Codex plugin turns a multi-agent plan into a small,
+reviewable JavaScript program. JavaScript owns deterministic control flow;
+headless Codex workers own reasoning and tool use.
+
+```text
+Codex skill -> workflow.js -> TypeScript runner -> codex exec workers
+                                 |
+                                 `-> durable state and cache
+```
+
+The runner calls `codex exec --json` directly. It does not require MCP, the
+Codex SDK, or separate API-key configuration.
+
+## Install
+
+The plugin can be installed independently of the repository's Python CLI. Do
+not run `uv tool install claude-code-tools`, and do not run `npm install`.
+The plugin ships both the skill and a compiled JavaScript runner. It requires
+only an authenticated Codex CLI and Node.js 20 or newer to execute that runner.
+
+```bash
+codex plugin marketplace add pchalasani/claude-code-tools
+codex plugin add dynamic-workflow@cctools-codex-plugins
+```
+
+Those two commands are the complete plugin installation.
+
+Restart Codex, then invoke `$dynamic-workflow` or ask for a durable multi-agent
+workflow.
+
+## Workflow shape
+
+Scripts use injected globals, top-level `await`, and top-level `return`:
+
+```javascript
+export const meta = {
+  name: "audit-routes",
+  description: "Audit routes in parallel",
+}
+
+const found = await agent("List route files.", {
+  id: "discover",
+  schema: {
+    type: "object",
+    required: ["files"],
+    properties: {
+      files: { type: "array", items: { type: "string" } },
+    },
+  },
+})
+
+const audits = await pipeline(
+  found.files,
+  file => agent(`Audit ${file}.`, {
+    id: "audit",
+    label: file,
+  }),
+  { concurrency: 4, key: file => file, maxItems: 50 },
+)
+
+const summary = await agent(
+  `Synthesize these audits:\n${JSON.stringify(audits)}`,
+  { id: "synthesize", cacheKey: audits },
+)
+
+return { audits, summary }
+```
+
+`agent()` returns the final worker message or parsed JSON when a schema is
+present. `pipeline()` fans out with bounded concurrency and preserves result
+order. `parallel()` handles heterogeneous callbacks. `args` contains parsed
+JSON supplied by the launcher.
+
+## Durable execution
+
+The runner records state under
+`~/.codex/workflows/runs/<run-id>/` by default. A completed step is reused when
+its stable ID and execution fingerprint still match.
+Use `maxItems` to cap dynamic fan-out. Include upstream results in a downstream
+prompt or `cacheKey` so changed dependencies invalidate that completed step.
+
+```bash
+node bin/workflow.mjs run workflow.js --detach --json
+node bin/workflow.mjs status <run-id> --json
+node bin/workflow.mjs logs <run-id>
+node bin/workflow.mjs pause <run-id>
+node bin/workflow.mjs resume <run-id>
+node bin/workflow.mjs cancel <run-id>
+node bin/workflow.mjs wait <run-id>
+```
+
+Pause is cooperative: active workers finish, while new workers wait. Resume
+replays the JavaScript and returns cached results for compatible completed
+steps. This works across Codex CLI sessions because state lives on disk.
+
+## Safety
+
+- Workflow JavaScript has no injected filesystem, shell, process, or imports.
+- The JavaScript VM is not a hardened sandbox for hostile code; review scripts.
+- Codex workers default to the `read-only` sandbox.
+- Headless approval policy is `never`, so unavailable permissions fail.
+- Write workers must declare `workspace-write` and the launcher must pass
+  `--allow-workspace-write` after review.
+- Danger-full-access also requires `--allow-danger-full-access` at launch.
+- Write authorization is bound to the reviewed workflow source hash.
+- Parallel write tasks should use non-overlapping files or worktrees.
+- Runs default to 100 agents and can be raised only as high as 1,000.
+- The default runner deadline is four hours; worker timeout is 30 minutes.
+- Pipelines without `maxItems` stop at 100 items; explicit caps stop at 1,000.
+- Prompts and results are capped at 1 MB; retries are limited to five.
+- A supervisor terminates runaway JavaScript and complete worker process groups.
+- Resume and cancel remove process groups orphaned by a supervisor crash.
+- An unexpected engine exit removes active worker groups before terminal state.
+- Workers receive prompts only after their process ownership is durable.
+- Every worker exit drains surviving descendants in its owned process group.
+- Persisted PIDs are signaled only when their process-start identity still
+  matches, protecting unrelated processes after PID reuse.
+- Unconfirmed cleanup remains recoverable and nonterminal for a later retry.
+- Unawaited agent, pipeline, and parallel calls fail instead of leaking work.
+
+Context-capacity failures are classified as non-retryable. Chunk the failing
+input or use tree reduction, then resume; completed compatible siblings remain
+cached. Every executed workflow source revision is retained in its run state
+directory for diagnosis.
+Failed context steps also retain any worker thread ID and token usage emitted
+before the failure.
+
+## Development
+
+The plugin commits a dependency-free JavaScript bundle for installation. Its
+TypeScript source and fake-worker integration tests live beside it.
+
+```bash
+cd plugins/dynamic-workflow
+npm ci
+npm run typecheck
+npm test
+```

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Plugin Changelog
 
+## 2026-07-12
+
+### dynamic-workflow
+
+- feat: add a Codex plugin for durable JavaScript agent workflows
+  - direct `codex exec --json` workers with no MCP dependency
+  - bounded fan-out, structured output, retries, and ordered results
+  - durable cache, pause, resume, cancel, status, logs, and detached runs
+  - restricted workflow context and read-only worker sandbox by default
+  - explicit persisted authorization gate for write-capable sandboxes
+  - supervisor deadlines and forced cancellation for runaway JavaScript
+  - process-group cleanup and in-flight worker draining before terminal state
+  - persisted engine ownership and split-brain-safe orphan recovery
+  - process-start identity checks before signaling persisted process IDs
+  - active worker cleanup after an unexpected engine crash
+  - durable worker registration before prompt delivery
+  - recoverable nonterminal state when cleanup cannot be confirmed
+  - process-group draining after normal, failed, or canceled worker exits
+  - conservative agent, retry, pipeline, prompt, and result limits
+  - non-retryable context diagnostics and executed-source snapshots
+
 ## 2026-02-15
 
 ### safety-hooks

--- a/plugins/dynamic-workflow/.codex-plugin/plugin.json
+++ b/plugins/dynamic-workflow/.codex-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "dynamic-workflow",
+  "version": "0.1.0",
+  "description": "Run durable JavaScript workflows over headless Codex agents",
+  "author": {
+    "name": "Prasad Chalasani"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Dynamic Workflow",
+    "shortDescription": "Run resumable multi-agent Codex workflows",
+    "longDescription": "Generate and run deterministic JavaScript orchestration with bounded parallel Codex workers, durable state, caching, pause, resume, and cancellation.",
+    "developerName": "Prasad Chalasani",
+    "category": "Developer Tools",
+    "capabilities": [
+      "JavaScript workflow generation",
+      "Parallel headless Codex workers",
+      "Durable pause and resume"
+    ],
+    "defaultPrompt": "Use $dynamic-workflow to create or run a durable Codex workflow for this task."
+  }
+}

--- a/plugins/dynamic-workflow/README.md
+++ b/plugins/dynamic-workflow/README.md
@@ -1,0 +1,106 @@
+# Dynamic Workflow
+
+`dynamic-workflow` is a Codex plugin for deterministic, durable JavaScript
+orchestration over headless Codex workers.
+
+The model writes a small script. The local runtime owns loops, branches,
+bounded concurrency, state, cache replay, pause, resume, and cancellation.
+Workers run through `codex exec --json`; MCP and the OpenAI API are not required.
+
+## Features
+
+- Claude-style workflow bodies with `agent()`, `pipeline()`, and `args`
+- structured worker output through JSON Schema
+- ordered fan-out and fan-in with configurable concurrency
+- durable state and completed-step cache replay across Codex sessions
+- foreground or detached execution
+- cooperative pause, resume, cancel, retry, logs, and raw JSONL events
+- supervisor-enforced run, agent, fan-out, prompt, and result limits
+- process-tree cancellation and durable executed-source snapshots
+- read-only workers by default with per-agent sandbox declarations
+- committed dependency-free runtime bundle
+
+## Install
+
+Node.js 20 or newer and an authenticated Codex CLI are required.
+
+```bash
+codex plugin marketplace add pchalasani/claude-code-tools
+codex plugin add dynamic-workflow@cctools-codex-plugins
+```
+
+Restart Codex after installation, then invoke `$dynamic-workflow` or ask Codex
+to create a durable multi-agent workflow.
+
+For local development from the repository root:
+
+```bash
+codex plugin marketplace add "$PWD"
+codex plugin add dynamic-workflow@cctools-codex-plugins
+```
+
+## Direct CLI use
+
+The skill resolves the installed runner automatically. From this directory:
+
+```bash
+node bin/workflow.mjs validate path/to/workflow.js
+node bin/workflow.mjs run path/to/workflow.js --detach --json \
+  --max-agents 50 --max-runtime-ms 7200000 --agent-timeout-ms 900000
+node bin/workflow.mjs status <run-id> --json
+node bin/workflow.mjs wait <run-id>
+```
+
+After reviewing a write-capable workflow, authorize it explicitly:
+
+```bash
+node bin/workflow.mjs run workflow.js --allow-workspace-write
+```
+
+Run `node bin/workflow.mjs help` for every command. Durable state defaults to
+`~/.codex/workflows/runs/`.
+
+## Develop
+
+```bash
+npm ci
+npm run typecheck
+npm test
+```
+
+`npm test` rebuilds `bin/workflow.mjs` and runs the fake-worker integration
+suite. The committed bundle lets installed plugins run without npm packages.
+
+## Security model
+
+Workflow scripts run in a restricted Node VM without injected filesystem,
+shell, process, or module APIs. That VM limits accidental capabilities but is
+not a hardened sandbox for hostile JavaScript, so inspect generated scripts.
+
+Each worker uses Codex sandboxing separately. Workers default to `read-only`
+and use approval policy `never`, which makes unavailable permissions fail
+instead of hanging a background process.
+
+The runtime also refuses `workspace-write` and `danger-full-access` workers
+unless the launcher supplies the matching authorization flag. That decision is
+persisted with the run and bound to the reviewed source hash. Editing the script
+requires renewed write authorization on resume.
+
+Runs default to 100 worker launches, a four-hour runner deadline, and a
+30-minute worker timeout. A supervisor owns each run, force-stops runaway
+workflow JavaScript, and terminates complete worker process groups. Context
+capacity failures are non-retryable so an unchanged oversized prompt is not
+blindly repeated.
+
+If a supervisor crashes, its engine notices the lost owner during normal
+execution. Resume and cancel also terminate any persisted orphan engine or
+worker groups before changing the run state or starting replacement work.
+An unexpected engine exit makes the supervisor terminate active worker groups
+before recording the run as failed.
+Before signaling a persisted PID, the runner verifies its recorded process
+start identity and refuses to signal a PID that has been reused.
+Workers receive their prompts only after ownership is durable. If process-exit
+confirmation times out, the run remains nonterminal with cleanup state intact
+so cancel or resume can retry safely.
+Every worker exit path also drains its owned process group, including children
+left behind after an abnormal worker exit.

--- a/plugins/dynamic-workflow/bin/workflow.mjs
+++ b/plugins/dynamic-workflow/bin/workflow.mjs
@@ -1,0 +1,2294 @@
+#!/usr/bin/env node
+
+// src/cli.ts
+import { spawn as spawn2 } from "node:child_process";
+import { open, readFile as readFile3 } from "node:fs/promises";
+import path4 from "node:path";
+import { fileURLToPath } from "node:url";
+
+// src/engine.ts
+import { AsyncLocalStorage } from "node:async_hooks";
+import vm from "node:vm";
+
+// src/codex-runner.ts
+import { spawn } from "node:child_process";
+import { mkdir as mkdir2, writeFile as writeFile2 } from "node:fs/promises";
+import path2 from "node:path";
+import readline from "node:readline";
+
+// src/utils.ts
+import { createHash, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { constants } from "node:fs";
+import {
+  access,
+  mkdir,
+  readFile,
+  rename,
+  writeFile
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+function nowIso() {
+  return (/* @__PURE__ */ new Date()).toISOString();
+}
+function createRunId() {
+  const stamp = (/* @__PURE__ */ new Date()).toISOString().replaceAll(/[-:.TZ]/g, "");
+  return `${stamp}-${randomUUID().slice(0, 8)}`;
+}
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+function stableStringify(value) {
+  const seen = /* @__PURE__ */ new WeakSet();
+  function normalize(item) {
+    if (item === null || typeof item !== "object") {
+      return item;
+    }
+    if (seen.has(item)) {
+      throw new TypeError("Cannot serialize a circular value");
+    }
+    seen.add(item);
+    if (Array.isArray(item)) {
+      const normalized2 = item.map(normalize);
+      seen.delete(item);
+      return normalized2;
+    }
+    const normalized = Object.fromEntries(
+      Object.entries(item).sort(([left], [right]) => left.localeCompare(right)).map(([key, child]) => [key, normalize(child)])
+    );
+    seen.delete(item);
+    return normalized;
+  }
+  return JSON.stringify(normalize(value));
+}
+function toJsonValue(value) {
+  if (value === void 0) {
+    return null;
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+async function sleep(milliseconds, signal) {
+  if (signal?.aborted) {
+    throw signal.reason;
+  }
+  await new Promise((resolve, reject) => {
+    const finish = () => {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    };
+    const timer = setTimeout(finish, milliseconds);
+    const abort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+async function atomicWriteJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const temporary = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}
+`, "utf8");
+  await rename(temporary, filePath);
+}
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+async function fileExists(filePath) {
+  try {
+    await access(filePath, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function workflowHome() {
+  const configured = process.env.CODEX_WORKFLOW_HOME;
+  return path.resolve(configured ?? path.join(homedir(), ".codex", "workflows"));
+}
+function isPidRunning(pid) {
+  if (pid === void 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    if (process.platform !== "win32") {
+      const state = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], {
+        encoding: "utf8"
+      });
+      const processState = state.stdout.trim();
+      if (state.status !== 0 || processState === "" || processState.startsWith("Z")) {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+function processStartIdentity(pid) {
+  if (!isPidRunning(pid)) {
+    return void 0;
+  }
+  const result = process.platform === "win32" ? spawnSync(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `(Get-Process -Id ${pid}).StartTime.ToUniversalTime().Ticks`
+    ],
+    { encoding: "utf8", windowsHide: true }
+  ) : spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    return void 0;
+  }
+  const identity = result.stdout.trim();
+  return identity === "" ? void 0 : identity;
+}
+function processIdentityMatches(pid, expectedStartedAt) {
+  return pid !== void 0 && expectedStartedAt !== void 0 && processStartIdentity(pid) === expectedStartedAt;
+}
+function safeIdentifier(value) {
+  const cleaned = value.replaceAll(/[^A-Za-z0-9_.\/-]+/g, "-");
+  return cleaned.replaceAll(/^[-/.]+|[-/.]+$/g, "") || "step";
+}
+
+// src/codex-runner.ts
+var MAX_PROMPT_BYTES = 1e6;
+var MAX_RESULT_BYTES = 1e6;
+var TERMINATION_GRACE_MS = 2e3;
+var CodexProcessError = class extends Error {
+  retryable;
+  threadId;
+  usage;
+  constructor(message, retryable = true, metadata = {}) {
+    super(message);
+    this.name = "CodexProcessError";
+    this.retryable = retryable;
+    this.threadId = metadata.threadId;
+    this.usage = metadata.usage;
+  }
+};
+var CodexCleanupPendingError = class extends CodexProcessError {
+  cleanupPending = true;
+  workerPid;
+  workerStartedAt;
+  constructor(message, workerPid, workerStartedAt, metadata = {}) {
+    super(message, false, metadata);
+    this.name = "CodexCleanupPendingError";
+    this.workerPid = workerPid;
+    this.workerStartedAt = workerStartedAt;
+  }
+};
+function isCodexCleanupPendingError(error) {
+  return typeof error === "object" && error !== null && "cleanupPending" in error && error.cleanupPending === true;
+}
+var CodexRunner = class {
+  constructor(onEvent, onSpawn) {
+    this.onEvent = onEvent;
+    this.onSpawn = onSpawn;
+  }
+  async run(request) {
+    const promptBytes = Buffer.byteLength(request.prompt, "utf8");
+    if (promptBytes > MAX_PROMPT_BYTES) {
+      throw new CodexProcessError(
+        `Codex worker prompt is ${promptBytes} bytes; maximum is ${MAX_PROMPT_BYTES}. Chunk inputs or use a tree reduction.`,
+        false
+      );
+    }
+    const command = process.env.CODEX_WORKFLOW_CODEX_BIN ?? "codex";
+    const args = await this.buildArgs(request);
+    const cwd = path2.resolve(
+      request.workflowCwd,
+      request.options.cwd ?? "."
+    );
+    return await new Promise((resolve, reject) => {
+      const child = spawn(command, args, {
+        cwd,
+        detached: process.platform !== "win32",
+        env: process.env,
+        stdio: ["pipe", "pipe", "pipe"]
+      });
+      let finalText = "";
+      let workerStartedAt;
+      let threadId;
+      let usage;
+      let standardError = "";
+      let eventError = "";
+      let timedOut = false;
+      let settled = false;
+      let terminationStarted = false;
+      let terminationDeadline = 0;
+      let killTimer;
+      let persistenceError;
+      let persistenceQueue = Promise.resolve();
+      const persist = (operation) => {
+        persistenceQueue = persistenceQueue.then(operation).catch((error) => {
+          persistenceError ??= error;
+          terminate();
+        });
+      };
+      const terminate = () => {
+        if (terminationStarted) {
+          return;
+        }
+        terminationStarted = true;
+        terminationDeadline = Date.now() + TERMINATION_GRACE_MS;
+        signalProcessGroup(child, "SIGTERM");
+        killTimer = setTimeout(
+          () => signalProcessGroup(child, "SIGKILL"),
+          TERMINATION_GRACE_MS
+        );
+        killTimer.unref();
+      };
+      const timeout = request.options.timeoutMs ?? request.defaultTimeoutMs;
+      const timeoutTimer = setTimeout(() => {
+        timedOut = true;
+        terminate();
+      }, timeout);
+      timeoutTimer.unref();
+      if (child.pid !== void 0 && this.onSpawn) {
+        const spawnedWorkerPid = child.pid;
+        const spawnedWorkerStartedAt = processStartIdentity(spawnedWorkerPid);
+        workerStartedAt = spawnedWorkerStartedAt;
+        if (spawnedWorkerStartedAt === void 0) {
+          persistenceError = new Error(
+            `Could not identify Codex worker PID ${spawnedWorkerPid}`
+          );
+          terminate();
+        } else {
+          persist(
+            async () => await this.onSpawn?.(
+              request.stepId,
+              spawnedWorkerPid,
+              spawnedWorkerStartedAt
+            )
+          );
+        }
+      }
+      const abort = () => terminate();
+      request.signal.addEventListener("abort", abort, { once: true });
+      const lines = readline.createInterface({ input: child.stdout });
+      lines.on("line", (line) => {
+        const trimmed = line.trim();
+        if (trimmed === "") {
+          return;
+        }
+        try {
+          const event = JSON.parse(trimmed);
+          if (this.onEvent) {
+            persist(async () => await this.onEvent?.(request.stepId, event));
+          }
+          if (event.type === "thread.started") {
+            threadId = event.thread_id;
+          } else if (event.type === "item.completed" && event.item?.type === "agent_message" && event.item.text) {
+            finalText = event.item.text;
+          } else if (event.type === "turn.completed" && event.usage) {
+            usage = {
+              ...event.usage.cached_input_tokens === void 0 ? {} : { cachedInputTokens: event.usage.cached_input_tokens },
+              ...event.usage.input_tokens === void 0 ? {} : { inputTokens: event.usage.input_tokens },
+              ...event.usage.output_tokens === void 0 ? {} : { outputTokens: event.usage.output_tokens }
+            };
+          } else if (event.type === "turn.failed" || event.type === "error") {
+            eventError = event.error?.message ?? event.message ?? trimmed;
+          }
+        } catch {
+          standardError += `${trimmed}
+`;
+          standardError = standardError.slice(-32e3);
+        }
+      });
+      child.stderr.on("data", (chunk) => {
+        standardError += chunk.toString("utf8");
+        if (standardError.length > 32e3) {
+          standardError = standardError.slice(-32e3);
+        }
+      });
+      child.on("error", (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutTimer);
+        clearTimeout(killTimer);
+        request.signal.removeEventListener("abort", abort);
+        reject(
+          new CodexProcessError(
+            `Could not start ${command}: ${errorMessage(error)}`,
+            false
+          )
+        );
+      });
+      child.on("close", (code, signal) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutTimer);
+        if (!terminationStarted) {
+          clearTimeout(killTimer);
+        }
+        request.signal.removeEventListener("abort", abort);
+        void (async () => {
+          if (child.pid !== void 0 && !await finishProcessGroupTermination(
+            child.pid,
+            terminationStarted ? terminationDeadline : Date.now()
+          )) {
+            reject(
+              new CodexCleanupPendingError(
+                `Codex worker process group ${child.pid} did not terminate`,
+                child.pid,
+                workerStartedAt,
+                { threadId, usage }
+              )
+            );
+            return;
+          }
+          clearTimeout(killTimer);
+          await persistenceQueue;
+          if (persistenceError) {
+            reject(
+              new CodexProcessError(
+                `Could not persist Codex worker events: ` + errorMessage(persistenceError),
+                false
+              )
+            );
+            return;
+          }
+          if (request.signal.aborted) {
+            reject(request.signal.reason);
+            return;
+          }
+          if (timedOut) {
+            reject(
+              new CodexProcessError(
+                `Codex worker timed out after ${timeout} ms`,
+                true,
+                { threadId, usage }
+              )
+            );
+            return;
+          }
+          const details = eventError || standardError.trim();
+          if (code !== 0) {
+            reject(
+              processFailure(
+                `Codex worker exited ${String(code)}${signal ? ` (${signal})` : ""}: ${details || "no error details"}`,
+                threadId,
+                usage
+              )
+            );
+            return;
+          }
+          if (eventError) {
+            reject(processFailure(eventError, threadId, usage));
+            return;
+          }
+          if (finalText === "") {
+            reject(
+              new CodexProcessError(
+                "Codex worker completed without an agent message"
+              )
+            );
+            return;
+          }
+          const resultBytes = Buffer.byteLength(finalText, "utf8");
+          if (resultBytes > MAX_RESULT_BYTES) {
+            reject(
+              new CodexProcessError(
+                `Codex worker result is ${resultBytes} bytes; maximum is ${MAX_RESULT_BYTES}. Return compact structured output.`,
+                false
+              )
+            );
+            return;
+          }
+          let data;
+          if (request.options.schema) {
+            try {
+              data = JSON.parse(finalText);
+            } catch (error) {
+              reject(
+                new CodexProcessError(
+                  `Structured Codex result was not JSON: ${errorMessage(error)}`,
+                  false
+                )
+              );
+              return;
+            }
+          }
+          resolve({
+            ...data === void 0 ? {} : { data },
+            text: finalText,
+            ...threadId === void 0 ? {} : { threadId },
+            ...usage === void 0 ? {} : { usage }
+          });
+        })();
+      });
+      child.stdin.on("error", () => {
+      });
+      const workerRegistration = persistenceQueue;
+      void (async () => {
+        await workerRegistration;
+        if (!settled && !terminationStarted && persistenceError === void 0) {
+          child.stdin.end(request.prompt);
+        }
+      })();
+    });
+  }
+  async buildArgs(request) {
+    const options = request.options;
+    const common = ["--json"];
+    if (options.model) {
+      common.push("--model", options.model);
+    }
+    if (options.reasoningEffort) {
+      common.push(
+        "--config",
+        `model_reasoning_effort=${JSON.stringify(options.reasoningEffort)}`
+      );
+    }
+    common.push("--config", 'approval_policy="never"');
+    if (options.ignoreUserConfig) {
+      common.push("--ignore-user-config");
+    }
+    common.push("--skip-git-repo-check");
+    if (options.schema) {
+      const schemaDirectory = path2.join(request.runDirectory, "schemas");
+      await mkdir2(schemaDirectory, { recursive: true });
+      const readableId = safeIdentifier(request.stepId).replaceAll("/", "-").slice(-80);
+      const schemaPath = path2.join(
+        schemaDirectory,
+        `${readableId}-${sha256(request.stepId).slice(0, 12)}.json`
+      );
+      await writeFile2(
+        schemaPath,
+        `${JSON.stringify(options.schema, null, 2)}
+`,
+        "utf8"
+      );
+      common.push("--output-schema", schemaPath);
+    }
+    if (options.resumeThreadId) {
+      return [
+        "exec",
+        "resume",
+        ...common,
+        options.resumeThreadId,
+        "-"
+      ];
+    }
+    const cwd = path2.resolve(request.workflowCwd, options.cwd ?? ".");
+    const args = [
+      "exec",
+      ...common,
+      "--sandbox",
+      options.sandbox ?? "read-only",
+      "--cd",
+      cwd
+    ];
+    for (const directory of options.addDirs ?? []) {
+      args.push("--add-dir", path2.resolve(cwd, directory));
+    }
+    args.push("-");
+    return args;
+  }
+};
+function signalProcessGroup(child, signal) {
+  try {
+    if (process.platform !== "win32" && child.pid !== void 0) {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch {
+  }
+}
+function processFailure(message, threadId, usage) {
+  if (/context[_ ]length[_ ]exceeded|context (window|length)|maximum context|too many tokens|prompt.{0,20}too long/i.test(message)) {
+    return new CodexProcessError(
+      `Codex worker exceeded its context capacity. Chunk the input or use a tree reduction, then resume the workflow. Details: ${message}`,
+      false,
+      { threadId, usage }
+    );
+  }
+  return new CodexProcessError(message, true, { threadId, usage });
+}
+async function finishProcessGroupTermination(pid, deadline) {
+  while (processGroupIsRunning(pid) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  if (processGroupIsRunning(pid)) {
+    signalProcessGroupByPid(pid, "SIGKILL");
+  }
+  const killDeadline = Date.now() + 1e3;
+  while (processGroupIsRunning(pid) && Date.now() < killDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return !processGroupIsRunning(pid);
+}
+function processGroupIsRunning(pid) {
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function signalProcessGroupByPid(pid, signal) {
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, signal);
+  } catch {
+  }
+}
+
+// src/engine.ts
+var DEFAULT_MAX_AGENT_INVOCATIONS = 100;
+var DEFAULT_MAX_PIPELINE_ITEMS = 100;
+var MAX_AGENT_RETRIES = 5;
+var MAX_AGENT_TIMEOUT_MS = 864e5;
+var CanceledError = class extends Error {
+  constructor() {
+    super("Workflow canceled");
+    this.name = "CanceledError";
+  }
+};
+var Semaphore = class {
+  constructor(limit) {
+    this.limit = limit;
+  }
+  active = 0;
+  waiting = [];
+  async acquire(signal) {
+    if (signal.aborted) {
+      throw signal.reason;
+    }
+    if (this.active >= this.limit) {
+      await new Promise((resolve, reject) => {
+        const grant = () => {
+          signal.removeEventListener("abort", abort);
+          resolve();
+        };
+        const abort = () => {
+          const index = this.waiting.indexOf(grant);
+          if (index >= 0) {
+            this.waiting.splice(index, 1);
+          }
+          reject(signal.reason);
+        };
+        signal.addEventListener("abort", abort, { once: true });
+        this.waiting.push(grant);
+      });
+    }
+    this.active += 1;
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      this.active -= 1;
+      this.waiting.shift()?.();
+    };
+  }
+};
+function compileWorkflow(source, filename) {
+  const metaPattern = /(^|\n)([\t ]*)export[\t ]+const[\t ]+meta[\t ]*=/m;
+  const transformed = source.replace(metaPattern, "$1$2const meta =");
+  return new vm.Script(`(async () => {
+${transformed}
+})()`, {
+    filename
+  });
+}
+var WorkflowEngine = class {
+  constructor(store, source, emit) {
+    this.store = store;
+    this.source = source;
+    this.emit = emit;
+    this.semaphore = new Semaphore(store.snapshot().concurrency);
+    this.codex = new CodexRunner(
+      async (stepId, event) => {
+        await this.store.appendEvent("codex", { stepId, event });
+      },
+      async (stepId, workerPid, workerStartedAt) => {
+        await this.store.update((state) => {
+          const step = state.steps[stepId];
+          if (step?.status === "running") {
+            step.workerPid = workerPid;
+            step.workerStartedAt = workerStartedAt;
+          }
+        });
+      }
+    );
+  }
+  abortController = new AbortController();
+  agentCalls = /* @__PURE__ */ new Set();
+  codex;
+  scope = new AsyncLocalStorage();
+  semaphore;
+  activeAgents = 0;
+  activeStepIds = /* @__PURE__ */ new Set();
+  monitoring = true;
+  async run() {
+    const monitor = this.monitorControl();
+    try {
+      const control = await this.store.readControl();
+      await this.store.update((state) => {
+        if (control.authorization) {
+          state.authorization = control.authorization;
+        }
+        state.status = "running";
+        state.startedAt ??= nowIso();
+        delete state.completedAt;
+        delete state.error;
+      });
+      await this.log(`run ${this.store.runId} started`);
+      const script = compileWorkflow(
+        this.source,
+        this.store.snapshot().workflowPath
+      );
+      const result = await this.executeScript(script);
+      if (this.agentCalls.size > 0) {
+        const error = new Error(
+          "Workflow returned while agent calls were still running; await every agent(), pipeline(), and parallel() call"
+        );
+        this.abortController.abort(error);
+        await this.drainAgentCalls();
+        throw error;
+      }
+      await this.store.update((state) => {
+        state.status = "completed";
+        state.result = toJsonValue(result);
+        state.completedAt = nowIso();
+        delete state.cleanupPending;
+        delete state.error;
+      });
+      await this.log(`run ${this.store.runId} completed`);
+    } catch (error) {
+      const cleanupError = isCodexCleanupPendingError(error) ? error : isCodexCleanupPendingError(this.abortController.signal.reason) ? this.abortController.signal.reason : void 0;
+      const cleanupPending = cleanupError !== void 0 || this.store.snapshot().cleanupPending === true;
+      const canceled = error instanceof CanceledError || this.abortController.signal.reason instanceof CanceledError;
+      if (!this.abortController.signal.aborted) {
+        this.abortController.abort(canceled ? new CanceledError() : error);
+      }
+      await this.drainAgentCalls();
+      await this.store.update((state) => {
+        if (cleanupPending) {
+          state.status = "canceling";
+          state.cleanupPending = true;
+          state.error = cleanupError?.message ?? errorMessage(error);
+          delete state.completedAt;
+        } else {
+          state.status = canceled ? "canceled" : "failed";
+          state.error = canceled ? "Workflow canceled" : errorMessage(error);
+          state.completedAt = nowIso();
+          delete state.cleanupPending;
+        }
+      });
+      await this.log(
+        cleanupPending ? `run ${this.store.runId} awaiting process cleanup: ` + (cleanupError?.message ?? errorMessage(error)) : canceled ? `run ${this.store.runId} canceled` : `run ${this.store.runId} failed: ${errorMessage(error)}`
+      );
+    } finally {
+      this.monitoring = false;
+      if (!this.abortController.signal.aborted) {
+        this.abortController.abort(new CanceledError());
+      }
+      await this.drainAgentCalls();
+      await monitor;
+    }
+    return this.store.snapshot();
+  }
+  async executeScript(script) {
+    const state = this.store.snapshot();
+    const api = {
+      agent: (prompt, options = {}) => this.trackAgentCall(this.agent(prompt, options)),
+      args: state.args,
+      checkpoint: async () => await this.checkpoint(),
+      log: async (...values) => {
+        const message = values.map(
+          (value) => typeof value === "string" ? value : stableStringify(value)
+        ).join(" ");
+        await this.log(message);
+      },
+      parallel: (tasks, options = {}) => this.trackAgentCall(this.parallel(tasks, options)),
+      pipeline: (items, worker, options = {}) => this.trackAgentCall(this.pipeline(items, worker, options)),
+      runId: state.runId
+    };
+    const context = vm.createContext(
+      {
+        __workflowArgsJson: api.args === void 0 ? void 0 : JSON.stringify(api.args),
+        __workflowBridge: {
+          agent: api.agent,
+          checkpoint: api.checkpoint,
+          log: api.log,
+          parallel: api.parallel,
+          pipeline: api.pipeline
+        },
+        __workflowRunId: api.runId
+      },
+      {
+        codeGeneration: { strings: false, wasm: false },
+        name: `workflow-${state.runId}`
+      }
+    );
+    installWorkflowGlobals(context);
+    return await this.scope.run(
+      { counters: /* @__PURE__ */ new Map(), name: "root" },
+      async () => await script.runInContext(context)
+    );
+  }
+  pipeline = async (items, worker, options = {}) => {
+    await this.checkpoint();
+    const parent = this.currentScope();
+    const pipelineNumber = this.nextCounter(parent, "pipeline");
+    const pipelineName = safeIdentifier(
+      options.label ? `pipeline-${pipelineNumber}-${options.label}` : `pipeline-${pipelineNumber}`
+    );
+    const concurrency = this.validateConcurrency(
+      options.concurrency ?? this.store.snapshot().concurrency
+    );
+    const maxItems = options.maxItems ?? DEFAULT_MAX_PIPELINE_ITEMS;
+    if (!Number.isInteger(maxItems) || maxItems < 0 || maxItems > 1e3) {
+      throw new RangeError(
+        "pipeline maxItems must be an integer from 0 to 1000"
+      );
+    }
+    if (items.length > maxItems) {
+      throw new RangeError(
+        `Pipeline received ${items.length} items; maximum is ${maxItems}`
+      );
+    }
+    const results = new Array(items.length);
+    let cursor = 0;
+    const keys = /* @__PURE__ */ new Set();
+    const runNext = async () => {
+      while (cursor < items.length) {
+        const index = cursor;
+        cursor += 1;
+        const item = items[index];
+        const key = safeIdentifier(options.key?.(item, index) ?? String(index));
+        if (keys.has(key)) {
+          throw new Error(`Duplicate pipeline key: ${key}`);
+        }
+        keys.add(key);
+        await this.checkpoint();
+        results[index] = await this.scope.run(
+          {
+            counters: /* @__PURE__ */ new Map(),
+            name: `${parent.name}/${pipelineName}/${key}`
+          },
+          async () => await worker(item, index)
+        );
+      }
+    };
+    await Promise.all(
+      Array.from(
+        { length: Math.min(concurrency, items.length) },
+        async () => await runNext()
+      )
+    );
+    return results;
+  };
+  parallel = async (tasks, options = {}) => {
+    return await this.pipeline(
+      tasks,
+      async (task) => await task(),
+      {
+        ...options.concurrency === void 0 ? {} : { concurrency: options.concurrency },
+        label: options.label ?? "parallel"
+      }
+    );
+  };
+  async agent(prompt, options) {
+    if (typeof prompt !== "string" || prompt.trim() === "") {
+      throw new TypeError("agent() requires a non-empty prompt string");
+    }
+    await this.checkpoint();
+    await this.assertSandboxAuthorized(options);
+    this.validateAgentLimits(options);
+    const scope = this.currentScope();
+    const sequence = this.nextCounter(scope, "agent");
+    const localId = options.id ?? `agent-${sequence}`;
+    const stepId = safeIdentifier(`${scope.name}/${localId}`);
+    const label = options.label ?? stepId;
+    const fingerprint = sha256(
+      stableStringify({
+        prompt,
+        cwd: options.cwd ?? this.store.snapshot().cwd,
+        model: options.model,
+        reasoningEffort: options.reasoningEffort,
+        resumeThreadId: options.resumeThreadId,
+        sandbox: options.sandbox ?? "read-only",
+        schema: options.schema,
+        addDirs: options.addDirs,
+        cacheKey: options.cacheKey,
+        ignoreUserConfig: options.ignoreUserConfig ?? false
+      })
+    );
+    const existing = this.store.snapshot().steps[stepId];
+    if (existing?.status === "completed" && existing.fingerprint === fingerprint) {
+      await this.log(`cache hit: ${label}`);
+      await this.store.appendEvent("cache.hit", { stepId });
+      return existing.result;
+    }
+    if (this.activeStepIds.has(stepId)) {
+      throw new Error(`Concurrent agent calls share the step ID: ${stepId}`);
+    }
+    this.activeStepIds.add(stepId);
+    let release;
+    try {
+      release = await this.semaphore.acquire(this.abortController.signal);
+    } catch (error) {
+      this.activeStepIds.delete(stepId);
+      throw error;
+    }
+    let countedActive = false;
+    try {
+      await this.checkpoint();
+      this.activeAgents += 1;
+      countedActive = true;
+      const retries = Math.max(0, Math.floor(options.retries ?? 0));
+      for (let retry = 0; retry <= retries; retry += 1) {
+        await this.reserveAgentInvocation();
+        const attempt = (existing?.attempt ?? 0) + retry + 1;
+        const step = {
+          attempt,
+          fingerprint,
+          id: stepId,
+          label,
+          startedAt: nowIso(),
+          status: "running"
+        };
+        await this.store.updateStep(step);
+        await this.store.appendEvent("agent.started", {
+          attempt,
+          label,
+          stepId
+        });
+        await this.log(`agent started: ${label} (attempt ${attempt})`);
+        try {
+          const execution = await this.codex.run({
+            defaultTimeoutMs: this.store.snapshot().defaultAgentTimeoutMs ?? 18e5,
+            options,
+            prompt,
+            runDirectory: this.store.directory,
+            signal: this.abortController.signal,
+            stepId,
+            workflowCwd: this.store.snapshot().cwd
+          });
+          const result = execution.data ?? execution.text;
+          step.status = "completed";
+          step.result = toJsonValue(result);
+          step.completedAt = nowIso();
+          if (execution.threadId) {
+            step.threadId = execution.threadId;
+          }
+          if (execution.usage) {
+            step.usage = execution.usage;
+          }
+          await this.store.updateStep(step);
+          await this.store.appendEvent("agent.completed", { stepId });
+          await this.log(`agent completed: ${label}`);
+          return result;
+        } catch (error) {
+          if (error instanceof CodexCleanupPendingError) {
+            await this.store.update((state) => {
+              const persisted = state.steps[stepId];
+              if (persisted) {
+                persisted.error = error.message;
+                persisted.workerPid = error.workerPid;
+                if (error.workerStartedAt !== void 0) {
+                  persisted.workerStartedAt = error.workerStartedAt;
+                }
+              }
+              state.cleanupPending = true;
+              state.status = "canceling";
+              state.error = error.message;
+              delete state.completedAt;
+            });
+            await this.store.appendEvent("agent.cleanup_pending", {
+              error: error.message,
+              stepId,
+              workerPid: error.workerPid
+            });
+            throw error;
+          }
+          const abortReason = this.abortController.signal.reason;
+          const canceled = abortReason instanceof CanceledError;
+          step.status = canceled ? "canceled" : "failed";
+          step.error = canceled ? "Workflow canceled" : errorMessage(
+            this.abortController.signal.aborted ? abortReason : error
+          );
+          step.completedAt = nowIso();
+          if (error instanceof CodexProcessError) {
+            if (error.threadId) {
+              step.threadId = error.threadId;
+            }
+            if (error.usage) {
+              step.usage = error.usage;
+            }
+          }
+          await this.store.updateStep(step);
+          await this.store.appendEvent("agent.failed", {
+            error: step.error,
+            stepId
+          });
+          if (this.abortController.signal.aborted) {
+            throw abortReason;
+          }
+          const canRetry = retry < retries && (!(error instanceof CodexProcessError) || error.retryable);
+          if (!canRetry) {
+            throw error;
+          }
+          const delay = Math.min(3e4, 1e3 * 2 ** retry);
+          await this.log(`retrying ${label} in ${delay} ms`);
+          await sleep(delay, this.abortController.signal);
+        }
+      }
+      throw new Error(`Agent failed without an error: ${label}`);
+    } finally {
+      if (countedActive) {
+        this.activeAgents -= 1;
+      }
+      release();
+      this.activeStepIds.delete(stepId);
+    }
+  }
+  async checkpoint() {
+    while (true) {
+      const control = await this.store.readControl();
+      if (control.command === "cancel" || this.abortController.signal.aborted) {
+        this.abortController.abort(new CanceledError());
+        throw new CanceledError();
+      }
+      if (control.command === "run") {
+        const status = this.store.snapshot().status;
+        if (status === "paused" || status === "pausing") {
+          await this.store.update((state) => {
+            state.status = "running";
+          });
+          await this.log("run resumed");
+        }
+        return;
+      }
+      const desired = this.activeAgents > 0 ? "pausing" : "paused";
+      if (this.store.snapshot().status !== desired) {
+        await this.store.update((state) => {
+          state.status = desired;
+        });
+      }
+      await sleep(250);
+    }
+  }
+  async monitorControl() {
+    while (this.monitoring) {
+      const supervisorPid = this.store.snapshot().pid;
+      const supervisorStartedAt = this.store.snapshot().pidStartedAt;
+      if (supervisorPid !== void 0 && !processIdentityMatches(supervisorPid, supervisorStartedAt)) {
+        if (!this.abortController.signal.aborted) {
+          this.abortController.abort(
+            new Error(`Workflow supervisor PID ${supervisorPid} exited`)
+          );
+        }
+        return;
+      }
+      const control = await this.store.readControl();
+      if (control.command === "cancel") {
+        if (isTerminal(this.store.snapshot().status)) {
+          return;
+        }
+        if (!this.abortController.signal.aborted) {
+          await this.store.update((state) => {
+            if (!isTerminal(state.status)) {
+              state.status = "canceling";
+            }
+          });
+          this.abortController.abort(new CanceledError());
+        }
+        return;
+      }
+      if (control.command === "pause") {
+        const desired = this.activeAgents > 0 ? "pausing" : "paused";
+        const current = this.store.snapshot().status;
+        if (!isTerminal(current) && current !== desired) {
+          await this.store.update((state) => {
+            if (!isTerminal(state.status)) {
+              state.status = desired;
+            }
+          });
+        }
+      }
+      await sleep(250);
+    }
+  }
+  currentScope() {
+    return this.scope.getStore() ?? { counters: /* @__PURE__ */ new Map(), name: "root" };
+  }
+  nextCounter(scope, kind) {
+    const next = (scope.counters.get(kind) ?? 0) + 1;
+    scope.counters.set(kind, next);
+    return next;
+  }
+  validateConcurrency(value) {
+    if (!Number.isInteger(value) || value < 1 || value > 64) {
+      throw new RangeError("Concurrency must be an integer from 1 to 64");
+    }
+    return value;
+  }
+  async reserveAgentInvocation() {
+    await this.store.update((state) => {
+      const count = state.agentInvocations ?? 0;
+      const maximum = state.maxAgentInvocations ?? DEFAULT_MAX_AGENT_INVOCATIONS;
+      if (count >= maximum) {
+        throw new Error(
+          `Workflow exceeded its ${maximum}-agent safety limit`
+        );
+      }
+      state.agentInvocations = count + 1;
+    });
+  }
+  validateAgentLimits(options) {
+    if (options.retries !== void 0 && (!Number.isInteger(options.retries) || options.retries < 0 || options.retries > MAX_AGENT_RETRIES)) {
+      throw new RangeError(
+        `agent retries must be an integer from 0 to ${MAX_AGENT_RETRIES}`
+      );
+    }
+    if (options.timeoutMs !== void 0 && (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 1 || options.timeoutMs > MAX_AGENT_TIMEOUT_MS)) {
+      throw new RangeError(
+        "agent timeoutMs must be an integer from 1 to 86400000"
+      );
+    }
+  }
+  trackAgentCall(promise) {
+    let tracked;
+    tracked = promise.finally(() => {
+      this.agentCalls.delete(tracked);
+    });
+    this.agentCalls.add(tracked);
+    return tracked;
+  }
+  async drainAgentCalls() {
+    while (this.agentCalls.size > 0) {
+      await Promise.allSettled([...this.agentCalls]);
+    }
+  }
+  async assertSandboxAuthorized(options) {
+    const control = await this.store.readControl();
+    const storedAuthorization = this.store.snapshot().authorization;
+    const authorization = control.authorization ?? storedAuthorization ?? defaultAuthorization();
+    if (control.authorization && (storedAuthorization?.dangerFullAccess !== control.authorization.dangerFullAccess || storedAuthorization?.workspaceWrite !== control.authorization.workspaceWrite || storedAuthorization?.workflowHash !== control.authorization.workflowHash)) {
+      await this.store.update((state) => {
+        state.authorization = control.authorization;
+      });
+    }
+    const sandbox = options.sandbox ?? "read-only";
+    if (options.resumeThreadId && !authorization.dangerFullAccess) {
+      throw new Error(
+        "resumeThreadId requires --allow-danger-full-access because the existing thread sandbox cannot be verified"
+      );
+    }
+    if (sandbox === "danger-full-access" && !authorization.dangerFullAccess) {
+      throw new Error(
+        "danger-full-access requires --allow-danger-full-access at launch"
+      );
+    }
+    if (sandbox === "workspace-write" && !authorization.workspaceWrite) {
+      throw new Error(
+        "workspace-write requires --allow-workspace-write at launch"
+      );
+    }
+    if (sandbox !== "read-only" && authorization.workflowHash !== this.store.snapshot().workflowHash) {
+      throw new Error(
+        "Write authorization does not match the current workflow source; launch again with the required --allow-* flag"
+      );
+    }
+  }
+  async log(message) {
+    await this.store.appendLog(message);
+    this.emit(message);
+  }
+};
+function isTerminal(status) {
+  return status === "canceled" || status === "completed" || status === "failed";
+}
+function defaultAuthorization() {
+  return {
+    dangerFullAccess: false,
+    workflowHash: "",
+    workspaceWrite: false
+  };
+}
+function installWorkflowGlobals(context) {
+  const bootstrap = new vm.Script(`
+    {
+      const bridge = globalThis.__workflowBridge
+      const clone = value => {
+        if (value === undefined) return undefined
+        return JSON.parse(JSON.stringify(value))
+      }
+      const call = async (fn, values) => {
+        try {
+          return clone(await fn(...values))
+        } catch (error) {
+          const message = error && error.message ? error.message : String(error)
+          throw new Error(String(message))
+        }
+      }
+      const start = (fn, values) => {
+        const promise = call(fn, values)
+        promise.catch(() => {})
+        return promise
+      }
+      const define = (name, value) => Object.defineProperty(globalThis, name, {
+        configurable: false,
+        enumerable: true,
+        value,
+        writable: false,
+      })
+      define("agent", (...values) => start(bridge.agent, values))
+      define("checkpoint", (...values) => start(bridge.checkpoint, values))
+      define("log", (...values) => start(bridge.log, values))
+      define("parallel", (...values) => start(bridge.parallel, values))
+      define("pipeline", (...values) => start(bridge.pipeline, values))
+      define(
+        "args",
+        globalThis.__workflowArgsJson === undefined
+          ? undefined
+          : JSON.parse(globalThis.__workflowArgsJson),
+      )
+      define("workflow", Object.freeze({ runId: globalThis.__workflowRunId }))
+    }
+    delete globalThis.__workflowArgsJson
+    delete globalThis.__workflowBridge
+    delete globalThis.__workflowRunId
+  `);
+  bootstrap.runInContext(context);
+}
+
+// src/state-store.ts
+import { randomUUID as randomUUID2 } from "node:crypto";
+import {
+  appendFile,
+  mkdir as mkdir3,
+  readdir,
+  readFile as readFile2,
+  rename as rename2,
+  rm,
+  writeFile as writeFile3
+} from "node:fs/promises";
+import path3 from "node:path";
+var StateStore = class _StateStore {
+  directory;
+  eventsPath;
+  logPath;
+  runId;
+  state;
+  queue = Promise.resolve();
+  constructor(state) {
+    this.state = state;
+    this.runId = state.runId;
+    this.directory = _StateStore.runDirectory(state.runId);
+    this.eventsPath = path3.join(this.directory, "events.jsonl");
+    this.logPath = path3.join(this.directory, "workflow.log");
+  }
+  static runDirectory(runId) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(runId)) {
+      throw new Error(`Invalid workflow run ID: ${runId}`);
+    }
+    const runsDirectory = path3.join(workflowHome(), "runs");
+    const directory = path3.resolve(runsDirectory, runId);
+    if (path3.dirname(directory) !== path3.resolve(runsDirectory)) {
+      throw new Error(`Workflow run ID escapes the state directory: ${runId}`);
+    }
+    return directory;
+  }
+  static statePath(runId) {
+    return path3.join(_StateStore.runDirectory(runId), "state.json");
+  }
+  static controlPath(runId) {
+    return path3.join(_StateStore.runDirectory(runId), "control.json");
+  }
+  static runnerLockDirectory(runId) {
+    return path3.join(_StateStore.runDirectory(runId), "runner.lock");
+  }
+  static async create(state) {
+    const store = new _StateStore(state);
+    await mkdir3(store.directory, { recursive: true });
+    await atomicWriteJson(_StateStore.statePath(state.runId), state);
+    await store.writeControl("run", state.authorization);
+    return store;
+  }
+  static async load(runId) {
+    const state = await readJson(_StateStore.statePath(runId));
+    return new _StateStore(state);
+  }
+  static async list() {
+    const runsDirectory = path3.join(workflowHome(), "runs");
+    if (!await fileExists(runsDirectory)) {
+      return [];
+    }
+    const entries = await readdir(runsDirectory, { withFileTypes: true });
+    const states = await Promise.all(
+      entries.filter((entry) => entry.isDirectory()).map(async (entry) => {
+        try {
+          return await readJson(
+            _StateStore.statePath(entry.name)
+          );
+        } catch {
+          return void 0;
+        }
+      })
+    );
+    return states.filter((state) => state !== void 0).sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  }
+  snapshot() {
+    return structuredClone(this.state);
+  }
+  async update(mutator) {
+    let result = this.snapshot();
+    const operation = this.queue.then(async () => {
+      mutator(this.state);
+      this.state.updatedAt = nowIso();
+      await atomicWriteJson(_StateStore.statePath(this.runId), this.state);
+      result = this.snapshot();
+    });
+    this.queue = operation.catch(() => {
+    });
+    await operation;
+    return result;
+  }
+  async updateStep(step) {
+    await this.update((state) => {
+      state.steps[step.id] = structuredClone(step);
+    });
+  }
+  async readControl() {
+    try {
+      return await readJson(_StateStore.controlPath(this.runId));
+    } catch {
+      return { command: "run", updatedAt: nowIso() };
+    }
+  }
+  async writeControl(command, authorization) {
+    const current = await this.readControl();
+    const effectiveAuthorization = authorization ?? current.authorization;
+    await atomicWriteJson(_StateStore.controlPath(this.runId), {
+      ...effectiveAuthorization === void 0 ? {} : { authorization: effectiveAuthorization },
+      command,
+      updatedAt: nowIso()
+    });
+  }
+  async claimRunner(pid, requestedToken) {
+    if (requestedToken) {
+      return await this.acceptRunnerHandoff(pid, requestedToken);
+    }
+    const lockDirectory = _StateStore.runnerLockDirectory(this.runId);
+    const ownerPath = path3.join(lockDirectory, "owner.json");
+    const token = randomUUID2();
+    const pidStartedAt = processStartIdentity(pid);
+    if (pidStartedAt === void 0) {
+      throw new Error(`Could not identify runner PID ${pid}`);
+    }
+    const candidateDirectory = `${lockDirectory}.candidate-${token}`;
+    await mkdir3(candidateDirectory);
+    await atomicWriteJson(path3.join(candidateDirectory, "owner.json"), {
+      pid,
+      pidStartedAt,
+      token,
+      updatedAt: nowIso()
+    });
+    try {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        try {
+          await rename2(candidateDirectory, lockDirectory);
+          return token;
+        } catch (error) {
+          if (!isLockContention(error)) {
+            throw error;
+          }
+        }
+        let owner;
+        try {
+          owner = await readJson(ownerPath);
+        } catch {
+          try {
+            await rename2(candidateDirectory, lockDirectory);
+            return token;
+          } catch (error) {
+            if (!isLockContention(error)) {
+              throw error;
+            }
+          }
+          await sleep(25);
+          continue;
+        }
+        const ownerAlive = owner.pidStartedAt ? processIdentityMatches(owner.pid, owner.pidStartedAt) : isPidRunning(owner.pid);
+        if (ownerAlive) {
+          throw new Error(
+            `Run ${this.runId} is already claimed by PID ${owner.pid}`
+          );
+        }
+        const quarantine = `${lockDirectory}.stale-${sha256(owner.token).slice(
+          0,
+          16
+        )}`;
+        try {
+          await rename2(lockDirectory, quarantine);
+        } catch (error) {
+          if (!isLockContention(error) && !isMissing(error)) {
+            throw error;
+          }
+        }
+        await sleep(10);
+      }
+      throw new Error(`Could not claim runner lock for ${this.runId}`);
+    } finally {
+      try {
+        if (await fileExists(candidateDirectory)) {
+          await rm(candidateDirectory, { force: true, recursive: true });
+        }
+      } catch {
+      }
+    }
+  }
+  async transferRunner(token, pid) {
+    const ownerPath = path3.join(
+      _StateStore.runnerLockDirectory(this.runId),
+      "owner.json"
+    );
+    const owner = await readJson(ownerPath);
+    if (owner.token !== token) {
+      throw new Error(`Runner lock for ${this.runId} changed during launch`);
+    }
+    const pidStartedAt = processStartIdentity(pid);
+    if (pidStartedAt === void 0) {
+      throw new Error(`Could not identify runner PID ${pid}`);
+    }
+    await atomicWriteJson(ownerPath, {
+      pid,
+      pidStartedAt,
+      token,
+      updatedAt: nowIso()
+    });
+  }
+  async releaseRunner(token) {
+    const lockDirectory = _StateStore.runnerLockDirectory(this.runId);
+    try {
+      const owner = await readJson(
+        path3.join(lockDirectory, "owner.json")
+      );
+      if (owner.token === token) {
+        await rm(lockDirectory, { force: true, recursive: true });
+      }
+    } catch {
+    }
+  }
+  async appendEvent(type, data = {}) {
+    await appendFile(
+      this.eventsPath,
+      `${JSON.stringify({ at: nowIso(), type, data })}
+`,
+      "utf8"
+    );
+  }
+  async appendLog(message) {
+    await appendFile(this.logPath, `[${nowIso()}] ${message}
+`, "utf8");
+  }
+  async readLog() {
+    try {
+      return await readFile2(this.logPath, "utf8");
+    } catch {
+      return "";
+    }
+  }
+  async snapshotWorkflow(source, hash) {
+    const directory = path3.join(this.directory, "workflow-snapshots");
+    const snapshotPath = path3.join(directory, `${hash}.js`);
+    await mkdir3(directory, { recursive: true });
+    try {
+      await writeFile3(snapshotPath, source, { encoding: "utf8", flag: "wx" });
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") {
+        throw error;
+      }
+    }
+  }
+  async acceptRunnerHandoff(pid, token) {
+    const ownerPath = path3.join(
+      _StateStore.runnerLockDirectory(this.runId),
+      "owner.json"
+    );
+    for (let attempt = 0; attempt < 80; attempt += 1) {
+      try {
+        const owner = await readJson(ownerPath);
+        if (owner.token !== token) {
+          throw new Error(`Runner handoff token for ${this.runId} is invalid`);
+        }
+        if (owner.pid === pid && (owner.pidStartedAt === void 0 || processIdentityMatches(pid, owner.pidStartedAt))) {
+          return token;
+        }
+      } catch (error) {
+        if (attempt === 79) {
+          throw new Error(
+            `Runner handoff for ${this.runId} failed: ${errorMessage(error)}`
+          );
+        }
+      }
+      await sleep(25);
+    }
+    throw new Error(`Runner handoff for ${this.runId} timed out`);
+  }
+};
+function errorCode(error) {
+  if (error instanceof Error && "code" in error) {
+    return error.code;
+  }
+  return void 0;
+}
+function isLockContention(error) {
+  return errorCode(error) === "EEXIST" || errorCode(error) === "ENOTEMPTY";
+}
+function isMissing(error) {
+  return errorCode(error) === "ENOENT";
+}
+
+// src/cli.ts
+var BOOLEAN_OPTIONS = /* @__PURE__ */ new Set([
+  "allow-danger-full-access",
+  "allow-workspace-write",
+  "detach",
+  "foreground",
+  "help",
+  "json"
+]);
+var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
+  "canceled",
+  "completed",
+  "failed"
+]);
+var DEFAULT_AGENT_TIMEOUT_MS = 18e5;
+var DEFAULT_MAX_AGENT_INVOCATIONS2 = 100;
+var DEFAULT_MAX_RUNTIME_MS = 144e5;
+var FORCE_STOP_GRACE_MS = 2e3;
+var CleanupPendingError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CleanupPendingError";
+  }
+};
+function printHelp() {
+  console.log(`codex-workflow - durable JavaScript workflows for Codex
+
+Usage:
+  codex-workflow run <file> [--input JSON|@FILE] [--cwd DIR]
+                     [--concurrency N] [--detach] [--json]
+                     [--max-agents N] [--max-runtime-ms N]
+                     [--agent-timeout-ms N]
+                     [--allow-workspace-write]
+                     [--allow-danger-full-access]
+  codex-workflow validate <file>
+  codex-workflow status <run-id> [--json]
+  codex-workflow list [--json]
+  codex-workflow logs <run-id>
+  codex-workflow wait <run-id> [--json]
+  codex-workflow pause <run-id>
+  codex-workflow resume <run-id> [--foreground] [--json]
+                        [--allow-workspace-write]
+                        [--allow-danger-full-access]
+  codex-workflow cancel <run-id>
+
+Environment:
+  CODEX_WORKFLOW_HOME       State root (default: ~/.codex/workflows)
+  CODEX_WORKFLOW_CODEX_BIN  Codex executable (default: codex)
+
+Workflow scripts receive agent(), pipeline(), parallel(), checkpoint(), log(),
+args, and workflow.runId. Workers default to the read-only Codex sandbox.`);
+}
+function parseArguments(args) {
+  const parsed = {
+    flags: /* @__PURE__ */ new Set(),
+    positionals: [],
+    values: /* @__PURE__ */ new Map()
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index];
+    if (!value.startsWith("--")) {
+      parsed.positionals.push(value);
+      continue;
+    }
+    const name = value.slice(2);
+    if (BOOLEAN_OPTIONS.has(name)) {
+      parsed.flags.add(name);
+      continue;
+    }
+    const optionValue = args[index + 1];
+    if (optionValue === void 0 || optionValue.startsWith("--")) {
+      throw new Error(`--${name} requires a value`);
+    }
+    parsed.values.set(name, optionValue);
+    index += 1;
+  }
+  return parsed;
+}
+function assertOptions(parsed, allowedValues, allowedFlags = []) {
+  for (const name of parsed.values.keys()) {
+    if (!allowedValues.includes(name)) {
+      throw new Error(`Unknown option: --${name}`);
+    }
+  }
+  for (const name of parsed.flags) {
+    if (!allowedFlags.includes(name) && name !== "help") {
+      throw new Error(`Unknown flag: --${name}`);
+    }
+  }
+}
+function requirePositional(parsed, index, description) {
+  const value = parsed.positionals[index];
+  if (value === void 0) {
+    throw new Error(`Missing ${description}`);
+  }
+  return value;
+}
+async function parseInput(value) {
+  if (value === void 0) {
+    return void 0;
+  }
+  const source = value.startsWith("@") ? await readFile3(path4.resolve(value.slice(1)), "utf8") : value;
+  return JSON.parse(source);
+}
+function parseConcurrency(value) {
+  const concurrency = value === void 0 ? 6 : Number(value);
+  if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 64) {
+    throw new Error("--concurrency must be an integer from 1 to 64");
+  }
+  return concurrency;
+}
+function parseIntegerOption(name, value, defaultValue, maximum) {
+  const parsed = value === void 0 ? defaultValue : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > maximum) {
+    throw new Error(`--${name} must be an integer from 1 to ${maximum}`);
+  }
+  return parsed;
+}
+function authorizationFromFlags(parsed, workflowHash, current) {
+  const changed = parsed.flags.has("allow-danger-full-access") || parsed.flags.has("allow-workspace-write");
+  if (!changed && current) {
+    return current;
+  }
+  const dangerFullAccess = parsed.flags.has("allow-danger-full-access");
+  return {
+    dangerFullAccess,
+    workflowHash,
+    workspaceWrite: dangerFullAccess || parsed.flags.has("allow-workspace-write")
+  };
+}
+function summary(state) {
+  const completed = Object.values(state.steps).filter(
+    (step) => step.status === "completed"
+  ).length;
+  const total = Object.keys(state.steps).length;
+  return `${state.runId}  ${state.status}  ${completed}/${total} agents`;
+}
+function outputState(state, json) {
+  if (json) {
+    console.log(JSON.stringify(state, null, 2));
+    return;
+  }
+  console.log(summary(state));
+  if (state.error) {
+    console.log(`Error: ${state.error}`);
+  }
+  if (state.status === "completed" && state.result !== void 0) {
+    console.log(JSON.stringify(state.result, null, 2));
+  }
+}
+async function executeRun(runId, json) {
+  const store = await StateStore.load(runId);
+  return await executeClaimedRun(store, json);
+}
+async function executeClaimedRun(store, json, requestedToken) {
+  let runnerToken;
+  try {
+    runnerToken = await store.claimRunner(process.pid, requestedToken);
+  } catch (error) {
+    if (requestedToken) {
+      const latest = await StateStore.load(store.runId);
+      const state = latest.snapshot();
+      if (state.pid === process.pid && !TERMINAL_STATUSES.has(state.status)) {
+        return await recordBootstrapFailure(latest, error, json);
+      }
+    }
+    throw error;
+  }
+  try {
+    const requestCancel = () => {
+      void store.writeControl("cancel");
+    };
+    process.once("SIGINT", requestCancel);
+    process.once("SIGTERM", requestCancel);
+    try {
+      const pidStartedAt = processStartIdentity(process.pid);
+      if (pidStartedAt === void 0) {
+        throw new Error(`Could not identify runner PID ${process.pid}`);
+      }
+      await store.update((state2) => {
+        state2.pid = process.pid;
+        state2.pidStartedAt = pidStartedAt;
+        state2.runnerStartedAt = nowIso();
+      });
+      const state = await superviseEngine(store);
+      if (json) {
+        outputState(state, true);
+      }
+      return state;
+    } finally {
+      process.removeListener("SIGINT", requestCancel);
+      process.removeListener("SIGTERM", requestCancel);
+    }
+  } catch (error) {
+    if (error instanceof CleanupPendingError) {
+      return await recordCleanupPending(store, error, json);
+    }
+    return await recordBootstrapFailure(store, error, json);
+  } finally {
+    await store.releaseRunner(runnerToken);
+  }
+}
+async function executeEngine(store) {
+  try {
+    const current = store.snapshot();
+    const source = await readFile3(current.workflowPath, "utf8");
+    compileWorkflow(source, current.workflowPath);
+    const currentHash = sha256(source);
+    await store.snapshotWorkflow(source, currentHash);
+    if (currentHash !== current.workflowHash) {
+      await store.appendEvent("workflow.changed", {
+        from: current.workflowHash,
+        to: currentHash
+      });
+      await store.update((state) => {
+        state.workflowHash = currentHash;
+      });
+    }
+    const engine = new WorkflowEngine(store, source, (message) => {
+      console.error(`[${store.runId}] ${message}`);
+    });
+    return await engine.run();
+  } catch (error) {
+    return await recordBootstrapFailure(store, error, false);
+  }
+}
+async function superviseEngine(store) {
+  const entry = fileURLToPath(import.meta.url);
+  const child = spawn2(process.execPath, [entry, "_engine", store.runId], {
+    detached: process.platform !== "win32",
+    env: process.env,
+    stdio: ["ignore", "inherit", "inherit"]
+  });
+  if (child.pid === void 0) {
+    throw new Error("Workflow engine did not receive a PID");
+  }
+  const enginePid = child.pid;
+  const engineStartedAt = processStartIdentity(enginePid);
+  if (engineStartedAt === void 0) {
+    signalProcessTree(enginePid, "SIGKILL");
+    throw new Error(`Could not identify workflow engine PID ${enginePid}`);
+  }
+  let childError;
+  let closed = false;
+  let exitCode = null;
+  let exitSignal = null;
+  const completion = new Promise((resolve) => {
+    child.once("error", (error) => {
+      childError = error;
+      closed = true;
+      resolve();
+    });
+    child.once("close", (code, signal) => {
+      exitCode = code;
+      exitSignal = signal;
+      closed = true;
+      resolve();
+    });
+  });
+  await store.update((state2) => {
+    state2.enginePid = enginePid;
+    state2.engineStartedAt = engineStartedAt;
+  });
+  const maximumRuntime = store.snapshot().maxRuntimeMs ?? DEFAULT_MAX_RUNTIME_MS;
+  const deadline = Date.now() + maximumRuntime;
+  let forcedAt;
+  let forcedReason;
+  while (!closed) {
+    const control = await store.readControl();
+    if (Date.now() >= deadline && forcedReason === void 0) {
+      forcedReason = "timeout";
+      forcedAt = Date.now() + FORCE_STOP_GRACE_MS;
+      await store.appendEvent("runner.deadline_exceeded", {
+        maxRuntimeMs: maximumRuntime
+      });
+      signalProcessTree(child.pid, "SIGTERM");
+      await signalRecordedWorkers(store, "SIGKILL", false);
+    } else if (control.command === "cancel" && forcedReason === void 0) {
+      forcedReason = "cancel";
+      forcedAt = Date.now() + FORCE_STOP_GRACE_MS;
+    }
+    if (forcedAt !== void 0 && Date.now() >= forcedAt) {
+      signalProcessTree(child.pid, "SIGKILL");
+      await signalRecordedWorkers(store, "SIGKILL", false);
+    }
+    await Promise.race([completion, sleep(100)]);
+  }
+  await completion;
+  await signalRecordedWorkers(store, "SIGKILL", false, true);
+  let latestStore = await StateStore.load(store.runId);
+  let state = latestStore.snapshot();
+  if (forcedReason === "timeout" && !TERMINAL_STATUSES.has(state.status)) {
+    state = await terminalizeForcedRun(
+      latestStore,
+      "failed",
+      `Workflow exceeded its ${maximumRuntime} ms runtime limit`
+    );
+  } else if (!TERMINAL_STATUSES.has(state.status)) {
+    const canceled = forcedReason === "cancel";
+    const detail = childError ? errorMessage(childError) : `exit ${String(exitCode)}${exitSignal ? ` (${exitSignal})` : ""}`;
+    const failureMessage = state.error ?? `Workflow engine stopped: ${detail}`;
+    state = await terminalizeForcedRun(
+      latestStore,
+      canceled ? "canceled" : "failed",
+      canceled ? "Workflow canceled" : failureMessage
+    );
+  }
+  latestStore = await StateStore.load(store.runId);
+  return await latestStore.update((current) => {
+    delete current.enginePid;
+    delete current.engineStartedAt;
+    delete current.pid;
+    delete current.pidStartedAt;
+  });
+}
+async function terminalizeForcedRun(store, status, message) {
+  return await store.update((state) => {
+    state.status = status;
+    state.error = message;
+    state.completedAt = nowIso();
+    delete state.cleanupPending;
+    delete state.enginePid;
+    delete state.engineStartedAt;
+    delete state.pid;
+    delete state.pidStartedAt;
+    for (const step of Object.values(state.steps)) {
+      if (step.status === "running") {
+        step.status = status === "canceled" ? "canceled" : "failed";
+        step.error = message;
+        step.completedAt = nowIso();
+        delete step.workerPid;
+        delete step.workerStartedAt;
+      }
+    }
+  });
+}
+function signalProcessTree(pid, signal) {
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, signal);
+  } catch {
+  }
+}
+async function signalRecordedWorkers(store, signal, strictIdentity = true, waitForExit = false) {
+  const state = (await StateStore.load(store.runId)).snapshot();
+  const signaledPids = [];
+  for (const step of Object.values(state.steps)) {
+    if (step.workerPid === void 0) {
+      continue;
+    }
+    const signaled = signalOwnedProcessTree(
+      step.workerPid,
+      step.workerStartedAt,
+      signal,
+      `worker ${step.id}`,
+      strictIdentity
+    );
+    if (signaled) {
+      signaledPids.push(step.workerPid);
+    }
+  }
+  if (!waitForExit) {
+    return;
+  }
+  for (const pid of signaledPids) {
+    if (!await waitForProcessTreeExit(pid)) {
+      throw new CleanupPendingError(
+        `Worker process group ${pid} did not terminate`
+      );
+    }
+  }
+}
+async function terminateOrphanedExecution(store, message) {
+  let state = (await StateStore.load(store.runId)).snapshot();
+  let engineSignaled = false;
+  if (state.enginePid !== void 0) {
+    engineSignaled = signalOwnedProcessTree(
+      state.enginePid,
+      state.engineStartedAt,
+      "SIGKILL",
+      "workflow engine"
+    );
+  }
+  await signalRecordedWorkers(store, "SIGKILL", true, true);
+  if (engineSignaled && state.enginePid !== void 0 && !await waitForProcessTreeExit(state.enginePid)) {
+    throw new CleanupPendingError(
+      `Workflow engine process group ${state.enginePid} did not terminate`
+    );
+  }
+  const latest = await StateStore.load(store.runId);
+  await latest.update((current) => {
+    delete current.cleanupPending;
+    delete current.enginePid;
+    delete current.engineStartedAt;
+    delete current.pid;
+    delete current.pidStartedAt;
+    for (const step of Object.values(current.steps)) {
+      if (step.status === "running") {
+        step.status = "failed";
+        step.error = message;
+        step.completedAt = nowIso();
+      }
+      delete step.workerPid;
+      delete step.workerStartedAt;
+    }
+  });
+  return await StateStore.load(store.runId);
+}
+function signalOwnedProcessTree(pid, expectedStartedAt, signal, label, strictIdentity = true) {
+  if (!isPidRunning(pid)) {
+    if (processTreeIsRunning(pid)) {
+      throw new CleanupPendingError(
+        `${label} PID ${pid} exited while its process group remains`
+      );
+    }
+    return false;
+  }
+  const actualStartedAt = processStartIdentity(pid);
+  if (expectedStartedAt === void 0 || actualStartedAt === void 0) {
+    if (processTreeIsRunning(pid)) {
+      throw new CleanupPendingError(
+        `Could not verify ${label} PID ${pid} before process-group cleanup`
+      );
+    }
+    return false;
+  }
+  if (actualStartedAt !== expectedStartedAt) {
+    if (strictIdentity) {
+      throw new Error(
+        `Refusing to signal ${label} PID ${pid}: process identity changed`
+      );
+    }
+    return false;
+  }
+  signalProcessTree(pid, signal);
+  return true;
+}
+async function waitForProcessTreeExit(pid, timeoutMs = 2e3) {
+  const deadline = Date.now() + timeoutMs;
+  while (processTreeIsRunning(pid) && Date.now() < deadline) {
+    await sleep(25);
+  }
+  return !processTreeIsRunning(pid);
+}
+function processTreeIsRunning(pid) {
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+async function waitForEngineRegistration(runId) {
+  const deadline = Date.now() + 5e3;
+  while (Date.now() < deadline) {
+    const store = await StateStore.load(runId);
+    const state = store.snapshot();
+    if (state.enginePid === process.pid && processIdentityMatches(process.pid, state.engineStartedAt)) {
+      return store;
+    }
+    await sleep(25);
+  }
+  throw new Error(`Workflow engine ${process.pid} was not registered`);
+}
+async function spawnDetached(store) {
+  const entry = fileURLToPath(import.meta.url);
+  const runnerToken = await store.claimRunner(process.pid);
+  let handedOff = false;
+  try {
+    const runnerLog = await open(path4.join(store.directory, "runner.log"), "a");
+    try {
+      const child = spawn2(
+        process.execPath,
+        [entry, "_execute", store.runId, runnerToken],
+        {
+          detached: true,
+          env: process.env,
+          stdio: ["ignore", runnerLog.fd, runnerLog.fd]
+        }
+      );
+      if (child.pid === void 0) {
+        throw new Error("Detached runner did not receive a PID");
+      }
+      const pid = child.pid;
+      const pidStartedAt = processStartIdentity(pid);
+      if (pidStartedAt === void 0) {
+        signalProcessTree(pid, "SIGKILL");
+        throw new Error(`Could not identify detached runner PID ${pid}`);
+      }
+      child.unref();
+      await store.update((state) => {
+        state.pid = pid;
+        state.pidStartedAt = pidStartedAt;
+        state.status = "starting";
+      });
+      await store.transferRunner(runnerToken, pid);
+      handedOff = true;
+      return pid;
+    } finally {
+      await runnerLog.close();
+    }
+  } catch (error) {
+    await recordBootstrapFailure(store, error, false);
+    throw error;
+  } finally {
+    if (!handedOff) {
+      await store.releaseRunner(runnerToken);
+    }
+  }
+}
+async function recordBootstrapFailure(store, error, json) {
+  const message = `Runner bootstrap failed: ${errorMessage(error)}`;
+  const state = await store.update((current) => {
+    if (!TERMINAL_STATUSES.has(current.status)) {
+      current.status = "failed";
+      current.error = message;
+      current.completedAt = nowIso();
+    }
+  });
+  await store.appendEvent("runner.bootstrap_failed", { error: message });
+  await store.appendLog(message);
+  if (json) {
+    outputState(state, true);
+  }
+  return state;
+}
+async function recordCleanupPending(store, error, json) {
+  const message = `Process cleanup is incomplete: ${error.message}. Retry cancel or resume to continue cleanup.`;
+  const state = await store.update((current) => {
+    current.status = "canceling";
+    current.cleanupPending = true;
+    current.error = message;
+    delete current.completedAt;
+    delete current.pid;
+    delete current.pidStartedAt;
+    if (!processIdentityMatches(
+      current.enginePid,
+      current.engineStartedAt
+    )) {
+      delete current.enginePid;
+      delete current.engineStartedAt;
+    }
+  });
+  await store.appendEvent("runner.cleanup_pending", { error: message });
+  await store.appendLog(message);
+  if (json) {
+    outputState(state, true);
+  }
+  return state;
+}
+async function runCommand(parsed) {
+  assertOptions(
+    parsed,
+    [
+      "agent-timeout-ms",
+      "concurrency",
+      "cwd",
+      "input",
+      "max-agents",
+      "max-runtime-ms"
+    ],
+    [
+      "allow-danger-full-access",
+      "allow-workspace-write",
+      "detach",
+      "json"
+    ]
+  );
+  const workflowPath = path4.resolve(
+    requirePositional(parsed, 0, "workflow file")
+  );
+  if (parsed.positionals.length > 1) {
+    throw new Error("run accepts exactly one workflow file");
+  }
+  const source = await readFile3(workflowPath, "utf8");
+  compileWorkflow(source, workflowPath);
+  const cwd = path4.resolve(parsed.values.get("cwd") ?? process.cwd());
+  const input = await parseInput(parsed.values.get("input"));
+  const timestamp = nowIso();
+  const workflowHash = sha256(source);
+  const state = {
+    ...input === void 0 ? {} : { args: input },
+    agentInvocations: 0,
+    authorization: authorizationFromFlags(parsed, workflowHash),
+    concurrency: parseConcurrency(parsed.values.get("concurrency")),
+    createdAt: timestamp,
+    cwd,
+    defaultAgentTimeoutMs: parseIntegerOption(
+      "agent-timeout-ms",
+      parsed.values.get("agent-timeout-ms"),
+      DEFAULT_AGENT_TIMEOUT_MS,
+      864e5
+    ),
+    maxAgentInvocations: parseIntegerOption(
+      "max-agents",
+      parsed.values.get("max-agents"),
+      DEFAULT_MAX_AGENT_INVOCATIONS2,
+      1e3
+    ),
+    maxRuntimeMs: parseIntegerOption(
+      "max-runtime-ms",
+      parsed.values.get("max-runtime-ms"),
+      DEFAULT_MAX_RUNTIME_MS,
+      6048e5
+    ),
+    runId: createRunId(),
+    status: "starting",
+    steps: {},
+    updatedAt: timestamp,
+    version: 1,
+    workflowHash,
+    workflowPath
+  };
+  const store = await StateStore.create(state);
+  await store.appendEvent("run.created", { workflowPath });
+  if (parsed.flags.has("detach")) {
+    const pid = await spawnDetached(store);
+    if (parsed.flags.has("json")) {
+      console.log(JSON.stringify({ pid, runId: state.runId }));
+    } else {
+      console.log(`Started ${state.runId} as PID ${pid}`);
+    }
+    return 0;
+  }
+  const finalState = await executeRun(state.runId, parsed.flags.has("json"));
+  if (!parsed.flags.has("json")) {
+    outputState(finalState, false);
+  }
+  return finalState.status === "completed" ? 0 : 1;
+}
+async function validateCommand(parsed) {
+  assertOptions(parsed, []);
+  const workflowPath = path4.resolve(
+    requirePositional(parsed, 0, "workflow file")
+  );
+  if (parsed.positionals.length > 1) {
+    throw new Error("validate accepts exactly one workflow file");
+  }
+  compileWorkflow(await readFile3(workflowPath, "utf8"), workflowPath);
+  console.log(`${workflowPath}: valid`);
+  return 0;
+}
+async function statusCommand(parsed) {
+  assertOptions(parsed, [], ["json"]);
+  const runId = requirePositional(parsed, 0, "run ID");
+  outputState(
+    (await StateStore.load(runId)).snapshot(),
+    parsed.flags.has("json")
+  );
+  return 0;
+}
+async function listCommand(parsed) {
+  assertOptions(parsed, [], ["json"]);
+  const states = await StateStore.list();
+  if (parsed.flags.has("json")) {
+    console.log(JSON.stringify(states, null, 2));
+  } else if (states.length === 0) {
+    console.log("No workflow runs found.");
+  } else {
+    for (const state of states) {
+      console.log(summary(state));
+    }
+  }
+  return 0;
+}
+async function logsCommand(parsed) {
+  assertOptions(parsed, []);
+  const store = await StateStore.load(
+    requirePositional(parsed, 0, "run ID")
+  );
+  process.stdout.write(await store.readLog());
+  return 0;
+}
+async function controlCommand(parsed, command) {
+  assertOptions(parsed, []);
+  const runId = requirePositional(parsed, 0, "run ID");
+  const store = await StateStore.load(runId);
+  const state = store.snapshot();
+  if (TERMINAL_STATUSES.has(state.status)) {
+    throw new Error(`Run ${runId} is already ${state.status}`);
+  }
+  await store.writeControl(command);
+  if (!processIdentityMatches(state.pid, state.pidStartedAt)) {
+    if (command === "cancel") {
+      const cleaned = await terminateOrphanedExecution(
+        store,
+        "Interrupted after the workflow supervisor exited"
+      );
+      await terminalizeForcedRun(cleaned, "canceled", "Workflow canceled");
+    } else if (!processIdentityMatches(state.enginePid, state.engineStartedAt)) {
+      await store.update((current) => {
+        current.status = "paused";
+      });
+    }
+  }
+  console.log(`${command === "pause" ? "Pausing" : "Canceling"} ${runId}`);
+  return 0;
+}
+async function resumeCommand(parsed) {
+  assertOptions(parsed, [], [
+    "allow-danger-full-access",
+    "allow-workspace-write",
+    "foreground",
+    "json"
+  ]);
+  const runId = requirePositional(parsed, 0, "run ID");
+  let store = await StateStore.load(runId);
+  let state = store.snapshot();
+  if (state.status === "completed") {
+    outputState(state, parsed.flags.has("json"));
+    return 0;
+  }
+  const runnerAlive = processIdentityMatches(
+    state.pid,
+    state.pidStartedAt
+  );
+  if (!runnerAlive) {
+    const cleaned = await terminateOrphanedExecution(
+      store,
+      "Interrupted after the workflow supervisor exited"
+    );
+    store = cleaned;
+    state = cleaned.snapshot();
+  }
+  const changingAuthorization = parsed.flags.has("allow-danger-full-access") || parsed.flags.has("allow-workspace-write");
+  const workflowHash = changingAuthorization && !runnerAlive ? sha256(await readFile3(state.workflowPath, "utf8")) : state.workflowHash;
+  const currentControl = await store.readControl();
+  const authorization = authorizationFromFlags(
+    parsed,
+    workflowHash,
+    currentControl.authorization ?? state.authorization
+  );
+  await store.writeControl("run", authorization);
+  if (runnerAlive) {
+    if (parsed.flags.has("json")) {
+      console.log(JSON.stringify({ pid: state.pid, resumed: true, runId }));
+    } else {
+      console.log(`Resumed ${runId} (PID ${state.pid})`);
+    }
+    return 0;
+  }
+  state = await store.update((current) => {
+    current.authorization = authorization;
+  });
+  if (parsed.flags.has("foreground")) {
+    const finalState = await executeRun(runId, parsed.flags.has("json"));
+    if (!parsed.flags.has("json")) {
+      outputState(finalState, false);
+    }
+    return finalState.status === "completed" ? 0 : 1;
+  }
+  const pid = await spawnDetached(store);
+  if (parsed.flags.has("json")) {
+    console.log(JSON.stringify({ pid, resumed: true, runId }));
+  } else {
+    console.log(`Resumed ${runId} as PID ${pid}`);
+  }
+  return 0;
+}
+async function waitCommand(parsed) {
+  assertOptions(parsed, [], ["json"]);
+  const runId = requirePositional(parsed, 0, "run ID");
+  while (true) {
+    const state = (await StateStore.load(runId)).snapshot();
+    if (TERMINAL_STATUSES.has(state.status)) {
+      outputState(state, parsed.flags.has("json"));
+      return state.status === "completed" ? 0 : 1;
+    }
+    if (!processIdentityMatches(state.pid, state.pidStartedAt)) {
+      throw new Error(
+        `Run ${runId} has no active runner; use resume to continue it`
+      );
+    }
+    await sleep(500);
+  }
+}
+async function main() {
+  const [command = "help", ...args] = process.argv.slice(2);
+  if (command === "help" || command === "--help" || command === "-h") {
+    printHelp();
+    return 0;
+  }
+  if (command === "_execute") {
+    const runId = args[0];
+    if (!runId) {
+      throw new Error("Internal runner requires a run ID");
+    }
+    const store = await StateStore.load(runId);
+    const state = await executeClaimedRun(store, false, args[1]);
+    return state.status === "completed" ? 0 : 1;
+  }
+  if (command === "_engine") {
+    const runId = args[0];
+    if (!runId) {
+      throw new Error("Internal engine requires a run ID");
+    }
+    const state = await executeEngine(await waitForEngineRegistration(runId));
+    return state.status === "completed" ? 0 : 1;
+  }
+  const parsed = parseArguments(args);
+  if (parsed.flags.has("help")) {
+    printHelp();
+    return 0;
+  }
+  switch (command) {
+    case "run":
+      return await runCommand(parsed);
+    case "validate":
+      return await validateCommand(parsed);
+    case "status":
+      return await statusCommand(parsed);
+    case "list":
+      return await listCommand(parsed);
+    case "logs":
+      return await logsCommand(parsed);
+    case "wait":
+      return await waitCommand(parsed);
+    case "pause":
+      return await controlCommand(parsed, "pause");
+    case "resume":
+      return await resumeCommand(parsed);
+    case "cancel":
+      return await controlCommand(parsed, "cancel");
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+}
+main().then((code) => {
+  process.exitCode = code;
+}).catch((error) => {
+  console.error(`codex-workflow: ${errorMessage(error)}`);
+  process.exitCode = 1;
+});

--- a/plugins/dynamic-workflow/package-lock.json
+++ b/plugins/dynamic-workflow/package-lock.json
@@ -1,0 +1,2148 @@
+{
+  "name": "@cctools/dynamic-workflow",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cctools/dynamic-workflow",
+      "version": "0.1.0",
+      "bin": {
+        "codex-workflow": "bin/workflow.mjs"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.30",
+        "esbuild": "^0.25.5",
+        "typescript": "^5.8.3",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/plugins/dynamic-workflow/package.json
+++ b/plugins/dynamic-workflow/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@cctools/dynamic-workflow",
+  "version": "0.1.0",
+  "description": "Durable JavaScript workflows for headless Codex agents",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "codex-workflow": "./bin/workflow.mjs"
+  },
+  "scripts": {
+    "build": "esbuild src/cli.ts --bundle --platform=node --format=esm --target=node20 --outfile=bin/workflow.mjs --banner:js='#!/usr/bin/env node'",
+    "test": "npm run build && vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.30",
+    "esbuild": "^0.25.5",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/plugins/dynamic-workflow/skills/dynamic-workflow/SKILL.md
+++ b/plugins/dynamic-workflow/skills/dynamic-workflow/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: dynamic-workflow
+description: >-
+  Create, review, run, inspect, pause, resume, and cancel durable JavaScript
+  workflows that coordinate multiple headless Codex agents. Use for dynamic
+  fan-out and fan-in, per-item analysis, multi-stage agent pipelines, loops or
+  branches driven by worker results, long background runs, and ports of Claude
+  Code dynamic workflows. Do not use for a small linear task that one Codex
+  turn can handle directly.
+---
+
+# Dynamic Workflow
+
+Use a deterministic JavaScript program to own control flow while separate
+Codex workers do the reasoning and tool work. The runtime uses direct
+`codex exec --json`; it does not require MCP or an API key beyond the normal
+Codex CLI authentication.
+
+## Locate the runner
+
+Resolve `bin/workflow.mjs` two directories above this `SKILL.md` and use its
+absolute path for every command. Do not assume the current repository contains
+the plugin or that a plugin-root environment variable exists.
+
+Set both paths explicitly, replacing the first value with the directory that
+contains this loaded `SKILL.md`, then verify prerequisites:
+
+```bash
+SKILL_DIR="/absolute/path/to/skills/dynamic-workflow"
+RUNNER="$(cd "$SKILL_DIR/../.." && pwd)/bin/workflow.mjs"
+node --version
+codex --version
+node "$RUNNER" help
+```
+
+Node.js 20 or newer is required. The committed bundle needs no `npm install`.
+
+## Decide whether to create a workflow
+
+Use a workflow when JavaScript control flow materially reduces context or
+coordinates at least one of these patterns:
+
+- discover items, fan out one worker per item, then synthesize
+- run heterogeneous agents in parallel and combine their results
+- branch or loop based on structured worker output
+- execute a long run in the background with durable progress
+- reuse or port an existing dynamic workflow script
+
+Continue directly for one or two ordinary sequential tasks.
+
+## Author the script
+
+Read [references/workflow-api.md](references/workflow-api.md) before writing or
+debugging a workflow. Start from
+[assets/workflow-template.js](assets/workflow-template.js) when useful.
+
+Save project workflows under `.codex/workflows/<name>.js`. A workflow uses a
+Claude-compatible script body with injected globals, top-level `await`, and a
+top-level `return`:
+
+```javascript
+export const meta = {
+  name: "audit-routes",
+  description: "Audit every route for missing authorization",
+}
+
+const found = await agent(
+  "Find every API route. Return method, path, and source file per route.",
+  {
+  id: "discover",
+  schema: {
+    type: "object",
+    required: ["routes"],
+    properties: {
+      routes: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["method", "path", "file"],
+          properties: {
+            method: { type: "string" },
+            path: { type: "string" },
+            file: { type: "string" },
+          },
+        },
+      },
+    },
+  },
+  },
+)
+
+const audits = await pipeline(
+  found.routes,
+  route => agent(
+    `Audit ${route.method} ${route.path} in ${route.file} for missing ` +
+      "authentication and authorization. Return evidence and severity.",
+    {
+    id: "audit",
+    label: `${route.method} ${route.path}`,
+    sandbox: "read-only",
+    },
+  ),
+  {
+    concurrency: 4,
+    key: route => `${route.method}-${route.path}`,
+    maxItems: 50,
+  },
+)
+
+const summary = await agent(
+  `Deduplicate and rank these route audits:\n${JSON.stringify(audits)}`,
+  { id: "synthesize", cacheKey: audits, sandbox: "read-only" },
+)
+
+return { audits, summary }
+```
+
+Follow these rules:
+
+- Give every important `agent()` call a stable `id`.
+- Use `schema` when later JavaScript reads fields from an agent result.
+- Keep discovery and review workers in `read-only` unless writes are required.
+- Use `workspace-write` only when the user authorized edits.
+- Partition parallel write work by file or worktree to avoid conflicts.
+- Set a task-specific `maxItems` on every dynamically discovered pipeline.
+- Bound loops explicitly and call `checkpoint()` inside long local loops.
+- Bound discovery arrays in JSON Schema with `maxItems` and string lengths.
+- Request compact worker output; use chunked or tree reduction for large fan-in.
+- Set explicit `timeoutMs` and use at most five retries for transient failures.
+- Keep prompts self-contained because workers do not share conversation state.
+- Put upstream results in downstream prompts or `cacheKey` to avoid stale cache.
+- Return only the compact result the parent Codex session needs.
+
+Workflow code has no injected filesystem, shell, `process`, or module import
+access. It delegates all such work to sandboxed agents. The Node VM is a
+capability boundary for accidental access, not a hardened hostile-code sandbox;
+always review generated code before running it.
+
+## Validate and obtain approval
+
+Run syntax validation before launch:
+
+```bash
+node "$RUNNER" validate .codex/workflows/<name>.js
+```
+
+Show the user the workflow source and summarize an agent-count formula and cap,
+concurrency, overall runtime, worker timeout, sandbox modes, expected writes,
+context-sensitive fan-in, and likely cost. A request to create a workflow is
+not approval to launch newly generated code. Obtain explicit launch approval
+after review. A request to run a previously reviewed script counts as launch
+approval, but never silently escalate a worker to `danger-full-access`.
+
+After approval, add `--allow-workspace-write` to `run` or `resume` when any
+worker declares `workspace-write`. Add `--allow-danger-full-access` only for a
+separately approved danger-full-access run. The runtime rejects write-capable
+workers when the corresponding authorization is absent.
+Authorization is bound to the reviewed source hash, so editing a write-capable
+workflow requires the flag again on its next launch or resume.
+
+## Run and monitor
+
+Foreground execution is useful for short runs:
+
+```bash
+node "$RUNNER" run .codex/workflows/<name>.js \
+  --cwd "$PWD" --input '{"target":"src"}'
+```
+
+Use detached execution for a long run:
+
+```bash
+node "$RUNNER" run .codex/workflows/<name>.js \
+  --cwd "$PWD" --input '{"target":"src"}' --detach --json \
+  --max-agents 50 --max-runtime-ms 7200000 --agent-timeout-ms 900000
+```
+
+Capture the returned run ID. Continue monitoring until the requested outcome
+is terminal unless the user asked only to launch it. For a long run, poll
+`status --json` at bounded intervals and provide periodic updates. Use `wait`
+only when completion is expected soon or the user explicitly requested a
+blocking wait.
+
+```bash
+node "$RUNNER" status <run-id> --json
+node "$RUNNER" logs <run-id>
+node "$RUNNER" wait <run-id> --json
+```
+
+Controls are cooperative. Pause lets active workers finish and blocks new
+workers. Resume replays the script and returns cached results for completed
+steps whose IDs and fingerprints still match.
+
+```bash
+node "$RUNNER" pause <run-id>
+node "$RUNNER" resume <run-id>
+node "$RUNNER" cancel <run-id>
+```
+
+Before resuming after a script edit:
+
+1. Run `status <run-id> --json` and read the stored workflow path.
+2. Review and validate the current file at that path.
+3. Explain which rendered prompts or cache keys changed and will rerun.
+4. Renew approval if sandbox, write scope, concurrency, model, or cost changed.
+5. Run `resume <run-id> --json` with any newly approved authorization flag.
+6. Monitor the resumed run to a terminal state.
+
+Resume rereads the current workflow file and reuses the stored `args`, cwd, and
+concurrency. It launches detached when the old runner is gone unless
+`--foreground` is present. Unchanged siblings remain cached. A downstream step
+reruns only if its own prompt, options, or `cacheKey` changes.
+
+On failure, inspect the failed step and logs. Fix the script or environment,
+then use `resume`; completed compatible steps remain cached. Do not delete the
+run directory merely to retry.
+
+Treat a context-capacity error as non-retryable. Reduce or chunk the failing
+prompt, replace large fan-in with a tree reduction, validate the edit, and then
+resume so compatible completed siblings stay cached.
+
+## Safety boundaries
+
+- Headless workers use approval policy `never`, so they fail instead of waiting
+  for an unavailable prompt.
+- The default Codex sandbox is `read-only`.
+- `workspace-write` also requires the CLI flag `--allow-workspace-write`.
+- `danger-full-access` requires a specific user decision for that workflow.
+- `danger-full-access` also requires `--allow-danger-full-access` at launch.
+- One failed pipeline item fails the run; completed sibling results persist.
+- A run defaults to 100 worker launches and can be raised only up to 1,000.
+- A run defaults to a four-hour deadline and workers to a 30-minute timeout.
+- A pipeline without `maxItems` is capped at 100; explicit caps stop at 1,000.
+- Agent retries are limited to five; prompts and results are capped at 1 MB.
+- The default concurrency is 6; choose a lower value for write-heavy work.
+- A supervisor can terminate runaway workflow JavaScript and worker trees.
+- Resume and cancel remove engine or worker groups orphaned by a supervisor
+  crash.
+- The supervisor removes active worker groups after an unexpected engine exit.
+- Workers receive prompts only after their process ownership is durable.
+- Every worker exit drains surviving descendants in its owned process group.
+- Persisted process IDs are signaled only when their process-start identity
+  still matches, preventing cleanup from killing a reused PID.
+- Unconfirmed cleanup remains recoverable and nonterminal for a later retry.
+- Never leave `agent()`, `pipeline()`, or `parallel()` promises unawaited.

--- a/plugins/dynamic-workflow/skills/dynamic-workflow/agents/openai.yaml
+++ b/plugins/dynamic-workflow/skills/dynamic-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Dynamic Workflow"
+  short_description: "Run resumable multi-agent Codex workflows"
+  default_prompt: "Use $dynamic-workflow to create or run a durable Codex workflow for this task."

--- a/plugins/dynamic-workflow/skills/dynamic-workflow/assets/workflow-template.js
+++ b/plugins/dynamic-workflow/skills/dynamic-workflow/assets/workflow-template.js
@@ -1,0 +1,64 @@
+export const meta = {
+  name: "replace-me",
+  description: "Discover items, process them in parallel, and synthesize",
+}
+
+const discovered = await agent(
+  "Discover at most 50 concrete work items. Return stable IDs and concise " +
+    "descriptions.",
+  {
+    id: "discover",
+    label: "Discover work",
+    sandbox: "read-only",
+    schema: {
+      type: "object",
+      required: ["items"],
+      properties: {
+        items: {
+          type: "array",
+          maxItems: 50,
+          items: {
+            type: "object",
+            required: ["id", "description"],
+            properties: {
+              id: { type: "string" },
+              description: { type: "string", maxLength: 1000 },
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
+const results = await pipeline(
+  discovered.items,
+  item => agent(
+    `Handle this item and return a concise result:\n${item.description}`,
+    {
+      id: "process",
+      label: item.id,
+      sandbox: "read-only",
+      timeoutMs: 900000,
+    },
+  ),
+  {
+    concurrency: 4,
+    key: item => item.id,
+    label: "process-items",
+    maxItems: 50,
+  },
+)
+
+const summary = await agent(
+  `Synthesize these results without repeating them:\n${JSON.stringify(results)}`,
+  {
+    cacheKey: results,
+    id: "synthesize",
+    label: "Synthesize results",
+    sandbox: "read-only",
+    timeoutMs: 900000,
+  },
+)
+
+return { results, summary }

--- a/plugins/dynamic-workflow/skills/dynamic-workflow/references/workflow-api.md
+++ b/plugins/dynamic-workflow/skills/dynamic-workflow/references/workflow-api.md
@@ -1,0 +1,189 @@
+# Workflow API
+
+The runtime accepts JavaScript script bodies rather than ordinary Node modules.
+This permits a compatibility header, top-level `await`, and top-level `return`:
+
+```javascript
+export const meta = { name: "example", description: "Example workflow" }
+const result = await agent("Do one focused task.", { id: "task" })
+return result
+```
+
+`export const meta` is optional and currently informational. Other imports and
+exports are rejected. The runtime injects the globals documented below.
+
+## `agent(prompt, options?)`
+
+Spawns one `codex exec --json` worker and returns its final message. If `schema`
+is present, the final message is parsed and returned as structured JSON.
+
+| Option | Meaning |
+|--------|---------|
+| `id` | Stable step ID used for durable cache replay |
+| `label` | Human-readable name in state and logs |
+| `cacheKey` | Extra dependency value included only in the cache fingerprint |
+| `schema` | JSON Schema passed through `--output-schema` |
+| `model` | Optional Codex model override |
+| `reasoningEffort` | `minimal`, `low`, `medium`, `high`, or `xhigh` |
+| `cwd` | Worker directory, relative to the workflow directory setting |
+| `sandbox` | `read-only`, `workspace-write`, or `danger-full-access` |
+| `addDirs` | Additional writable directories for a new Codex thread |
+| `retries` | Automatic retry count after the first attempt; maximum 5 |
+| `timeoutMs` | Worker deadline in milliseconds; default 30 minutes |
+| `resumeThreadId` | Continue an existing Codex thread; see safety note below |
+| `ignoreUserConfig` | Pass `--ignore-user-config` to the worker |
+
+The default sandbox is `read-only`. Workers set approval policy `never` so a
+headless process never waits for interactive approval. A resumed Codex thread
+keeps its original working and sandbox configuration.
+
+A script declaration alone cannot authorize writes. `run` and `resume` require
+`--allow-workspace-write` before a `workspace-write` worker can launch, and
+`--allow-danger-full-access` before a `danger-full-access` worker can launch.
+Authorization is stored with the run. The danger flag also authorizes ordinary
+workspace writes.
+Authorization is bound to the current workflow source hash. Editing the script
+invalidates an earlier write authorization until `resume` receives the matching
+flag again.
+
+The runner cannot inspect an existing Codex thread's inherited sandbox.
+`resumeThreadId` therefore requires `--allow-danger-full-access`, even when the
+author believes that thread was read-only. This does not apply to resuming the
+workflow run itself with the CLI `resume` command.
+
+The runner stores the worker thread ID and token usage in run state. Workflow
+code receives only the final string or parsed JSON; inspect state for metadata.
+Prompts and final results are limited to 1 MB each. Context-capacity failures
+are non-retryable and explain how to chunk the input before resuming. Failed
+steps retain any worker thread ID and token usage emitted before the failure.
+
+## `pipeline(items, worker, options?)`
+
+Runs a callback for each list item with bounded concurrency and returns results
+in input order:
+
+```javascript
+const results = await pipeline(
+  items,
+  (item, index) => agent(`Review ${item.path}.`, {
+    id: "review",
+    label: item.path,
+  }),
+  {
+    concurrency: 4,
+    key: (item, index) => item.id ?? String(index),
+    label: "reviews",
+    maxItems: 50,
+  },
+)
+```
+
+`key` values must be unique within the pipeline. The pipeline scope plus the
+agent `id` creates a stable step ID for cache replay. If one callback fails,
+the pipeline rejects, but already completed agent results remain stored.
+`maxItems` is a required safety practice for dynamic discovery; the runner
+throws before fan-out when the list exceeds it. An omitted cap defaults to 100,
+and an explicit cap cannot exceed 1,000. Also set `maxItems` and `maxLength` in
+the discovery worker's JSON Schema so oversized output fails at its source.
+
+## `parallel(tasks, options?)`
+
+Runs heterogeneous async callbacks with the same ordered, bounded scheduler:
+
+```javascript
+const [security, tests, docs] = await parallel(
+  [
+    () => agent("Review security.", { id: "security" }),
+    () => agent("Review tests.", { id: "tests" }),
+    () => agent("Review docs.", { id: "docs" }),
+  ],
+  { concurrency: 3, label: "reviewers" },
+)
+```
+
+## Other globals
+
+- `args`: parsed JSON from `--input`; `undefined` when omitted
+- `checkpoint()`: cooperatively honor pause or cancel inside local loops
+- `log(...values)`: append a timestamped message to the workflow log
+- `workflow.runId`: durable run identifier
+
+## Cache identity
+
+A completed step is reused only when its stable step ID and fingerprint match.
+The fingerprint includes the prompt, schema, `cacheKey`, model, reasoning
+effort, working directory, sandbox, additional directories, user-config mode,
+and resumed thread ID. Labels, retries, and timeouts do not change the result
+fingerprint.
+
+Changing JavaScript control flow can change automatically generated IDs. Use
+explicit `id` values and pipeline keys for reliable resume behavior.
+
+Cache dependencies are explicit. If a downstream prompt is constant but its
+answer depends on upstream results or workspace state, pass those results or a
+version digest as `cacheKey`. Otherwise a resume can correctly identify the
+same invocation while the author incorrectly expected it to rerun.
+
+Resume rereads the workflow file stored in `state.json` and retains the run's
+original `args`, cwd, and concurrency. It does not invalidate every step merely
+because source text changed. Each completed step is evaluated independently.
+
+## CLI reference
+
+```text
+run <file> [--input JSON|@FILE] [--cwd DIR] [--concurrency N]
+           [--max-agents N] [--max-runtime-ms N]
+           [--agent-timeout-ms N]
+           [--detach] [--json] [--allow-workspace-write]
+           [--allow-danger-full-access]
+validate <file>
+status <run-id> [--json]
+list [--json]
+logs <run-id>
+wait <run-id> [--json]
+pause <run-id>
+resume <run-id> [--foreground] [--json] [--allow-workspace-write]
+                [--allow-danger-full-access]
+cancel <run-id>
+```
+
+State defaults to `~/.codex/workflows/runs/<run-id>/`. Set
+`CODEX_WORKFLOW_HOME` to move the state root and
+`CODEX_WORKFLOW_CODEX_BIN` to select another Codex executable.
+
+Each run directory contains:
+
+- `state.json`: atomic run and agent state
+- `control.json`: external pause, resume, or cancel request
+- `events.jsonl`: raw lifecycle and Codex JSONL events
+- `workflow.log`: concise human-readable progress
+- `runner.log`: stdout and stderr for a detached runner
+- `runner.lock/`: cross-process claim preventing duplicate runners
+- `schemas/`: JSON Schemas supplied to structured workers
+- `workflow-snapshots/`: exact source revisions executed by the runner
+
+The default run budget is 100 worker launches, four hours per runner execution,
+and 30 minutes per worker. `--max-agents` can raise the launch cap to at most
+1,000. The supervisor owns the runner lock and force-stops runaway JavaScript
+or worker process trees after graceful cancellation cannot finish. Engine and
+worker process IDs are persisted so resume or cancel can remove an execution
+orphaned by a supervisor crash before another engine starts. Each PID is paired
+with its process-start identity. Cleanup refuses to signal a live PID when that
+identity is missing or changed, which protects unrelated processes after PID
+reuse.
+
+If the workflow engine exits unexpectedly while its supervisor remains alive,
+the supervisor terminates and verifies active worker process groups before it
+records the run as failed and releases the runner lock.
+
+A newly spawned worker receives its prompt only after its PID and process-start
+identity are durable. If exit confirmation times out, the run stays in the
+nonterminal `canceling` state with process identities intact. Retry `cancel` or
+`resume` to continue cleanup; the runner does not report false completion.
+Normal, failed, and canceled worker exit paths all drain the worker's process
+group so descendants cannot outlive their recorded agent step.
+
+Write-capable workers have at-least-once side-effect semantics if the operating
+system kills the runner between a side effect and its completion record. Make
+write steps idempotent and inspect workspace state before resuming a crashed
+run.

--- a/plugins/dynamic-workflow/src/cli.ts
+++ b/plugins/dynamic-workflow/src/cli.ts
@@ -1,0 +1,992 @@
+import { spawn } from "node:child_process";
+import { open, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { compileWorkflow, WorkflowEngine } from "./engine.js";
+import { StateStore } from "./state-store.js";
+import type {
+  JsonValue,
+  RunAuthorization,
+  RunState,
+  RunStatus,
+} from "./types.js";
+import {
+  createRunId,
+  errorMessage,
+  isPidRunning,
+  nowIso,
+  processIdentityMatches,
+  processStartIdentity,
+  sha256,
+  sleep,
+} from "./utils.js";
+
+interface ParsedArguments {
+  flags: Set<string>;
+  positionals: string[];
+  values: Map<string, string>;
+}
+
+const BOOLEAN_OPTIONS = new Set([
+  "allow-danger-full-access",
+  "allow-workspace-write",
+  "detach",
+  "foreground",
+  "help",
+  "json",
+]);
+const TERMINAL_STATUSES = new Set<RunStatus>([
+  "canceled",
+  "completed",
+  "failed",
+]);
+const DEFAULT_AGENT_TIMEOUT_MS = 1_800_000;
+const DEFAULT_MAX_AGENT_INVOCATIONS = 100;
+const DEFAULT_MAX_RUNTIME_MS = 14_400_000;
+const FORCE_STOP_GRACE_MS = 2_000;
+
+class CleanupPendingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CleanupPendingError";
+  }
+}
+
+function printHelp(): void {
+  console.log(`codex-workflow - durable JavaScript workflows for Codex
+
+Usage:
+  codex-workflow run <file> [--input JSON|@FILE] [--cwd DIR]
+                     [--concurrency N] [--detach] [--json]
+                     [--max-agents N] [--max-runtime-ms N]
+                     [--agent-timeout-ms N]
+                     [--allow-workspace-write]
+                     [--allow-danger-full-access]
+  codex-workflow validate <file>
+  codex-workflow status <run-id> [--json]
+  codex-workflow list [--json]
+  codex-workflow logs <run-id>
+  codex-workflow wait <run-id> [--json]
+  codex-workflow pause <run-id>
+  codex-workflow resume <run-id> [--foreground] [--json]
+                        [--allow-workspace-write]
+                        [--allow-danger-full-access]
+  codex-workflow cancel <run-id>
+
+Environment:
+  CODEX_WORKFLOW_HOME       State root (default: ~/.codex/workflows)
+  CODEX_WORKFLOW_CODEX_BIN  Codex executable (default: codex)
+
+Workflow scripts receive agent(), pipeline(), parallel(), checkpoint(), log(),
+args, and workflow.runId. Workers default to the read-only Codex sandbox.`);
+}
+
+function parseArguments(args: string[]): ParsedArguments {
+  const parsed: ParsedArguments = {
+    flags: new Set(),
+    positionals: [],
+    values: new Map(),
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const value = args[index] as string;
+    if (!value.startsWith("--")) {
+      parsed.positionals.push(value);
+      continue;
+    }
+    const name = value.slice(2);
+    if (BOOLEAN_OPTIONS.has(name)) {
+      parsed.flags.add(name);
+      continue;
+    }
+    const optionValue = args[index + 1];
+    if (optionValue === undefined || optionValue.startsWith("--")) {
+      throw new Error(`--${name} requires a value`);
+    }
+    parsed.values.set(name, optionValue);
+    index += 1;
+  }
+  return parsed;
+}
+
+function assertOptions(
+  parsed: ParsedArguments,
+  allowedValues: string[],
+  allowedFlags: string[] = [],
+): void {
+  for (const name of parsed.values.keys()) {
+    if (!allowedValues.includes(name)) {
+      throw new Error(`Unknown option: --${name}`);
+    }
+  }
+  for (const name of parsed.flags) {
+    if (!allowedFlags.includes(name) && name !== "help") {
+      throw new Error(`Unknown flag: --${name}`);
+    }
+  }
+}
+
+function requirePositional(
+  parsed: ParsedArguments,
+  index: number,
+  description: string,
+): string {
+  const value = parsed.positionals[index];
+  if (value === undefined) {
+    throw new Error(`Missing ${description}`);
+  }
+  return value;
+}
+
+async function parseInput(value: string | undefined): Promise<JsonValue | undefined> {
+  if (value === undefined) {
+    return undefined;
+  }
+  const source = value.startsWith("@")
+    ? await readFile(path.resolve(value.slice(1)), "utf8")
+    : value;
+  return JSON.parse(source) as JsonValue;
+}
+
+function parseConcurrency(value: string | undefined): number {
+  const concurrency = value === undefined ? 6 : Number(value);
+  if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 64) {
+    throw new Error("--concurrency must be an integer from 1 to 64");
+  }
+  return concurrency;
+}
+
+function parseIntegerOption(
+  name: string,
+  value: string | undefined,
+  defaultValue: number,
+  maximum: number,
+): number {
+  const parsed = value === undefined ? defaultValue : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > maximum) {
+    throw new Error(`--${name} must be an integer from 1 to ${maximum}`);
+  }
+  return parsed;
+}
+
+function authorizationFromFlags(
+  parsed: ParsedArguments,
+  workflowHash: string,
+  current?: RunAuthorization,
+): RunAuthorization {
+  const changed =
+    parsed.flags.has("allow-danger-full-access") ||
+    parsed.flags.has("allow-workspace-write");
+  if (!changed && current) {
+    return current;
+  }
+  const dangerFullAccess = parsed.flags.has("allow-danger-full-access");
+  return {
+    dangerFullAccess,
+    workflowHash,
+    workspaceWrite:
+      dangerFullAccess || parsed.flags.has("allow-workspace-write"),
+  };
+}
+
+function summary(state: RunState): string {
+  const completed = Object.values(state.steps).filter(
+    (step) => step.status === "completed",
+  ).length;
+  const total = Object.keys(state.steps).length;
+  return `${state.runId}  ${state.status}  ${completed}/${total} agents`;
+}
+
+function outputState(state: RunState, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(state, null, 2));
+    return;
+  }
+  console.log(summary(state));
+  if (state.error) {
+    console.log(`Error: ${state.error}`);
+  }
+  if (state.status === "completed" && state.result !== undefined) {
+    console.log(JSON.stringify(state.result, null, 2));
+  }
+}
+
+async function executeRun(runId: string, json: boolean): Promise<RunState> {
+  const store = await StateStore.load(runId);
+  return await executeClaimedRun(store, json);
+}
+
+async function executeClaimedRun(
+  store: StateStore,
+  json: boolean,
+  requestedToken?: string,
+): Promise<RunState> {
+  let runnerToken: string;
+  try {
+    runnerToken = await store.claimRunner(process.pid, requestedToken);
+  } catch (error) {
+    if (requestedToken) {
+      const latest = await StateStore.load(store.runId);
+      const state = latest.snapshot();
+      if (state.pid === process.pid && !TERMINAL_STATUSES.has(state.status)) {
+        return await recordBootstrapFailure(latest, error, json);
+      }
+    }
+    throw error;
+  }
+  try {
+    const requestCancel = (): void => {
+      void store.writeControl("cancel");
+    };
+    process.once("SIGINT", requestCancel);
+    process.once("SIGTERM", requestCancel);
+    try {
+      const pidStartedAt = processStartIdentity(process.pid);
+      if (pidStartedAt === undefined) {
+        throw new Error(`Could not identify runner PID ${process.pid}`);
+      }
+      await store.update((state) => {
+        state.pid = process.pid;
+        state.pidStartedAt = pidStartedAt;
+        state.runnerStartedAt = nowIso();
+      });
+      const state = await superviseEngine(store);
+      if (json) {
+        outputState(state, true);
+      }
+      return state;
+    } finally {
+      process.removeListener("SIGINT", requestCancel);
+      process.removeListener("SIGTERM", requestCancel);
+    }
+  } catch (error) {
+    if (error instanceof CleanupPendingError) {
+      return await recordCleanupPending(store, error, json);
+    }
+    return await recordBootstrapFailure(store, error, json);
+  } finally {
+    await store.releaseRunner(runnerToken);
+  }
+}
+
+async function executeEngine(store: StateStore): Promise<RunState> {
+  try {
+    const current = store.snapshot();
+    const source = await readFile(current.workflowPath, "utf8");
+    compileWorkflow(source, current.workflowPath);
+    const currentHash = sha256(source);
+    await store.snapshotWorkflow(source, currentHash);
+    if (currentHash !== current.workflowHash) {
+      await store.appendEvent("workflow.changed", {
+        from: current.workflowHash,
+        to: currentHash,
+      });
+      await store.update((state) => {
+        state.workflowHash = currentHash;
+      });
+    }
+    const engine = new WorkflowEngine(store, source, (message) => {
+      console.error(`[${store.runId}] ${message}`);
+    });
+    return await engine.run();
+  } catch (error) {
+    return await recordBootstrapFailure(store, error, false);
+  }
+}
+
+async function superviseEngine(store: StateStore): Promise<RunState> {
+  const entry = fileURLToPath(import.meta.url);
+  const child = spawn(process.execPath, [entry, "_engine", store.runId], {
+    detached: process.platform !== "win32",
+    env: process.env,
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  if (child.pid === undefined) {
+    throw new Error("Workflow engine did not receive a PID");
+  }
+  const enginePid = child.pid;
+  const engineStartedAt = processStartIdentity(enginePid);
+  if (engineStartedAt === undefined) {
+    signalProcessTree(enginePid, "SIGKILL");
+    throw new Error(`Could not identify workflow engine PID ${enginePid}`);
+  }
+
+  let childError: unknown;
+  let closed = false;
+  let exitCode: number | null = null;
+  let exitSignal: NodeJS.Signals | null = null;
+  const completion = new Promise<void>((resolve) => {
+    child.once("error", (error) => {
+      childError = error;
+      closed = true;
+      resolve();
+    });
+    child.once("close", (code, signal) => {
+      exitCode = code;
+      exitSignal = signal;
+      closed = true;
+      resolve();
+    });
+  });
+  await store.update((state) => {
+    state.enginePid = enginePid;
+    state.engineStartedAt = engineStartedAt;
+  });
+
+  const maximumRuntime =
+    store.snapshot().maxRuntimeMs ?? DEFAULT_MAX_RUNTIME_MS;
+  const deadline = Date.now() + maximumRuntime;
+  let forcedAt: number | undefined;
+  let forcedReason: "cancel" | "timeout" | undefined;
+
+  while (!closed) {
+    const control = await store.readControl();
+    if (Date.now() >= deadline && forcedReason === undefined) {
+      forcedReason = "timeout";
+      forcedAt = Date.now() + FORCE_STOP_GRACE_MS;
+      await store.appendEvent("runner.deadline_exceeded", {
+        maxRuntimeMs: maximumRuntime,
+      });
+      signalProcessTree(child.pid, "SIGTERM");
+      await signalRecordedWorkers(store, "SIGKILL", false);
+    } else if (control.command === "cancel" && forcedReason === undefined) {
+      forcedReason = "cancel";
+      forcedAt = Date.now() + FORCE_STOP_GRACE_MS;
+    }
+    if (forcedAt !== undefined && Date.now() >= forcedAt) {
+      signalProcessTree(child.pid, "SIGKILL");
+      await signalRecordedWorkers(store, "SIGKILL", false);
+    }
+    await Promise.race([completion, sleep(100)]);
+  }
+  await completion;
+
+  await signalRecordedWorkers(store, "SIGKILL", false, true);
+
+  let latestStore = await StateStore.load(store.runId);
+  let state = latestStore.snapshot();
+  if (
+    forcedReason === "timeout" &&
+    !TERMINAL_STATUSES.has(state.status)
+  ) {
+    state = await terminalizeForcedRun(
+      latestStore,
+      "failed",
+      `Workflow exceeded its ${maximumRuntime} ms runtime limit`,
+    );
+  } else if (!TERMINAL_STATUSES.has(state.status)) {
+    const canceled = forcedReason === "cancel";
+    const detail = childError
+      ? errorMessage(childError)
+      : `exit ${String(exitCode)}${exitSignal ? ` (${exitSignal})` : ""}`;
+    const failureMessage = state.error ?? `Workflow engine stopped: ${detail}`;
+    state = await terminalizeForcedRun(
+      latestStore,
+      canceled ? "canceled" : "failed",
+      canceled ? "Workflow canceled" : failureMessage,
+    );
+  }
+  latestStore = await StateStore.load(store.runId);
+  return await latestStore.update((current) => {
+    delete current.enginePid;
+    delete current.engineStartedAt;
+    delete current.pid;
+    delete current.pidStartedAt;
+  });
+}
+
+async function terminalizeForcedRun(
+  store: StateStore,
+  status: "canceled" | "failed",
+  message: string,
+): Promise<RunState> {
+  return await store.update((state) => {
+    state.status = status;
+    state.error = message;
+    state.completedAt = nowIso();
+    delete state.cleanupPending;
+    delete state.enginePid;
+    delete state.engineStartedAt;
+    delete state.pid;
+    delete state.pidStartedAt;
+    for (const step of Object.values(state.steps)) {
+      if (step.status === "running") {
+        step.status = status === "canceled" ? "canceled" : "failed";
+        step.error = message;
+        step.completedAt = nowIso();
+        delete step.workerPid;
+        delete step.workerStartedAt;
+      }
+    }
+  });
+}
+
+function signalProcessTree(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, signal);
+  } catch {
+    // The owned process tree may already be gone.
+  }
+}
+
+async function signalRecordedWorkers(
+  store: StateStore,
+  signal: NodeJS.Signals,
+  strictIdentity = true,
+  waitForExit = false,
+): Promise<void> {
+  const state = (await StateStore.load(store.runId)).snapshot();
+  const signaledPids: number[] = [];
+  for (const step of Object.values(state.steps)) {
+    if (step.workerPid === undefined) {
+      continue;
+    }
+    const signaled = signalOwnedProcessTree(
+      step.workerPid,
+      step.workerStartedAt,
+      signal,
+      `worker ${step.id}`,
+      strictIdentity,
+    );
+    if (signaled) {
+      signaledPids.push(step.workerPid);
+    }
+  }
+  if (!waitForExit) {
+    return;
+  }
+  for (const pid of signaledPids) {
+    if (!(await waitForProcessTreeExit(pid))) {
+      throw new CleanupPendingError(
+        `Worker process group ${pid} did not terminate`,
+      );
+    }
+  }
+}
+
+async function terminateOrphanedExecution(
+  store: StateStore,
+  message: string,
+): Promise<StateStore> {
+  let state = (await StateStore.load(store.runId)).snapshot();
+  let engineSignaled = false;
+  if (state.enginePid !== undefined) {
+    engineSignaled = signalOwnedProcessTree(
+      state.enginePid,
+      state.engineStartedAt,
+      "SIGKILL",
+      "workflow engine",
+    );
+  }
+  await signalRecordedWorkers(store, "SIGKILL", true, true);
+  if (
+    engineSignaled &&
+    state.enginePid !== undefined &&
+    !(await waitForProcessTreeExit(state.enginePid))
+  ) {
+    throw new CleanupPendingError(
+      `Workflow engine process group ${state.enginePid} did not terminate`,
+    );
+  }
+
+  const latest = await StateStore.load(store.runId);
+  await latest.update((current) => {
+    delete current.cleanupPending;
+    delete current.enginePid;
+    delete current.engineStartedAt;
+    delete current.pid;
+    delete current.pidStartedAt;
+    for (const step of Object.values(current.steps)) {
+      if (step.status === "running") {
+        step.status = "failed";
+        step.error = message;
+        step.completedAt = nowIso();
+      }
+      delete step.workerPid;
+      delete step.workerStartedAt;
+    }
+  });
+  return await StateStore.load(store.runId);
+}
+
+function signalOwnedProcessTree(
+  pid: number,
+  expectedStartedAt: string | undefined,
+  signal: NodeJS.Signals,
+  label: string,
+  strictIdentity = true,
+): boolean {
+  if (!isPidRunning(pid)) {
+    if (processTreeIsRunning(pid)) {
+      throw new CleanupPendingError(
+        `${label} PID ${pid} exited while its process group remains`,
+      );
+    }
+    return false;
+  }
+  const actualStartedAt = processStartIdentity(pid);
+  if (
+    expectedStartedAt === undefined || actualStartedAt === undefined
+  ) {
+    if (processTreeIsRunning(pid)) {
+      throw new CleanupPendingError(
+        `Could not verify ${label} PID ${pid} before process-group cleanup`,
+      );
+    }
+    return false;
+  }
+  if (actualStartedAt !== expectedStartedAt) {
+    if (strictIdentity) {
+      throw new Error(
+        `Refusing to signal ${label} PID ${pid}: process identity changed`,
+      );
+    }
+    return false;
+  }
+  signalProcessTree(pid, signal);
+  return true;
+}
+
+async function waitForProcessTreeExit(
+  pid: number,
+  timeoutMs = 2_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (processTreeIsRunning(pid) && Date.now() < deadline) {
+    await sleep(25);
+  }
+  return !processTreeIsRunning(pid);
+}
+
+function processTreeIsRunning(pid: number): boolean {
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForEngineRegistration(runId: string): Promise<StateStore> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const store = await StateStore.load(runId);
+    const state = store.snapshot();
+    if (
+      state.enginePid === process.pid &&
+      processIdentityMatches(process.pid, state.engineStartedAt)
+    ) {
+      return store;
+    }
+    await sleep(25);
+  }
+  throw new Error(`Workflow engine ${process.pid} was not registered`);
+}
+
+async function spawnDetached(store: StateStore): Promise<number> {
+  const entry = fileURLToPath(import.meta.url);
+  const runnerToken = await store.claimRunner(process.pid);
+  let handedOff = false;
+  try {
+    const runnerLog = await open(path.join(store.directory, "runner.log"), "a");
+    try {
+      const child = spawn(
+        process.execPath,
+        [entry, "_execute", store.runId, runnerToken],
+        {
+          detached: true,
+          env: process.env,
+          stdio: ["ignore", runnerLog.fd, runnerLog.fd],
+        },
+      );
+      if (child.pid === undefined) {
+        throw new Error("Detached runner did not receive a PID");
+      }
+      const pid = child.pid;
+      const pidStartedAt = processStartIdentity(pid);
+      if (pidStartedAt === undefined) {
+        signalProcessTree(pid, "SIGKILL");
+        throw new Error(`Could not identify detached runner PID ${pid}`);
+      }
+      child.unref();
+      await store.update((state) => {
+        state.pid = pid;
+        state.pidStartedAt = pidStartedAt;
+        state.status = "starting";
+      });
+      await store.transferRunner(runnerToken, pid);
+      handedOff = true;
+      return pid;
+    } finally {
+      await runnerLog.close();
+    }
+  } catch (error) {
+    await recordBootstrapFailure(store, error, false);
+    throw error;
+  } finally {
+    if (!handedOff) {
+      await store.releaseRunner(runnerToken);
+    }
+  }
+}
+
+async function recordBootstrapFailure(
+  store: StateStore,
+  error: unknown,
+  json: boolean,
+): Promise<RunState> {
+  const message = `Runner bootstrap failed: ${errorMessage(error)}`;
+  const state = await store.update((current) => {
+    if (!TERMINAL_STATUSES.has(current.status)) {
+      current.status = "failed";
+      current.error = message;
+      current.completedAt = nowIso();
+    }
+  });
+  await store.appendEvent("runner.bootstrap_failed", { error: message });
+  await store.appendLog(message);
+  if (json) {
+    outputState(state, true);
+  }
+  return state;
+}
+
+async function recordCleanupPending(
+  store: StateStore,
+  error: CleanupPendingError,
+  json: boolean,
+): Promise<RunState> {
+  const message =
+    `Process cleanup is incomplete: ${error.message}. ` +
+    "Retry cancel or resume to continue cleanup.";
+  const state = await store.update((current) => {
+    current.status = "canceling";
+    current.cleanupPending = true;
+    current.error = message;
+    delete current.completedAt;
+    delete current.pid;
+    delete current.pidStartedAt;
+    if (
+      !processIdentityMatches(
+        current.enginePid,
+        current.engineStartedAt,
+      )
+    ) {
+      delete current.enginePid;
+      delete current.engineStartedAt;
+    }
+  });
+  await store.appendEvent("runner.cleanup_pending", { error: message });
+  await store.appendLog(message);
+  if (json) {
+    outputState(state, true);
+  }
+  return state;
+}
+
+async function runCommand(parsed: ParsedArguments): Promise<number> {
+  assertOptions(
+    parsed,
+    [
+      "agent-timeout-ms",
+      "concurrency",
+      "cwd",
+      "input",
+      "max-agents",
+      "max-runtime-ms",
+    ],
+    [
+      "allow-danger-full-access",
+      "allow-workspace-write",
+      "detach",
+      "json",
+    ],
+  );
+  const workflowPath = path.resolve(
+    requirePositional(parsed, 0, "workflow file"),
+  );
+  if (parsed.positionals.length > 1) {
+    throw new Error("run accepts exactly one workflow file");
+  }
+  const source = await readFile(workflowPath, "utf8");
+  compileWorkflow(source, workflowPath);
+  const cwd = path.resolve(parsed.values.get("cwd") ?? process.cwd());
+  const input = await parseInput(parsed.values.get("input"));
+  const timestamp = nowIso();
+  const workflowHash = sha256(source);
+  const state: RunState = {
+    ...(input === undefined ? {} : { args: input }),
+    agentInvocations: 0,
+    authorization: authorizationFromFlags(parsed, workflowHash),
+    concurrency: parseConcurrency(parsed.values.get("concurrency")),
+    createdAt: timestamp,
+    cwd,
+    defaultAgentTimeoutMs: parseIntegerOption(
+      "agent-timeout-ms",
+      parsed.values.get("agent-timeout-ms"),
+      DEFAULT_AGENT_TIMEOUT_MS,
+      86_400_000,
+    ),
+    maxAgentInvocations: parseIntegerOption(
+      "max-agents",
+      parsed.values.get("max-agents"),
+      DEFAULT_MAX_AGENT_INVOCATIONS,
+      1_000,
+    ),
+    maxRuntimeMs: parseIntegerOption(
+      "max-runtime-ms",
+      parsed.values.get("max-runtime-ms"),
+      DEFAULT_MAX_RUNTIME_MS,
+      604_800_000,
+    ),
+    runId: createRunId(),
+    status: "starting",
+    steps: {},
+    updatedAt: timestamp,
+    version: 1,
+    workflowHash,
+    workflowPath,
+  };
+  const store = await StateStore.create(state);
+  await store.appendEvent("run.created", { workflowPath });
+
+  if (parsed.flags.has("detach")) {
+    const pid = await spawnDetached(store);
+    if (parsed.flags.has("json")) {
+      console.log(JSON.stringify({ pid, runId: state.runId }));
+    } else {
+      console.log(`Started ${state.runId} as PID ${pid}`);
+    }
+    return 0;
+  }
+
+  const finalState = await executeRun(state.runId, parsed.flags.has("json"));
+  if (!parsed.flags.has("json")) {
+    outputState(finalState, false);
+  }
+  return finalState.status === "completed" ? 0 : 1;
+}
+
+async function validateCommand(parsed: ParsedArguments): Promise<number> {
+  assertOptions(parsed, []);
+  const workflowPath = path.resolve(
+    requirePositional(parsed, 0, "workflow file"),
+  );
+  if (parsed.positionals.length > 1) {
+    throw new Error("validate accepts exactly one workflow file");
+  }
+  compileWorkflow(await readFile(workflowPath, "utf8"), workflowPath);
+  console.log(`${workflowPath}: valid`);
+  return 0;
+}
+
+async function statusCommand(parsed: ParsedArguments): Promise<number> {
+  assertOptions(parsed, [], ["json"]);
+  const runId = requirePositional(parsed, 0, "run ID");
+  outputState(
+    (await StateStore.load(runId)).snapshot(),
+    parsed.flags.has("json"),
+  );
+  return 0;
+}
+
+async function listCommand(parsed: ParsedArguments): Promise<number> {
+  assertOptions(parsed, [], ["json"]);
+  const states = await StateStore.list();
+  if (parsed.flags.has("json")) {
+    console.log(JSON.stringify(states, null, 2));
+  } else if (states.length === 0) {
+    console.log("No workflow runs found.");
+  } else {
+    for (const state of states) {
+      console.log(summary(state));
+    }
+  }
+  return 0;
+}
+
+async function logsCommand(parsed: ParsedArguments): Promise<number> {
+  assertOptions(parsed, []);
+  const store = await StateStore.load(
+    requirePositional(parsed, 0, "run ID"),
+  );
+  process.stdout.write(await store.readLog());
+  return 0;
+}
+
+async function controlCommand(
+  parsed: ParsedArguments,
+  command: "pause" | "cancel",
+): Promise<number> {
+  assertOptions(parsed, []);
+  const runId = requirePositional(parsed, 0, "run ID");
+  const store = await StateStore.load(runId);
+  const state = store.snapshot();
+  if (TERMINAL_STATUSES.has(state.status)) {
+    throw new Error(`Run ${runId} is already ${state.status}`);
+  }
+  await store.writeControl(command);
+  if (!processIdentityMatches(state.pid, state.pidStartedAt)) {
+    if (command === "cancel") {
+      const cleaned = await terminateOrphanedExecution(
+        store,
+        "Interrupted after the workflow supervisor exited",
+      );
+      await terminalizeForcedRun(cleaned, "canceled", "Workflow canceled");
+    } else if (
+      !processIdentityMatches(state.enginePid, state.engineStartedAt)
+    ) {
+      await store.update((current) => {
+        current.status = "paused";
+      });
+    }
+  }
+  console.log(`${command === "pause" ? "Pausing" : "Canceling"} ${runId}`);
+  return 0;
+}
+
+async function resumeCommand(parsed: ParsedArguments): Promise<number> {
+  assertOptions(parsed, [], [
+    "allow-danger-full-access",
+    "allow-workspace-write",
+    "foreground",
+    "json",
+  ]);
+  const runId = requirePositional(parsed, 0, "run ID");
+  let store = await StateStore.load(runId);
+  let state = store.snapshot();
+  if (state.status === "completed") {
+    outputState(state, parsed.flags.has("json"));
+    return 0;
+  }
+  const runnerAlive = processIdentityMatches(
+    state.pid,
+    state.pidStartedAt,
+  );
+  if (!runnerAlive) {
+    const cleaned = await terminateOrphanedExecution(
+      store,
+      "Interrupted after the workflow supervisor exited",
+    );
+    store = cleaned;
+    state = cleaned.snapshot();
+  }
+  const changingAuthorization =
+    parsed.flags.has("allow-danger-full-access") ||
+    parsed.flags.has("allow-workspace-write");
+  const workflowHash =
+    changingAuthorization && !runnerAlive
+      ? sha256(await readFile(state.workflowPath, "utf8"))
+      : state.workflowHash;
+  const currentControl = await store.readControl();
+  const authorization = authorizationFromFlags(
+    parsed,
+    workflowHash,
+    currentControl.authorization ?? state.authorization,
+  );
+  await store.writeControl("run", authorization);
+  if (runnerAlive) {
+    if (parsed.flags.has("json")) {
+      console.log(JSON.stringify({ pid: state.pid, resumed: true, runId }));
+    } else {
+      console.log(`Resumed ${runId} (PID ${state.pid})`);
+    }
+    return 0;
+  }
+  state = await store.update((current) => {
+    current.authorization = authorization;
+  });
+  if (parsed.flags.has("foreground")) {
+    const finalState = await executeRun(runId, parsed.flags.has("json"));
+    if (!parsed.flags.has("json")) {
+      outputState(finalState, false);
+    }
+    return finalState.status === "completed" ? 0 : 1;
+  }
+  const pid = await spawnDetached(store);
+  if (parsed.flags.has("json")) {
+    console.log(JSON.stringify({ pid, resumed: true, runId }));
+  } else {
+    console.log(`Resumed ${runId} as PID ${pid}`);
+  }
+  return 0;
+}
+
+async function waitCommand(parsed: ParsedArguments): Promise<number> {
+  assertOptions(parsed, [], ["json"]);
+  const runId = requirePositional(parsed, 0, "run ID");
+  while (true) {
+    const state = (await StateStore.load(runId)).snapshot();
+    if (TERMINAL_STATUSES.has(state.status)) {
+      outputState(state, parsed.flags.has("json"));
+      return state.status === "completed" ? 0 : 1;
+    }
+    if (!processIdentityMatches(state.pid, state.pidStartedAt)) {
+      throw new Error(
+        `Run ${runId} has no active runner; use resume to continue it`,
+      );
+    }
+    await sleep(500);
+  }
+}
+
+async function main(): Promise<number> {
+  const [command = "help", ...args] = process.argv.slice(2);
+  if (command === "help" || command === "--help" || command === "-h") {
+    printHelp();
+    return 0;
+  }
+  if (command === "_execute") {
+    const runId = args[0];
+    if (!runId) {
+      throw new Error("Internal runner requires a run ID");
+    }
+    const store = await StateStore.load(runId);
+    const state = await executeClaimedRun(store, false, args[1]);
+    return state.status === "completed" ? 0 : 1;
+  }
+  if (command === "_engine") {
+    const runId = args[0];
+    if (!runId) {
+      throw new Error("Internal engine requires a run ID");
+    }
+    const state = await executeEngine(await waitForEngineRegistration(runId));
+    return state.status === "completed" ? 0 : 1;
+  }
+  const parsed = parseArguments(args);
+  if (parsed.flags.has("help")) {
+    printHelp();
+    return 0;
+  }
+  switch (command) {
+    case "run":
+      return await runCommand(parsed);
+    case "validate":
+      return await validateCommand(parsed);
+    case "status":
+      return await statusCommand(parsed);
+    case "list":
+      return await listCommand(parsed);
+    case "logs":
+      return await logsCommand(parsed);
+    case "wait":
+      return await waitCommand(parsed);
+    case "pause":
+      return await controlCommand(parsed, "pause");
+    case "resume":
+      return await resumeCommand(parsed);
+    case "cancel":
+      return await controlCommand(parsed, "cancel");
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    console.error(`codex-workflow: ${errorMessage(error)}`);
+    process.exitCode = 1;
+  });

--- a/plugins/dynamic-workflow/src/codex-runner.ts
+++ b/plugins/dynamic-workflow/src/codex-runner.ts
@@ -1,0 +1,513 @@
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import readline from "node:readline";
+
+import type {
+  CodexExecution,
+  CodexRequest,
+  JsonValue,
+  TokenUsage,
+} from "./types.js";
+import {
+  errorMessage,
+  processStartIdentity,
+  safeIdentifier,
+  sha256,
+} from "./utils.js";
+
+interface CodexEvent {
+  error?: { message?: string };
+  item?: { text?: string; type?: string };
+  message?: string;
+  thread_id?: string;
+  type?: string;
+  usage?: {
+    cached_input_tokens?: number;
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+}
+
+const MAX_PROMPT_BYTES = 1_000_000;
+const MAX_RESULT_BYTES = 1_000_000;
+const TERMINATION_GRACE_MS = 2_000;
+
+export class CodexProcessError extends Error {
+  readonly retryable: boolean;
+  readonly threadId: string | undefined;
+  readonly usage: TokenUsage | undefined;
+
+  constructor(
+    message: string,
+    retryable = true,
+    metadata: {
+      threadId?: string | undefined;
+      usage?: TokenUsage | undefined;
+    } = {},
+  ) {
+    super(message);
+    this.name = "CodexProcessError";
+    this.retryable = retryable;
+    this.threadId = metadata.threadId;
+    this.usage = metadata.usage;
+  }
+}
+
+export class CodexCleanupPendingError extends CodexProcessError {
+  readonly cleanupPending = true;
+  readonly workerPid: number;
+  readonly workerStartedAt: string | undefined;
+
+  constructor(
+    message: string,
+    workerPid: number,
+    workerStartedAt: string | undefined,
+    metadata: {
+      threadId?: string | undefined;
+      usage?: TokenUsage | undefined;
+    } = {},
+  ) {
+    super(message, false, metadata);
+    this.name = "CodexCleanupPendingError";
+    this.workerPid = workerPid;
+    this.workerStartedAt = workerStartedAt;
+  }
+}
+
+export function isCodexCleanupPendingError(
+  error: unknown,
+): error is CodexCleanupPendingError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "cleanupPending" in error &&
+    error.cleanupPending === true
+  );
+}
+
+export class CodexRunner {
+  constructor(
+    private readonly onEvent?: (
+      stepId: string,
+      event: unknown,
+    ) => Promise<void>,
+    private readonly onSpawn?: (
+      stepId: string,
+      workerPid: number,
+      workerStartedAt: string,
+    ) => Promise<void>,
+  ) {}
+
+  async run(request: CodexRequest): Promise<CodexExecution> {
+    const promptBytes = Buffer.byteLength(request.prompt, "utf8");
+    if (promptBytes > MAX_PROMPT_BYTES) {
+      throw new CodexProcessError(
+        `Codex worker prompt is ${promptBytes} bytes; maximum is ` +
+          `${MAX_PROMPT_BYTES}. Chunk inputs or use a tree reduction.`,
+        false,
+      );
+    }
+    const command = process.env.CODEX_WORKFLOW_CODEX_BIN ?? "codex";
+    const args = await this.buildArgs(request);
+    const cwd = path.resolve(
+      request.workflowCwd,
+      request.options.cwd ?? ".",
+    );
+
+    return await new Promise<CodexExecution>((resolve, reject) => {
+      const child = spawn(command, args, {
+        cwd,
+        detached: process.platform !== "win32",
+        env: process.env,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let finalText = "";
+      let workerStartedAt: string | undefined;
+      let threadId: string | undefined;
+      let usage: TokenUsage | undefined;
+      let standardError = "";
+      let eventError = "";
+      let timedOut = false;
+      let settled = false;
+      let terminationStarted = false;
+      let terminationDeadline = 0;
+      let killTimer: NodeJS.Timeout | undefined;
+      let persistenceError: unknown;
+      let persistenceQueue = Promise.resolve();
+
+      const persist = (operation: () => Promise<void>): void => {
+        persistenceQueue = persistenceQueue
+          .then(operation)
+          .catch((error: unknown) => {
+            persistenceError ??= error;
+            terminate();
+          });
+      };
+
+      const terminate = (): void => {
+        if (terminationStarted) {
+          return;
+        }
+        terminationStarted = true;
+        terminationDeadline = Date.now() + TERMINATION_GRACE_MS;
+        signalProcessGroup(child, "SIGTERM");
+        killTimer = setTimeout(
+          () => signalProcessGroup(child, "SIGKILL"),
+          TERMINATION_GRACE_MS,
+        );
+        killTimer.unref();
+      };
+
+      const timeout = request.options.timeoutMs ?? request.defaultTimeoutMs;
+      const timeoutTimer = setTimeout(() => {
+        timedOut = true;
+        terminate();
+      }, timeout);
+      timeoutTimer.unref();
+
+      if (child.pid !== undefined && this.onSpawn) {
+        const spawnedWorkerPid = child.pid;
+        const spawnedWorkerStartedAt = processStartIdentity(spawnedWorkerPid);
+        workerStartedAt = spawnedWorkerStartedAt;
+        if (spawnedWorkerStartedAt === undefined) {
+          persistenceError = new Error(
+            `Could not identify Codex worker PID ${spawnedWorkerPid}`,
+          );
+          terminate();
+        } else {
+          persist(
+            async () =>
+              await this.onSpawn?.(
+                request.stepId,
+                spawnedWorkerPid,
+                spawnedWorkerStartedAt,
+              ),
+          );
+        }
+      }
+
+      const abort = (): void => terminate();
+      request.signal.addEventListener("abort", abort, { once: true });
+
+      const lines = readline.createInterface({ input: child.stdout });
+      lines.on("line", (line) => {
+        const trimmed = line.trim();
+        if (trimmed === "") {
+          return;
+        }
+        try {
+          const event = JSON.parse(trimmed) as CodexEvent;
+          if (this.onEvent) {
+            persist(async () => await this.onEvent?.(request.stepId, event));
+          }
+          if (event.type === "thread.started") {
+            threadId = event.thread_id;
+          } else if (
+            event.type === "item.completed" &&
+            event.item?.type === "agent_message" &&
+            event.item.text
+          ) {
+            finalText = event.item.text;
+          } else if (event.type === "turn.completed" && event.usage) {
+            usage = {
+              ...(event.usage.cached_input_tokens === undefined
+                ? {}
+                : { cachedInputTokens: event.usage.cached_input_tokens }),
+              ...(event.usage.input_tokens === undefined
+                ? {}
+                : { inputTokens: event.usage.input_tokens }),
+              ...(event.usage.output_tokens === undefined
+                ? {}
+                : { outputTokens: event.usage.output_tokens }),
+            };
+          } else if (event.type === "turn.failed" || event.type === "error") {
+            eventError = event.error?.message ?? event.message ?? trimmed;
+          }
+        } catch {
+          standardError += `${trimmed}\n`;
+          standardError = standardError.slice(-32_000);
+        }
+      });
+
+      child.stderr.on("data", (chunk: Buffer) => {
+        standardError += chunk.toString("utf8");
+        if (standardError.length > 32_000) {
+          standardError = standardError.slice(-32_000);
+        }
+      });
+
+      child.on("error", (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutTimer);
+        clearTimeout(killTimer);
+        request.signal.removeEventListener("abort", abort);
+        reject(
+          new CodexProcessError(
+            `Could not start ${command}: ${errorMessage(error)}`,
+            false,
+          ),
+        );
+      });
+
+      child.on("close", (code, signal) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutTimer);
+        if (!terminationStarted) {
+          clearTimeout(killTimer);
+        }
+        request.signal.removeEventListener("abort", abort);
+        void (async () => {
+          if (
+            child.pid !== undefined &&
+            !(await finishProcessGroupTermination(
+              child.pid,
+              terminationStarted ? terminationDeadline : Date.now(),
+            ))
+          ) {
+            reject(
+              new CodexCleanupPendingError(
+                `Codex worker process group ${child.pid} did not terminate`,
+                child.pid,
+                workerStartedAt,
+                { threadId, usage },
+              ),
+            );
+            return;
+          }
+          clearTimeout(killTimer);
+          await persistenceQueue;
+          if (persistenceError) {
+            reject(
+              new CodexProcessError(
+                `Could not persist Codex worker events: ` +
+                  errorMessage(persistenceError),
+                false,
+              ),
+            );
+            return;
+          }
+          if (request.signal.aborted) {
+            reject(request.signal.reason);
+            return;
+          }
+          if (timedOut) {
+            reject(
+              new CodexProcessError(
+                `Codex worker timed out after ${timeout} ms`,
+                true,
+                { threadId, usage },
+              ),
+            );
+            return;
+          }
+          const details = eventError || standardError.trim();
+          if (code !== 0) {
+            reject(
+              processFailure(
+                `Codex worker exited ${String(code)}${
+                  signal ? ` (${signal})` : ""
+                }: ${details || "no error details"}`,
+                threadId,
+                usage,
+              ),
+            );
+            return;
+          }
+          if (eventError) {
+            reject(processFailure(eventError, threadId, usage));
+            return;
+          }
+          if (finalText === "") {
+            reject(
+              new CodexProcessError(
+                "Codex worker completed without an agent message",
+              ),
+            );
+            return;
+          }
+          const resultBytes = Buffer.byteLength(finalText, "utf8");
+          if (resultBytes > MAX_RESULT_BYTES) {
+            reject(
+              new CodexProcessError(
+                `Codex worker result is ${resultBytes} bytes; maximum is ` +
+                  `${MAX_RESULT_BYTES}. Return compact structured output.`,
+                false,
+              ),
+            );
+            return;
+          }
+
+          let data: JsonValue | undefined;
+          if (request.options.schema) {
+            try {
+              data = JSON.parse(finalText) as JsonValue;
+            } catch (error) {
+              reject(
+                new CodexProcessError(
+                  `Structured Codex result was not JSON: ${errorMessage(error)}`,
+                  false,
+                ),
+              );
+              return;
+            }
+          }
+          resolve({
+            ...(data === undefined ? {} : { data }),
+            text: finalText,
+            ...(threadId === undefined ? {} : { threadId }),
+            ...(usage === undefined ? {} : { usage }),
+          });
+        })();
+      });
+
+      child.stdin.on("error", () => {
+        // The child may exit before consuming stdin; close handling reports why.
+      });
+      const workerRegistration = persistenceQueue;
+      void (async () => {
+        await workerRegistration;
+        if (!settled && !terminationStarted && persistenceError === undefined) {
+          child.stdin.end(request.prompt);
+        }
+      })();
+    });
+  }
+
+  private async buildArgs(request: CodexRequest): Promise<string[]> {
+    const options = request.options;
+    const common: string[] = ["--json"];
+
+    if (options.model) {
+      common.push("--model", options.model);
+    }
+    if (options.reasoningEffort) {
+      common.push(
+        "--config",
+        `model_reasoning_effort=${JSON.stringify(options.reasoningEffort)}`,
+      );
+    }
+    common.push("--config", 'approval_policy="never"');
+    if (options.ignoreUserConfig) {
+      common.push("--ignore-user-config");
+    }
+    common.push("--skip-git-repo-check");
+
+    if (options.schema) {
+      const schemaDirectory = path.join(request.runDirectory, "schemas");
+      await mkdir(schemaDirectory, { recursive: true });
+      const readableId = safeIdentifier(request.stepId)
+        .replaceAll("/", "-")
+        .slice(-80);
+      const schemaPath = path.join(
+        schemaDirectory,
+        `${readableId}-${sha256(request.stepId).slice(0, 12)}.json`,
+      );
+      await writeFile(
+        schemaPath,
+        `${JSON.stringify(options.schema, null, 2)}\n`,
+        "utf8",
+      );
+      common.push("--output-schema", schemaPath);
+    }
+
+    if (options.resumeThreadId) {
+      return [
+        "exec",
+        "resume",
+        ...common,
+        options.resumeThreadId,
+        "-",
+      ];
+    }
+
+    const cwd = path.resolve(request.workflowCwd, options.cwd ?? ".");
+    const args = [
+      "exec",
+      ...common,
+      "--sandbox",
+      options.sandbox ?? "read-only",
+      "--cd",
+      cwd,
+    ];
+    for (const directory of options.addDirs ?? []) {
+      args.push("--add-dir", path.resolve(cwd, directory));
+    }
+    args.push("-");
+    return args;
+  }
+}
+
+function signalProcessGroup(
+  child: ReturnType<typeof spawn>,
+  signal: NodeJS.Signals,
+): void {
+  try {
+    if (process.platform !== "win32" && child.pid !== undefined) {
+      process.kill(-child.pid, signal);
+    } else {
+      child.kill(signal);
+    }
+  } catch {
+    // The process may have exited between the liveness check and the signal.
+  }
+}
+
+function processFailure(
+  message: string,
+  threadId?: string,
+  usage?: TokenUsage,
+): CodexProcessError {
+  if (
+    /context[_ ]length[_ ]exceeded|context (window|length)|maximum context|too many tokens|prompt.{0,20}too long/i
+      .test(message)
+  ) {
+    return new CodexProcessError(
+      `Codex worker exceeded its context capacity. Chunk the input or use a ` +
+        `tree reduction, then resume the workflow. Details: ${message}`,
+      false,
+      { threadId, usage },
+    );
+  }
+  return new CodexProcessError(message, true, { threadId, usage });
+}
+
+async function finishProcessGroupTermination(
+  pid: number,
+  deadline: number,
+): Promise<boolean> {
+  while (processGroupIsRunning(pid) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  if (processGroupIsRunning(pid)) {
+    signalProcessGroupByPid(pid, "SIGKILL");
+  }
+  const killDeadline = Date.now() + 1_000;
+  while (processGroupIsRunning(pid) && Date.now() < killDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return !processGroupIsRunning(pid);
+}
+
+function processGroupIsRunning(pid: number): boolean {
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function signalProcessGroupByPid(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, signal);
+  } catch {
+    // The process group may already be gone.
+  }
+}

--- a/plugins/dynamic-workflow/src/engine.ts
+++ b/plugins/dynamic-workflow/src/engine.ts
@@ -1,0 +1,758 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import vm from "node:vm";
+
+import {
+  CodexCleanupPendingError,
+  CodexProcessError,
+  CodexRunner,
+  isCodexCleanupPendingError,
+} from "./codex-runner.js";
+import { StateStore } from "./state-store.js";
+import type {
+  AgentOptions,
+  AgentStep,
+  ParallelFunction,
+  PipelineFunction,
+  PipelineOptions,
+  RunState,
+  RunAuthorization,
+  WorkflowApi,
+} from "./types.js";
+import {
+  errorMessage,
+  nowIso,
+  processIdentityMatches,
+  safeIdentifier,
+  sha256,
+  sleep,
+  stableStringify,
+  toJsonValue,
+} from "./utils.js";
+
+interface Scope {
+  counters: Map<string, number>;
+  name: string;
+}
+
+const DEFAULT_MAX_AGENT_INVOCATIONS = 100;
+const DEFAULT_MAX_PIPELINE_ITEMS = 100;
+const MAX_AGENT_RETRIES = 5;
+const MAX_AGENT_TIMEOUT_MS = 86_400_000;
+
+class CanceledError extends Error {
+  constructor() {
+    super("Workflow canceled");
+    this.name = "CanceledError";
+  }
+}
+
+class Semaphore {
+  private active = 0;
+  private readonly waiting: Array<() => void> = [];
+
+  constructor(private readonly limit: number) {}
+
+  async acquire(signal: AbortSignal): Promise<() => void> {
+    if (signal.aborted) {
+      throw signal.reason;
+    }
+    if (this.active >= this.limit) {
+      await new Promise<void>((resolve, reject) => {
+        const grant = (): void => {
+          signal.removeEventListener("abort", abort);
+          resolve();
+        };
+        const abort = (): void => {
+          const index = this.waiting.indexOf(grant);
+          if (index >= 0) {
+            this.waiting.splice(index, 1);
+          }
+          reject(signal.reason);
+        };
+        signal.addEventListener("abort", abort, { once: true });
+        this.waiting.push(grant);
+      });
+    }
+    this.active += 1;
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      this.active -= 1;
+      this.waiting.shift()?.();
+    };
+  }
+}
+
+export function compileWorkflow(source: string, filename: string): vm.Script {
+  const metaPattern = /(^|\n)([\t ]*)export[\t ]+const[\t ]+meta[\t ]*=/m;
+  const transformed = source.replace(metaPattern, "$1$2const meta =");
+  return new vm.Script(`(async () => {\n${transformed}\n})()`, {
+    filename,
+  });
+}
+
+export class WorkflowEngine {
+  private readonly abortController = new AbortController();
+  private readonly agentCalls = new Set<Promise<unknown>>();
+  private readonly codex: CodexRunner;
+  private readonly scope = new AsyncLocalStorage<Scope>();
+  private readonly semaphore: Semaphore;
+  private activeAgents = 0;
+  private readonly activeStepIds = new Set<string>();
+  private monitoring = true;
+
+  constructor(
+    private readonly store: StateStore,
+    private readonly source: string,
+    private readonly emit: (message: string) => void,
+  ) {
+    this.semaphore = new Semaphore(store.snapshot().concurrency);
+    this.codex = new CodexRunner(
+      async (stepId, event) => {
+        await this.store.appendEvent("codex", { stepId, event });
+      },
+      async (stepId, workerPid, workerStartedAt) => {
+        await this.store.update((state) => {
+          const step = state.steps[stepId];
+          if (step?.status === "running") {
+            step.workerPid = workerPid;
+            step.workerStartedAt = workerStartedAt;
+          }
+        });
+      },
+    );
+  }
+
+  async run(): Promise<RunState> {
+    const monitor = this.monitorControl();
+    try {
+      const control = await this.store.readControl();
+      await this.store.update((state) => {
+        if (control.authorization) {
+          state.authorization = control.authorization;
+        }
+        state.status = "running";
+        state.startedAt ??= nowIso();
+        delete state.completedAt;
+        delete state.error;
+      });
+      await this.log(`run ${this.store.runId} started`);
+      const script = compileWorkflow(
+        this.source,
+        this.store.snapshot().workflowPath,
+      );
+      const result = await this.executeScript(script);
+      if (this.agentCalls.size > 0) {
+        const error = new Error(
+          "Workflow returned while agent calls were still running; " +
+            "await every agent(), pipeline(), and parallel() call",
+        );
+        this.abortController.abort(error);
+        await this.drainAgentCalls();
+        throw error;
+      }
+      await this.store.update((state) => {
+        state.status = "completed";
+        state.result = toJsonValue(result);
+        state.completedAt = nowIso();
+        delete state.cleanupPending;
+        delete state.error;
+      });
+      await this.log(`run ${this.store.runId} completed`);
+    } catch (error) {
+      const cleanupError =
+        isCodexCleanupPendingError(error)
+          ? error
+          : isCodexCleanupPendingError(this.abortController.signal.reason)
+            ? this.abortController.signal.reason
+            : undefined;
+      const cleanupPending =
+        cleanupError !== undefined ||
+        this.store.snapshot().cleanupPending === true;
+      const canceled =
+        error instanceof CanceledError ||
+        this.abortController.signal.reason instanceof CanceledError;
+      if (!this.abortController.signal.aborted) {
+        this.abortController.abort(canceled ? new CanceledError() : error);
+      }
+      await this.drainAgentCalls();
+      await this.store.update((state) => {
+        if (cleanupPending) {
+          state.status = "canceling";
+          state.cleanupPending = true;
+          state.error = cleanupError?.message ?? errorMessage(error);
+          delete state.completedAt;
+        } else {
+          state.status = canceled ? "canceled" : "failed";
+          state.error = canceled ? "Workflow canceled" : errorMessage(error);
+          state.completedAt = nowIso();
+          delete state.cleanupPending;
+        }
+      });
+      await this.log(
+        cleanupPending
+          ? `run ${this.store.runId} awaiting process cleanup: ` +
+              (cleanupError?.message ?? errorMessage(error))
+          : canceled
+          ? `run ${this.store.runId} canceled`
+          : `run ${this.store.runId} failed: ${errorMessage(error)}`,
+      );
+    } finally {
+      this.monitoring = false;
+      if (!this.abortController.signal.aborted) {
+        this.abortController.abort(new CanceledError());
+      }
+      await this.drainAgentCalls();
+      await monitor;
+    }
+    return this.store.snapshot();
+  }
+
+  private async executeScript(script: vm.Script): Promise<unknown> {
+    const state = this.store.snapshot();
+    const api: WorkflowApi = {
+      agent: <T = string>(prompt: string, options: AgentOptions = {}) =>
+        this.trackAgentCall(this.agent(prompt, options)) as Promise<T>,
+      args: state.args,
+      checkpoint: async () => await this.checkpoint(),
+      log: async (...values: unknown[]) => {
+        const message = values
+          .map((value) =>
+            typeof value === "string" ? value : stableStringify(value),
+          )
+          .join(" ");
+        await this.log(message);
+      },
+      parallel: <T>(
+        tasks: ReadonlyArray<() => Promise<T>>,
+        options: { concurrency?: number; label?: string } = {},
+      ) => this.trackAgentCall(this.parallel(tasks, options)),
+      pipeline: <T, R>(
+        items: readonly T[],
+        worker: (item: T, index: number) => Promise<R>,
+        options: PipelineOptions<T> = {},
+      ) => this.trackAgentCall(this.pipeline(items, worker, options)),
+      runId: state.runId,
+    };
+    const context = vm.createContext(
+      {
+        __workflowArgsJson:
+          api.args === undefined ? undefined : JSON.stringify(api.args),
+        __workflowBridge: {
+          agent: api.agent,
+          checkpoint: api.checkpoint,
+          log: api.log,
+          parallel: api.parallel,
+          pipeline: api.pipeline,
+        },
+        __workflowRunId: api.runId,
+      },
+      {
+        codeGeneration: { strings: false, wasm: false },
+        name: `workflow-${state.runId}`,
+      },
+    );
+    installWorkflowGlobals(context);
+    return await this.scope.run(
+      { counters: new Map(), name: "root" },
+      async () => await (script.runInContext(context) as Promise<unknown>),
+    );
+  }
+
+  private readonly pipeline: PipelineFunction = async <T, R>(
+    items: readonly T[],
+    worker: (item: T, index: number) => Promise<R>,
+    options: PipelineOptions<T> = {},
+  ): Promise<R[]> => {
+    await this.checkpoint();
+    const parent = this.currentScope();
+    const pipelineNumber = this.nextCounter(parent, "pipeline");
+    const pipelineName = safeIdentifier(
+      options.label
+        ? `pipeline-${pipelineNumber}-${options.label}`
+        : `pipeline-${pipelineNumber}`,
+    );
+    const concurrency = this.validateConcurrency(
+      options.concurrency ?? this.store.snapshot().concurrency,
+    );
+    const maxItems = options.maxItems ?? DEFAULT_MAX_PIPELINE_ITEMS;
+    if (!Number.isInteger(maxItems) || maxItems < 0 || maxItems > 1_000) {
+      throw new RangeError(
+        "pipeline maxItems must be an integer from 0 to 1000",
+      );
+    }
+    if (items.length > maxItems) {
+      throw new RangeError(
+        `Pipeline received ${items.length} items; maximum is ${maxItems}`,
+      );
+    }
+    const results = new Array<R>(items.length);
+    let cursor = 0;
+    const keys = new Set<string>();
+
+    const runNext = async (): Promise<void> => {
+      while (cursor < items.length) {
+        const index = cursor;
+        cursor += 1;
+        const item = items[index] as T;
+        const key = safeIdentifier(options.key?.(item, index) ?? String(index));
+        if (keys.has(key)) {
+          throw new Error(`Duplicate pipeline key: ${key}`);
+        }
+        keys.add(key);
+        await this.checkpoint();
+        results[index] = await this.scope.run(
+          {
+            counters: new Map(),
+            name: `${parent.name}/${pipelineName}/${key}`,
+          },
+          async () => await worker(item, index),
+        );
+      }
+    };
+
+    await Promise.all(
+      Array.from(
+        { length: Math.min(concurrency, items.length) },
+        async () => await runNext(),
+      ),
+    );
+    return results;
+  };
+
+  private readonly parallel: ParallelFunction = async <T>(
+    tasks: ReadonlyArray<() => Promise<T>>,
+    options: { concurrency?: number; label?: string } = {},
+  ): Promise<T[]> => {
+    return await this.pipeline(
+      tasks,
+      async (task) => await task(),
+      {
+        ...(options.concurrency === undefined
+          ? {}
+          : { concurrency: options.concurrency }),
+        label: options.label ?? "parallel",
+      },
+    );
+  };
+
+  private async agent(prompt: string, options: AgentOptions): Promise<unknown> {
+    if (typeof prompt !== "string" || prompt.trim() === "") {
+      throw new TypeError("agent() requires a non-empty prompt string");
+    }
+    await this.checkpoint();
+    await this.assertSandboxAuthorized(options);
+    this.validateAgentLimits(options);
+    const scope = this.currentScope();
+    const sequence = this.nextCounter(scope, "agent");
+    const localId = options.id ?? `agent-${sequence}`;
+    const stepId = safeIdentifier(`${scope.name}/${localId}`);
+    const label = options.label ?? stepId;
+    const fingerprint = sha256(
+      stableStringify({
+        prompt,
+        cwd: options.cwd ?? this.store.snapshot().cwd,
+        model: options.model,
+        reasoningEffort: options.reasoningEffort,
+        resumeThreadId: options.resumeThreadId,
+        sandbox: options.sandbox ?? "read-only",
+        schema: options.schema,
+        addDirs: options.addDirs,
+        cacheKey: options.cacheKey,
+        ignoreUserConfig: options.ignoreUserConfig ?? false,
+      }),
+    );
+    const existing = this.store.snapshot().steps[stepId];
+    if (
+      existing?.status === "completed" &&
+      existing.fingerprint === fingerprint
+    ) {
+      await this.log(`cache hit: ${label}`);
+      await this.store.appendEvent("cache.hit", { stepId });
+      return existing.result;
+    }
+    if (this.activeStepIds.has(stepId)) {
+      throw new Error(`Concurrent agent calls share the step ID: ${stepId}`);
+    }
+
+    this.activeStepIds.add(stepId);
+    let release: () => void;
+    try {
+      release = await this.semaphore.acquire(this.abortController.signal);
+    } catch (error) {
+      this.activeStepIds.delete(stepId);
+      throw error;
+    }
+    let countedActive = false;
+    try {
+      await this.checkpoint();
+      this.activeAgents += 1;
+      countedActive = true;
+      const retries = Math.max(0, Math.floor(options.retries ?? 0));
+      for (let retry = 0; retry <= retries; retry += 1) {
+        await this.reserveAgentInvocation();
+        const attempt = (existing?.attempt ?? 0) + retry + 1;
+        const step: AgentStep = {
+          attempt,
+          fingerprint,
+          id: stepId,
+          label,
+          startedAt: nowIso(),
+          status: "running",
+        };
+        await this.store.updateStep(step);
+        await this.store.appendEvent("agent.started", {
+          attempt,
+          label,
+          stepId,
+        });
+        await this.log(`agent started: ${label} (attempt ${attempt})`);
+        try {
+          const execution = await this.codex.run({
+            defaultTimeoutMs:
+              this.store.snapshot().defaultAgentTimeoutMs ?? 1_800_000,
+            options,
+            prompt,
+            runDirectory: this.store.directory,
+            signal: this.abortController.signal,
+            stepId,
+            workflowCwd: this.store.snapshot().cwd,
+          });
+          const result = execution.data ?? execution.text;
+          step.status = "completed";
+          step.result = toJsonValue(result);
+          step.completedAt = nowIso();
+          if (execution.threadId) {
+            step.threadId = execution.threadId;
+          }
+          if (execution.usage) {
+            step.usage = execution.usage;
+          }
+          await this.store.updateStep(step);
+          await this.store.appendEvent("agent.completed", { stepId });
+          await this.log(`agent completed: ${label}`);
+          return result;
+        } catch (error) {
+          if (error instanceof CodexCleanupPendingError) {
+            await this.store.update((state) => {
+              const persisted = state.steps[stepId];
+              if (persisted) {
+                persisted.error = error.message;
+                persisted.workerPid = error.workerPid;
+                if (error.workerStartedAt !== undefined) {
+                  persisted.workerStartedAt = error.workerStartedAt;
+                }
+              }
+              state.cleanupPending = true;
+              state.status = "canceling";
+              state.error = error.message;
+              delete state.completedAt;
+            });
+            await this.store.appendEvent("agent.cleanup_pending", {
+              error: error.message,
+              stepId,
+              workerPid: error.workerPid,
+            });
+            throw error;
+          }
+          const abortReason = this.abortController.signal.reason;
+          const canceled = abortReason instanceof CanceledError;
+          step.status = canceled ? "canceled" : "failed";
+          step.error = canceled
+            ? "Workflow canceled"
+            : errorMessage(
+                this.abortController.signal.aborted ? abortReason : error,
+              );
+          step.completedAt = nowIso();
+          if (error instanceof CodexProcessError) {
+            if (error.threadId) {
+              step.threadId = error.threadId;
+            }
+            if (error.usage) {
+              step.usage = error.usage;
+            }
+          }
+          await this.store.updateStep(step);
+          await this.store.appendEvent("agent.failed", {
+            error: step.error,
+            stepId,
+          });
+          if (this.abortController.signal.aborted) {
+            throw abortReason;
+          }
+          const canRetry =
+            retry < retries &&
+            (!(error instanceof CodexProcessError) || error.retryable);
+          if (!canRetry) {
+            throw error;
+          }
+          const delay = Math.min(30_000, 1_000 * 2 ** retry);
+          await this.log(`retrying ${label} in ${delay} ms`);
+          await sleep(delay, this.abortController.signal);
+        }
+      }
+      throw new Error(`Agent failed without an error: ${label}`);
+    } finally {
+      if (countedActive) {
+        this.activeAgents -= 1;
+      }
+      release();
+      this.activeStepIds.delete(stepId);
+    }
+  }
+
+  private async checkpoint(): Promise<void> {
+    while (true) {
+      const control = await this.store.readControl();
+      if (control.command === "cancel" || this.abortController.signal.aborted) {
+        this.abortController.abort(new CanceledError());
+        throw new CanceledError();
+      }
+      if (control.command === "run") {
+        const status = this.store.snapshot().status;
+        if (status === "paused" || status === "pausing") {
+          await this.store.update((state) => {
+            state.status = "running";
+          });
+          await this.log("run resumed");
+        }
+        return;
+      }
+      const desired = this.activeAgents > 0 ? "pausing" : "paused";
+      if (this.store.snapshot().status !== desired) {
+        await this.store.update((state) => {
+          state.status = desired;
+        });
+      }
+      await sleep(250);
+    }
+  }
+
+  private async monitorControl(): Promise<void> {
+    while (this.monitoring) {
+      const supervisorPid = this.store.snapshot().pid;
+      const supervisorStartedAt = this.store.snapshot().pidStartedAt;
+      if (
+        supervisorPid !== undefined &&
+        !processIdentityMatches(supervisorPid, supervisorStartedAt)
+      ) {
+        if (!this.abortController.signal.aborted) {
+          this.abortController.abort(
+            new Error(`Workflow supervisor PID ${supervisorPid} exited`),
+          );
+        }
+        return;
+      }
+      const control = await this.store.readControl();
+      if (control.command === "cancel") {
+        if (isTerminal(this.store.snapshot().status)) {
+          return;
+        }
+        if (!this.abortController.signal.aborted) {
+          await this.store.update((state) => {
+            if (!isTerminal(state.status)) {
+              state.status = "canceling";
+            }
+          });
+          this.abortController.abort(new CanceledError());
+        }
+        return;
+      }
+      if (control.command === "pause") {
+        const desired = this.activeAgents > 0 ? "pausing" : "paused";
+        const current = this.store.snapshot().status;
+        if (!isTerminal(current) && current !== desired) {
+          await this.store.update((state) => {
+            if (!isTerminal(state.status)) {
+              state.status = desired;
+            }
+          });
+        }
+      }
+      await sleep(250);
+    }
+  }
+
+  private currentScope(): Scope {
+    return this.scope.getStore() ?? { counters: new Map(), name: "root" };
+  }
+
+  private nextCounter(scope: Scope, kind: string): number {
+    const next = (scope.counters.get(kind) ?? 0) + 1;
+    scope.counters.set(kind, next);
+    return next;
+  }
+
+  private validateConcurrency(value: number): number {
+    if (!Number.isInteger(value) || value < 1 || value > 64) {
+      throw new RangeError("Concurrency must be an integer from 1 to 64");
+    }
+    return value;
+  }
+
+  private async reserveAgentInvocation(): Promise<void> {
+    await this.store.update((state) => {
+      const count = state.agentInvocations ?? 0;
+      const maximum =
+        state.maxAgentInvocations ?? DEFAULT_MAX_AGENT_INVOCATIONS;
+      if (count >= maximum) {
+        throw new Error(
+          `Workflow exceeded its ${maximum}-agent safety limit`,
+        );
+      }
+      state.agentInvocations = count + 1;
+    });
+  }
+
+  private validateAgentLimits(options: AgentOptions): void {
+    if (
+      options.retries !== undefined &&
+      (!Number.isInteger(options.retries) ||
+        options.retries < 0 ||
+        options.retries > MAX_AGENT_RETRIES)
+    ) {
+      throw new RangeError(
+        `agent retries must be an integer from 0 to ${MAX_AGENT_RETRIES}`,
+      );
+    }
+    if (
+      options.timeoutMs !== undefined &&
+      (!Number.isInteger(options.timeoutMs) ||
+        options.timeoutMs < 1 ||
+        options.timeoutMs > MAX_AGENT_TIMEOUT_MS)
+    ) {
+      throw new RangeError(
+        "agent timeoutMs must be an integer from 1 to 86400000",
+      );
+    }
+  }
+
+  private trackAgentCall<T>(promise: Promise<T>): Promise<T> {
+    let tracked: Promise<T>;
+    tracked = promise.finally(() => {
+      this.agentCalls.delete(tracked);
+    });
+    this.agentCalls.add(tracked);
+    return tracked;
+  }
+
+  private async drainAgentCalls(): Promise<void> {
+    while (this.agentCalls.size > 0) {
+      await Promise.allSettled([...this.agentCalls]);
+    }
+  }
+
+  private async assertSandboxAuthorized(options: AgentOptions): Promise<void> {
+    const control = await this.store.readControl();
+    const storedAuthorization = this.store.snapshot().authorization;
+    const authorization =
+      control.authorization ??
+      storedAuthorization ??
+      defaultAuthorization();
+    if (
+      control.authorization &&
+      (storedAuthorization?.dangerFullAccess !==
+        control.authorization.dangerFullAccess ||
+        storedAuthorization?.workspaceWrite !==
+          control.authorization.workspaceWrite ||
+        storedAuthorization?.workflowHash !== control.authorization.workflowHash)
+    ) {
+      await this.store.update((state) => {
+        state.authorization = control.authorization as RunAuthorization;
+      });
+    }
+    const sandbox = options.sandbox ?? "read-only";
+    if (options.resumeThreadId && !authorization.dangerFullAccess) {
+      throw new Error(
+        "resumeThreadId requires --allow-danger-full-access because the " +
+          "existing thread sandbox cannot be verified",
+      );
+    }
+    if (sandbox === "danger-full-access" && !authorization.dangerFullAccess) {
+      throw new Error(
+        "danger-full-access requires --allow-danger-full-access at launch",
+      );
+    }
+    if (sandbox === "workspace-write" && !authorization.workspaceWrite) {
+      throw new Error(
+        "workspace-write requires --allow-workspace-write at launch",
+      );
+    }
+    if (
+      sandbox !== "read-only" &&
+      authorization.workflowHash !== this.store.snapshot().workflowHash
+    ) {
+      throw new Error(
+        "Write authorization does not match the current workflow source; " +
+          "launch again with the required --allow-* flag",
+      );
+    }
+  }
+
+  private async log(message: string): Promise<void> {
+    await this.store.appendLog(message);
+    this.emit(message);
+  }
+}
+
+function isTerminal(status: RunState["status"]): boolean {
+  return status === "canceled" || status === "completed" || status === "failed";
+}
+
+function defaultAuthorization(): RunAuthorization {
+  return {
+    dangerFullAccess: false,
+    workflowHash: "",
+    workspaceWrite: false,
+  };
+}
+
+function installWorkflowGlobals(context: vm.Context): void {
+  const bootstrap = new vm.Script(`
+    {
+      const bridge = globalThis.__workflowBridge
+      const clone = value => {
+        if (value === undefined) return undefined
+        return JSON.parse(JSON.stringify(value))
+      }
+      const call = async (fn, values) => {
+        try {
+          return clone(await fn(...values))
+        } catch (error) {
+          const message = error && error.message ? error.message : String(error)
+          throw new Error(String(message))
+        }
+      }
+      const start = (fn, values) => {
+        const promise = call(fn, values)
+        promise.catch(() => {})
+        return promise
+      }
+      const define = (name, value) => Object.defineProperty(globalThis, name, {
+        configurable: false,
+        enumerable: true,
+        value,
+        writable: false,
+      })
+      define("agent", (...values) => start(bridge.agent, values))
+      define("checkpoint", (...values) => start(bridge.checkpoint, values))
+      define("log", (...values) => start(bridge.log, values))
+      define("parallel", (...values) => start(bridge.parallel, values))
+      define("pipeline", (...values) => start(bridge.pipeline, values))
+      define(
+        "args",
+        globalThis.__workflowArgsJson === undefined
+          ? undefined
+          : JSON.parse(globalThis.__workflowArgsJson),
+      )
+      define("workflow", Object.freeze({ runId: globalThis.__workflowRunId }))
+    }
+    delete globalThis.__workflowArgsJson
+    delete globalThis.__workflowBridge
+    delete globalThis.__workflowRunId
+  `);
+  bootstrap.runInContext(context);
+}

--- a/plugins/dynamic-workflow/src/state-store.ts
+++ b/plugins/dynamic-workflow/src/state-store.ts
@@ -1,0 +1,365 @@
+import { randomUUID } from "node:crypto";
+import {
+  appendFile,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  AgentStep,
+  RunAuthorization,
+  RunControl,
+  RunState,
+} from "./types.js";
+import {
+  atomicWriteJson,
+  errorMessage,
+  fileExists,
+  isPidRunning,
+  nowIso,
+  processIdentityMatches,
+  processStartIdentity,
+  readJson,
+  sha256,
+  sleep,
+  workflowHome,
+} from "./utils.js";
+
+export class StateStore {
+  readonly directory: string;
+  readonly eventsPath: string;
+  readonly logPath: string;
+  readonly runId: string;
+
+  private state: RunState;
+  private queue: Promise<void> = Promise.resolve();
+
+  private constructor(state: RunState) {
+    this.state = state;
+    this.runId = state.runId;
+    this.directory = StateStore.runDirectory(state.runId);
+    this.eventsPath = path.join(this.directory, "events.jsonl");
+    this.logPath = path.join(this.directory, "workflow.log");
+  }
+
+  static runDirectory(runId: string): string {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(runId)) {
+      throw new Error(`Invalid workflow run ID: ${runId}`);
+    }
+    const runsDirectory = path.join(workflowHome(), "runs");
+    const directory = path.resolve(runsDirectory, runId);
+    if (path.dirname(directory) !== path.resolve(runsDirectory)) {
+      throw new Error(`Workflow run ID escapes the state directory: ${runId}`);
+    }
+    return directory;
+  }
+
+  static statePath(runId: string): string {
+    return path.join(StateStore.runDirectory(runId), "state.json");
+  }
+
+  static controlPath(runId: string): string {
+    return path.join(StateStore.runDirectory(runId), "control.json");
+  }
+
+  static runnerLockDirectory(runId: string): string {
+    return path.join(StateStore.runDirectory(runId), "runner.lock");
+  }
+
+  static async create(state: RunState): Promise<StateStore> {
+    const store = new StateStore(state);
+    await mkdir(store.directory, { recursive: true });
+    await atomicWriteJson(StateStore.statePath(state.runId), state);
+    await store.writeControl("run", state.authorization);
+    return store;
+  }
+
+  static async load(runId: string): Promise<StateStore> {
+    const state = await readJson<RunState>(StateStore.statePath(runId));
+    return new StateStore(state);
+  }
+
+  static async list(): Promise<RunState[]> {
+    const runsDirectory = path.join(workflowHome(), "runs");
+    if (!(await fileExists(runsDirectory))) {
+      return [];
+    }
+    const entries = await readdir(runsDirectory, { withFileTypes: true });
+    const states = await Promise.all(
+      entries
+        .filter((entry) => entry.isDirectory())
+        .map(async (entry) => {
+          try {
+            return await readJson<RunState>(
+              StateStore.statePath(entry.name),
+            );
+          } catch {
+            return undefined;
+          }
+        }),
+    );
+    return states
+      .filter((state): state is RunState => state !== undefined)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  }
+
+  snapshot(): RunState {
+    return structuredClone(this.state);
+  }
+
+  async update(mutator: (state: RunState) => void): Promise<RunState> {
+    let result = this.snapshot();
+    const operation = this.queue.then(async () => {
+      mutator(this.state);
+      this.state.updatedAt = nowIso();
+      await atomicWriteJson(StateStore.statePath(this.runId), this.state);
+      result = this.snapshot();
+    });
+    this.queue = operation.catch(() => {});
+    await operation;
+    return result;
+  }
+
+  async updateStep(step: AgentStep): Promise<void> {
+    await this.update((state) => {
+      state.steps[step.id] = structuredClone(step);
+    });
+  }
+
+  async readControl(): Promise<RunControl> {
+    try {
+      return await readJson<RunControl>(StateStore.controlPath(this.runId));
+    } catch {
+      return { command: "run", updatedAt: nowIso() };
+    }
+  }
+
+  async writeControl(
+    command: RunControl["command"],
+    authorization?: RunAuthorization,
+  ): Promise<void> {
+    const current = await this.readControl();
+    const effectiveAuthorization = authorization ?? current.authorization;
+    await atomicWriteJson(StateStore.controlPath(this.runId), {
+      ...(effectiveAuthorization === undefined
+        ? {}
+        : { authorization: effectiveAuthorization }),
+      command,
+      updatedAt: nowIso(),
+    } satisfies RunControl);
+  }
+
+  async claimRunner(pid: number, requestedToken?: string): Promise<string> {
+    if (requestedToken) {
+      return await this.acceptRunnerHandoff(pid, requestedToken);
+    }
+    const lockDirectory = StateStore.runnerLockDirectory(this.runId);
+    const ownerPath = path.join(lockDirectory, "owner.json");
+    const token = randomUUID();
+    const pidStartedAt = processStartIdentity(pid);
+    if (pidStartedAt === undefined) {
+      throw new Error(`Could not identify runner PID ${pid}`);
+    }
+    const candidateDirectory = `${lockDirectory}.candidate-${token}`;
+    await mkdir(candidateDirectory);
+    await atomicWriteJson(path.join(candidateDirectory, "owner.json"), {
+      pid,
+      pidStartedAt,
+      token,
+      updatedAt: nowIso(),
+    });
+
+    try {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        try {
+          await rename(candidateDirectory, lockDirectory);
+          return token;
+        } catch (error) {
+          if (!isLockContention(error)) {
+            throw error;
+          }
+        }
+
+        let owner: {
+          pid: number;
+          pidStartedAt?: string;
+          token: string;
+        };
+        try {
+          owner = await readJson<{
+            pid: number;
+            pidStartedAt?: string;
+            token: string;
+          }>(ownerPath);
+        } catch {
+          // A legacy empty lock can be replaced by the prepared directory.
+          try {
+            await rename(candidateDirectory, lockDirectory);
+            return token;
+          } catch (error) {
+            if (!isLockContention(error)) {
+              throw error;
+            }
+          }
+          await sleep(25);
+          continue;
+        }
+        const ownerAlive = owner.pidStartedAt
+          ? processIdentityMatches(owner.pid, owner.pidStartedAt)
+          : isPidRunning(owner.pid);
+        if (ownerAlive) {
+          throw new Error(
+            `Run ${this.runId} is already claimed by PID ${owner.pid}`,
+          );
+        }
+
+        const quarantine = `${lockDirectory}.stale-${sha256(owner.token).slice(
+          0,
+          16,
+        )}`;
+        try {
+          await rename(lockDirectory, quarantine);
+        } catch (error) {
+          if (!isLockContention(error) && !isMissing(error)) {
+            throw error;
+          }
+        }
+        await sleep(10);
+      }
+      throw new Error(`Could not claim runner lock for ${this.runId}`);
+    } finally {
+      try {
+        if (await fileExists(candidateDirectory)) {
+          await rm(candidateDirectory, { force: true, recursive: true });
+        }
+      } catch {
+        // Candidate cleanup is best effort after a successful atomic publish.
+      }
+    }
+  }
+
+  async transferRunner(token: string, pid: number): Promise<void> {
+    const ownerPath = path.join(
+      StateStore.runnerLockDirectory(this.runId),
+      "owner.json",
+    );
+    const owner = await readJson<{ token: string }>(ownerPath);
+    if (owner.token !== token) {
+      throw new Error(`Runner lock for ${this.runId} changed during launch`);
+    }
+    const pidStartedAt = processStartIdentity(pid);
+    if (pidStartedAt === undefined) {
+      throw new Error(`Could not identify runner PID ${pid}`);
+    }
+    await atomicWriteJson(ownerPath, {
+      pid,
+      pidStartedAt,
+      token,
+      updatedAt: nowIso(),
+    });
+  }
+
+  async releaseRunner(token: string): Promise<void> {
+    const lockDirectory = StateStore.runnerLockDirectory(this.runId);
+    try {
+      const owner = await readJson<{ token: string }>(
+        path.join(lockDirectory, "owner.json"),
+      );
+      if (owner.token === token) {
+        await rm(lockDirectory, { force: true, recursive: true });
+      }
+    } catch {
+      // A missing or replaced lock is not owned by this runner.
+    }
+  }
+
+  async appendEvent(type: string, data: unknown = {}): Promise<void> {
+    await appendFile(
+      this.eventsPath,
+      `${JSON.stringify({ at: nowIso(), type, data })}\n`,
+      "utf8",
+    );
+  }
+
+  async appendLog(message: string): Promise<void> {
+    await appendFile(this.logPath, `[${nowIso()}] ${message}\n`, "utf8");
+  }
+
+  async readLog(): Promise<string> {
+    try {
+      return await readFile(this.logPath, "utf8");
+    } catch {
+      return "";
+    }
+  }
+
+  async snapshotWorkflow(source: string, hash: string): Promise<void> {
+    const directory = path.join(this.directory, "workflow-snapshots");
+    const snapshotPath = path.join(directory, `${hash}.js`);
+    await mkdir(directory, { recursive: true });
+    try {
+      await writeFile(snapshotPath, source, { encoding: "utf8", flag: "wx" });
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") {
+        throw error;
+      }
+    }
+  }
+
+  private async acceptRunnerHandoff(
+    pid: number,
+    token: string,
+  ): Promise<string> {
+    const ownerPath = path.join(
+      StateStore.runnerLockDirectory(this.runId),
+      "owner.json",
+    );
+    for (let attempt = 0; attempt < 80; attempt += 1) {
+      try {
+        const owner = await readJson<{
+          pid: number;
+          pidStartedAt?: string;
+          token: string;
+        }>(ownerPath);
+        if (owner.token !== token) {
+          throw new Error(`Runner handoff token for ${this.runId} is invalid`);
+        }
+        if (
+          owner.pid === pid &&
+          (owner.pidStartedAt === undefined ||
+            processIdentityMatches(pid, owner.pidStartedAt))
+        ) {
+          return token;
+        }
+      } catch (error) {
+        if (attempt === 79) {
+          throw new Error(
+            `Runner handoff for ${this.runId} failed: ${errorMessage(error)}`,
+          );
+        }
+      }
+      await sleep(25);
+    }
+    throw new Error(`Runner handoff for ${this.runId} timed out`);
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (error instanceof Error && "code" in error) {
+    return (error as NodeJS.ErrnoException).code;
+  }
+  return undefined;
+}
+
+function isLockContention(error: unknown): boolean {
+  return errorCode(error) === "EEXIST" || errorCode(error) === "ENOTEMPTY";
+}
+
+function isMissing(error: unknown): boolean {
+  return errorCode(error) === "ENOENT";
+}

--- a/plugins/dynamic-workflow/src/types.ts
+++ b/plugins/dynamic-workflow/src/types.ts
@@ -1,0 +1,166 @@
+export type JsonPrimitive = boolean | number | string | null;
+
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export type SandboxMode =
+  | "read-only"
+  | "workspace-write"
+  | "danger-full-access";
+
+export type ReasoningEffort =
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
+
+export interface AgentOptions {
+  addDirs?: string[];
+  cacheKey?: unknown;
+  cwd?: string;
+  id?: string;
+  ignoreUserConfig?: boolean;
+  label?: string;
+  model?: string;
+  reasoningEffort?: ReasoningEffort;
+  resumeThreadId?: string;
+  retries?: number;
+  sandbox?: SandboxMode;
+  schema?: Record<string, unknown>;
+  timeoutMs?: number;
+}
+
+export interface PipelineOptions<T> {
+  concurrency?: number;
+  key?: (item: T, index: number) => string;
+  label?: string;
+  maxItems?: number;
+}
+
+export interface WorkflowMeta {
+  description?: string;
+  name?: string;
+}
+
+export type AgentFunction = <T = string>(
+  prompt: string,
+  options?: AgentOptions,
+) => Promise<T>;
+
+export type PipelineFunction = <T, R>(
+  items: readonly T[],
+  worker: (item: T, index: number) => Promise<R>,
+  options?: PipelineOptions<T>,
+) => Promise<R[]>;
+
+export type ParallelFunction = <T>(
+  tasks: ReadonlyArray<() => Promise<T>>,
+  options?: { concurrency?: number; label?: string },
+) => Promise<T[]>;
+
+export interface WorkflowApi {
+  agent: AgentFunction;
+  args: unknown;
+  checkpoint: () => Promise<void>;
+  log: (...values: unknown[]) => Promise<void>;
+  parallel: ParallelFunction;
+  pipeline: PipelineFunction;
+  runId: string;
+}
+
+export type RunStatus =
+  | "starting"
+  | "running"
+  | "pausing"
+  | "paused"
+  | "canceling"
+  | "canceled"
+  | "completed"
+  | "failed";
+
+export type StepStatus = "running" | "completed" | "failed" | "canceled";
+
+export interface TokenUsage {
+  cachedInputTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export interface AgentStep {
+  attempt: number;
+  completedAt?: string;
+  error?: string;
+  fingerprint: string;
+  id: string;
+  label: string;
+  result?: JsonValue;
+  startedAt: string;
+  status: StepStatus;
+  threadId?: string;
+  usage?: TokenUsage;
+  workerPid?: number;
+  workerStartedAt?: string;
+}
+
+export interface RunState {
+  agentInvocations?: number;
+  args?: JsonValue;
+  authorization?: RunAuthorization;
+  cleanupPending?: boolean;
+  completedAt?: string;
+  concurrency: number;
+  createdAt: string;
+  cwd: string;
+  defaultAgentTimeoutMs?: number;
+  enginePid?: number;
+  engineStartedAt?: string;
+  error?: string;
+  maxAgentInvocations?: number;
+  maxRuntimeMs?: number;
+  pid?: number;
+  pidStartedAt?: string;
+  result?: JsonValue;
+  runnerStartedAt?: string;
+  runId: string;
+  startedAt?: string;
+  status: RunStatus;
+  steps: Record<string, AgentStep>;
+  updatedAt: string;
+  version: 1;
+  workflowHash: string;
+  workflowPath: string;
+}
+
+export type ControlCommand = "run" | "pause" | "cancel";
+
+export interface RunAuthorization {
+  dangerFullAccess: boolean;
+  workflowHash: string;
+  workspaceWrite: boolean;
+}
+
+export interface RunControl {
+  authorization?: RunAuthorization;
+  command: ControlCommand;
+  updatedAt: string;
+}
+
+export interface CodexExecution {
+  data?: JsonValue;
+  text: string;
+  threadId?: string;
+  usage?: TokenUsage;
+}
+
+export interface CodexRequest {
+  defaultTimeoutMs: number;
+  options: AgentOptions;
+  prompt: string;
+  runDirectory: string;
+  signal: AbortSignal;
+  stepId: string;
+  workflowCwd: string;
+}

--- a/plugins/dynamic-workflow/src/utils.ts
+++ b/plugins/dynamic-workflow/src/utils.ts
@@ -1,0 +1,182 @@
+import { createHash, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { constants } from "node:fs";
+import {
+  access,
+  mkdir,
+  readFile,
+  rename,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type { JsonValue } from "./types.js";
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function createRunId(): string {
+  const stamp = new Date().toISOString().replaceAll(/[-:.TZ]/g, "");
+  return `${stamp}-${randomUUID().slice(0, 8)}`;
+}
+
+export function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function stableStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  function normalize(item: unknown): unknown {
+    if (item === null || typeof item !== "object") {
+      return item;
+    }
+    if (seen.has(item)) {
+      throw new TypeError("Cannot serialize a circular value");
+    }
+    seen.add(item);
+    if (Array.isArray(item)) {
+      const normalized = item.map(normalize);
+      seen.delete(item);
+      return normalized;
+    }
+    const normalized = Object.fromEntries(
+      Object.entries(item)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, normalize(child)]),
+    );
+    seen.delete(item);
+    return normalized;
+  }
+
+  return JSON.stringify(normalize(value));
+}
+
+export function toJsonValue(value: unknown): JsonValue {
+  if (value === undefined) {
+    return null;
+  }
+  return JSON.parse(JSON.stringify(value)) as JsonValue;
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function sleep(
+  milliseconds: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (signal?.aborted) {
+    throw signal.reason;
+  }
+  await new Promise<void>((resolve, reject) => {
+    const finish = (): void => {
+      signal?.removeEventListener("abort", abort);
+      resolve();
+    };
+    const timer = setTimeout(finish, milliseconds);
+    const abort = (): void => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+  });
+}
+
+export async function atomicWriteJson(
+  filePath: string,
+  value: unknown,
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const temporary = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await rename(temporary, filePath);
+}
+
+export async function readJson<T>(filePath: string): Promise<T> {
+  return JSON.parse(await readFile(filePath, "utf8")) as T;
+}
+
+export async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function workflowHome(): string {
+  const configured = process.env.CODEX_WORKFLOW_HOME;
+  return path.resolve(configured ?? path.join(homedir(), ".codex", "workflows"));
+}
+
+export function isPidRunning(pid: number | undefined): boolean {
+  if (pid === undefined) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    if (process.platform !== "win32") {
+      const state = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], {
+        encoding: "utf8",
+      });
+      const processState = state.stdout.trim();
+      if (
+        state.status !== 0 ||
+        processState === "" ||
+        processState.startsWith("Z")
+      ) {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function processStartIdentity(pid: number): string | undefined {
+  if (!isPidRunning(pid)) {
+    return undefined;
+  }
+  const result =
+    process.platform === "win32"
+      ? spawnSync(
+          "powershell.exe",
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            `(Get-Process -Id ${pid}).StartTime.ToUniversalTime().Ticks`,
+          ],
+          { encoding: "utf8", windowsHide: true },
+        )
+      : spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+          encoding: "utf8",
+        });
+  if (result.status !== 0) {
+    return undefined;
+  }
+  const identity = result.stdout.trim();
+  return identity === "" ? undefined : identity;
+}
+
+export function processIdentityMatches(
+  pid: number | undefined,
+  expectedStartedAt: string | undefined,
+): boolean {
+  return (
+    pid !== undefined &&
+    expectedStartedAt !== undefined &&
+    processStartIdentity(pid) === expectedStartedAt
+  );
+}
+
+export function safeIdentifier(value: string): string {
+  const cleaned = value.replaceAll(/[^A-Za-z0-9_.\/-]+/g, "-");
+  return cleaned.replaceAll(/^[-/.]+|[-/.]+$/g, "") || "step";
+}

--- a/plugins/dynamic-workflow/tests/cli.test.ts
+++ b/plugins/dynamic-workflow/tests/cli.test.ts
@@ -1,0 +1,480 @@
+import { execFile, spawn } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { afterEach, beforeEach, expect, test } from "vitest";
+
+import { StateStore } from "../src/state-store.js";
+import type { RunState } from "../src/types.js";
+import { isPidRunning, nowIso } from "../src/utils.js";
+import { createFakeCodex } from "./helpers.js";
+
+const execFileAsync = promisify(execFile);
+const packageDirectory = path.resolve(import.meta.dirname, "..");
+const cliPath = path.join(packageDirectory, "bin", "workflow.mjs");
+
+let temporaryDirectory: string;
+let environment: NodeJS.ProcessEnv;
+
+beforeEach(async () => {
+  temporaryDirectory = await mkdtemp(path.join(tmpdir(), "workflow-cli-"));
+  const codex = await createFakeCodex(temporaryDirectory);
+  environment = {
+    ...process.env,
+    CODEX_WORKFLOW_CODEX_BIN: codex,
+    CODEX_WORKFLOW_HOME: path.join(temporaryDirectory, "state"),
+    FAKE_CODEX_LOG: path.join(temporaryDirectory, "codex.jsonl"),
+  };
+});
+
+afterEach(async () => {
+  await rm(temporaryDirectory, { force: true, recursive: true });
+});
+
+test("runs and inspects a workflow through the bundled CLI", async () => {
+  const workflowPath = path.join(temporaryDirectory, "workflow.js");
+  await writeFile(
+    workflowPath,
+    'return await agent("hello", { id: "hello" })\n',
+    "utf8",
+  );
+
+  const run = await invoke([
+    "run",
+    workflowPath,
+    "--cwd",
+    temporaryDirectory,
+    "--json",
+  ]);
+  expect(run.stdout, run.stderr).not.toBe("");
+  const state = JSON.parse(run.stdout) as RunState;
+  expect(state.status).toBe("completed");
+  expect(state.result).toBe("result:hello");
+  const snapshotPath = path.join(
+    environment.CODEX_WORKFLOW_HOME as string,
+    "runs",
+    state.runId,
+    "workflow-snapshots",
+    `${state.workflowHash}.js`,
+  );
+  expect(await readFile(snapshotPath, "utf8")).toContain('agent("hello"');
+
+  const status = await invoke(["status", state.runId, "--json"]);
+  expect((JSON.parse(status.stdout) as RunState).status).toBe("completed");
+
+  const listed = await invoke(["list", "--json"]);
+  expect(JSON.parse(listed.stdout)).toHaveLength(1);
+
+  const validated = await invoke(["validate", workflowPath]);
+  expect(validated.stdout).toContain(": valid");
+});
+
+test("runs a detached workflow and waits for its durable result", async () => {
+  const workflowPath = path.join(temporaryDirectory, "detached.js");
+  await writeFile(
+    workflowPath,
+    'return await agent("[delay=100] detached", { id: "work" })\n',
+    "utf8",
+  );
+
+  const launched = await invoke([
+    "run",
+    workflowPath,
+    "--detach",
+    "--json",
+  ]);
+  const { runId } = JSON.parse(launched.stdout) as { runId: string };
+  const waited = await invoke(["wait", runId, "--json"]);
+  expect(waited.stdout, waited.stderr).not.toBe("");
+  const state = JSON.parse(waited.stdout) as RunState;
+  expect(state.status).toBe("completed");
+  expect(state.result).toBe("result:[delay=100] detached");
+});
+
+test("records a detached runner bootstrap failure as terminal state", async () => {
+  const runId = "missing-workflow-run";
+  const originalHome = process.env.CODEX_WORKFLOW_HOME;
+  process.env.CODEX_WORKFLOW_HOME = environment.CODEX_WORKFLOW_HOME;
+  try {
+    const timestamp = nowIso();
+    await StateStore.create({
+      agentInvocations: 0,
+      authorization: {
+        dangerFullAccess: false,
+        workflowHash: "missing",
+        workspaceWrite: false,
+      },
+      concurrency: 1,
+      createdAt: timestamp,
+      cwd: temporaryDirectory,
+      runId,
+      status: "starting",
+      steps: {},
+      updatedAt: timestamp,
+      version: 1,
+      workflowHash: "missing",
+      workflowPath: path.join(temporaryDirectory, "missing.js"),
+    });
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.CODEX_WORKFLOW_HOME;
+    } else {
+      process.env.CODEX_WORKFLOW_HOME = originalHome;
+    }
+  }
+
+  await expect(invoke(["_execute", runId])).rejects.toMatchObject({ code: 1 });
+  const status = await invoke(["status", runId, "--json"]);
+  const state = JSON.parse(status.stdout) as RunState;
+  expect(state.status).toBe("failed");
+  expect(state.error).toMatch(/Runner bootstrap failed/);
+});
+
+test("preserves a pause requested during detached startup", async () => {
+  const workflowPath = path.join(temporaryDirectory, "pause-startup.js");
+  await writeFile(
+    workflowPath,
+    `
+await agent("[delay=300] first", { id: "first" })
+return await agent("second", { id: "second" })
+`,
+    "utf8",
+  );
+  const launched = await invoke([
+    "run",
+    workflowPath,
+    "--detach",
+    "--json",
+  ]);
+  const { runId } = JSON.parse(launched.stdout) as { runId: string };
+  await invoke(["pause", runId]);
+  const paused = await waitForRun(runId, (state) => state.status === "paused");
+  expect(paused.steps["root/second"]).toBeUndefined();
+
+  await invoke(["cancel", runId]);
+  const canceled = await waitForRun(
+    runId,
+    (state) => state.status === "canceled",
+  );
+  expect(canceled.status).toBe("canceled");
+});
+
+test("binds explicit write authorization to the workflow source", async () => {
+  const workflowPath = path.join(temporaryDirectory, "write.js");
+  await writeFile(
+    workflowPath,
+    `
+return await agent("edit", { id: "edit", sandbox: "workspace-write" })
+`,
+    "utf8",
+  );
+  const result = await invoke([
+    "run",
+    workflowPath,
+    "--allow-workspace-write",
+    "--json",
+  ]);
+  const state = JSON.parse(result.stdout) as RunState;
+  expect(state.status).toBe("completed");
+  expect(state.authorization?.workspaceWrite).toBe(true);
+  expect(state.authorization?.workflowHash).toBe(state.workflowHash);
+});
+
+test("forcibly cancels runaway workflow JavaScript", async () => {
+  const workflowPath = path.join(temporaryDirectory, "runaway.js");
+  await writeFile(workflowPath, "await checkpoint(); while (true) {}\n", "utf8");
+  const launched = await invoke([
+    "run",
+    workflowPath,
+    "--detach",
+    "--json",
+  ]);
+  const { runId } = JSON.parse(launched.stdout) as { runId: string };
+
+  await invoke(["cancel", runId]);
+  const state = await waitForRun(runId, (item) => item.status === "canceled");
+  expect(state.error).toBe("Workflow canceled");
+});
+
+test("fails runaway JavaScript at the persisted runtime deadline", async () => {
+  const workflowPath = path.join(temporaryDirectory, "deadline.js");
+  await writeFile(workflowPath, "while (true) {}\n", "utf8");
+  const launched = await invoke([
+    "run",
+    workflowPath,
+    "--detach",
+    "--json",
+    "--max-runtime-ms",
+    "300",
+  ]);
+  const { runId } = JSON.parse(launched.stdout) as { runId: string };
+
+  const state = await waitForRun(runId, (item) => item.status === "failed");
+  expect(state.error).toMatch(/300 ms runtime limit/);
+});
+
+test("a completed run wins a simultaneous supervisor deadline", async () => {
+  const workflowPath = path.join(temporaryDirectory, "deadline-race.js");
+  await writeFile(workflowPath, "return 42\n", "utf8");
+  const result = await invoke([
+    "run",
+    workflowPath,
+    "--json",
+    "--max-runtime-ms",
+    "200",
+  ]);
+  const state = JSON.parse(result.stdout) as RunState;
+  expect(state.status).toBe("completed");
+  expect(state.result).toBe(42);
+});
+
+test("a runtime deadline removes active worker descendants", async () => {
+  const workflowPath = path.join(temporaryDirectory, "tree-deadline.js");
+  const grandchildPath = path.join(temporaryDirectory, "deadline-child.pid");
+  await writeFile(
+    workflowPath,
+    `return await agent(
+  "[grandchild=${grandchildPath}][delay=5000] tree",
+  { id: "tree" },
+)\n`,
+    "utf8",
+  );
+  const launched = await invoke([
+    "run",
+    workflowPath,
+    "--detach",
+    "--json",
+    "--max-runtime-ms",
+    "700",
+  ]);
+  const { runId } = JSON.parse(launched.stdout) as { runId: string };
+  const state = await waitForRun(runId, (item) => item.status === "failed");
+  const grandchildPid = Number(await readFile(grandchildPath, "utf8"));
+  try {
+    const deadline = Date.now() + 2_000;
+    while (isPidRunning(grandchildPid) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    expect(isPidRunning(grandchildPid)).toBe(false);
+    expect(state.error).toMatch(/700 ms runtime limit/);
+  } finally {
+    if (isPidRunning(grandchildPid)) {
+      process.kill(grandchildPid, "SIGKILL");
+    }
+  }
+});
+
+test("rejects run IDs that could escape the state directory", async () => {
+  await expect(invoke(["status", "../outside", "--json"]))
+    .rejects.toMatchObject({ code: 1 });
+});
+
+test("resume replaces an engine orphaned by a supervisor crash", async () => {
+  const workflowPath = path.join(temporaryDirectory, "orphan.js");
+  await writeFile(workflowPath, "while (true) {}\n", "utf8");
+  const launched = await invoke([
+    "run",
+    workflowPath,
+    "--detach",
+    "--json",
+  ]);
+  const launch = JSON.parse(launched.stdout) as { pid: number; runId: string };
+  const initial = await waitForRun(
+    launch.runId,
+    (state) => state.enginePid !== undefined && state.status === "running",
+  );
+  const oldEnginePid = initial.enginePid as number;
+
+  process.kill(launch.pid, "SIGKILL");
+  await waitForProcessExit(launch.pid);
+  try {
+    await invoke(["resume", launch.runId, "--json"]);
+    const resumed = await waitForRun(
+      launch.runId,
+      (state) =>
+        state.enginePid !== undefined && state.enginePid !== oldEnginePid,
+    );
+    expect(isPidRunning(oldEnginePid)).toBe(false);
+    expect(resumed.status).toBe("running");
+
+    await invoke(["cancel", launch.runId]);
+    const canceled = await waitForRun(
+      launch.runId,
+      (state) => state.status === "canceled",
+    );
+    expect(canceled.enginePid).toBeUndefined();
+    expect(canceled.pid).toBeUndefined();
+  } finally {
+    const state = await readRunState(launch.runId);
+    killProcessGroup(state.enginePid);
+    killProcessGroup(state.pid);
+    killProcessGroup(oldEnginePid);
+  }
+});
+
+test("an engine crash removes active worker descendants", async () => {
+  const workflowPath = path.join(temporaryDirectory, "engine-crash.js");
+  const grandchildPath = path.join(temporaryDirectory, "engine-child.pid");
+  await writeFile(
+    workflowPath,
+    `return await agent(
+  "[grandchild=${grandchildPath}][delay=5000] engine crash",
+  { id: "worker" },
+)\n`,
+    "utf8",
+  );
+  const launched = await invoke([
+    "run",
+    workflowPath,
+    "--detach",
+    "--json",
+  ]);
+  const launch = JSON.parse(launched.stdout) as { pid: number; runId: string };
+  const running = await waitForRun(
+    launch.runId,
+    (state) =>
+      state.enginePid !== undefined &&
+      state.steps["root/worker"]?.workerPid !== undefined,
+  );
+  const enginePid = running.enginePid as number;
+  const workerStep = running.steps["root/worker"];
+  if (workerStep?.workerPid === undefined) {
+    throw new Error("Active worker did not persist its PID");
+  }
+  const workerPid = workerStep.workerPid;
+  const grandchildPid = await waitForPidFile(grandchildPath);
+
+  killProcessGroup(enginePid);
+  try {
+    const failed = await waitForRun(
+      launch.runId,
+      (state) => state.status === "failed",
+    );
+    expect(failed.error).toMatch(/Workflow engine stopped/);
+    expect(failed.steps["root/worker"]?.status).toBe("failed");
+    expect(isPidRunning(workerPid)).toBe(false);
+    expect(isPidRunning(grandchildPid)).toBe(false);
+  } finally {
+    killProcessGroup(workerPid);
+    killProcessGroup(grandchildPid);
+    killProcessGroup(launch.pid);
+  }
+});
+
+test("resume refuses to signal a reused process ID", async () => {
+  const workflowPath = path.join(temporaryDirectory, "pid-reuse.js");
+  await writeFile(workflowPath, "while (true) {}\n", "utf8");
+  const launched = await invoke([
+    "run",
+    workflowPath,
+    "--detach",
+    "--json",
+  ]);
+  const launch = JSON.parse(launched.stdout) as { pid: number; runId: string };
+  const initial = await waitForRun(
+    launch.runId,
+    (state) => state.enginePid !== undefined && state.status === "running",
+  );
+  const oldEnginePid = initial.enginePid as number;
+  const unrelated = spawn(
+    process.execPath,
+    ["-e", "setInterval(() => {}, 1000)"],
+    { detached: process.platform !== "win32", stdio: "ignore" },
+  );
+  const unrelatedPid = unrelated.pid;
+  if (unrelatedPid === undefined) {
+    throw new Error("Unrelated test process did not receive a PID");
+  }
+  unrelated.unref();
+
+  process.kill(launch.pid, "SIGKILL");
+  await waitForProcessExit(launch.pid);
+  try {
+    const statePath = path.join(
+      environment.CODEX_WORKFLOW_HOME as string,
+      "runs",
+      launch.runId,
+      "state.json",
+    );
+    const stale = JSON.parse(await readFile(statePath, "utf8")) as RunState;
+    stale.enginePid = unrelatedPid;
+    stale.engineStartedAt = "different-process-start";
+    await writeFile(statePath, `${JSON.stringify(stale, null, 2)}\n`, "utf8");
+
+    await expect(invoke(["resume", launch.runId, "--json"]))
+      .rejects.toMatchObject({
+        code: 1,
+        stderr: expect.stringMatching(/process identity changed/),
+      });
+    expect(isPidRunning(unrelatedPid)).toBe(true);
+  } finally {
+    killProcessGroup(unrelatedPid);
+    killProcessGroup(oldEnginePid);
+    killProcessGroup(launch.pid);
+  }
+});
+
+async function invoke(args: string[]): Promise<{ stderr: string; stdout: string }> {
+  return await execFileAsync(process.execPath, [cliPath, ...args], {
+    cwd: temporaryDirectory,
+    encoding: "utf8",
+    env: environment,
+    timeout: 8_000,
+  });
+}
+
+async function waitForRun(
+  runId: string,
+  predicate: (state: RunState) => boolean,
+): Promise<RunState> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const result = await invoke(["status", runId, "--json"]);
+    const state = JSON.parse(result.stdout) as RunState;
+    if (predicate(state)) {
+      return state;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for run ${runId}`);
+}
+
+async function readRunState(runId: string): Promise<RunState> {
+  const result = await invoke(["status", runId, "--json"]);
+  return JSON.parse(result.stdout) as RunState;
+}
+
+async function waitForProcessExit(pid: number): Promise<void> {
+  const deadline = Date.now() + 3_000;
+  while (isPidRunning(pid) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  if (isPidRunning(pid)) {
+    throw new Error(`PID ${pid} did not exit`);
+  }
+}
+
+async function waitForPidFile(filePath: string): Promise<number> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    try {
+      return Number(await readFile(filePath, "utf8"));
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+  throw new Error(`Timed out waiting for PID file ${filePath}`);
+}
+
+function killProcessGroup(pid: number | undefined): void {
+  if (pid === undefined) {
+    return;
+  }
+  try {
+    process.kill(process.platform === "win32" ? pid : -pid, "SIGKILL");
+  } catch {
+    // Test cleanup is best effort after the owned process has exited.
+  }
+}

--- a/plugins/dynamic-workflow/tests/engine.test.ts
+++ b/plugins/dynamic-workflow/tests/engine.test.ts
@@ -1,0 +1,523 @@
+import { readFileSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { CodexRunner } from "../src/codex-runner.js";
+import { compileWorkflow, WorkflowEngine } from "../src/engine.js";
+import { StateStore } from "../src/state-store.js";
+import type { RunState } from "../src/types.js";
+import { isPidRunning, nowIso, sha256 } from "../src/utils.js";
+import { createFakeCodex, waitFor } from "./helpers.js";
+
+let temporaryDirectory: string;
+let originalHome: string | undefined;
+let originalCodexBin: string | undefined;
+let originalFakeLog: string | undefined;
+
+beforeEach(async () => {
+  temporaryDirectory = await mkdtemp(path.join(tmpdir(), "workflow-engine-"));
+  originalHome = process.env.CODEX_WORKFLOW_HOME;
+  originalCodexBin = process.env.CODEX_WORKFLOW_CODEX_BIN;
+  originalFakeLog = process.env.FAKE_CODEX_LOG;
+  process.env.CODEX_WORKFLOW_HOME = path.join(temporaryDirectory, "state");
+  process.env.CODEX_WORKFLOW_CODEX_BIN = await createFakeCodex(
+    temporaryDirectory,
+  );
+  process.env.FAKE_CODEX_LOG = path.join(temporaryDirectory, "codex.jsonl");
+});
+
+afterEach(async () => {
+  restoreEnvironment("CODEX_WORKFLOW_HOME", originalHome);
+  restoreEnvironment("CODEX_WORKFLOW_CODEX_BIN", originalCodexBin);
+  restoreEnvironment("FAKE_CODEX_LOG", originalFakeLog);
+  await rm(temporaryDirectory, { force: true, recursive: true });
+});
+
+describe("compileWorkflow", () => {
+  test("accepts the Claude-style meta block and top-level return", () => {
+    expect(() =>
+      compileWorkflow(
+        "export const meta = { name: 'demo' }; return 42;",
+        "demo.js",
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects module imports", () => {
+    expect(() =>
+      compileWorkflow("import fs from 'node:fs'; return fs;", "bad.js"),
+    ).toThrow(/import statement|Unexpected token/);
+  });
+});
+
+test("persists worker ownership before delivering its prompt", async () => {
+  let allowRegistration: (() => void) | undefined;
+  const registrationGate = new Promise<void>((resolve) => {
+    allowRegistration = resolve;
+  });
+  let observedSpawn: (() => void) | undefined;
+  const spawned = new Promise<void>((resolve) => {
+    observedSpawn = resolve;
+  });
+  const runner = new CodexRunner(
+    undefined,
+    async () => {
+      observedSpawn?.();
+      await registrationGate;
+    },
+  );
+  const controller = new AbortController();
+  const running = runner.run({
+    defaultTimeoutMs: 3_000,
+    options: {},
+    prompt: "ownership gate",
+    runDirectory: temporaryDirectory,
+    signal: controller.signal,
+    stepId: "root/gated",
+    workflowCwd: temporaryDirectory,
+  });
+
+  await spawned;
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(await invocationCount()).toBe(0);
+  allowRegistration?.();
+  await expect(running).resolves.toMatchObject({
+    text: "result:ownership gate",
+  });
+  expect(await invocationCount()).toBe(1);
+});
+
+test("does not expose Node globals through injected host functions", async () => {
+  const safeSource = "return typeof process";
+  const safeStore = await createStore("safe-vm-run", safeSource);
+  const safe = await new WorkflowEngine(safeStore, safeSource, () => {}).run();
+  expect(safe.result).toBe("undefined");
+
+  const escapeSource = 'return agent.constructor("return process")()';
+  const escapeStore = await createStore("escape-vm-run", escapeSource);
+  const escaped = await new WorkflowEngine(
+    escapeStore,
+    escapeSource,
+    () => {},
+  ).run();
+  expect(escaped.status).toBe("failed");
+  expect(escaped.error).toMatch(/Code generation from strings disallowed/);
+});
+
+test("enforces item caps before fan-out", async () => {
+  const source = `
+return await pipeline(
+  ["a", "b"],
+  item => agent(item, { id: "work" }),
+  { maxItems: 1 },
+)
+`;
+  const store = await createStore("capped-run", source);
+  const final = await new WorkflowEngine(store, source, () => {}).run();
+  expect(final.status).toBe("failed");
+  expect(final.error).toMatch(/maximum is 1/);
+  expect(final.agentInvocations).toBe(0);
+});
+
+test("applies a default pipeline cap when maxItems is omitted", async () => {
+  const source = `
+return await pipeline(
+  Array.from({ length: 101 }, (_, index) => index),
+  item => agent(String(item), { id: "work" }),
+)
+`;
+  const store = await createStore("default-cap-run", source);
+  const final = await new WorkflowEngine(store, source, () => {}).run();
+  expect(final.status).toBe("failed");
+  expect(final.error).toMatch(/maximum is 100/);
+  expect(final.agentInvocations).toBe(0);
+});
+
+test("enforces the persisted run-level agent budget", async () => {
+  const source = `
+await agent("one", { id: "one" })
+await agent("two", { id: "two" })
+return await agent("three", { id: "three" })
+`;
+  const store = await createStore("agent-budget-run", source);
+  await store.update((state) => {
+    state.maxAgentInvocations = 2;
+  });
+  const final = await new WorkflowEngine(store, source, () => {}).run();
+  expect(final.status).toBe("failed");
+  expect(final.error).toMatch(/2-agent safety limit/);
+  expect(final.agentInvocations).toBe(2);
+});
+
+test("uses cacheKey to invalidate an otherwise identical step", async () => {
+  const firstSource = `
+return await agent("same prompt", { id: "same", cacheKey: "version-1" })
+`;
+  const store = await createStore("dependency-run", firstSource);
+  const first = await new WorkflowEngine(store, firstSource, () => {}).run();
+  expect(first.status).toBe("completed");
+  expect(await invocationCount()).toBe(1);
+
+  await store.writeControl("run");
+  const secondSource = `
+return await agent("same prompt", { id: "same", cacheKey: "version-2" })
+`;
+  const second = await new WorkflowEngine(store, secondSource, () => {}).run();
+  expect(second.status).toBe("completed");
+  expect(await invocationCount()).toBe(2);
+});
+
+test("uses the supported Codex resume argument surface", async () => {
+  const source = `
+return await agent("continue", {
+  id: "continued",
+  resumeThreadId: "11111111-1111-4111-8111-111111111111",
+})
+`;
+  const store = await createStore("thread-run", source);
+  const authorization = {
+    dangerFullAccess: true,
+    workflowHash: sha256(source),
+    workspaceWrite: true,
+  };
+  await store.update((state) => {
+    state.authorization = authorization;
+  });
+  await store.writeControl("run", authorization);
+  const final = await new WorkflowEngine(store, source, () => {}).run();
+  expect(final.status).toBe("completed");
+
+  const invocation = (await readInvocations())[0];
+  expect(invocation?.args.slice(0, 3)).toEqual(["exec", "resume", "--json"]);
+  expect(invocation?.args).not.toContain("--sandbox");
+  expect(invocation?.args).not.toContain("--color");
+});
+
+test("requires persisted authorization for write-capable workers", async () => {
+  const source = `
+return await agent("edit one file", {
+  id: "edit",
+  sandbox: "workspace-write",
+})
+`;
+  const deniedStore = await createStore("write-denied-run", source);
+  const denied = await new WorkflowEngine(
+    deniedStore,
+    source,
+    () => {},
+  ).run();
+  expect(denied.status).toBe("failed");
+  expect(denied.error).toMatch(/--allow-workspace-write/);
+  expect(denied.agentInvocations).toBe(0);
+
+  const allowedStore = await createStore("write-allowed-run", source);
+  const authorization = {
+    dangerFullAccess: false,
+    workflowHash: sha256(source),
+    workspaceWrite: true,
+  };
+  await allowedStore.update((state) => {
+    state.authorization = authorization;
+  });
+  await allowedStore.writeControl("run", authorization);
+  const allowed = await new WorkflowEngine(
+    allowedStore,
+    source,
+    () => {},
+  ).run();
+  expect(allowed.status).toBe("completed");
+  expect((await readInvocations())[0]?.args).toContain("workspace-write");
+
+  const changedSource = source.replace("edit one file", "edit a different file");
+  await allowedStore.update((state) => {
+    state.workflowHash = sha256(changedSource);
+  });
+  await allowedStore.writeControl("run", authorization);
+  const invalidated = await new WorkflowEngine(
+    allowedStore,
+    changedSource,
+    () => {},
+  ).run();
+  expect(invalidated.status).toBe("failed");
+  expect(invalidated.error).toMatch(/does not match the current workflow/);
+});
+
+test("fans out, preserves order, and reuses completed agent results", async () => {
+  const source = `
+export const meta = { name: "audit" }
+const discovered = await agent("discover", {
+  id: "discover",
+  schema: {
+    type: "object",
+    required: ["items"],
+    properties: { items: { type: "array", items: { type: "string" } } },
+  },
+})
+const results = await pipeline(
+  discovered.items,
+  item => agent(\`work \${item}\`, { id: "work", label: item }),
+  { concurrency: 2 },
+)
+return results
+`;
+  const store = await createStore("cache-run", source);
+  const first = await new WorkflowEngine(store, source, () => {}).run();
+
+  expect(first.status).toBe("completed");
+  expect(first.result).toEqual([
+    "result:work a",
+    "result:work b",
+    "result:work c",
+  ]);
+  expect(Object.keys(first.steps)).toHaveLength(4);
+  const firstInvocations = await invocationCount();
+  expect(firstInvocations).toBe(4);
+  const invocations = await readInvocations();
+  expect(invocations[0]?.args).toContain("read-only");
+  expect(invocations[0]?.args).toContain('approval_policy="never"');
+  expect(invocations[0]?.args).toContain("--output-schema");
+
+  await store.writeControl("run");
+  const second = await new WorkflowEngine(store, source, () => {}).run();
+  expect(second.status).toBe("completed");
+  expect(await invocationCount()).toBe(firstInvocations);
+  expect(await store.readLog()).toContain("cache hit");
+});
+
+test("pauses between active agents and resumes cooperatively", async () => {
+  const source = `
+const first = await agent("[delay=250] first", { id: "first" })
+const second = await agent("second", { id: "second" })
+return [first, second]
+`;
+  const store = await createStore("pause-run", source);
+  const running = new WorkflowEngine(store, source, () => {}).run();
+
+  await waitFor(
+    () => store.snapshot().steps["root/first"]?.status === "running",
+  );
+  await store.writeControl("pause");
+  await waitFor(() => store.snapshot().status === "paused");
+  expect(store.snapshot().steps["root/second"]).toBeUndefined();
+
+  await store.writeControl("run");
+  const final = await running;
+  expect(final.status).toBe("completed");
+  expect(final.result).toEqual([
+    "result:[delay=250] first",
+    "result:second",
+  ]);
+});
+
+test("cancels an active Codex worker", async () => {
+  const source = `
+return await agent("[delay=5000] slow", { id: "slow" })
+`;
+  const store = await createStore("cancel-run", source);
+  const running = new WorkflowEngine(store, source, () => {}).run();
+
+  await waitFor(
+    () => store.snapshot().steps["root/slow"]?.status === "running",
+  );
+  await store.writeControl("cancel");
+  const final = await running;
+  expect(final.status).toBe("canceled");
+  expect(final.steps["root/slow"]?.status).toBe("canceled");
+});
+
+test("fails only after unawaited agents are canceled and drained", async () => {
+  const source = `
+agent("[delay=5000] forgotten", { id: "forgotten" })
+return 42
+`;
+  const store = await createStore("unawaited-run", source);
+  const final = await new WorkflowEngine(store, source, () => {}).run();
+
+  expect(final.status).toBe("failed");
+  expect(final.error).toMatch(/await every agent/);
+  expect(
+    Object.values(final.steps).every((step) => step.status !== "running"),
+  ).toBe(true);
+});
+
+test("drains slow siblings before a failed parallel run returns", async () => {
+  const source = `
+return await parallel([
+  () => agent("[fail] fast", { id: "fast" }),
+  () => agent("[delay=5000] slow", { id: "slow" }),
+])
+`;
+  const store = await createStore("sibling-failure-run", source);
+  const final = await new WorkflowEngine(store, source, () => {}).run();
+
+  expect(final.status).toBe("failed");
+  expect(
+    Object.values(final.steps).every((step) => step.status !== "running"),
+  ).toBe(true);
+});
+
+test("does not retry deterministic context exhaustion", async () => {
+  const source = `
+return await agent("[context-fail] oversized", {
+  id: "context",
+  retries: 3,
+})
+`;
+  const store = await createStore("context-run", source);
+  const final = await new WorkflowEngine(store, source, () => {}).run();
+
+  expect(final.status).toBe("failed");
+  expect(final.error).toMatch(/Chunk the input or use a tree reduction/);
+  expect(await invocationCount()).toBe(1);
+  expect(final.steps["root/context"]?.threadId).toBe(
+    "thread-context-failure",
+  );
+  expect(final.steps["root/context"]?.usage?.inputTokens).toBe(99);
+});
+
+test("cancellation kills descendants that ignore SIGTERM", async () => {
+  const grandchildPath = path.join(temporaryDirectory, "grandchild.pid");
+  const source = `
+return await agent(
+  "[grandchild-ignore=${grandchildPath}][delay=5000] process tree",
+  { id: "tree" },
+)
+`;
+  const store = await createStore("process-tree-run", source);
+  const running = new WorkflowEngine(store, source, () => {}).run();
+  await waitFor(() => store.snapshot().steps["root/tree"]?.workerPid !== undefined);
+  await waitFor(() => isPidRunning(readPid(grandchildPath)));
+  const grandchildPid = readPid(grandchildPath);
+
+  await store.writeControl("cancel");
+  const final = await running;
+  expect(final.status, final.error).toBe("canceled");
+  await waitFor(() => !isPidRunning(grandchildPid));
+});
+
+test("an abnormal worker exit removes surviving descendants", async () => {
+  const grandchildPath = path.join(
+    temporaryDirectory,
+    "failed-worker-grandchild.pid",
+  );
+  const source = `
+return await agent(
+  "[grandchild-ignore=${grandchildPath}][fail] process tree",
+  { id: "tree" },
+)
+`;
+  const store = await createStore("failed-process-tree-run", source);
+  const final = await new WorkflowEngine(store, source, () => {}).run();
+  const grandchildPid = readPid(grandchildPath);
+
+  await waitFor(() => !isPidRunning(grandchildPid));
+  expect(final.status).toBe("failed");
+  expect(final.steps["root/tree"]?.status).toBe("failed");
+});
+
+test("a worker cleanup timeout preserves durable ownership", async () => {
+  const grandchildPath = path.join(
+    temporaryDirectory,
+    "cleanup-pending-grandchild.pid",
+  );
+  const source = `
+return await agent(
+  "[grandchild-ignore=${grandchildPath}][fail] process tree",
+  { id: "tree" },
+)
+`;
+  const store = await createStore("cleanup-pending-run", source);
+  const originalKill = process.kill.bind(process);
+  const killSpy = vi.spyOn(process, "kill").mockImplementation(
+    (pid, signal) => {
+      const workerPid = store.snapshot().steps["root/tree"]?.workerPid;
+      if (
+        workerPid !== undefined &&
+        pid === -workerPid &&
+        (signal === 0 || signal === "SIGKILL")
+      ) {
+        return true;
+      }
+      return originalKill(pid, signal);
+    },
+  );
+
+  try {
+    const final = await new WorkflowEngine(store, source, () => {}).run();
+    const step = final.steps["root/tree"];
+    expect(final.status, final.error).toBe("canceling");
+    expect(final.completedAt).toBeUndefined();
+    expect(step?.status).toBe("running");
+    expect(step?.workerPid).toBeDefined();
+    expect(step?.workerStartedAt).toBeDefined();
+  } finally {
+    killSpy.mockRestore();
+    const workerPid = store.snapshot().steps["root/tree"]?.workerPid;
+    if (workerPid !== undefined) {
+      try {
+        originalKill(
+          process.platform === "win32" ? workerPid : -workerPid,
+          "SIGKILL",
+        );
+      } catch {
+        // Test cleanup is best effort after the owned process group exits.
+      }
+    }
+  }
+});
+
+async function createStore(runId: string, source: string): Promise<StateStore> {
+  const timestamp = nowIso();
+  const state: RunState = {
+    agentInvocations: 0,
+    concurrency: 3,
+    createdAt: timestamp,
+    cwd: temporaryDirectory,
+    runId,
+    status: "starting",
+    steps: {},
+    updatedAt: timestamp,
+    version: 1,
+    workflowHash: sha256(source),
+    workflowPath: path.join(temporaryDirectory, `${runId}.js`),
+  };
+  return await StateStore.create(state);
+}
+
+async function invocationCount(): Promise<number> {
+  return (await readInvocations()).length;
+}
+
+async function readInvocations(): Promise<
+  Array<{ args: string[]; prompt: string }>
+> {
+  try {
+    const contents = await readFile(process.env.FAKE_CODEX_LOG as string, "utf8");
+    return contents
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { args: string[]; prompt: string });
+  } catch {
+    return [];
+  }
+}
+
+function restoreEnvironment(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+function readPid(filePath: string): number {
+  try {
+    return Number(readFileSync(filePath, "utf8"));
+  } catch {
+    return -1;
+  }
+}

--- a/plugins/dynamic-workflow/tests/helpers.ts
+++ b/plugins/dynamic-workflow/tests/helpers.ts
@@ -1,0 +1,111 @@
+import { chmod, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export async function createFakeCodex(directory: string): Promise<string> {
+  const scriptPath = path.join(directory, "fake-codex.mjs");
+  const source = `#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { appendFile, writeFile } from "node:fs/promises";
+
+let prompt = "";
+for await (const chunk of process.stdin) {
+  prompt += chunk.toString("utf8");
+}
+const record = {
+  args: process.argv.slice(2),
+  prompt,
+  startedAt: Date.now(),
+};
+if (process.env.FAKE_CODEX_LOG) {
+  await appendFile(
+    process.env.FAKE_CODEX_LOG,
+    JSON.stringify(record) + "\\n",
+    "utf8",
+  );
+}
+const delay = Number(prompt.match(/\\[delay=(\\d+)\\]/)?.[1] ?? 0);
+const stubbornGrandchildPath =
+  prompt.match(/\\[grandchild-ignore=([^\\]]+)\\]/)?.[1];
+const grandchildPath =
+  prompt.match(/\\[grandchild=([^\\]]+)\\]/)?.[1] ?? stubbornGrandchildPath;
+if (grandchildPath) {
+  const grandchildSource = stubbornGrandchildPath
+    ? "const { writeFileSync } = require('node:fs'); " +
+      "process.on('SIGTERM', () => {}); " +
+      "writeFileSync(" + JSON.stringify(stubbornGrandchildPath) +
+      ", String(process.pid), 'utf8'); " +
+      "setInterval(() => {}, 1000)"
+    : "setInterval(() => {}, 1000)";
+  const grandchild = spawn(
+    process.execPath,
+    ["-e", grandchildSource],
+    { stdio: "ignore" },
+  );
+  if (!stubbornGrandchildPath) {
+    await writeFile(grandchildPath, String(grandchild.pid), "utf8");
+  }
+}
+if (delay > 0) {
+  await new Promise((resolve) => setTimeout(resolve, delay));
+}
+if (prompt.includes("[context-fail]")) {
+  console.log(JSON.stringify({
+    type: "thread.started",
+    thread_id: "thread-context-failure",
+  }));
+  console.log(JSON.stringify({
+    type: "turn.completed",
+    usage: {
+      input_tokens: 99,
+      cached_input_tokens: 3,
+      output_tokens: 1,
+    },
+  }));
+  console.log(JSON.stringify({
+    type: "turn.failed",
+    error: { message: "context_length_exceeded" },
+  }));
+  process.exit(1);
+}
+if (prompt.includes("[fail]")) {
+  process.stderr.write("synthetic worker failure\\n");
+  process.exit(17);
+}
+const structured = process.argv.includes("--output-schema");
+const text = structured
+  ? JSON.stringify({ items: ["a", "b", "c"] })
+  : "result:" + prompt;
+console.log(JSON.stringify({
+  type: "thread.started",
+  thread_id: "thread-" + Math.random().toString(16).slice(2),
+}));
+console.log(JSON.stringify({
+  type: "item.completed",
+  item: { type: "agent_message", text },
+}));
+console.log(JSON.stringify({
+  type: "turn.completed",
+  usage: {
+    input_tokens: 10,
+    cached_input_tokens: 2,
+    output_tokens: 4,
+  },
+}));
+`;
+  await writeFile(scriptPath, source, "utf8");
+  await chmod(scriptPath, 0o755);
+  return scriptPath;
+}
+
+export async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 3_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}

--- a/plugins/dynamic-workflow/tests/state-store.test.ts
+++ b/plugins/dynamic-workflow/tests/state-store.test.ts
@@ -1,0 +1,94 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, expect, test } from "vitest";
+
+import { StateStore } from "../src/state-store.js";
+import type { RunState } from "../src/types.js";
+import { isPidRunning, nowIso } from "../src/utils.js";
+
+let temporaryDirectory: string;
+let originalHome: string | undefined;
+
+beforeEach(async () => {
+  temporaryDirectory = await mkdtemp(path.join(tmpdir(), "workflow-store-"));
+  originalHome = process.env.CODEX_WORKFLOW_HOME;
+  process.env.CODEX_WORKFLOW_HOME = temporaryDirectory;
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) {
+    delete process.env.CODEX_WORKFLOW_HOME;
+  } else {
+    process.env.CODEX_WORKFLOW_HOME = originalHome;
+  }
+  await rm(temporaryDirectory, { force: true, recursive: true });
+});
+
+test("allows only one runner claim and supports a detached handoff", async () => {
+  const first = await createStore("claim-run");
+  const second = await StateStore.load("claim-run");
+  const claims = await Promise.allSettled([
+    first.claimRunner(process.pid),
+    second.claimRunner(process.pid),
+  ]);
+  const winners = claims.filter((result) => result.status === "fulfilled");
+  const losers = claims.filter((result) => result.status === "rejected");
+  expect(winners).toHaveLength(1);
+  expect(losers).toHaveLength(1);
+
+  const token = (winners[0] as PromiseFulfilledResult<string>).value;
+  await first.transferRunner(token, process.pid);
+  await expect(second.claimRunner(process.pid, token)).resolves.toBe(token);
+  await second.releaseRunner(token);
+});
+
+test("recovers a stale owner without allowing split-brain claims", async () => {
+  const initial = await createStore("stale-claim-run");
+  const staleOwner = spawn(
+    process.execPath,
+    ["-e", "setInterval(() => {}, 1000)"],
+    { stdio: "ignore" },
+  );
+  if (staleOwner.pid === undefined) {
+    throw new Error("Stale owner test process did not receive a PID");
+  }
+  await initial.claimRunner(staleOwner.pid);
+  staleOwner.kill("SIGKILL");
+  await new Promise<void>((resolve) => staleOwner.once("exit", () => resolve()));
+  expect(isPidRunning(staleOwner.pid)).toBe(false);
+  const first = await StateStore.load("stale-claim-run");
+  const second = await StateStore.load("stale-claim-run");
+
+  const claims = await Promise.allSettled([
+    first.claimRunner(process.pid),
+    second.claimRunner(process.pid),
+  ]);
+  const winners = claims.filter((result) => result.status === "fulfilled");
+  const losers = claims.filter((result) => result.status === "rejected");
+  expect(winners).toHaveLength(1);
+  expect(losers).toHaveLength(1);
+
+  const token = (winners[0] as PromiseFulfilledResult<string>).value;
+  await first.releaseRunner(token);
+});
+
+async function createStore(runId: string): Promise<StateStore> {
+  const timestamp = nowIso();
+  const state: RunState = {
+    agentInvocations: 0,
+    concurrency: 1,
+    createdAt: timestamp,
+    cwd: temporaryDirectory,
+    runId,
+    status: "starting",
+    steps: {},
+    updatedAt: timestamp,
+    version: 1,
+    workflowHash: "test",
+    workflowPath: path.join(temporaryDirectory, "workflow.js"),
+  };
+  return await StateStore.create(state);
+}

--- a/plugins/dynamic-workflow/tsconfig.json
+++ b/plugins/dynamic-workflow/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/plugins/dynamic-workflow/vitest.config.ts
+++ b/plugins/dynamic-workflow/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    fileParallelism: false,
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Summary

- add a Codex plugin for durable JavaScript workflows over headless Codex agents
- support bounded fan-out, structured results, caching, pause, resume, cancel,
  detached runs, and direct `codex exec --json` workers without MCP
- harden runtime limits, write authorization, process ownership, crash recovery,
  descendant cleanup, context exhaustion, and cleanup-timeout recovery
- add a Codex marketplace, installation instructions, plugin reference, and a
  Claude-to-Codex migration guide with matching README and Starlight cards

## Why

Codex does not provide the same interactive dynamic-workflow surface. This adds
an installable plugin that preserves the useful multi-agent orchestration model
while making execution durable, bounded, reviewable, and recoverable.

## User impact

Users can install the plugin directly from this repository's Codex marketplace
and invoke `$dynamic-workflow` to create or run a workflow. The plugin is
independent of the Python `claude-code-tools` package and ships its compiled
JavaScript runner; no npm installation or MCP setup is required.

## Validation

- TypeScript typecheck passed
- 34 runtime and integration tests passed
- Starlight production build passed
- Codex plugin and skill validators passed
- npm dependency audit reported zero vulnerabilities
- clean isolated marketplace add and plugin installation passed
- desktop and mobile documentation pages were browser-verified
- independent release audit reported no remaining blocker
