### PR TITLE
Preserve Codex sessions across dynamic-server updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ codex-dynamic resume --last
 ```
 
 `codex-dynamic` starts or reuses the local app server and then hands the
-terminal directly to Codex. Use `codex-server status` or `logs` for
-nondisruptive inspection. A forced stop or restart disconnects every attached
-TUI, so exit those sessions before running `codex-server stop --force` or
-`codex-server restart --force` from an ordinary terminal.
+terminal directly to Codex. After a plugin or Codex upgrade, the next launch
+automatically starts a fresh server generation; existing sessions and workflow
+callbacks stay connected to their old generation. No manual restart is needed.
+Use `codex-server status` or `logs` for nondisruptive inspection. A forced stop
+or restart cleans up every retained generation and disconnects its attached
+TUIs, so use those commands only after exiting the sessions normally.
 
 The Python package also installs `codex-workflows`, an observational dashboard
 for durable workflow runs:

--- a/claude_code_tools/codex_server.py
+++ b/claude_code_tools/codex_server.py
@@ -26,10 +26,11 @@ from claude_code_tools.codex_server_fingerprint import (
     plugin_configuration_snapshot as _plugin_configuration_snapshot,
     read_plugin_configuration as _read_plugin_configuration,  # noqa: F401
 )
+from claude_code_tools.codex_server_generation import server_generation
 
 from claude_code_tools.codex_server_models import (
+    CODEX_SERVER_GENERATION_ENV,
     CODEX_SERVER_OPTIONS_ENV,
-    ENDPOINT,
     FORCED_STOP_SECONDS,
     GRACEFUL_STOP_SECONDS,
     LOG_TRUNCATION_MARKER_MAX_BYTES,
@@ -43,14 +44,20 @@ from claude_code_tools.codex_server_models import (
     ServerProbe,
     ServerStatus,
     StateFileError,
+    all_server_paths,
+    base_paths_from_env,
+    clear_current_generation,
     log_tail,
     log_tail_stream,
     open_log_append,
     open_log_reader,
     paths_from_env,
+    paths_for_generation,
     prepare_runtime,
+    publish_current_generation,
     quarantine_invalid_state,
     read_state,
+    require_generation_capacity,
     remove_state,
     write_state,
 )
@@ -66,6 +73,11 @@ from claude_code_tools.codex_server_process import (
     terminate_owned,
     wait_for_process_group_exit,
     wait_for_process_identity,
+)
+from claude_code_tools.codex_server_reuse import (
+    disconnect_refusal as _disconnect_refusal,
+    helper_restart_reason as _reuse_restart_reason,
+    require_external_compatible as _external_compatible,
 )
 
 
@@ -166,6 +178,10 @@ def _command_env(env: Mapping[str, str], paths: ServerPaths) -> dict[str, str]:
     """Return a child environment pinned to the resolved Codex home."""
     child_env = dict(env)
     child_env["CODEX_HOME"] = str(paths.codex_home)
+    if paths.generation is None:
+        child_env.pop(CODEX_SERVER_GENERATION_ENV, None)
+    else:
+        child_env[CODEX_SERVER_GENERATION_ENV] = paths.generation
     return child_env
 
 
@@ -345,6 +361,13 @@ def _probe_server(
     paths: ServerPaths,
 ) -> ServerProbe:
     """Probe the app-server protocol, with an older-CLI socket fallback."""
+    if paths.generation is not None:
+        accepting = _socket_accepts(paths.socket_path)
+        return ServerProbe(
+            running=accepting,
+            method="socket" if accepting else None,
+            accepting=accepting,
+        )
     if codex_path:
         result = _run_command(
             [codex_path, "app-server", "daemon", "version"],
@@ -508,66 +531,21 @@ def _helper_restart_reason(
     probe: ServerProbe,
     plugin_fingerprint: str,
     paths: ServerPaths,
+    codex_options: Sequence[str] = (),
 ) -> str | None:
     """Explain why a helper listener cannot be safely reused."""
-    if not state_controller_matches(state):
-        return "its durable supervisor exited"
-    if state.codex_path != codex_path:
-        return "the active Codex executable path changed"
-    if state.codex_executable_identity is None:
-        return "its Codex executable identity predates replacement detection"
-    if state.codex_executable_identity != codex_executable_identity:
-        return "the active Codex executable was replaced"
-    if _version_key(state.codex_version) != _version_key(codex_version):
-        return "the active Codex CLI version changed"
-    if probe.server_version is not None and _version_key(
-        probe.server_version
-    ) != _version_key(codex_version):
-        return "the running app-server version differs from the Codex CLI"
-    if (probe.running or probe.accepting) and not _listener_matches_worker(
+    return _reuse_restart_reason(
         state,
+        codex_path,
+        codex_executable_identity,
+        codex_version,
+        probe,
+        plugin_fingerprint,
         paths,
-    ):
-        return "its socket listener is not owned by the supervised worker"
-    if state.plugin_fingerprint is None:
-        return "its plugin snapshot predates plugin-change detection"
-    if state.plugin_fingerprint != plugin_fingerprint:
-        return "the Codex plugin or marketplace configuration changed"
-    return None
-
-
-def _disconnect_refusal(action: str) -> CodexServerError:
-    """Explain why a shared-server lifecycle action needs acknowledgement."""
-    return CodexServerError(
-        f"refusing to {action} the shared app server without --force: this "
-        "disconnects every codex-dynamic TUI, and Codex exits those sessions. "
-        "Exit connected sessions first, then retry with --force; their "
-        "transcripts remain resumable"
-    )
-
-
-def _require_external_compatible(
-    codex_version: str,
-    probe: ServerProbe,
-) -> None:
-    """Reject external listeners, whose plugin snapshot is uncertifiable."""
-    server_key = _version_key(probe.server_version)
-    cli_key = _version_key(codex_version)
-    if server_key is None:
-        raise CodexServerError(
-            "an external app server is running, but its version could not be "
-            "verified; stop it before using codex-server"
-        )
-    if server_key != cli_key:
-        raise CodexServerError(
-            f"external app-server version {probe.server_version!r} does not "
-            f"match the selected Codex CLI {codex_version!r}; stop or restart "
-            "the external server"
-        )
-    raise CodexServerError(
-        "an external app server is running, but codex-server cannot verify "
-        "which plugin snapshot it loaded; stop it before using "
-        "codex-dynamic workflow callbacks"
+        codex_options,
+        _listener_matches_worker,
+        state_controller_matches,
+        _version_key,
     )
 
 
@@ -646,7 +624,9 @@ def _certify_helper_boundary(
     probe = _probe_server(codex_path, child_env, paths)
     if not probe.running:
         raise CodexServerError(f"the app-server listener vanished during {operation}")
-    if _version_key(probe.server_version) != _version_key(codex_version):
+    if paths.generation is None and _version_key(probe.server_version) != _version_key(
+        codex_version
+    ):
         raise CodexServerError(
             f"the app-server version changed or was uncertified during {operation}"
         )
@@ -671,6 +651,10 @@ def _certified_helper_status(
     probe: ServerProbe,
 ) -> ServerStatus:
     """Build a helper result only from final certified evidence."""
+    version = probe.server_version
+    if version is None:
+        key = _version_key(state.codex_version)
+        version = ".".join(map(str, key)) if key is not None else None
     return ServerStatus(
         status="running",
         ownership="helper",
@@ -678,7 +662,7 @@ def _certified_helper_status(
         pid=state.pid,
         codex_path=state.codex_path,
         codex_version=state.codex_version,
-        server_version=probe.server_version,
+        server_version=version,
         probe_method=probe.method,
     )
 
@@ -747,17 +731,34 @@ def ensure_server(
 ) -> ServerStatus:
     """Reuse a compatible listener or start a supervised app server."""
     active_env = dict(os.environ if env is None else env)
-    paths = _paths(active_env)
+    base_paths = base_paths_from_env(active_env)
     codex_path = _resolve_codex(active_env)
     codex_executable_identity = _codex_executable_identity(codex_path)
+    base_child_env = _command_env(active_env, base_paths)
+    codex_version = _require_compatible_codex(codex_path, base_child_env)
+    plugin_snapshot = _plugin_configuration_snapshot(base_paths, codex_options)
+    generation = server_generation(
+        codex_path,
+        codex_executable_identity,
+        codex_version,
+        plugin_snapshot.fingerprint,
+        codex_options,
+    )
+    paths = paths_for_generation(base_paths, generation)
+    require_generation_capacity(base_paths, generation)
     child_env = _command_env(active_env, paths)
     child_env[CODEX_SERVER_OPTIONS_ENV] = json.dumps(
         list(codex_options),
         separators=(",", ":"),
     )
-    codex_version = _require_compatible_codex(codex_path, child_env)
     with _lifecycle_lock(paths):
-        plugin_snapshot = _plugin_configuration_snapshot(paths, codex_options)
+        locked_snapshot = _plugin_configuration_snapshot(paths, codex_options)
+        if locked_snapshot.fingerprint != plugin_snapshot.fingerprint:
+            raise CodexServerError(
+                "the Codex plugin or marketplace snapshot changed during "
+                "app-server generation selection; retry after updates finish"
+            )
+        plugin_snapshot = locked_snapshot
         plugin_fingerprint = plugin_snapshot.fingerprint
         try:
             state = _read_state(paths)
@@ -774,7 +775,7 @@ def ensure_server(
                     "shared app server cannot be reused because its socket "
                     "listener is not owned by the supervised worker"
                 )
-            _require_external_compatible(codex_version, probe)
+            _external_compatible(codex_version, probe, _version_key)
             return status
         if state is not None and _state_is_owned(state):
             restart_reason = _helper_restart_reason(
@@ -785,6 +786,7 @@ def ensure_server(
                 probe,
                 plugin_fingerprint,
                 paths,
+                codex_options,
             )
             if restart_reason is None and not probe.running:
                 probe = _retry_helper_probe(
@@ -802,6 +804,7 @@ def ensure_server(
                     probe,
                     plugin_fingerprint,
                     paths,
+                    codex_options,
                 )
             if restart_reason is None:
                 certified_state, certified_probe = _certify_helper_boundary(
@@ -813,17 +816,16 @@ def ensure_server(
                     codex_options,
                     "app-server reuse checks",
                 )
-                return _certified_helper_status(
+                result = _certified_helper_status(
                     paths,
                     certified_state,
                     certified_probe,
                 )
+                publish_current_generation(base_paths, generation)
+                return result
             raise CodexServerError(
-                "shared app server cannot be reused because "
-                f"{restart_reason}. Refusing to restart it automatically "
-                "because that would disconnect every codex-dynamic TUI. Exit "
-                "connected sessions, run `codex-server restart --force`, then "
-                "start or resume Codex"
+                "selected app-server generation cannot be reused because "
+                f"{restart_reason}; refusing to replace an uncertified listener"
             )
 
         if state_error:
@@ -888,11 +890,13 @@ def ensure_server(
                 codex_options,
                 "app-server startup checks",
             )
-            return _certified_helper_status(
+            result = _certified_helper_status(
                 paths,
                 certified_state,
                 certified_probe,
             )
+            publish_current_generation(base_paths, generation)
+            return result
         except BaseException as exc:
             if starting is not None:
                 try:
@@ -910,14 +914,12 @@ def ensure_server(
             raise
 
 
-def stop_server(
-    env: Mapping[str, str] | None = None,
-    *,
-    allow_disconnect: bool = False,
+def _stop_server_at(
+    active_env: Mapping[str, str],
+    paths: ServerPaths,
+    allow_disconnect: bool,
 ) -> ServerStatus:
-    """Stop a helper-owned server after explicit disconnect acknowledgement."""
-    active_env = dict(os.environ if env is None else env)
-    paths = _paths(active_env)
+    """Stop one selected helper generation."""
     try:
         codex_path = _resolve_codex(active_env)
     except CodexServerError:
@@ -954,6 +956,23 @@ def stop_server(
         return ServerStatus(status="stopped", ownership=None, paths=paths)
 
 
+def stop_server(
+    env: Mapping[str, str] | None = None,
+    *,
+    allow_disconnect: bool = False,
+) -> ServerStatus:
+    """Stop helper-owned servers after explicit disconnect acknowledgement."""
+    active_env = dict(os.environ if env is None else env)
+    selected = _paths(active_env)
+    if not allow_disconnect:
+        return _stop_server_at(active_env, selected, False)
+    base = base_paths_from_env(active_env)
+    for paths in all_server_paths(base):
+        _stop_server_at(active_env, paths, True)
+    clear_current_generation(base)
+    return ServerStatus(status="stopped", ownership=None, paths=selected)
+
+
 def restart_server(
     env: Mapping[str, str] | None = None,
     *,
@@ -974,18 +993,3 @@ def restart_server(
         codex_options = state.codex_options
     stop_server(active_env, allow_disconnect=allow_disconnect)
     return ensure_server(active_env, codex_options=codex_options)
-
-
-__all__ = [
-    "ENDPOINT",
-    "CodexServerError",
-    "OwnedServer",
-    "ServerPaths",
-    "ServerProbe",
-    "ServerStatus",
-    "StateFileError",
-    "ensure_server",
-    "get_status",
-    "restart_server",
-    "stop_server",
-]

--- a/claude_code_tools/codex_server_cli.py
+++ b/claude_code_tools/codex_server_cli.py
@@ -12,7 +12,6 @@ from typing import BinaryIO, NoReturn, Sequence
 import click
 
 from claude_code_tools.codex_server import (
-    ENDPOINT,
     CodexServerError,
     ServerStatus,
     _command_env,
@@ -58,9 +57,6 @@ NON_TUI_COMMANDS = {
 }
 
 CALLBACK_ENDPOINT_ENV = "CCTOOLS_CODEX_CALLBACK_ENDPOINT"
-CALLBACK_SHELL_CONFIG = (
-    f'shell_environment_policy.set.{CALLBACK_ENDPOINT_ENV}="{ENDPOINT}"'
-)
 
 GLOBAL_OPTIONS_WITH_VALUES = {
     "--add-dir",
@@ -107,20 +103,20 @@ def _echo_status(status: ServerStatus, json_output: bool) -> None:
         click.echo(f"{status.status} (managed by codex-server, pid {status.pid})")
     else:
         click.echo(status.status)
-    click.echo(f"endpoint: {ENDPOINT}")
+    click.echo(f"endpoint: {status.paths.endpoint}")
     if status.detail:
         click.echo(f"detail: {status.detail}")
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 def server_cli() -> None:
-    """Manage the shared app server used for Codex workflow callbacks."""
+    """Manage generated app servers used for Codex workflow callbacks."""
 
 
 @server_cli.command("start")
 @click.option("--json", "json_output", is_flag=True, help="Emit JSON status.")
 def start_command(json_output: bool) -> None:
-    """Start the server, or reuse the listener already running."""
+    """Start or reuse the server for the current Codex/plugin generation."""
     try:
         status = ensure_server()
     except CodexServerError as exc:
@@ -143,11 +139,11 @@ def status_command(json_output: bool) -> None:
 @click.option(
     "--force",
     is_flag=True,
-    help="Acknowledge that every connected codex-dynamic TUI will exit.",
+    help="Stop all generations; every connected codex-dynamic TUI will exit.",
 )
 @click.option("--json", "json_output", is_flag=True, help="Emit JSON status.")
 def stop_command(force: bool, json_output: bool) -> None:
-    """Stop a helper-owned server after acknowledging TUI disconnection."""
+    """Stop the current generation; use --force to stop all generations."""
     try:
         status = stop_server(allow_disconnect=force)
     except CodexServerError as exc:
@@ -159,11 +155,11 @@ def stop_command(force: bool, json_output: bool) -> None:
 @click.option(
     "--force",
     is_flag=True,
-    help="Acknowledge that every connected codex-dynamic TUI will exit.",
+    help="Restart all generations; every connected codex-dynamic TUI will exit.",
 )
 @click.option("--json", "json_output", is_flag=True, help="Emit JSON status.")
 def restart_command(force: bool, json_output: bool) -> None:
-    """Restart after acknowledging that connected TUIs will exit."""
+    """Restart the current generation; use --force to clean up all."""
     try:
         status = restart_server(allow_disconnect=force)
     except CodexServerError as exc:
@@ -331,34 +327,38 @@ def dynamic_main() -> NoReturn:
         raise SystemExit(2)
     active_env = dict(os.environ)
     use_remote = not (_is_information_only(arguments) or _is_non_tui_command(arguments))
+    endpoint: str | None = None
     try:
         codex_path = _resolve_codex(active_env)
         if use_remote:
-            paths = _paths(active_env)
-            child_env = _command_env(active_env, paths)
-            ensure_server(
-                child_env,
+            status = ensure_server(
+                active_env,
                 codex_options=_server_configuration_options(arguments),
             )
-            child_env[CALLBACK_ENDPOINT_ENV] = ENDPOINT
+            endpoint = status.paths.endpoint
+            child_env = _command_env(active_env, status.paths)
+            child_env[CALLBACK_ENDPOINT_ENV] = endpoint
         else:
             child_env = dict(active_env)
             child_env.pop(CALLBACK_ENDPOINT_ENV, None)
     except CodexServerError as exc:
         click.echo(f"Error: {exc}", err=True)
         raise SystemExit(1) from exc
-    command = (
-        [
+    if use_remote:
+        assert endpoint is not None
+        command = [
             codex_path,
             "--config",
-            CALLBACK_SHELL_CONFIG,
+            (
+                f"shell_environment_policy.set.{CALLBACK_ENDPOINT_ENV}="
+                f"{json.dumps(endpoint)}"
+            ),
             "--remote",
-            ENDPOINT,
+            endpoint,
             *arguments,
         ]
-        if use_remote
-        else [codex_path, *arguments]
-    )
+    else:
+        command = [codex_path, *arguments]
     try:
         os.execvpe(codex_path, command, child_env)
     except OSError as exc:

--- a/claude_code_tools/codex_server_generation.py
+++ b/claude_code_tools/codex_server_generation.py
@@ -1,0 +1,52 @@
+"""Deterministic identities for independently running app-server generations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Sequence
+
+
+GENERATION_PATTERN = re.compile(r"[0-9a-f]{24}")
+
+
+def server_generation(
+    codex_path: str,
+    executable_identity: str,
+    codex_version: str,
+    plugin_fingerprint: str,
+    codex_options: Sequence[str],
+) -> str:
+    """Return the generation selected by every server-affecting input.
+
+    Args:
+        codex_path: Canonical path to the selected Codex executable.
+        executable_identity: Stable identity of the executable file.
+        codex_version: Version reported by that executable.
+        plugin_fingerprint: Fingerprint of the effective plugin configuration.
+        codex_options: Global Codex options forwarded to the app server.
+
+    Returns:
+        A short lowercase hexadecimal generation identifier.
+    """
+    payload = json.dumps(
+        {
+            "codexOptions": list(codex_options),
+            "codexPath": codex_path,
+            "codexVersion": codex_version,
+            "executableIdentity": executable_identity,
+            "pluginFingerprint": plugin_fingerprint,
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:24]
+
+
+def validate_generation(value: str) -> str:
+    """Validate an app-server generation received through the environment."""
+    if GENERATION_PATTERN.fullmatch(value) is None:
+        raise ValueError("app-server generation must be 24 lowercase hex characters")
+    return value

--- a/claude_code_tools/codex_server_models.py
+++ b/claude_code_tools/codex_server_models.py
@@ -11,9 +11,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO, Mapping
 
+from claude_code_tools.codex_server_generation import validate_generation
+
 
 ENDPOINT = "unix://"
 CODEX_SERVER_OPTIONS_ENV = "CCTOOLS_CODEX_SERVER_OPTIONS"
+CODEX_SERVER_GENERATION_ENV = "CCTOOLS_CODEX_SERVER_GENERATION"
 STATE_VERSION = 1
 START_TIMEOUT_SECONDS = 10.0
 GRACEFUL_STOP_SECONDS = 60.0
@@ -32,6 +35,9 @@ LOG_TRUNCATION_MARKER_MAX_BYTES = (
     len(LOG_TRUNCATION_MARKER_PREFIX) + LOG_TRUNCATION_GENERATION_BYTES + 2
 )
 MAX_PROCESS_IDENTIFIER = (1 << 31) - 1
+MAX_SERVER_GENERATIONS = 64
+MAX_SERVER_GENERATION_DIRECTORIES = 256
+MAX_SERVER_DIRECTORY_ENTRIES = 512
 
 
 class CodexServerError(RuntimeError):
@@ -52,6 +58,14 @@ class ServerPaths:
     state_path: Path
     lock_path: Path
     log_path: Path
+    generation: str | None = None
+
+    @property
+    def endpoint(self) -> str:
+        """Return the Unix WebSocket endpoint represented by these paths."""
+        if self.generation is None:
+            return ENDPOINT
+        return f"unix://{self.socket_path}"
 
 
 @dataclass(frozen=True)
@@ -266,7 +280,8 @@ class ServerStatus:
         return {
             "status": self.status,
             "ownership": self.ownership,
-            "endpoint": ENDPOINT,
+            "endpoint": self.paths.endpoint,
+            "generation": self.paths.generation,
             "socketPath": str(self.paths.socket_path),
             "pid": self.pid,
             "codexPath": self.codex_path,
@@ -292,13 +307,29 @@ def paths_from_env(env: Mapping[str, str]) -> ServerPaths:
     Raises:
         CodexServerError: If ``CODEX_HOME`` is inaccessible or not a directory.
     """
+    base = base_paths_from_env(env)
+    raw_generation = env.get(CODEX_SERVER_GENERATION_ENV)
+    if raw_generation is not None:
+        try:
+            generation = validate_generation(raw_generation)
+        except ValueError as exc:
+            raise CodexServerError(str(exc)) from exc
+    else:
+        generation = read_current_generation(base)
+    if generation is None:
+        return base
+    return paths_for_generation(base, generation)
+
+
+def base_paths_from_env(env: Mapping[str, str]) -> ServerPaths:
+    """Resolve legacy base paths without consulting the generation marker."""
     home_value = env.get("CODEX_HOME")
     raw_home = Path(home_value).expanduser() if home_value else Path.home() / ".codex"
     raw_home = raw_home.absolute()
     try:
         info = raw_home.stat()
     except FileNotFoundError:
-        codex_home = raw_home
+        codex_home = raw_home.resolve(strict=False)
     except OSError as exc:
         raise CodexServerError(f"cannot access CODEX_HOME {raw_home}: {exc}") from exc
     else:
@@ -322,6 +353,176 @@ def paths_from_env(env: Mapping[str, str]) -> ServerPaths:
     )
 
 
+def paths_for_generation(base: ServerPaths, generation: str) -> ServerPaths:
+    """Resolve isolated runtime and socket paths for one generation."""
+    try:
+        checked = validate_generation(generation)
+    except ValueError as exc:
+        raise CodexServerError(str(exc)) from exc
+    runtime_dir = base.runtime_dir / checked
+    return ServerPaths(
+        codex_home=base.codex_home,
+        runtime_dir=runtime_dir,
+        socket_path=base.socket_path.parent / f"g-{checked[:16]}.sock",
+        state_path=runtime_dir / "state.json",
+        lock_path=runtime_dir / "lifecycle.lock",
+        log_path=runtime_dir / "app-server.log",
+        generation=checked,
+    )
+
+
+def read_current_generation(base: ServerPaths) -> str | None:
+    """Read the safely published default generation, if one exists."""
+    marker = base.runtime_dir / "current-generation"
+    info = _lstat(marker)
+    if info is None:
+        return None
+    _require_regular_owned(info, marker, "generation marker")
+    no_follow = getattr(os, "O_NOFOLLOW", None)
+    if no_follow is None:
+        raise CodexServerError("safe generation selection requires O_NOFOLLOW")
+    try:
+        fd = os.open(marker, os.O_RDONLY | os.O_NONBLOCK | no_follow)
+        try:
+            initial = os.fstat(fd)
+            _require_regular_owned(initial, marker, "generation marker")
+            raw = _read_bounded_fd(fd, 64)
+            if _file_generation(os.fstat(fd)) != _file_generation(initial):
+                raise CodexServerError("app-server generation changed while read")
+        finally:
+            os.close(fd)
+        value = raw.decode("ascii").strip()
+        return validate_generation(value)
+    except (OSError, UnicodeError, ValueError, StateFileError) as exc:
+        raise CodexServerError(
+            f"cannot read generation marker {marker}: {exc}"
+        ) from exc
+
+
+def publish_current_generation(base: ServerPaths, generation: str) -> None:
+    """Atomically select a fully certified generation for future launches."""
+    checked = validate_generation(generation)
+    prepare_runtime(base)
+    marker = base.runtime_dir / "current-generation"
+    marker_info = _lstat(marker)
+    if marker_info is not None:
+        _require_regular_owned(marker_info, marker, "generation marker")
+    temporary = base.runtime_dir / f"current-generation.{os.getpid()}.tmp"
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(temporary, flags, 0o600)
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(f"{checked}\n".encode("ascii"))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, marker)
+        marker.chmod(0o600)
+        _fsync_directory(base.runtime_dir)
+    except OSError as exc:
+        raise CodexServerError(f"cannot publish app-server generation: {exc}") from exc
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def clear_current_generation(base: ServerPaths) -> None:
+    """Remove the default-generation marker after explicit server cleanup."""
+    marker = base.runtime_dir / "current-generation"
+    info = _lstat(marker)
+    if info is None:
+        return
+    _require_regular_owned(info, marker, "generation marker")
+    try:
+        marker.unlink()
+        _fsync_directory(base.runtime_dir)
+    except OSError as exc:
+        raise CodexServerError(f"cannot clear generation marker: {exc}") from exc
+
+
+def all_server_paths(base: ServerPaths) -> list[ServerPaths]:
+    """Return bounded helper generations eligible for explicit cleanup."""
+    info = _lstat(base.runtime_dir)
+    if info is None:
+        return [base]
+    if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
+        raise CodexServerError(f"unsafe runtime path: {base.runtime_dir}")
+    if info.st_uid != os.getuid():
+        raise CodexServerError(
+            f"runtime directory is owned by another user: {base.runtime_dir}"
+        )
+    no_follow = getattr(os, "O_NOFOLLOW", None)
+    directory = getattr(os, "O_DIRECTORY", None)
+    if no_follow is None or directory is None:
+        raise CodexServerError("safe generation scanning is unsupported")
+    try:
+        directory_fd = os.open(
+            base.runtime_dir,
+            os.O_RDONLY | no_follow | directory,
+        )
+    except OSError as exc:
+        raise CodexServerError(
+            f"cannot enumerate app-server generations: {exc}"
+        ) from exc
+    generations: list[str] = []
+    scanned = 0
+    try:
+        if _file_generation(os.fstat(directory_fd)) != _file_generation(info):
+            raise CodexServerError("app-server runtime changed during inspection")
+        with os.scandir(directory_fd) as entries:
+            for entry in entries:
+                scanned += 1
+                if scanned > MAX_SERVER_DIRECTORY_ENTRIES:
+                    raise CodexServerError("too many app-server runtime entries")
+                try:
+                    generation = validate_generation(entry.name)
+                except ValueError:
+                    continue
+                try:
+                    entry_info = entry.stat(follow_symlinks=False)
+                except OSError as exc:
+                    raise CodexServerError(
+                        f"cannot inspect app-server generation {entry.name}: {exc}"
+                    ) from exc
+                if not stat.S_ISDIR(entry_info.st_mode) or stat.S_ISLNK(
+                    entry_info.st_mode
+                ):
+                    raise CodexServerError(
+                        f"unsafe app-server generation path: {entry.name}"
+                    )
+                if entry_info.st_uid != os.getuid():
+                    raise CodexServerError(
+                        f"app-server generation is owned by another user: {entry.name}"
+                    )
+                generations.append(generation)
+                if len(generations) > MAX_SERVER_GENERATION_DIRECTORIES:
+                    raise CodexServerError(
+                        "too many app-server generations to inspect safely"
+                    )
+    finally:
+        os.close(directory_fd)
+    return [base, *(paths_for_generation(base, item) for item in sorted(generations))]
+
+
+def require_generation_capacity(base: ServerPaths, generation: str) -> None:
+    """Bound retained servers before creating another generation."""
+    target = paths_for_generation(base, generation)
+    if _lstat(target.runtime_dir) is not None:
+        return
+    retained = sum(
+        _lstat(paths.state_path) is not None or _lstat(paths.socket_path) is not None
+        for paths in all_server_paths(base)[1:]
+    )
+    if retained >= MAX_SERVER_GENERATIONS:
+        raise CodexServerError(
+            "app-server generation limit reached; exit callback-ready sessions "
+            "and run `codex-server stop --force` before launching another"
+        )
+
+
 def prepare_runtime(paths: ServerPaths) -> None:
     """Create a private, non-symlinked helper runtime directory."""
     try:
@@ -329,7 +530,18 @@ def prepare_runtime(paths: ServerPaths) -> None:
         home_info = paths.codex_home.stat()
         if not stat.S_ISDIR(home_info.st_mode):
             raise CodexServerError(f"CODEX_HOME is not a directory: {paths.codex_home}")
-        paths.runtime_dir.mkdir(mode=0o700, exist_ok=True)
+        base_runtime = paths.codex_home / "cctools-app-server"
+        base_runtime.mkdir(mode=0o700, exist_ok=True)
+        base_info = base_runtime.lstat()
+        if not stat.S_ISDIR(base_info.st_mode) or stat.S_ISLNK(base_info.st_mode):
+            raise CodexServerError(
+                f"unsafe runtime path (must be a directory): {base_runtime}"
+            )
+        if base_info.st_uid != os.getuid():
+            raise CodexServerError(
+                f"runtime directory is owned by another user: {base_runtime}"
+            )
+        paths.runtime_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
         info = paths.runtime_dir.lstat()
         control_dir = paths.socket_path.parent
         control_dir.mkdir(mode=0o700, exist_ok=True)
@@ -359,6 +571,8 @@ def prepare_runtime(paths: ServerPaths) -> None:
     try:
         if stat.S_IMODE(info.st_mode) != 0o700:
             paths.runtime_dir.chmod(0o700)
+        if stat.S_IMODE(base_info.st_mode) != 0o700:
+            base_runtime.chmod(0o700)
         if stat.S_IMODE(control_info.st_mode) != 0o700:
             control_dir.chmod(0o700)
     except OSError as exc:

--- a/claude_code_tools/codex_server_reuse.py
+++ b/claude_code_tools/codex_server_reuse.py
@@ -1,0 +1,90 @@
+"""Compatibility checks for reusing a supervised Codex app server."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from claude_code_tools.codex_server_models import (
+    CodexServerError,
+    OwnedServer,
+    ServerPaths,
+    ServerProbe,
+)
+
+
+def helper_restart_reason(
+    state: OwnedServer,
+    codex_path: str,
+    executable_identity: str,
+    codex_version: str,
+    probe: ServerProbe,
+    plugin_fingerprint: str,
+    paths: ServerPaths,
+    codex_options: Sequence[str],
+    listener_matches_worker: Callable[[OwnedServer, ServerPaths], bool],
+    controller_matches: Callable[[OwnedServer], bool],
+    version_key: Callable[[str | None], tuple[int, int, int] | None],
+) -> str | None:
+    """Explain why a helper listener cannot be safely reused."""
+    if not controller_matches(state):
+        return "its durable supervisor exited"
+    if state.codex_path != codex_path:
+        return "the active Codex executable path changed"
+    if state.codex_executable_identity is None:
+        return "its Codex executable identity predates replacement detection"
+    if state.codex_executable_identity != executable_identity:
+        return "the active Codex executable was replaced"
+    if version_key(state.codex_version) != version_key(codex_version):
+        return "the active Codex CLI version changed"
+    if probe.server_version is not None and version_key(
+        probe.server_version
+    ) != version_key(codex_version):
+        return "the running app-server version differs from the Codex CLI"
+    if (probe.running or probe.accepting) and not listener_matches_worker(
+        state,
+        paths,
+    ):
+        return "its socket listener is not owned by the supervised worker"
+    if state.plugin_fingerprint is None:
+        return "its plugin snapshot predates plugin-change detection"
+    if state.plugin_fingerprint != plugin_fingerprint:
+        return "the Codex plugin or marketplace configuration changed"
+    if state.codex_options != tuple(codex_options):
+        return "the app-server configuration options changed"
+    return None
+
+
+def disconnect_refusal(action: str) -> CodexServerError:
+    """Explain why a shared-server lifecycle action needs acknowledgement."""
+    return CodexServerError(
+        f"refusing to {action} the shared app server without --force: this "
+        "disconnects every codex-dynamic TUI on that generation, and Codex "
+        "exits those sessions. Exit connected sessions first, then retry "
+        "with --force; their transcripts remain resumable"
+    )
+
+
+def require_external_compatible(
+    codex_version: str,
+    probe: ServerProbe,
+    version_key: Callable[[str | None], tuple[int, int, int] | None],
+) -> None:
+    """Reject external listeners, whose plugin snapshot is uncertifiable."""
+    server_key = version_key(probe.server_version)
+    cli_key = version_key(codex_version)
+    if server_key is None:
+        raise CodexServerError(
+            "an external app server is running, but its version could not be "
+            "verified; stop it before using codex-server"
+        )
+    if server_key != cli_key:
+        raise CodexServerError(
+            f"external app-server version {probe.server_version!r} does not "
+            f"match the selected Codex CLI {codex_version!r}; stop or restart "
+            "the external server"
+        )
+    raise CodexServerError(
+        "an external app server is running, but codex-server cannot verify "
+        "which plugin snapshot it loaded; stop it before using "
+        "codex-dynamic workflow callbacks"
+    )

--- a/claude_code_tools/codex_server_worker.py
+++ b/claude_code_tools/codex_server_worker.py
@@ -10,8 +10,8 @@ from typing import Mapping, NoReturn, Sequence
 
 from claude_code_tools.codex_server_models import (
     CODEX_SERVER_OPTIONS_ENV,
-    ENDPOINT,
     CodexServerError,
+    paths_from_env,
 )
 
 
@@ -37,9 +37,10 @@ def run_worker_gate(
     if release != launch_token:
         raise CodexServerError("app-server worker release token did not match")
     options = _server_options(env)
+    endpoint = paths_from_env(env).endpoint
     os.execve(
         codex_path,
-        [codex_path, *options, "app-server", "--listen", ENDPOINT],
+        [codex_path, *options, "app-server", "--listen", endpoint],
         dict(env),
     )
     raise AssertionError("os.execve returned unexpectedly")

--- a/docs-site/src/content/docs/getting-started/plugins.mdx
+++ b/docs-site/src/content/docs/getting-started/plugins.mdx
@@ -48,19 +48,15 @@ remote TUI interfaces as experimental, so their CLI and protocol surfaces may
 evolve.
 
 If a `codex-dynamic` app server is already running during an install or update,
-exit every connected TUI and run `codex-server restart --force` from an ordinary
-terminal before starting Codex again. The forced restart disconnects all
-attached TUIs, so never invoke it from inside Codex. See the
-[safe plugin-reload sequence][codex-dynamic-reload].
+start Codex normally afterward. The helper automatically selects a fresh
+server generation while existing TUIs and callbacks remain connected to their
+original generation.
 
 See the
 [Dynamic Workflow detail page](/claude-code-tools/plugins-detail/dynamic-workflow/)
 for its JavaScript API, state model, and safety boundaries.
 
 [codex-dynamic]: /claude-code-tools/tools/codex-dynamic/
-[codex-dynamic-reload]:
-  /claude-code-tools/tools/codex-dynamic/#reload-after-a-plugin-change
-
 ## Claude Code Plugin Installation
 
 <Steps>

--- a/docs-site/src/content/docs/guides/claude-to-codex/index.mdx
+++ b/docs-site/src/content/docs/guides/claude-to-codex/index.mdx
@@ -129,14 +129,11 @@ To continue the most recent conversation instead of starting a new one:
 codex-dynamic resume --last
 ```
 
