### PR TITLE
Prevent inactive Codex server history from exhausting generation caps

### DIFF
--- a/claude_code_tools/codex_server_models.py
+++ b/claude_code_tools/codex_server_models.py
@@ -444,7 +444,7 @@ def clear_current_generation(base: ServerPaths) -> None:
 
 
 def all_server_paths(base: ServerPaths) -> list[ServerPaths]:
-    """Return bounded helper generations eligible for explicit cleanup."""
+    """Return bounded helper generations retaining state or a socket."""
     info = _lstat(base.runtime_dir)
     if info is None:
         return [base]
@@ -474,12 +474,12 @@ def all_server_paths(base: ServerPaths) -> list[ServerPaths]:
             raise CodexServerError("app-server runtime changed during inspection")
         with os.scandir(directory_fd) as entries:
             for entry in entries:
-                scanned += 1
-                if scanned > MAX_SERVER_DIRECTORY_ENTRIES:
-                    raise CodexServerError("too many app-server runtime entries")
                 try:
                     generation = validate_generation(entry.name)
                 except ValueError:
+                    scanned += 1
+                    if scanned > MAX_SERVER_DIRECTORY_ENTRIES:
+                        raise CodexServerError("too many app-server runtime entries")
                     continue
                 try:
                     entry_info = entry.stat(follow_symlinks=False)
@@ -497,6 +497,15 @@ def all_server_paths(base: ServerPaths) -> list[ServerPaths]:
                     raise CodexServerError(
                         f"app-server generation is owned by another user: {entry.name}"
                     )
+                paths = paths_for_generation(base, generation)
+                if (
+                    _lstat(paths.state_path) is None
+                    and _lstat(paths.socket_path) is None
+                ):
+                    continue
+                scanned += 1
+                if scanned > MAX_SERVER_DIRECTORY_ENTRIES:
+                    raise CodexServerError("too many app-server runtime entries")
                 generations.append(generation)
                 if len(generations) > MAX_SERVER_GENERATION_DIRECTORIES:
                     raise CodexServerError(
@@ -510,13 +519,10 @@ def all_server_paths(base: ServerPaths) -> list[ServerPaths]:
 def require_generation_capacity(base: ServerPaths, generation: str) -> None:
     """Bound retained servers before creating another generation."""
     target = paths_for_generation(base, generation)
-    if _lstat(target.runtime_dir) is not None:
+    retained = all_server_paths(base)[1:]
+    if any(paths.generation == target.generation for paths in retained):
         return
-    retained = sum(
-        _lstat(paths.state_path) is not None or _lstat(paths.socket_path) is not None
-        for paths in all_server_paths(base)[1:]
-    )
-    if retained >= MAX_SERVER_GENERATIONS:
+    if len(retained) >= MAX_SERVER_GENERATIONS:
         raise CodexServerError(
             "app-server generation limit reached; exit callback-ready sessions "
             "and run `codex-server stop --force` before launching another"

--- a/tests/test_codex_server.py
+++ b/tests/test_codex_server.py
@@ -399,6 +399,62 @@ def test_force_cleanup_releases_generation_capacity(
     assert second.paths.generation != first.paths.generation
 
 
+def test_inactive_history_does_not_block_start_or_force_cleanup(
+    server_environment: tuple[Path, dict[str, str]],
+) -> None:
+    """Stopped log directories do not consume bounded live scan entries."""
+    _root, environment = server_environment
+    base = server_models.base_paths_from_env(environment)
+    base.runtime_dir.mkdir(mode=0o700, parents=True)
+    histories = server_models.MAX_SERVER_GENERATION_DIRECTORIES + 1
+    for index in range(histories):
+        runtime = base.runtime_dir / f"{index:024x}"
+        runtime.mkdir(mode=0o700)
+        (runtime / "lifecycle.lock").write_text("", encoding="utf-8")
+        (runtime / "app-server.log").write_text("stopped\n", encoding="utf-8")
+
+    started = ensure_server(environment)
+    stopped = stop_server(environment, allow_disconnect=True)
+
+    assert started.status == "running"
+    assert stopped.status == "stopped"
+    assert (base.runtime_dir / f"{0:024x}").is_dir()
+
+
+def test_empty_existing_target_does_not_bypass_live_generation_cap(
+    server_environment: tuple[Path, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An inactive target directory still requires free live capacity."""
+    _root, environment = server_environment
+    monkeypatch.setattr(server_models, "MAX_SERVER_GENERATIONS", 1)
+    base = server_models.base_paths_from_env(environment)
+    live = server_models.paths_for_generation(base, "a" * 24)
+    target = server_models.paths_for_generation(base, "b" * 24)
+    live.runtime_dir.mkdir(mode=0o700, parents=True)
+    live.state_path.write_text("{}", encoding="utf-8")
+    target.runtime_dir.mkdir(mode=0o700)
+
+    with pytest.raises(CodexServerError, match="generation limit"):
+        server_models.require_generation_capacity(base, target.generation or "")
+
+
+def test_generation_scan_still_bounds_unrecognized_runtime_entries(
+    server_environment: tuple[Path, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ignoring inactive history does not unbound unrelated root entries."""
+    _root, environment = server_environment
+    monkeypatch.setattr(server_models, "MAX_SERVER_DIRECTORY_ENTRIES", 1)
+    base = server_models.base_paths_from_env(environment)
+    base.runtime_dir.mkdir(mode=0o700, parents=True)
+    (base.runtime_dir / "first").write_text("", encoding="utf-8")
+    (base.runtime_dir / "second").write_text("", encoding="utf-8")
+
+    with pytest.raises(CodexServerError, match="too many app-server runtime"):
+        server_models.all_server_paths(base)
+
+
 def test_non_plugin_configuration_change_reuses_server(
     server_environment: tuple[Path, dict[str, str]],
 ) -> None:


### PR DESCRIPTION
## Summary

Follow-up to the automated review on #101.

- exclude stopped generation directories that retain neither state nor a socket from live and cleanup candidate limits
- preserve type, ownership, unsafe-entry, live-generation, and unrelated-root-entry bounds
- prevent an existing empty generation directory from bypassing the 64-live-generation cap
- add regressions covering 257 inactive histories, forced cleanup, and bounded hostile root entries

The fix performs no deletion, renaming, or lifecycle redesign. Historical logs remain intact.

## Verification

- `pytest -q tests/test_codex_server*.py` — 140 passed, 2 skipped
- Ruff lint and format checks — passed
- Pyright — passed
- `git diff --check` — passed
- focused read-only local Codex review — no findings