-<Aside type="caution" title="Plugin updates require a safe server restart">
-  A new TUI does not reload plugins while an older shared app server is still
-  running. After installing or upgrading the plugin, exit every
-  `codex-dynamic` TUI, then run `codex-server restart --force` from an ordinary
-  terminal. Start `codex-dynamic` again afterward. Never run the forced restart
-  inside Codex: it disconnects every TUI attached to that server, interrupts
-  active turns, and makes those TUIs exit. Saved conversations remain
-  resumable. Codex currently has no in-session plugin-reload command.
+<Aside type="tip" title="Plugin updates do not require a restart">
+  After installing or upgrading the plugin, run `codex-dynamic` normally. It
+  starts a fresh server generation while existing sessions and callbacks keep
+  using their original generation. Forced lifecycle commands are needed only
+  for explicit cleanup, and they disconnect every retained session.
 </Aside>
 
 Omit `--last` to use Codex's session picker. `codex-dynamic` quietly starts or

--- a/docs-site/src/content/docs/plugins-detail/dynamic-workflow.mdx
+++ b/docs-site/src/content/docs/plugins-detail/dynamic-workflow.mdx
@@ -36,14 +36,10 @@ Those two commands are the complete plugin installation.
 Restart Codex, then invoke `$dynamic-workflow` or ask for a durable multi-agent
 workflow.
 
-<Aside type="caution" title="Shared-server sessions need a full reload">
-  If you use `codex-dynamic`, starting another TUI does not reload plugins from
-  an app server that was already running. After a plugin update, exit every
-  connected TUI and run `codex-server restart --force` from an ordinary
-  terminal, then start `codex-dynamic` again. A forced restart disconnects all
-  attached TUIs and interrupts their active turns, so never invoke it from
-  inside Codex. Saved conversations remain resumable. See the
-  [`codex-dynamic` lifecycle instructions][codex-dynamic-reload].
+<Aside type="tip" title="Plugin updates use a fresh server generation">
+  After a plugin update, start `codex-dynamic` normally. It starts or reuses a
+  server generation containing the new plugin while existing TUIs and
+  callbacks keep their original generation. No forced restart is required.
 </Aside>
 
 ## Workflow shape
@@ -285,5 +281,3 @@ npm test
 
 [codex-app-server]: https://developers.openai.com/codex/app-server
 [codex-dynamic]: /claude-code-tools/tools/codex-dynamic/
-[codex-dynamic-reload]:
-  /claude-code-tools/tools/codex-dynamic/#reload-after-a-plugin-change

--- a/docs-site/src/content/docs/tools/codex-dynamic.mdx
+++ b/docs-site/src/content/docs/tools/codex-dynamic.mdx
@@ -38,10 +38,11 @@ main Codex session ──launch──> detached workflow
 codex-dynamic
 ```
 
-The command quietly ensures that Codex's local app server is running, then
-replaces itself with `codex --remote unix://`. Because it uses process
-replacement, Codex keeps direct control of the terminal, keyboard, signals,
-window resizing, and exit status.
+The command quietly ensures that the right generation of Codex's local app
+server is running, then replaces itself with `codex --remote` connected to that
+generation's Unix socket. Because it uses process replacement, Codex keeps
+direct control of the terminal, keyboard, signals, window resizing, and exit
+status.
 
 ## Install
 
@@ -347,15 +348,11 @@ visible as diagnostics instead of hiding otherwise readable runs. Set
   callback retry. `codex-workflows` deliberately has no control operations.
 </Aside>
 
-## Reload after a plugin change
+## Plugin updates without restarts
 
-The shared app server loads the plugin catalog for every TUI connected to it.
-Starting another `codex-dynamic` TUI does not reload that catalog when the same
-server remains alive. Codex currently has no in-session plugin-reload command.
-
-`codex-dynamic` records the plugin and marketplace configuration used when it
-starts the server. If that configuration later changes, the launcher refuses
-to connect another TUI to the stale server and prints the safe recovery steps.
+An app server loads its plugin catalog once, and Codex currently has no
+in-session plugin-reload command. `codex-dynamic` handles this automatically by
+using versioned server generations instead of replacing the shared server.
 
 <Steps>
 
@@ -363,24 +360,7 @@ to connect another TUI to the stale server and prints the safe recovery steps.
 
    Complete the marketplace or plugin update normally.
 
-2. **Exit every callback-ready Codex TUI**
-
-   Finish or interrupt active turns, then exit each session normally. Merely
-   opening a new terminal is not enough because all `codex-dynamic` TUIs share
-   one app-server process.
-
-3. **Restart the now-unused server**
-
-   Run this from an ordinary terminal, not from inside a Codex tool call:
-
-   ```bash
-   codex-server restart --force
-   ```
-
-   `--force` acknowledges that any TUI still connected to the server will be
-   disconnected and will exit.
-
-4. **Start or resume Codex**
+2. **Start or resume Codex**
 
    ```bash
    codex-dynamic
@@ -390,13 +370,24 @@ to connect another TUI to the stale server and prints the safe recovery steps.
 
 </Steps>
 
-<Aside type="caution" title="Restarting disconnects every attached TUI">
-  Codex does not currently reconnect a remote TUI when its app server exits,
-  and the server does not send a WebSocket closing handshake during shutdown.
-  A connected TUI exits with a transport error such as `Connection reset
-  without closing handshake`. Its transcript remains resumable, but any active
-  turn is interrupted. Never run `restart --force` or `stop --force` from
-  inside a connected Codex session.
+The launcher fingerprints the selected Codex executable, plugin catalog, and
+server-affecting options. If they match an existing healthy generation, it
+reuses that generation. Otherwise it starts and certifies a new socket before
+making it the default. Existing TUIs and in-flight callbacks remain connected
+to the old socket, so they are not interrupted and keep the plugin snapshot
+with which they started.
+
+Codex does not expose a reliable count of clients attached to an app server,
+so the helper never guesses that an old generation is unused and kills it.
+Retained generations are capped at 64; reaching that defensive limit produces
+an explicit cleanup instruction instead of disconnecting sessions silently.
+
+<Aside type="caution" title="Forced cleanup still disconnects sessions">
+  Old generations remain available for sessions and callbacks that still use
+  them. `codex-server stop --force` and `restart --force` deliberately stop
+  every retained generation. Codex cannot reconnect those TUIs, so exit them
+  normally before forced cleanup. Ordinary installs and `codex-dynamic`
+  launches never require these commands.
 </Aside>
 
 ## Server controls
@@ -406,17 +397,18 @@ automatically. These commands are useful for inspection and cleanup:
 
 | Command | Purpose |
 | --- | --- |
-| `codex-server status` | Show endpoint health and process ownership |
-| `codex-server logs` | Show the most recent app-server output |
-| `codex-server logs --follow` | Follow app-server output |
-| `codex-server restart --force` | Restart after acknowledging TUI exits |
-| `codex-server stop --force` | Stop after acknowledging TUI exits |
+| `codex-server status` | Show the current default generation |
+| `codex-server logs` | Show the current generation's recent output |
+| `codex-server logs --follow` | Follow the current generation's output |
+| `codex-server restart --force` | Stop all generations, then start a fresh one |
+| `codex-server stop --force` | Stop every retained generation |
 
 Add `--json` to lifecycle commands for machine-readable output.
 
-Without `--force`, `stop` and `restart` refuse to terminate a running shared
-server. The guard is deliberately conservative because a server can have more
-than one TUI attached and Codex exposes no graceful reconnect protocol.
+Without `--force`, `stop` and `restart` refuse to terminate a running
+generation. The guard is deliberately conservative because a generation can
+have more than one TUI attached and Codex exposes no graceful reconnect
+protocol.
 
 The helper reuses only a healthy app server that it previously started and can
 certify against its recorded ownership and plugin state. It rejects an app
@@ -424,9 +416,10 @@ server started another way because it cannot verify which plugin snapshot that
 server loaded. Lifecycle commands also verify the recorded process identity
 before sending a signal.
 
-State and logs live under `$CODEX_HOME/cctools-app-server/`. The default
-`CODEX_HOME` is `~/.codex`. Set `CCTOOLS_CODEX_BIN` when the desired Codex
-executable is not the first `codex` on `PATH`.
+Per-generation state and logs live under
+`$CODEX_HOME/cctools-app-server/<generation>/`. The default `CODEX_HOME` is
+`~/.codex`. Set `CCTOOLS_CODEX_BIN` when the desired Codex executable is not
+the first `codex` on `PATH`.
 
 ## Manual alternative
 
@@ -460,10 +453,10 @@ MCP layer, extra API key, or hosted coordination service.
 
 ```text
 codex-dynamic
-  |-- ensure/reuse --> [app-server supervisor] --> [local app server]
+  |-- select generation --> [versioned supervisor] --> [versioned app server]
   `-- exec ---------> [Codex TUI]
                             |
-                            `-- local Unix socket --> [local app server]
+                            `-- generation socket --> [versioned app server]
 
 [Codex TUI] -- reviewed launch --> [workflow supervisor]
                                            |
@@ -488,14 +481,19 @@ codex-dynamic
 1. **Establish a callback-capable session**
 
    `codex-dynamic` resolves the exact Codex executable, checks its version, and
-   takes a lifecycle lock. It reuses a compatible app server when one already
-   exists or starts a supervised `codex app-server --listen unix://`.
+   fingerprints that executable together with the effective plugin catalog and
+   server options. It reuses the matching healthy generation or starts a
+   supervised app server on a generation-specific Unix socket. The current
+   generation marker changes only after the new listener passes ownership,
+   process-identity, plugin-snapshot, and socket-peer checks. A failed rollout
+   therefore leaves the previous default untouched.
 
-   The launcher then replaces itself with `codex --remote unix://`. It is not a
-   proxy in front of the TUI, so Codex still owns the terminal, signals, and
-   exit status directly. It also injects the local callback endpoint through
-   Codex's shell-environment policy, making callbacks the default for detached
-   workflow launches even under a restrictive inheritance policy.
+   The launcher then replaces itself with `codex --remote` using that exact
+   socket. It is not a proxy in front of the TUI, so Codex still owns the
+   terminal, signals, and exit status directly. The same immutable endpoint is
+   injected through Codex's shell-environment policy, making callbacks the
+   default for detached workflow launches even under a restrictive inheritance
+   policy.
 
 2. **Verify the callback before creating the run**
 

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Plugin Changelog
 
+## 2026-07-16
+
+### dynamic-workflow 0.2.1
+
+- fix: document automatic `codex-dynamic` server-generation rollover
+  - plugin and Codex upgrades no longer require a forced shared-server restart
+  - existing sessions and callbacks remain connected to their original server
+
 ## 2026-07-13
 
 ### dynamic-workflow 0.2.0

--- a/plugins/dynamic-workflow/.codex-plugin/plugin.json
+++ b/plugins/dynamic-workflow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-workflow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Run durable JavaScript workflows with Codex callbacks",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/dynamic-workflow/README.md
+++ b/plugins/dynamic-workflow/README.md
@@ -33,11 +33,10 @@ codex plugin add dynamic-workflow@cctools-codex-plugins
 Restart Codex after installation, then invoke `$dynamic-workflow` or ask Codex
 to create a durable multi-agent workflow.
 
-When `codex-dynamic` already has a shared app server running, a new TUI alone
-does not reload an updated plugin. Exit every connected TUI, run
-`codex-server restart --force` from an ordinary terminal, and then start Codex
-again. Never force a restart from inside Codex: it disconnects every TUI on the
-server and interrupts active turns. Saved conversations remain resumable.
+After a plugin update, start `codex-dynamic` normally. It automatically uses a
+fresh server generation containing the new plugin while existing sessions and
+callbacks remain connected to their original generation. A forced restart is
+needed only for explicit cleanup and disconnects every retained session.
 
 For local development from the repository root:
 

--- a/plugins/dynamic-workflow/package-lock.json
+++ b/plugins/dynamic-workflow/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cctools/dynamic-workflow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cctools/dynamic-workflow",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "bin": {
         "codex-workflow": "bin/workflow.mjs"
       },

--- a/plugins/dynamic-workflow/package.json
+++ b/plugins/dynamic-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cctools/dynamic-workflow",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Durable JavaScript workflows with Codex thread callbacks",
   "private": true,
   "type": "module",

--- a/plugins/dynamic-workflow/skills/dynamic-workflow/SKILL.md
+++ b/plugins/dynamic-workflow/skills/dynamic-workflow/SKILL.md
@@ -244,16 +244,14 @@ request. The plugin itself does not require that package. The equivalent manual
 setup keeps `codex app-server --listen unix://` running in one terminal and
 starts `codex --remote unix://` in another.
 
-The shared app server snapshots plugin configuration for its connected TUIs.
-After a plugin or marketplace change, a new TUI alone may still receive the old
-snapshot. `codex-dynamic` detects a changed configuration and refuses to reuse
-that server. Tell the user to exit every connected `codex-dynamic` TUI, then run
-`codex-server restart --force` from an ordinary terminal before starting or
-resuming Codex. Never run `codex-server restart --force` or
-`codex-server stop --force` from inside a connected Codex turn: the command
-disconnects every attached TUI, interrupts active turns, and makes those TUIs
-exit. Saved transcripts remain resumable. Without `--force`, lifecycle commands
-refuse to stop a running shared server.
+The app server snapshots plugin configuration for its connected TUIs. After a
+plugin or marketplace change, tell the user to start or resume with
+`codex-dynamic` normally. The helper selects a fresh server generation while
+existing TUIs and callbacks keep using their original generation. Do not tell
+the user to restart the server after an ordinary update. Forced lifecycle
+commands are only for explicit cleanup; they stop every retained generation,
+disconnect attached TUIs, and interrupt active turns. Without `--force`, those
+commands refuse to stop a running generation.
 
 Callbacks require Codex CLI 0.136.0 or newer. It is the first compatible CLI
 release combining WebSocket-over-Unix framing with the echoed client message

--- a/tests/test_codex_server.py
+++ b/tests/test_codex_server.py
@@ -18,6 +18,7 @@ import pytest
 from click.testing import CliRunner
 
 import claude_code_tools.codex_server as codex_server
+import claude_code_tools.codex_server_models as server_models
 import claude_code_tools.codex_server_process as codex_server_process
 from claude_code_tools.codex_server import (
     CodexServerError,
@@ -27,7 +28,6 @@ from claude_code_tools.codex_server import (
     _process_group_exists,
     ensure_server,
     get_status,
-    restart_server,
     stop_server,
 )
 from claude_code_tools.codex_server_cli import server_cli
@@ -46,16 +46,18 @@ import sys
 from pathlib import Path
 
 
-def socket_path() -> Path:
+def socket_path(endpoint: str = "unix://") -> Path:
+    if endpoint != "unix://":
+        return Path(endpoint.removeprefix("unix://"))
     home = Path(os.environ["CODEX_HOME"])
     return home / "app-server-control" / "app-server-control.sock"
 
 
-def can_connect() -> bool:
+def can_connect(path: Path | None = None) -> bool:
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     client.settimeout(0.2)
     try:
-        client.connect(str(socket_path()))
+        client.connect(str(path or socket_path()))
     except OSError:
         return False
     finally:
@@ -63,7 +65,7 @@ def can_connect() -> bool:
     return True
 
 
-def run_server() -> int:
+def run_server(path: Path) -> int:
     if os.environ.get("FAKE_CODEX_FAIL_START"):
         print("intentional startup failure", flush=True)
         return 23
@@ -72,14 +74,13 @@ def run_server() -> int:
         import time
 
         time.sleep(delay)
-    path = socket_path()
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     if path.exists() or path.is_socket():
         info = path.lstat()
         if not stat.S_ISSOCK(info.st_mode):
             print("refusing non-socket path", flush=True)
             return 24
-        if can_connect():
+        if can_connect(path):
             print("listener already exists", flush=True)
             return 25
         path.unlink()
@@ -143,14 +144,17 @@ def main() -> int:
             "appServerVersion": cli_version.split()[-1],
         }))
         return 0
-    if arguments[-3:] == ["app-server", "--listen", "unix://"]:
+    if len(arguments) >= 3 and arguments[-3:-1] == ["app-server", "--listen"]:
+        endpoint = arguments[-1]
+        if not endpoint.startswith("unix://"):
+            return 26
         destination = os.environ.get("FAKE_CODEX_SERVER_ARGS")
         if destination:
             Path(destination).write_text(
                 json.dumps(arguments[:-3]),
                 encoding="utf-8",
             )
-        return run_server()
+        return run_server(socket_path(endpoint))
     destination = os.environ.get("FAKE_CODEX_ARGS")
     if destination:
         Path(destination).write_text(json.dumps({
@@ -306,10 +310,10 @@ def test_start_status_restart_and_stop(
     assert json.loads(output)["status"] == "stopped"
 
 
-def test_plugin_configuration_change_requires_explicit_restart(
+def test_plugin_configuration_change_rolls_to_a_new_generation(
     server_environment: tuple[Path, dict[str, str]],
 ) -> None:
-    """A new TUI never silently reuses a stale plugin snapshot."""
+    """A new TUI gets fresh plugins without disconnecting the old server."""
     root, environment = server_environment
     started = ensure_server(environment)
     config_path = _paths(environment).codex_home / "config.toml"
@@ -318,15 +322,81 @@ def test_plugin_configuration_change_requires_explicit_restart(
         encoding="utf-8",
     )
 
-    with pytest.raises(CodexServerError, match="plugin or marketplace"):
-        ensure_server(environment)
+    rolled = ensure_server(environment)
 
-    preserved = get_status(environment)
-    assert preserved.pid == started.pid
-    restarted = restart_server(environment, allow_disconnect=True)
-    assert restarted.pid != started.pid
+    assert rolled.pid != started.pid
+    assert rolled.paths.endpoint != started.paths.endpoint
+    assert _process_group_exists(started.pid)
+    _wait_for_socket(started.paths.socket_path)
+    assert get_status(environment).pid == rolled.pid
     launches = (root / "launches.txt").read_text(encoding="utf-8").splitlines()
     assert len(launches) == 2
+
+
+def test_failed_rollover_preserves_the_current_generation(
+    server_environment: tuple[Path, dict[str, str]],
+) -> None:
+    """A failed replacement cannot redirect future clients from a live server."""
+    _root, environment = server_environment
+    first = ensure_server(environment)
+    config_path = first.paths.codex_home / "config.toml"
+    config_path.write_text(
+        '[plugins."sample@example"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+    environment["FAKE_CODEX_FAIL_START"] = "1"
+
+    with pytest.raises(CodexServerError, match="app-server"):
+        ensure_server(environment)
+
+    assert _paths(environment) == first.paths
+    assert _process_group_exists(first.pid or 0)
+    _wait_for_socket(first.paths.socket_path)
+
+
+def test_force_stop_cleans_every_retained_generation(
+    server_environment: tuple[Path, dict[str, str]],
+) -> None:
+    """Explicit cleanup stops old and current generations together."""
+    _root, environment = server_environment
+    first = ensure_server(environment)
+    config_path = first.paths.codex_home / "config.toml"
+    config_path.write_text(
+        '[plugins."sample@example"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+    second = ensure_server(environment)
+
+    stopped = stop_server(environment, allow_disconnect=True)
+
+    assert stopped.status == "stopped"
+    assert not _process_group_exists(first.pid or 0)
+    assert not _process_group_exists(second.pid or 0)
+    assert not first.paths.socket_path.exists()
+    assert not second.paths.socket_path.exists()
+    assert _paths(environment).generation is None
+
+
+def test_force_cleanup_releases_generation_capacity(
+    server_environment: tuple[Path, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stopped historical directories do not consume the live-server cap."""
+    _root, environment = server_environment
+    monkeypatch.setattr(server_models, "MAX_SERVER_GENERATIONS", 1)
+    first = ensure_server(environment)
+    config_path = first.paths.codex_home / "config.toml"
+    config_path.write_text(
+        '[plugins."sample@example"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(CodexServerError, match="generation limit"):
+        ensure_server(environment)
+
+    stop_server(environment, allow_disconnect=True)
+    second = ensure_server(environment)
+
+    assert second.paths.generation != first.paths.generation
 
 
 def test_non_plugin_configuration_change_reuses_server(

--- a/tests/test_codex_server_cli.py
+++ b/tests/test_codex_server_cli.py
@@ -15,8 +15,10 @@ from typing import BinaryIO, NoReturn, cast
 import pytest
 from click.testing import CliRunner
 
+import claude_code_tools.codex_server as codex_server
 import claude_code_tools.codex_server_cli as server_cli_module
 import claude_code_tools.codex_server_models as server_models
+from claude_code_tools.codex_server_generation import server_generation
 from claude_code_tools.codex_server import (
     CodexServerError,
     _paths,
@@ -36,6 +38,24 @@ _IMPORTED_FIXTURES = (
     _process_identity_without_ps_fixture,
     _server_environment_fixture,
 )
+
+
+def _desired_paths(environment: dict[str, str]) -> server_models.ServerPaths:
+    """Resolve the generation a fresh server launch would select."""
+    base = server_models.base_paths_from_env(environment)
+    codex_path = codex_server._resolve_codex(environment)
+    identity = codex_server._codex_executable_identity(codex_path)
+    child_env = codex_server._command_env(environment, base)
+    version = codex_server._require_compatible_codex(codex_path, child_env)
+    snapshot = codex_server._plugin_configuration_snapshot(base)
+    generation = server_generation(
+        codex_path,
+        identity,
+        version,
+        snapshot.fingerprint,
+        (),
+    )
+    return server_models.paths_for_generation(base, generation)
 
 
 @pytest.fixture(name="server_environment")
@@ -270,17 +290,73 @@ def test_codex_dynamic_starts_server_and_forwards_resume_arguments(
     )
     assert result.returncode == 0, result.stderr
     invocation = json.loads(arguments_path.read_text(encoding="utf-8"))
+    endpoint = invocation["callbackEndpoint"]
+    assert endpoint.startswith("unix://")
+    assert endpoint.endswith(".sock")
     assert invocation["args"] == [
         "--config",
-        ('shell_environment_policy.set.CCTOOLS_CODEX_CALLBACK_ENDPOINT="unix://"'),
+        (
+            "shell_environment_policy.set.CCTOOLS_CODEX_CALLBACK_ENDPOINT="
+            f"{json.dumps(endpoint)}"
+        ),
         "--remote",
-        "unix://",
+        endpoint,
         "resume",
         "--last",
     ]
-    assert invocation["callbackEndpoint"] == "unix://"
-    assert invocation["codexHome"] == environment["CODEX_HOME"]
+    assert Path(invocation["codexHome"]) == Path(environment["CODEX_HOME"]).resolve()
     assert get_status(environment).status == "running"
+
+
+def test_codex_dynamic_rolls_plugins_without_disconnecting_old_session(
+    server_environment: tuple[Path, dict[str, str]],
+) -> None:
+    """Two wrapper launches can use different live plugin generations."""
+    root, environment = server_environment
+    first_arguments = root / "first-arguments.json"
+    environment["FAKE_CODEX_ARGS"] = str(first_arguments)
+    command = [
+        sys.executable,
+        "-c",
+        "from claude_code_tools.codex_server_cli import dynamic_main; dynamic_main()",
+    ]
+    first_result = subprocess.run(
+        command,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=15,
+    )
+    assert first_result.returncode == 0, first_result.stderr
+    first_invocation = json.loads(first_arguments.read_text(encoding="utf-8"))
+    first_status = get_status(environment)
+
+    config_path = first_status.paths.codex_home / "config.toml"
+    config_path.write_text(
+        '[plugins."sample@example"]\nenabled = true\n',
+        encoding="utf-8",
+    )
+    second_arguments = root / "second-arguments.json"
+    environment["FAKE_CODEX_ARGS"] = str(second_arguments)
+    second_result = subprocess.run(
+        command,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=15,
+    )
+    assert second_result.returncode == 0, second_result.stderr
+    second_invocation = json.loads(second_arguments.read_text(encoding="utf-8"))
+    second_status = get_status(environment)
+
+    assert first_invocation["callbackEndpoint"] != second_invocation["callbackEndpoint"]
+    assert first_invocation["args"][3] == first_invocation["callbackEndpoint"]
+    assert second_invocation["args"][3] == second_invocation["callbackEndpoint"]
+    assert first_status.pid != second_status.pid
+    assert codex_server._process_group_exists(first_status.pid or 0)
+    _wait_for_socket(first_status.paths.socket_path)
 
 
 def test_codex_dynamic_propagates_plugin_configuration_to_server(
@@ -516,8 +592,11 @@ def test_external_server_is_rejected_and_never_stopped(
     """An uncertified listener remains outside helper control."""
     _root, environment = server_environment
     codex = environment["CCTOOLS_CODEX_BIN"]
+    paths = _desired_paths(environment)
+    assert paths.generation is not None
+    environment[server_models.CODEX_SERVER_GENERATION_ENV] = paths.generation
     external = subprocess.Popen(
-        [codex, "app-server", "--listen", "unix://"],
+        [codex, "app-server", "--listen", paths.endpoint],
         env=environment,
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
@@ -525,8 +604,8 @@ def test_external_server_is_rejected_and_never_stopped(
         start_new_session=True,
     )
     try:
-        _wait_for_socket(_paths(environment).socket_path)
-        with pytest.raises(CodexServerError, match="plugin snapshot"):
+        _wait_for_socket(paths.socket_path)
+        with pytest.raises(CodexServerError, match="version could not be verified"):
             ensure_server(environment)
 
         code, output = _invoke(["stop"], environment)
@@ -548,7 +627,7 @@ def test_stale_wrong_identity_with_live_group_is_retained_without_signalling(
 ) -> None:
     """PID reuse protection retains ambiguous group ownership without signals."""
     root, environment = server_environment
-    paths = _paths(environment)
+    paths = _desired_paths(environment)
     paths.runtime_dir.mkdir(mode=0o700, parents=True)
     innocent = subprocess.Popen(
         [sys.executable, "-c", "import time; time.sleep(300)"],
@@ -630,7 +709,7 @@ def test_stale_socket_and_malformed_state_are_recovered(
 ) -> None:
     """Safe stale artifacts do not permanently block a new server."""
     _root, environment = server_environment
-    paths = _paths(environment)
+    paths = _desired_paths(environment)
     paths.socket_path.parent.mkdir(mode=0o700, parents=True)
     stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     stale.bind(str(paths.socket_path))
@@ -650,7 +729,7 @@ def test_non_socket_endpoint_entry_is_preserved(
 ) -> None:
     """The helper refuses a regular file at Codex's socket path."""
     _root, environment = server_environment
-    socket_path = _paths(environment).socket_path
+    socket_path = _desired_paths(environment).socket_path
     socket_path.parent.mkdir(mode=0o700, parents=True)
     socket_path.write_text("keep me", encoding="utf-8")
 
@@ -665,7 +744,7 @@ def test_app_server_log_symlink_is_refused(
 ) -> None:
     """Starting the helper never follows or modifies an existing log symlink."""
     root, environment = server_environment
-    paths = _paths(environment)
+    paths = _desired_paths(environment)
     paths.runtime_dir.mkdir(mode=0o700, parents=True)
     target = root / "keep.txt"
     target.write_text("keep me", encoding="utf-8")

--- a/tests/test_codex_server_hardening.py
+++ b/tests/test_codex_server_hardening.py
@@ -20,6 +20,7 @@ from click.testing import CliRunner
 
 import claude_code_tools.codex_server as codex_server
 import claude_code_tools.codex_server_fingerprint as fingerprinting
+from claude_code_tools.codex_server_generation import server_generation
 from claude_code_tools.codex_server import (
     CodexServerError,
     _plugin_configuration_snapshot,
@@ -27,7 +28,6 @@ from claude_code_tools.codex_server import (
     _read_state,
     ensure_server,
     get_status,
-    restart_server,
     stop_server,
 )
 from claude_code_tools.codex_server_cli import server_cli
@@ -36,8 +36,11 @@ from claude_code_tools.codex_server_models import (
     LOG_TAIL_MAX_BYTES,
     STATE_MAX_BYTES,
     StateFileError,
+    ServerPaths,
+    base_paths_from_env,
     log_tail,
     read_state,
+    paths_for_generation,
     trim_oversized_log,
 )
 from claude_code_tools.codex_server_process import (
@@ -67,11 +70,18 @@ def control_path(name: str) -> Path:
     return Path(os.environ["CODEX_HOME"]) / "app-server-control" / name
 
 
-def can_connect() -> bool:
+def server_path() -> Path:
+    endpoint = os.environ.get("FAKE_CODEX_LISTEN_ENDPOINT", "unix://")
+    if endpoint != "unix://":
+        return Path(endpoint.removeprefix("unix://"))
+    return control_path("app-server-control.sock")
+
+
+def can_connect(path: Path | None = None) -> bool:
     client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     client.settimeout(0.2)
     try:
-        client.connect(str(control_path("app-server-control.sock")))
+        client.connect(str(path or control_path("app-server-control.sock")))
     except OSError:
         return False
     finally:
@@ -96,12 +106,12 @@ def emit_noise(total: int) -> None:
 
 def run_server() -> int:
     emit_noise(int(os.environ.get("FAKE_CODEX_STARTUP_NOISE", "0")))
-    path = control_path("app-server-control.sock")
+    path = server_path()
     version_path = control_path("server-version")
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     if path.exists() or path.is_socket():
         info = path.lstat()
-        if not stat.S_ISSOCK(info.st_mode) or can_connect():
+        if not stat.S_ISSOCK(info.st_mode) or can_connect(path):
             return 24
         path.unlink()
     launches = os.environ.get("FAKE_CODEX_LAUNCHES")
@@ -171,7 +181,10 @@ def main() -> int:
             value["appServerVersion"] = control_path("server-version").read_text()
         print(json.dumps(value))
         return 0
-    if arguments == ["app-server", "--listen", "unix://"]:
+    if len(arguments) == 3 and arguments[:2] == ["app-server", "--listen"]:
+        if not arguments[2].startswith("unix://"):
+            return 25
+        os.environ["FAKE_CODEX_LISTEN_ENDPOINT"] = arguments[2]
         if os.environ.get("FAKE_CODEX_NODE_WRAPPER"):
             return run_wrapper()
         return run_server()
@@ -182,6 +195,24 @@ def main() -> int:
 
 raise SystemExit(main())
 """
+
+
+def _desired_paths(environment: dict[str, str]) -> ServerPaths:
+    """Resolve the generation a fresh server launch would select."""
+    base = base_paths_from_env(environment)
+    codex_path = codex_server._resolve_codex(environment)
+    identity = codex_server._codex_executable_identity(codex_path)
+    child_env = codex_server._command_env(environment, base)
+    version = codex_server._require_compatible_codex(codex_path, child_env)
+    snapshot = codex_server._plugin_configuration_snapshot(base)
+    generation = server_generation(
+        codex_path,
+        identity,
+        version,
+        snapshot.fingerprint,
+        (),
+    )
+    return paths_for_generation(base, generation)
 
 
 class _RecordingDigest:
@@ -736,52 +767,46 @@ def test_callback_version_floor_obeys_semver_prereleases(
     assert not (root / "launches.txt").exists()
 
 
-def test_helper_with_unknown_server_version_is_not_certified(
+def test_generated_helper_is_certified_from_its_pinned_executable(
     hardened_environment: tuple[Path, dict[str, str]],
 ) -> None:
-    """A helper cannot succeed without a final certified server version."""
-    root, environment = hardened_environment
+    """A generated socket need not rely on the default daemon-version probe."""
+    _root, environment = hardened_environment
     environment["FAKE_CODEX_HIDE_SERVER_VERSION"] = "1"
 
-    with pytest.raises(CodexServerError, match="version.*uncertified"):
-        ensure_server(environment)
+    status = ensure_server(environment)
 
-    assert len((root / "launches.txt").read_text().splitlines()) == 1
-    assert get_status(environment).status == "stopped"
+    assert status.status == "running"
+    assert status.server_version == "9.9.9"
 
 
-def test_helper_requires_explicit_restart_after_cli_changes(
+def test_helper_rolls_generations_after_cli_changes(
     hardened_environment: tuple[Path, dict[str, str]],
 ) -> None:
-    """CLI changes never silently disconnect attached remote TUIs."""
+    """CLI changes select a fresh server and preserve attached remote TUIs."""
     root, environment = hardened_environment
     first = ensure_server(environment)
     environment["FAKE_CODEX_VERSION"] = "codex-cli 9.9.10"
-    with pytest.raises(CodexServerError, match="disconnect every"):
-        ensure_server(environment)
-    assert get_status(environment).pid == first.pid
-    second = restart_server(environment, allow_disconnect=True)
+    second = ensure_server(environment)
     assert second.pid != first.pid
-    assert second.server_version == "9.9.10"
+    assert process_group_exists(first.pid)
 
     replacement = root / "replacement-codex"
     shutil.copy2(environment["CCTOOLS_CODEX_BIN"], replacement)
     replacement.chmod(0o755)
     environment["CCTOOLS_CODEX_BIN"] = str(replacement)
-    with pytest.raises(CodexServerError, match="disconnect every"):
-        ensure_server(environment)
-    assert get_status(environment).pid == second.pid
-    third = restart_server(environment, allow_disconnect=True)
+    third = ensure_server(environment)
 
     assert third.pid != second.pid
+    assert process_group_exists(second.pid)
     assert third.codex_path == str(replacement.resolve())
     assert len((root / "launches.txt").read_text().splitlines()) == 3
 
 
-def test_same_path_executable_replacement_is_not_certified(
+def test_same_path_executable_replacement_rolls_generation(
     hardened_environment: tuple[Path, dict[str, str]],
 ) -> None:
-    """An inode replacement cannot inherit the old executable identity."""
+    """An inode replacement cannot inherit the old server generation."""
     root, environment = hardened_environment
     first = ensure_server(environment)
     codex = Path(environment["CCTOOLS_CODEX_BIN"])
@@ -790,10 +815,10 @@ def test_same_path_executable_replacement_is_not_certified(
     incoming.chmod(0o755)
     os.replace(incoming, codex)
 
-    with pytest.raises(CodexServerError, match="executable was replaced"):
-        ensure_server(environment)
+    second = ensure_server(environment)
 
-    assert get_status(environment).pid == first.pid
+    assert second.pid != first.pid
+    assert process_group_exists(first.pid)
 
 
 def test_external_server_without_plugin_certification_is_rejected(
@@ -802,8 +827,9 @@ def test_external_server_without_plugin_certification_is_rejected(
     """Even version-matched listeners cannot prove their plugin snapshot."""
     _root, environment = hardened_environment
     codex = environment["CCTOOLS_CODEX_BIN"]
+    paths = _desired_paths(environment)
     external = subprocess.Popen(
-        [codex, "app-server", "--listen", "unix://"],
+        [codex, "app-server", "--listen", paths.endpoint],
         env=environment,
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
@@ -811,21 +837,9 @@ def test_external_server_without_plugin_certification_is_rejected(
         start_new_session=True,
     )
     try:
-        _wait_for_socket(_paths(environment).socket_path)
-        with pytest.raises(CodexServerError, match="plugin snapshot"):
+        _wait_for_socket(paths.socket_path)
+        with pytest.raises(CodexServerError, match="version could not be verified"):
             ensure_server(environment)
-        assert external.poll() is None
-
-        changed = dict(environment)
-        changed["FAKE_CODEX_VERSION"] = "codex-cli 9.9.10"
-        with pytest.raises(CodexServerError, match="does not match"):
-            ensure_server(changed)
-        assert external.poll() is None
-
-        unknown = dict(environment)
-        unknown["FAKE_CODEX_HIDE_SERVER_VERSION"] = "1"
-        with pytest.raises(CodexServerError, match="could not be verified"):
-            ensure_server(unknown)
         assert external.poll() is None
     finally:
         os.killpg(external.pid, signal.SIGTERM)
@@ -838,7 +852,7 @@ def test_accepting_uncertified_socket_is_refused_without_spawning(
 ) -> None:
     """A generic protocol failure cannot launch over an accepting socket."""
     _root, environment = hardened_environment
-    paths = _paths(environment)
+    paths = _desired_paths(environment)
     paths.socket_path.parent.mkdir(parents=True)
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(paths.socket_path))
@@ -849,24 +863,6 @@ def test_accepting_uncertified_socket_is_refused_without_spawning(
         nonlocal spawned
         spawned = True
 
-    diagnostic = subprocess.CompletedProcess(
-        args=[],
-        returncode=1,
-        stdout="",
-        stderr="temporary protocol failure",
-    )
-    monkeypatch.setattr(codex_server, "_resolve_codex", lambda _env: "/codex")
-    monkeypatch.setattr(
-        codex_server,
-        "_codex_executable_identity",
-        lambda _path: "verified executable",
-    )
-    monkeypatch.setattr(
-        codex_server,
-        "_require_compatible_codex",
-        lambda _path, _env: "codex-cli 9.9.9",
-    )
-    monkeypatch.setattr(codex_server, "_run_command", lambda *_args: diagnostic)
     monkeypatch.setattr(codex_server, "spawn_supervisor", spawn)
     try:
         with pytest.raises(CodexServerError, match="version could not be verified"):
@@ -890,7 +886,12 @@ def test_replacement_listener_cannot_inherit_helper_certification(
     paths = _paths(environment)
     paths.socket_path.unlink()
     replacement = subprocess.Popen(
-        [environment["CCTOOLS_CODEX_BIN"], "app-server", "--listen", "unix://"],
+        [
+            environment["CCTOOLS_CODEX_BIN"],
+            "app-server",
+            "--listen",
+            paths.endpoint,
+        ],
         env=environment,
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
@@ -926,7 +927,7 @@ def test_invalid_home_and_fifo_log_fail_without_traceback_or_blocking(
         assert "not a directory" in result.output
         assert "Traceback" not in result.output
 
-    paths = _paths(environment)
+    paths = _desired_paths(environment)
     paths.runtime_dir.mkdir(mode=0o700, parents=True)
     os.mkfifo(paths.log_path, mode=0o600)
     result = subprocess.run(
@@ -960,7 +961,11 @@ def test_hostile_config_and_state_are_prompt_diagnostic_failures(
 ) -> None:
     """Hostile parsed files fail without following, blocking, or traceback."""
     root, environment = hardened_environment
-    paths = _paths(environment)
+    paths = (
+        _paths(environment)
+        if input_name == "configuration"
+        else _desired_paths(environment)
+    )
     if input_name == "configuration":
         paths.codex_home.mkdir(parents=True, exist_ok=True)
         hostile = paths.codex_home / "config.toml"

--- a/tests/test_codex_server_probe_safety.py
+++ b/tests/test_codex_server_probe_safety.py
@@ -174,12 +174,17 @@ def _arrange_live_helper(
     sleeps: list[float] = []
     commands: list[Sequence[str]] = []
 
-    def run_command(
-        command: Sequence[str],
-        _env: Mapping[str, str],
-    ) -> Diagnostic:
-        commands.append(command)
-        return diagnostics()
+    def probe(*_args: object) -> ServerProbe:
+        commands.append(("socket-probe",))
+        diagnostic = diagnostics()
+        if diagnostic is None or diagnostic.returncode != 0:
+            return ServerProbe(running=False)
+        return ServerProbe(
+            running=True,
+            server_version=codex_server._server_version_from_output(diagnostic.stdout),
+            method="socket",
+            accepting=True,
+        )
 
     monkeypatch.setattr(codex_server, "_resolve_codex", lambda _env: state.codex_path)
     monkeypatch.setattr(
@@ -208,7 +213,7 @@ def _arrange_live_helper(
         "_listener_matches_worker",
         lambda _state, _paths: True,
     )
-    monkeypatch.setattr(codex_server, "_run_command", run_command)
+    monkeypatch.setattr(codex_server, "_probe_server", probe)
     monkeypatch.setattr(
         codex_server,
         "_plugin_configuration_snapshot",
@@ -348,6 +353,7 @@ def test_plugin_change_during_reuse_probe_is_revalidated(
     snapshots = iter(
         [
             _snapshot(),
+            _snapshot(),
             _snapshot(generation="changed during probe"),
         ]
     )
@@ -370,7 +376,11 @@ def test_plugin_change_during_reuse_probe_is_revalidated(
     with pytest.raises(CodexServerError, match="changed during app-server reuse"):
         ensure_server(environment)
 
-    assert observed == ["stable generation", "changed during probe"]
+    assert observed == [
+        "stable generation",
+        "stable generation",
+        "changed during probe",
+    ]
 
 
 def test_listener_replacement_during_final_snapshot_is_not_certified(
@@ -393,7 +403,7 @@ def test_listener_replacement_during_final_snapshot_is_not_certified(
     ) -> codex_server._PluginSnapshot:
         nonlocal replaced, snapshots
         snapshots += 1
-        if snapshots == 2:
+        if snapshots == 3:
             replaced = True
         return _snapshot()
 
@@ -412,7 +422,7 @@ def test_listener_replacement_during_final_snapshot_is_not_certified(
     with pytest.raises(CodexServerError, match="changed during app-server reuse"):
         ensure_server(environment)
 
-    assert snapshots == 2
+    assert snapshots == 3
     assert listener_checks >= 3
 
 
@@ -437,18 +447,17 @@ def test_final_reuse_revalidates_server_version(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A replaced app server cannot reuse an earlier version probe."""
-    replacement = subprocess.CompletedProcess(
-        args=[],
-        returncode=0,
-        stdout=json.dumps({"appServerVersion": "9.9.10"}),
-        stderr="",
-    )
-    diagnostics = iter([_success(), replacement])
+    """A changed selected Codex version cannot inherit certification."""
     environment, _sleeps, _commands = _arrange_live_helper(
         monkeypatch,
         tmp_path,
-        lambda: next(diagnostics),
+        _success,
+    )
+    versions = iter(["codex-cli 9.9.9", "codex-cli 9.9.10"])
+    monkeypatch.setattr(
+        codex_server,
+        "_require_compatible_codex",
+        lambda _path, _env: next(versions),
     )
 
     with pytest.raises(CodexServerError, match="version"):
@@ -490,7 +499,7 @@ def test_final_reuse_revalidates_worker_liveness(
     ) -> codex_server._PluginSnapshot:
         nonlocal snapshots, vanished
         snapshots += 1
-        if snapshots == 2:
+        if snapshots == 3:
             vanished = True
         return _snapshot()
 
@@ -517,6 +526,7 @@ def test_plugin_change_during_startup_is_not_certified(
     )
     snapshots = iter(
         [
+            _snapshot("startup snapshot", "startup generation"),
             _snapshot("startup snapshot", "startup generation"),
             _snapshot("startup snapshot", "changed during startup"),
         ]
@@ -592,6 +602,7 @@ def test_plugin_change_during_startup_is_not_certified(
 
     assert observed == [
         "startup generation",
+        "startup generation",
         "changed during startup",
     ]
     assert terminated == [starting]
@@ -620,7 +631,7 @@ def test_listener_replacement_during_startup_snapshot_is_not_certified(
     ) -> codex_server._PluginSnapshot:
         nonlocal replaced, snapshots
         snapshots += 1
-        if snapshots == 2:
+        if snapshots == 3:
             replaced = True
         return _snapshot("startup snapshot", "startup generation")
 
@@ -677,7 +688,7 @@ def test_listener_replacement_during_startup_snapshot_is_not_certified(
     with pytest.raises(CodexServerError, match="changed during startup checks"):
         ensure_server({"CODEX_HOME": str(tmp_path / "home")})
 
-    assert snapshots == 2
+    assert snapshots == 3
     assert terminated == [starting]
     assert len(removals) == 1
 
@@ -779,11 +790,11 @@ def test_listener_replacement_after_running_state_is_not_certified(
     assert terminated == [starting]
 
 
-def test_upgrade_metadata_refuses_automatic_rollover(
+def test_generation_collision_refuses_mismatched_metadata(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A CLI version change cannot silently disconnect remote TUIs."""
+    """Mismatched state at a selected generation fails closed."""
     state = _live_state(codex_version="codex-cli 9.9.8")
     probes = 0
 
@@ -828,7 +839,7 @@ def test_upgrade_metadata_refuses_automatic_rollover(
     monkeypatch.setattr(codex_server, "_remove_state", _forbid_mutation)
     monkeypatch.setattr(codex_server, "spawn_supervisor", _forbid_mutation)
 
-    with pytest.raises(CodexServerError, match="disconnect every"):
+    with pytest.raises(CodexServerError, match="Codex CLI version changed"):
         ensure_server({"CODEX_HOME": str(tmp_path / "home")})
 
     assert probes == 1

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.15.0"
+version = "1.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
## Summary

- run each Codex app-server configuration as a deterministic, versioned generation
- let `codex-dynamic` start or reuse the required generation without disconnecting existing sessions
- retain old endpoints for active TUIs and workflow callbacks while publishing new generations atomically
- add bounded cleanup, fail-closed rollout checks, comprehensive tests, and user-facing documentation
- bump the dynamic-workflow plugin to 0.2.1 for the updated guidance

## Verification

- `pytest -q tests/test_codex_server*.py` — 137 passed, 2 skipped
- dynamic-workflow typecheck and tests — 139 passed
- Ruff lint and format checks — passed
- Pyright — passed
- `git diff --check` — passed
- Starlight documentation build — passed
- full Python suite — 1077 passed, 7 skipped; 5 pre-existing unrelated failures in legacy search and tmux-controller tests