### PR TITLE
Fix Codex app-server upgrade cleanup and import

### DIFF
--- a/claude_code_tools/codex_server.py
+++ b/claude_code_tools/codex_server.py
@@ -14,11 +14,13 @@ import struct
 import subprocess
 import sys
 import time
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import replace
 from pathlib import Path
 from typing import Iterator, Mapping, Sequence
 
+from claude_code_tools import codex_server_retry
+from claude_code_tools.codex_server_legacy import reauthenticate_legacy_state
 from claude_code_tools.codex_server_fingerprint import (
     PluginSnapshot as _PluginSnapshot,
     hash_plugin_tree as _hash_plugin_tree,  # noqa: F401
@@ -78,6 +80,7 @@ from claude_code_tools.codex_server_reuse import (
     disconnect_refusal as _disconnect_refusal,
     helper_restart_reason as _reuse_restart_reason,
     require_external_compatible as _external_compatible,
+    same_server_launch as _same_server_launch,
 )
 
 
@@ -148,6 +151,22 @@ def _lifecycle_lock(paths: ServerPaths) -> Iterator[None]:
         except OSError:
             pass
         os.close(fd)
+
+
+@contextmanager
+def _reserved_generation_lifecycle(
+    base: ServerPaths,
+    paths: ServerPaths,
+    generation: str,
+) -> Iterator[None]:
+    """Reserve capacity before releasing the base lifecycle lock."""
+    generation_lock = ExitStack()
+    with _lifecycle_lock(base):
+        require_generation_capacity(base, generation)
+        prepare_runtime(paths)
+        generation_lock.enter_context(_lifecycle_lock(paths))
+    with generation_lock:
+        yield
 
 
 def _resolve_codex(env: Mapping[str, str]) -> str:
@@ -519,6 +538,7 @@ def get_status(env: Mapping[str, str] | None = None) -> ServerStatus:
     except StateFileError as exc:
         state = None
         state_error = str(exc)
+    state = reauthenticate_legacy_state(paths, state, _socket_peer_pid)
     probe = _probe_server(codex_path, child_env, paths)
     return _status_from(paths, state, probe, state_error)
 
@@ -557,31 +577,10 @@ def _require_unchanged_plugin_snapshot(
 ) -> None:
     """Reject a lifecycle decision made across a plugin input change."""
     if _plugin_configuration_snapshot(paths, codex_options) != expected:
-        raise CodexServerError(
+        raise codex_server_retry.PluginSnapshotChangedError(
             "the Codex plugin or marketplace snapshot changed during "
             f"{operation}; retry after plugin updates finish"
         )
-
-
-def _same_server_launch(expected: OwnedServer, current: OwnedServer) -> bool:
-    """Return whether two states name the same exact supervised launch."""
-    return (
-        current.pid,
-        current.pgid,
-        current.process_started_at,
-        current.launch_token,
-        current.worker_pid,
-        current.worker_pgid,
-        current.worker_started_at,
-    ) == (
-        expected.pid,
-        expected.pgid,
-        expected.process_started_at,
-        expected.launch_token,
-        expected.worker_pid,
-        expected.worker_pgid,
-        expected.worker_started_at,
-    )
 
 
 def _certify_helper_boundary(
@@ -724,6 +723,7 @@ def _wait_for_process_group_exit(
     )
 
 
+@codex_server_retry.retry_plugin_snapshot_changes
 def ensure_server(
     env: Mapping[str, str] | None = None,
     *,
@@ -745,16 +745,15 @@ def ensure_server(
         codex_options,
     )
     paths = paths_for_generation(base_paths, generation)
-    require_generation_capacity(base_paths, generation)
-    child_env = _command_env(active_env, paths)
-    child_env[CODEX_SERVER_OPTIONS_ENV] = json.dumps(
-        list(codex_options),
-        separators=(",", ":"),
-    )
-    with _lifecycle_lock(paths):
+    with _reserved_generation_lifecycle(base_paths, paths, generation):
+        child_env = _command_env(active_env, paths)
+        child_env[CODEX_SERVER_OPTIONS_ENV] = json.dumps(
+            list(codex_options),
+            separators=(",", ":"),
+        )
         locked_snapshot = _plugin_configuration_snapshot(paths, codex_options)
         if locked_snapshot.fingerprint != plugin_snapshot.fingerprint:
-            raise CodexServerError(
+            raise codex_server_retry.PluginSnapshotChangedError(
                 "the Codex plugin or marketplace snapshot changed during "
                 "app-server generation selection; retry after updates finish"
             )
@@ -766,6 +765,7 @@ def ensure_server(
         except StateFileError as exc:
             state = None
             state_error = str(exc)
+        state = reauthenticate_legacy_state(paths, state, _socket_peer_pid)
 
         probe = _probe_server(codex_path, child_env, paths)
         status = _status_from(paths, state, probe, state_error)
@@ -938,6 +938,7 @@ def _stop_server_at(
                 ) from exc
             _quarantine_invalid_state(paths)
             state = None
+        state = reauthenticate_legacy_state(paths, state, _socket_peer_pid)
 
         if state is not None and _state_is_owned(state):
             if not allow_disconnect:

--- a/claude_code_tools/codex_server_fingerprint.py
+++ b/claude_code_tools/codex_server_fingerprint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import os
@@ -12,6 +13,7 @@ from pathlib import Path
 from typing import Protocol, Sequence
 
 from claude_code_tools.codex_server_models import CodexServerError, ServerPaths
+from claude_code_tools.codex_server_retry import PluginSnapshotChangedError
 
 
 PLUGIN_CONFIG_MAX_BYTES = 1024 * 1024
@@ -27,6 +29,16 @@ PLUGIN_APP_FEATURES = (
     "plugin_sharing",
     "remote_plugin",
 )
+_PLUGIN_MUTATION_ERRNOS = {
+    errno.ELOOP,
+    errno.ENOENT,
+    errno.ENOTDIR,
+    errno.ESTALE,
+}
+_PLUGIN_PATH_RACE_ERRNOS = {
+    errno.ENOTDIR,
+    errno.ESTALE,
+}
 
 
 @dataclass(frozen=True)
@@ -137,8 +149,17 @@ def read_plugin_configuration(path: Path) -> tuple[dict[str, object], str]:
     try:
         fd = os.open(path, flags)
     except FileNotFoundError:
-        return {}, _missing_generation(path)
+        generation = _missing_generation(path)
+        _require_missing_path(
+            path,
+            f"Codex plugin configuration changed while being read: {path}",
+        )
+        return {}, generation
     except OSError as exc:
+        if exc.errno in _PLUGIN_PATH_RACE_ERRNOS:
+            raise PluginSnapshotChangedError(
+                f"Codex plugin configuration changed while being read: {path}"
+            ) from exc
         raise CodexServerError(
             f"cannot read Codex plugin configuration {path}: {exc}"
         ) from exc
@@ -151,10 +172,19 @@ def read_plugin_configuration(path: Path) -> tuple[dict[str, object], str]:
         data = _read_bounded(fd, PLUGIN_CONFIG_MAX_BYTES)
         generation = _stat_generation(os.fstat(fd))
         if generation != _stat_generation(initial_info):
-            raise CodexServerError(
+            raise PluginSnapshotChangedError(
                 f"Codex plugin configuration changed while being read: {path}"
             )
+        _require_unchanged_path(
+            path,
+            initial_info,
+            f"Codex plugin configuration changed while being read: {path}",
+        )
     except OSError as exc:
+        if exc.errno in _PLUGIN_MUTATION_ERRNOS:
+            raise PluginSnapshotChangedError(
+                f"Codex plugin configuration changed while being read: {path}"
+            ) from exc
         raise CodexServerError(
             f"cannot read Codex plugin configuration {path}: {exc}"
         ) from exc
@@ -194,16 +224,35 @@ def hash_plugin_tree(root: Path, label: Path, digest: HashWriter) -> str:
         root_fd = os.open(root, flags)
     except FileNotFoundError:
         digest.update(b"missing:" + os.fsencode(str(label)) + b"\0")
-        return _missing_generation(root)
+        generation = _missing_generation(root)
+        _require_missing_path(
+            root,
+            f"Codex plugin cache root changed while being read: {root!r}",
+        )
+        return generation
     except OSError as exc:
+        if exc.errno in _PLUGIN_PATH_RACE_ERRNOS:
+            raise PluginSnapshotChangedError(
+                f"Codex plugin cache root changed while being read: {root!r}"
+            ) from exc
         raise CodexServerError(
             f"cannot inspect Codex plugin cache {root!r}: {exc}"
         ) from exc
     generation = hashlib.sha256()
     budget = [0, 0]
     try:
+        initial_info = os.fstat(root_fd)
         _hash_directory(root_fd, label, digest, generation, budget, 0)
+        _require_unchanged_path(
+            root,
+            initial_info,
+            f"Codex plugin cache root changed while being read: {root!r}",
+        )
     except OSError as exc:
+        if exc.errno in _PLUGIN_MUTATION_ERRNOS:
+            raise PluginSnapshotChangedError(
+                f"Codex plugin cache changed while being read: {root!r}"
+            ) from exc
         raise CodexServerError(
             f"cannot inspect Codex plugin cache {root!r}: {exc}"
         ) from exc
@@ -260,7 +309,7 @@ def _hash_directory(
             child_fd = os.open(name, _directory_flags(), dir_fd=directory_fd)
             try:
                 if _stat_generation(os.fstat(child_fd)) != _stat_generation(info):
-                    raise CodexServerError(
+                    raise PluginSnapshotChangedError(
                         "Codex plugin directory changed while being read: "
                         f"{child_relative!r}"
                     )
@@ -287,7 +336,7 @@ def _hash_directory(
         else:
             _update_entry(digest, generation, b"special", child_relative, info)
     if _stat_generation(os.fstat(directory_fd)) != _stat_generation(initial_info):
-        raise CodexServerError(
+        raise PluginSnapshotChangedError(
             f"Codex plugin directory changed while being read: {relative!r}"
         )
 
@@ -307,11 +356,11 @@ def _hash_regular_file(
     try:
         initial_info = os.fstat(fd)
         if not stat.S_ISREG(initial_info.st_mode):
-            raise CodexServerError(
-                f"Codex plugin artifact is not a regular file: {relative!r}"
+            raise PluginSnapshotChangedError(
+                f"Codex plugin artifact changed while being read: {relative!r}"
             )
         if _stat_generation(initial_info) != _stat_generation(expected):
-            raise CodexServerError(
+            raise PluginSnapshotChangedError(
                 f"Codex plugin artifact changed while being read: {relative!r}"
             )
         _hash_regular_descriptor(
@@ -349,13 +398,18 @@ def _hash_symlink_target(
             + target_generation.encode()
             + b"\0"
         )
+        _require_missing_path_at(
+            directory_fd,
+            name,
+            f"Codex plugin symlink target changed: {relative!r}",
+        )
         return
     if stat.S_ISDIR(expected.st_mode):
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
         fd = os.open(name, flags, dir_fd=directory_fd)
         try:
             if _stat_generation(os.fstat(fd)) != _stat_generation(expected):
-                raise CodexServerError(
+                raise PluginSnapshotChangedError(
                     f"Codex plugin symlink target changed: {relative!r}"
                 )
             _hash_directory(
@@ -365,6 +419,12 @@ def _hash_symlink_target(
                 generation,
                 budget,
                 depth + 1,
+            )
+            _require_unchanged_path_at(
+                directory_fd,
+                name,
+                expected,
+                f"Codex plugin symlink target changed: {relative!r}",
             )
         finally:
             os.close(fd)
@@ -377,12 +437,20 @@ def _hash_symlink_target(
             relative,
             expected,
         )
+        _require_unchanged_path_at(
+            directory_fd,
+            name,
+            expected,
+            f"Codex plugin symlink target changed: {relative!r}",
+        )
         return
     fd = os.open(name, os.O_RDONLY | os.O_NONBLOCK, dir_fd=directory_fd)
     try:
         initial_info = os.fstat(fd)
         if _stat_generation(initial_info) != _stat_generation(expected):
-            raise CodexServerError(f"Codex plugin symlink target changed: {relative!r}")
+            raise PluginSnapshotChangedError(
+                f"Codex plugin symlink target changed: {relative!r}"
+            )
         _hash_regular_descriptor(
             fd,
             relative / "<symlink-target>",
@@ -390,6 +458,12 @@ def _hash_symlink_target(
             digest,
             generation,
             budget,
+        )
+        _require_unchanged_path_at(
+            directory_fd,
+            name,
+            expected,
+            f"Codex plugin symlink target changed: {relative!r}",
         )
     finally:
         os.close(fd)
@@ -412,18 +486,18 @@ def _hash_regular_descriptor(
     while remaining:
         chunk = os.read(fd, min(65_536, remaining))
         if not chunk:
-            raise CodexServerError(
+            raise PluginSnapshotChangedError(
                 f"Codex plugin artifact changed while being read: {relative!r}"
             )
         digest.update(chunk)
         remaining -= len(chunk)
     digest.update(b"\0")
     if os.read(fd, 1):
-        raise CodexServerError(
+        raise PluginSnapshotChangedError(
             f"Codex plugin artifact changed while being read: {relative!r}"
         )
     if _stat_generation(os.fstat(fd)) != _stat_generation(initial_info):
-        raise CodexServerError(
+        raise PluginSnapshotChangedError(
             f"Codex plugin artifact changed while being read: {relative!r}"
         )
 
@@ -448,6 +522,81 @@ def _update_entry(
     generation.update(record)
 
 
+def _require_unchanged_path(
+    path: Path,
+    expected: os.stat_result,
+    message: str,
+) -> None:
+    """Reject atomic pathname replacement hidden by an open descriptor."""
+    try:
+        current = path.lstat()
+    except OSError as exc:
+        if exc.errno in _PLUGIN_MUTATION_ERRNOS:
+            raise PluginSnapshotChangedError(message) from exc
+        raise
+    if _stat_generation(current) != _stat_generation(expected):
+        raise PluginSnapshotChangedError(message)
+
+
+def _require_missing_path(path: Path, message: str) -> None:
+    """Require an input path to remain absent after parent-generation capture."""
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        if exc.errno in _PLUGIN_MUTATION_ERRNOS:
+            raise PluginSnapshotChangedError(message) from exc
+        raise
+    raise PluginSnapshotChangedError(message)
+
+
+def _require_unchanged_path_at(
+    directory_fd: int,
+    name: str,
+    expected: os.stat_result,
+    message: str,
+    *,
+    follow_symlinks: bool = True,
+) -> None:
+    """Reject replacement of a followed path relative to a pinned directory."""
+    try:
+        current = os.stat(
+            name,
+            dir_fd=directory_fd,
+            follow_symlinks=follow_symlinks,
+        )
+    except OSError as exc:
+        if exc.errno in _PLUGIN_MUTATION_ERRNOS:
+            raise PluginSnapshotChangedError(message) from exc
+        raise
+    if _stat_generation(current) != _stat_generation(expected):
+        raise PluginSnapshotChangedError(message)
+
+
+def _require_missing_path_at(
+    directory_fd: int,
+    name: str,
+    message: str,
+    *,
+    follow_symlinks: bool = True,
+) -> None:
+    """Require a path to remain absent after missing-parent capture."""
+    try:
+        os.stat(
+            name,
+            dir_fd=directory_fd,
+            follow_symlinks=follow_symlinks,
+        )
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        if exc.errno in _PLUGIN_MUTATION_ERRNOS:
+            raise PluginSnapshotChangedError(message) from exc
+        raise
+    raise PluginSnapshotChangedError(message)
+
+
 def _missing_generation(path: Path) -> str:
     """Identify a missing input through its nearest existing parent."""
     candidate = path.parent
@@ -465,11 +614,26 @@ def _missing_generation(path: Path) -> str:
             candidate = candidate.parent
             continue
         except OSError as exc:
+            if exc.errno in _PLUGIN_PATH_RACE_ERRNOS:
+                raise PluginSnapshotChangedError(
+                    f"Codex plugin input changed while being read: {path}"
+                ) from exc
             raise CodexServerError(
                 f"cannot inspect parent of Codex plugin input {path}: {exc}"
             ) from exc
+        message = f"Codex plugin input changed while being read: {path}"
         try:
-            info = os.fstat(fd)
+            try:
+                info = os.fstat(fd)
+                _require_missing_path(candidate / unresolved[-1], message)
+                _require_missing_path(path, message)
+                _require_unchanged_path(candidate, info, message)
+                if _stat_generation(os.fstat(fd)) != _stat_generation(info):
+                    raise PluginSnapshotChangedError(message)
+            except OSError as exc:
+                if exc.errno in _PLUGIN_MUTATION_ERRNOS:
+                    raise PluginSnapshotChangedError(message) from exc
+                raise
         finally:
             os.close(fd)
         suffix = "/".join(reversed(unresolved))
@@ -495,11 +659,37 @@ def _missing_generation_at(directory_fd: int, target: str) -> str:
             candidate = candidate.parent
             continue
         except OSError as exc:
+            if exc.errno in _PLUGIN_PATH_RACE_ERRNOS:
+                raise PluginSnapshotChangedError(
+                    f"plugin symlink target changed while being read: {target!r}"
+                ) from exc
             raise CodexServerError(
                 f"cannot inspect parent of plugin symlink target {target!r}: {exc}"
             ) from exc
+        message = f"plugin symlink target changed while being read: {target!r}"
         try:
-            info = os.fstat(fd)
+            try:
+                info = os.fstat(fd)
+                _require_missing_path_at(
+                    fd,
+                    unresolved[-1],
+                    message,
+                    follow_symlinks=False,
+                )
+                _require_missing_path_at(directory_fd, target, message)
+                _require_unchanged_path_at(
+                    directory_fd,
+                    candidate_name,
+                    info,
+                    message,
+                    follow_symlinks=False,
+                )
+                if _stat_generation(os.fstat(fd)) != _stat_generation(info):
+                    raise PluginSnapshotChangedError(message)
+            except OSError as exc:
+                if exc.errno in _PLUGIN_MUTATION_ERRNOS:
+                    raise PluginSnapshotChangedError(message) from exc
+                raise
         finally:
             os.close(fd)
         suffix = "/".join(reversed(unresolved))

--- a/claude_code_tools/codex_server_legacy.py
+++ b/claude_code_tools/codex_server_legacy.py
@@ -1,0 +1,278 @@
+"""Fail-closed recovery for app servers started before native identities."""
+
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+
+from claude_code_tools.codex_server_models import (
+    OwnedServer,
+    ServerPaths,
+    StateFileError,
+)
+from claude_code_tools.codex_server_process import (
+    process_identity,
+    process_matches,
+    run_diagnostic,
+)
+from claude_code_tools.codex_server_state import (
+    StateCreationEvidence,
+    read_state_with_evidence,
+)
+
+
+_PS_EXECUTABLE = "/bin/ps"
+_NATIVE_IDENTITY_PREFIXES = ("darwin:", "linux:")
+_DARWIN_IDENTITY_PREFIX = "darwin:"
+
+
+def reauthenticate_legacy_state(
+    paths: ServerPaths,
+    state: OwnedServer | None,
+    peer_pid: Callable[[Path], int | None],
+    state_reader: Callable[
+        [ServerPaths],
+        tuple[OwnedServer | None, StateCreationEvidence | None],
+    ] = read_state_with_evidence,
+) -> OwnedServer | None:
+    """Replace legacy start text with native identities after full validation.
+
+    Args:
+        paths: Runtime and listener paths for the persisted server.
+        state: Validated ownership state, if present.
+        peer_pid: Platform-specific provider for the listener process ID.
+        state_reader: Descriptor-bound state reader, injectable for tests.
+
+    Returns:
+        Native reauthenticated state, the unchanged state when no migration is
+        needed or safe, or ``None`` when no state was supplied.
+    """
+    if state is None or _has_native_identities(state):
+        return state
+    if not _is_complete_legacy_state(state):
+        return state
+    if state.worker_pid is None or state.worker_pgid is None:
+        return state
+
+    try:
+        current, state_barrier = state_reader(paths)
+    except StateFileError:
+        return state
+    if current is None or current != state or state_barrier is None:
+        return state
+    state = current
+    assert state.worker_pid is not None
+    assert state.worker_pgid is not None
+    socket_identity = _socket_identity(paths.socket_path)
+    if socket_identity is None or not _legacy_processes_match(state):
+        return state
+    if _parent_pid(state.worker_pid) != state.pid:
+        return state
+
+    listener_pid = peer_pid(paths.socket_path)
+    listener_identity = _verified_group_identity(listener_pid, state.worker_pgid)
+    controller_identity = process_identity(state.pid)
+    worker_identity = process_identity(state.worker_pid)
+    if (
+        listener_identity is None
+        or controller_identity is None
+        or worker_identity is None
+        or not all(
+            _identity_predates_barrier(identity, state_barrier)
+            for identity in (
+                listener_identity,
+                controller_identity,
+                worker_identity,
+            )
+        )
+    ):
+        return state
+
+    if not _revalidation_matches(
+        paths,
+        state,
+        peer_pid,
+        socket_identity,
+        state_barrier,
+        listener_pid,
+        listener_identity,
+        controller_identity,
+        worker_identity,
+    ):
+        return state
+    return replace(
+        state,
+        process_started_at=controller_identity,
+        worker_started_at=worker_identity,
+    )
+
+
+def _has_native_identities(state: OwnedServer) -> bool:
+    """Return whether both recorded leaders already use native identities."""
+    return state.process_started_at.startswith(_NATIVE_IDENTITY_PREFIXES) and (
+        state.worker_started_at or ""
+    ).startswith(_NATIVE_IDENTITY_PREFIXES)
+
+
+def _is_complete_legacy_state(state: OwnedServer) -> bool:
+    """Return whether state has the exact shape produced before 1.16.2."""
+    identities = (state.process_started_at, state.worker_started_at)
+    return bool(
+        state.supervised
+        and state.worker_pid is not None
+        and state.worker_pgid is not None
+        and state.pid == state.pgid
+        and state.worker_pid == state.worker_pgid
+        and all(
+            identity
+            and len(identity) <= 128
+            and identity.isascii()
+            and not identity.startswith(_NATIVE_IDENTITY_PREFIXES)
+            and not any(character in identity for character in "\r\n\0")
+            for identity in identities
+        )
+    )
+
+
+def _legacy_processes_match(state: OwnedServer) -> bool:
+    """Validate both legacy start claims, groups, and their parent edge."""
+    assert state.worker_pid is not None
+    assert state.worker_pgid is not None
+    assert state.worker_started_at is not None
+    return _legacy_process_matches(
+        state.pid,
+        state.pgid,
+        state.process_started_at,
+    ) and _legacy_process_matches(
+        state.worker_pid,
+        state.worker_pgid,
+        state.worker_started_at,
+    )
+
+
+def _legacy_process_matches(pid: int, pgid: int, expected: str) -> bool:
+    """Compare one old textual start claim and its process group."""
+    if _legacy_process_identity(pid) != expected:
+        return False
+    try:
+        return os.getpgid(pid) == pgid
+    except (OSError, ProcessLookupError):
+        return False
+
+
+def _legacy_process_identity(pid: int) -> str | None:
+    """Read the textual start identity persisted by releases before 1.16.2."""
+    result = run_diagnostic(
+        [_PS_EXECUTABLE, "-o", "stat=", "-o", "lstart=", "-p", str(pid)],
+        os.environ,
+    )
+    if result is None or result.returncode != 0:
+        return None
+    pieces = result.stdout.strip().split(maxsplit=1)
+    if len(pieces) != 2 or not pieces[0] or pieces[0][0] in {"X", "x", "Z"}:
+        return None
+    return pieces[1].strip() or None
+
+
+def _parent_pid(pid: int | None) -> int | None:
+    """Return one live process's parent through trusted system ``ps``."""
+    if pid is None:
+        return None
+    result = run_diagnostic(
+        [_PS_EXECUTABLE, "-o", "ppid=", "-o", "stat=", "-p", str(pid)],
+        os.environ,
+    )
+    if result is None or result.returncode != 0:
+        return None
+    pieces = result.stdout.strip().split()
+    if len(pieces) != 2 or pieces[1][0] in {"X", "x", "Z"}:
+        return None
+    try:
+        parent = int(pieces[0])
+    except ValueError:
+        return None
+    return parent if parent > 0 else None
+
+
+def _socket_identity(path: Path) -> tuple[int, int] | None:
+    """Return a current-user Unix socket's stable filesystem identity."""
+    try:
+        info = path.lstat()
+    except OSError:
+        return None
+    if not stat.S_ISSOCK(info.st_mode) or info.st_uid != os.getuid():
+        return None
+    return info.st_dev, info.st_ino
+
+
+def _state_creation_barrier(path: Path) -> StateCreationEvidence | None:
+    """Return a stable state-file identity and immutable creation timestamp."""
+    try:
+        info = path.lstat()
+    except OSError:
+        return None
+    birthtime = getattr(info, "st_birthtime", None)
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or info.st_uid != os.getuid()
+        or not isinstance(birthtime, (float, int))
+        or birthtime <= 0
+    ):
+        return None
+    return info.st_dev, info.st_ino, int(birthtime * 1_000_000)
+
+
+def _identity_predates_barrier(
+    identity: str,
+    barrier: StateCreationEvidence,
+) -> bool:
+    """Return whether a native Darwin start time predates state publication."""
+    if not identity.startswith(_DARWIN_IDENTITY_PREFIX):
+        return False
+    pieces = identity.split(":")
+    if len(pieces) != 3 or not pieces[1].isdigit() or not pieces[2].isdigit():
+        return False
+    seconds = int(pieces[1])
+    microseconds = int(pieces[2])
+    if seconds <= 0 or not 0 <= microseconds <= 999_999:
+        return False
+    return seconds * 1_000_000 + microseconds <= barrier[2]
+
+
+def _verified_group_identity(pid: int | None, pgid: int | None) -> str | None:
+    """Return a native identity only for a member of the expected group."""
+    if pid is None or pgid is None:
+        return None
+    identity = process_identity(pid)
+    if identity is None or not process_matches(pid, pgid, identity):
+        return None
+    return identity
+
+
+def _revalidation_matches(
+    paths: ServerPaths,
+    state: OwnedServer,
+    peer_pid: Callable[[Path], int | None],
+    socket_identity: tuple[int, int],
+    state_barrier: StateCreationEvidence,
+    listener_pid: int | None,
+    listener_identity: str,
+    controller_identity: str,
+    worker_identity: str,
+) -> bool:
+    """Close replacement races before native ownership is authorized."""
+    assert state.worker_pid is not None
+    assert state.worker_pgid is not None
+    return bool(
+        _state_creation_barrier(paths.state_path) == state_barrier
+        and _socket_identity(paths.socket_path) == socket_identity
+        and peer_pid(paths.socket_path) == listener_pid
+        and _parent_pid(state.worker_pid) == state.pid
+        and _legacy_processes_match(state)
+        and process_matches(state.pid, state.pgid, controller_identity)
+        and process_matches(state.worker_pid, state.worker_pgid, worker_identity)
+        and process_matches(listener_pid or 0, state.worker_pgid, listener_identity)
+    )

--- a/claude_code_tools/codex_server_models.py
+++ b/claude_code_tools/codex_server_models.py
@@ -444,7 +444,11 @@ def clear_current_generation(base: ServerPaths) -> None:
 
 
 def all_server_paths(base: ServerPaths) -> list[ServerPaths]:
-    """Return bounded helper generations retaining state or a socket."""
+    """Return bounded helper generations retaining state, a socket, or a lock."""
+    from claude_code_tools.codex_server_reservation import (
+        generation_has_active_reservation,
+    )
+
     info = _lstat(base.runtime_dir)
     if info is None:
         return [base]
@@ -501,6 +505,7 @@ def all_server_paths(base: ServerPaths) -> list[ServerPaths]:
                 if (
                     _lstat(paths.state_path) is None
                     and _lstat(paths.socket_path) is None
+                    and not generation_has_active_reservation(paths)
                 ):
                     continue
                 scanned += 1
@@ -588,37 +593,10 @@ def prepare_runtime(paths: ServerPaths) -> None:
 
 
 def read_state(paths: ServerPaths) -> OwnedServer | None:
-    """Read and validate owned-process state."""
-    info = _lstat(paths.state_path)
-    if info is None:
-        return None
-    _require_regular_owned(info, paths.state_path, "state")
-    try:
-        no_follow = getattr(os, "O_NOFOLLOW", None)
-        if no_follow is None:
-            raise StateFileError("safe state parsing requires O_NOFOLLOW support")
-        flags = os.O_RDONLY | os.O_NONBLOCK | no_follow
-        fd = os.open(paths.state_path, flags)
-        try:
-            initial_info = os.fstat(fd)
-            _require_regular_owned(initial_info, paths.state_path, "state")
-            data = _read_bounded_fd(fd, STATE_MAX_BYTES)
-            if _file_generation(os.fstat(fd)) != _file_generation(initial_info):
-                raise StateFileError(
-                    "codex-server ownership state changed while being read"
-                )
-        finally:
-            os.close(fd)
-        value = json.loads(data.decode("utf-8"))
-        _require_bounded_state(value)
-    except (
-        OSError,
-        UnicodeDecodeError,
-        ValueError,
-        RecursionError,
-    ) as exc:
-        raise StateFileError(f"cannot read {paths.state_path}: {exc}") from exc
-    return OwnedServer.from_json(value)
+    """Read and validate owned-process state without returning read evidence."""
+    from claude_code_tools.codex_server_state import read_state_with_evidence
+
+    return read_state_with_evidence(paths)[0]
 
 
 def write_state(paths: ServerPaths, state: OwnedServer) -> None:

--- a/claude_code_tools/codex_server_reservation.py
+++ b/claude_code_tools/codex_server_reservation.py
@@ -1,0 +1,70 @@
+"""Crash-safe app-server capacity reservations through lifecycle locks."""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import os
+
+from claude_code_tools.codex_server_models import (
+    CodexServerError,
+    ServerPaths,
+    _file_generation,
+    _lstat,
+    _require_regular_owned,
+)
+
+
+def generation_has_active_reservation(paths: ServerPaths) -> bool:
+    """Return whether another process holds this generation's lifecycle lock.
+
+    An unlocked lock file is inactive history. A held lock is a reservation
+    that the kernel automatically releases if its launcher exits or crashes.
+    """
+    info = _lstat(paths.lock_path)
+    if info is None:
+        return False
+    _require_regular_owned(info, paths.lock_path, "lifecycle lock")
+    no_follow = getattr(os, "O_NOFOLLOW", None)
+    if no_follow is None:
+        raise CodexServerError("safe lifecycle lock inspection requires O_NOFOLLOW")
+    try:
+        fd = os.open(
+            paths.lock_path,
+            os.O_RDWR | os.O_NONBLOCK | no_follow,
+        )
+    except OSError as exc:
+        raise CodexServerError(
+            f"cannot inspect lifecycle lock {paths.lock_path}: {exc}"
+        ) from exc
+    locked = False
+    try:
+        initial = os.fstat(fd)
+        _require_regular_owned(initial, paths.lock_path, "lifecycle lock")
+        if _file_generation(initial) != _file_generation(info):
+            raise CodexServerError(
+                f"lifecycle lock changed during inspection: {paths.lock_path}"
+            )
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            if exc.errno not in {errno.EACCES, errno.EAGAIN}:
+                raise
+            locked = True
+        current = _lstat(paths.lock_path)
+        if current is None or _file_generation(current) != _file_generation(initial):
+            raise CodexServerError(
+                f"lifecycle lock changed during inspection: {paths.lock_path}"
+            )
+        return locked
+    except OSError as exc:
+        raise CodexServerError(
+            f"cannot inspect lifecycle lock {paths.lock_path}: {exc}"
+        ) from exc
+    finally:
+        if not locked:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+        os.close(fd)

--- a/claude_code_tools/codex_server_retry.py
+++ b/claude_code_tools/codex_server_retry.py
@@ -1,0 +1,45 @@
+"""Bounded retry policy for transient Codex plugin snapshot races."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from functools import wraps
+from typing import ParamSpec, TypeVar
+
+from claude_code_tools.codex_server_models import CodexServerError
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+PLUGIN_SNAPSHOT_ATTEMPTS = 4
+PLUGIN_SNAPSHOT_BACKOFF_SECONDS = (0.05, 0.15, 0.45)
+
+
+class PluginSnapshotChangedError(CodexServerError):
+    """A transient race while reading or certifying plugin inputs."""
+
+
+def retry_plugin_snapshot_changes(function: Callable[P, R]) -> Callable[P, R]:
+    """Retry one lifecycle operation after transient plugin snapshot changes.
+
+    Args:
+        function: Lifecycle function whose failed attempt cleans up before raising.
+
+    Returns:
+        A function with the same signature and a bounded retry policy.
+    """
+
+    @wraps(function)
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        for attempt in range(PLUGIN_SNAPSHOT_ATTEMPTS):
+            try:
+                return function(*args, **kwargs)
+            except PluginSnapshotChangedError:
+                if attempt + 1 >= PLUGIN_SNAPSHOT_ATTEMPTS:
+                    raise
+                time.sleep(PLUGIN_SNAPSHOT_BACKOFF_SECONDS[attempt])
+        raise AssertionError("plugin snapshot retry loop exhausted unexpectedly")
+
+    return wrapped

--- a/claude_code_tools/codex_server_reuse.py
+++ b/claude_code_tools/codex_server_reuse.py
@@ -64,6 +64,27 @@ def disconnect_refusal(action: str) -> CodexServerError:
     )
 
 
+def same_server_launch(expected: OwnedServer, current: OwnedServer) -> bool:
+    """Return whether two states name the same exact supervised launch."""
+    return (
+        current.pid,
+        current.pgid,
+        current.process_started_at,
+        current.launch_token,
+        current.worker_pid,
+        current.worker_pgid,
+        current.worker_started_at,
+    ) == (
+        expected.pid,
+        expected.pgid,
+        expected.process_started_at,
+        expected.launch_token,
+        expected.worker_pid,
+        expected.worker_pgid,
+        expected.worker_started_at,
+    )
+
+
 def require_external_compatible(
     codex_version: str,
     probe: ServerProbe,

--- a/claude_code_tools/codex_server_state.py
+++ b/claude_code_tools/codex_server_state.py
@@ -1,0 +1,65 @@
+"""Descriptor-bound reads of Codex app-server ownership state."""
+
+from __future__ import annotations
+
+import json
+import os
+
+from claude_code_tools.codex_server_models import (
+    STATE_MAX_BYTES,
+    OwnedServer,
+    ServerPaths,
+    StateFileError,
+    _file_generation,
+    _lstat,
+    _read_bounded_fd,
+    _require_bounded_state,
+    _require_regular_owned,
+)
+
+
+StateCreationEvidence = tuple[int, int, int]
+
+
+def read_state_with_evidence(
+    paths: ServerPaths,
+) -> tuple[OwnedServer | None, StateCreationEvidence | None]:
+    """Read state and bind it to the same descriptor's creation evidence."""
+    info = _lstat(paths.state_path)
+    if info is None:
+        return None, None
+    _require_regular_owned(info, paths.state_path, "state")
+    try:
+        no_follow = getattr(os, "O_NOFOLLOW", None)
+        if no_follow is None:
+            raise StateFileError("safe state parsing requires O_NOFOLLOW support")
+        fd = os.open(paths.state_path, os.O_RDONLY | os.O_NONBLOCK | no_follow)
+        try:
+            initial_info = os.fstat(fd)
+            _require_regular_owned(initial_info, paths.state_path, "state")
+            evidence = _creation_evidence(initial_info)
+            data = _read_bounded_fd(fd, STATE_MAX_BYTES)
+            if _file_generation(os.fstat(fd)) != _file_generation(initial_info):
+                raise StateFileError(
+                    "codex-server ownership state changed while being read"
+                )
+        finally:
+            os.close(fd)
+        value = json.loads(data.decode("utf-8"))
+        _require_bounded_state(value)
+    except (
+        OSError,
+        UnicodeDecodeError,
+        ValueError,
+        RecursionError,
+    ) as exc:
+        raise StateFileError(f"cannot read {paths.state_path}: {exc}") from exc
+    return OwnedServer.from_json(value), evidence
+
+
+def _creation_evidence(info: os.stat_result) -> StateCreationEvidence | None:
+    """Return descriptor identity and creation time when the OS exposes it."""
+    birthtime = getattr(info, "st_birthtime", None)
+    if not isinstance(birthtime, (float, int)) or birthtime <= 0:
+        return None
+    return info.st_dev, info.st_ino, int(birthtime * 1_000_000)

--- a/docs-site/src/content/docs/tools/codex-dynamic.mdx
+++ b/docs-site/src/content/docs/tools/codex-dynamic.mdx
@@ -103,6 +103,37 @@ was started outside the helper.
 
 </Steps>
 
+### Import Claude Code Data
+
+Codex disables `/import` in a remote TUI, including a TUI started by
+`codex-dynamic`. Run the import from an ordinary local Codex session:
+
+```bash
+codex
+```
+
+Enter `/import` there. After the import finishes, exit that TUI and start or
+resume your callback-ready session with `codex-dynamic`.
+
+An app server created by an early release of this helper may still occupy
+Codex's default local socket. In that case, even plain `codex` reports that it
+is connected to the local app-server daemon. Wait for active workflow
+callbacks to finish, exit every `codex-dynamic` TUI, and then run:
+
+```bash
+codex-server stop --force
+codex
+```
+
+On macOS, current releases safely reauthenticate the old helper process before
+stopping it. The check binds the state content and filesystem creation-time
+evidence to the same open file. On a filesystem or platform that does not
+expose that proof, the helper remains fail-closed and reports the retained
+process groups for manual inspection. New `codex-dynamic` servers use
+generation-specific sockets, so they do not occupy Codex's default local
+socket. Do not stop the old server while a callback is armed; the workflow can
+finish, but its notification would lose its target.
+
 Every workflow `run` or `resume` needs host execution for that exact reviewed
 supervisor command. This lets the supervisor write durable state and launch
 headless workers without inheriting the outer tool sandbox. For a callback, the
@@ -383,10 +414,18 @@ making it the default. Existing TUIs and in-flight callbacks remain connected
 to the old socket, so they are not interrupted and keep the plugin snapshot
 with which they started.
 
+Plugin installation can rewrite the catalog while the launcher reads it. The
+launcher cleans up the uncertified attempt, takes a fresh snapshot, and retries
+with a small fixed limit. Persistent catalog changes still fail closed; wait
+for the installation to finish and run `codex-dynamic` again.
+
 Codex does not expose a reliable count of clients attached to an app server,
 so the helper never guesses that an old generation is unused and kills it.
 Retained generations are capped at 64; reaching that defensive limit produces
 an explicit cleanup instruction instead of disconnecting sessions silently.
+Concurrent launches reserve capacity with their generation lifecycle locks.
+The kernel releases a reservation if its launcher exits or crashes, and a
+second launcher cannot race past the limit.
 
 <Aside type="caution" title="Forced cleanup still disconnects sessions">
   Old generations remain available for sessions and callbacks that still use
@@ -577,7 +616,12 @@ There are two supervisors with different lifetimes:
   the TUI process. During startup, it publishes both supervisor and worker
   identities before releasing the worker to become the app server. Lifecycle
   commands verify recorded process start identities before sending signals and
-  never stop a compatible server they do not own.
+  never stop a compatible server they do not own. When an upgrade encounters
+  an older textual process identity, the helper first verifies the socket
+  inode, listener PID and process group, supervisor-to-worker parent edge, and
+  fresh native identities. Every process must also predate the immutable
+  creation time of its ownership state. Only that complete check can authorize
+  cleanup.
 - The **workflow supervisor** owns one durable run and its worker process
   groups. It contains runaway workflow JavaScript, terminates orphaned worker
   trees, and preserves nonterminal cleanup state when shutdown cannot be

--- a/docs-site/src/content/docs/tools/codex-dynamic.mdx
+++ b/docs-site/src/content/docs/tools/codex-dynamic.mdx
@@ -134,6 +134,13 @@ generation-specific sockets, so they do not occupy Codex's default local
 socket. Do not stop the old server while a callback is armed; the workflow can
 finish, but its notification would lose its target.
 
+The helper cannot currently reauthenticate a Linux server that remains alive
+across an upgrade from a release older than 1.16.2. Safe automatic cleanup
+requires a native process identity and the creation time of the exact state file
+being read. The current Linux implementation cannot obtain that file evidence,
+so it reports the retained process groups for manual inspection. This
+limitation does not affect servers started by 1.16.2 or later.
+
 Every workflow `run` or `resume` needs host execution for that exact reviewed
 supervisor command. This lets the supervisor write durable state and launch
 headless workers without inheriting the outer tool sandbox. For a callback, the

--- a/tests/test_codex_server.py
+++ b/tests/test_codex_server.py
@@ -10,6 +10,7 @@ import socket
 import subprocess
 import sys
 import tempfile
+import textwrap
 import time
 from collections.abc import Iterator
 from pathlib import Path
@@ -437,6 +438,74 @@ def test_empty_existing_target_does_not_bypass_live_generation_cap(
 
     with pytest.raises(CodexServerError, match="generation limit"):
         server_models.require_generation_capacity(base, target.generation or "")
+
+
+def test_concurrent_generation_reservation_enforces_capacity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two launchers cannot both consume the final retained-server slot."""
+    environment = {"CODEX_HOME": str(tmp_path / "home")}
+    base = server_models.base_paths_from_env(environment)
+    retained = server_models.paths_for_generation(base, "a" * 24)
+    reserved = server_models.paths_for_generation(base, "b" * 24)
+    candidate = server_models.paths_for_generation(base, "c" * 24)
+    retained.runtime_dir.mkdir(mode=0o700, parents=True)
+    retained.state_path.write_text("{}", encoding="utf-8")
+    ready = tmp_path / "reservation-ready"
+    release = tmp_path / "reservation-release"
+    program = textwrap.dedent(
+        f"""
+        import time
+        from pathlib import Path
+
+        import claude_code_tools.codex_server as server
+        import claude_code_tools.codex_server_models as models
+
+        environment = {environment!r}
+        base = models.base_paths_from_env(environment)
+        paths = models.paths_for_generation(base, {reserved.generation!r})
+        models.MAX_SERVER_GENERATIONS = 2
+        with server._reserved_generation_lifecycle(
+            base,
+            paths,
+            {reserved.generation!r},
+        ):
+            Path({str(ready)!r}).write_text("ready", encoding="utf-8")
+            deadline = time.monotonic() + 10
+            while not Path({str(release)!r}).exists():
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("parent did not release reservation")
+                time.sleep(0.01)
+        """
+    )
+    process = subprocess.Popen(
+        [sys.executable, "-c", program],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 5
+    try:
+        while not ready.exists():
+            if process.poll() is not None:
+                stdout, stderr = process.communicate()
+                pytest.fail(f"reservation helper exited: {stdout}{stderr}")
+            if time.monotonic() >= deadline:
+                pytest.fail("reservation helper did not become ready")
+            time.sleep(0.01)
+        monkeypatch.setattr(server_models, "MAX_SERVER_GENERATIONS", 2)
+        with pytest.raises(CodexServerError, match="generation limit"):
+            with codex_server._reserved_generation_lifecycle(
+                base,
+                candidate,
+                candidate.generation or "",
+            ):
+                pytest.fail("over-capacity generation acquired a reservation")
+    finally:
+        release.write_text("release", encoding="utf-8")
+        stdout, stderr = process.communicate(timeout=5)
+    assert process.returncode == 0, stdout + stderr
 
 
 def test_generation_scan_still_bounds_unrecognized_runtime_entries(

--- a/tests/test_codex_server_fingerprint.py
+++ b/tests/test_codex_server_fingerprint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import shutil
@@ -100,6 +101,438 @@ def test_plugin_regular_file_content_is_hashed_when_metadata_matches(
     artifact.write_text("BBBB", encoding="utf-8")
 
     assert _plugin_configuration_snapshot(paths).fingerprint != before.fingerprint
+
+
+def test_atomic_configuration_replacement_is_a_retryable_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An open descriptor cannot hide replacement of its configuration path."""
+    paths = _paths({"CODEX_HOME": str(tmp_path / "home")})
+    paths.codex_home.mkdir(parents=True)
+    config = paths.codex_home / "config.toml"
+    replacement = paths.codex_home / "replacement.toml"
+    config.write_text("[features]\nplugins = true\n", encoding="utf-8")
+    replacement.write_text("[features]\nplugins = false\n", encoding="utf-8")
+    original_read = fingerprinting._read_bounded
+
+    def replace_after_read(fd: int, limit: int) -> bytes:
+        data = original_read(fd, limit)
+        replacement.replace(config)
+        return data
+
+    monkeypatch.setattr(fingerprinting, "_read_bounded", replace_after_read)
+
+    with pytest.raises(
+        fingerprinting.PluginSnapshotChangedError,
+        match="configuration changed",
+    ):
+        _plugin_configuration_snapshot(paths)
+
+
+@pytest.mark.parametrize("input_name", ["configuration", "plugin-root"])
+@pytest.mark.parametrize("error_number", [errno.ENOTDIR, errno.ESTALE])
+def test_initial_plugin_input_race_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    input_name: str,
+    error_number: int,
+) -> None:
+    """Initial-open path races enter the bounded snapshot retry policy."""
+    paths = _paths({"CODEX_HOME": str(tmp_path / "home")})
+    paths.codex_home.mkdir(parents=True)
+    target = (
+        paths.codex_home / "config.toml"
+        if input_name == "configuration"
+        else paths.codex_home / "plugins"
+    )
+    original_open = os.open
+
+    def racing_open(
+        path: os.PathLike[str] | str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        if os.fspath(path) == os.fspath(target):
+            raise OSError(error_number, os.strerror(error_number))
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(fingerprinting.os, "open", racing_open)
+
+    with pytest.raises(fingerprinting.PluginSnapshotChangedError):
+        _plugin_configuration_snapshot(paths)
+
+
+@pytest.mark.parametrize(
+    "error_number",
+    [errno.ENOENT, errno.ENOTDIR, errno.ESTALE],
+)
+def test_configuration_descriptor_race_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error_number: int,
+) -> None:
+    """Descriptor-phase configuration errors enter the bounded retry policy."""
+    paths = _paths({"CODEX_HOME": str(tmp_path / "home")})
+    paths.codex_home.mkdir(parents=True)
+    paths.codex_home.joinpath("config.toml").write_text("", encoding="utf-8")
+
+    def racing_read(_fd: int, _limit: int) -> bytes:
+        raise OSError(error_number, os.strerror(error_number))
+
+    monkeypatch.setattr(fingerprinting, "_read_bounded", racing_read)
+
+    with pytest.raises(fingerprinting.PluginSnapshotChangedError):
+        _plugin_configuration_snapshot(paths)
+
+
+@pytest.mark.parametrize("input_name", ["configuration", "plugin-root"])
+def test_missing_plugin_input_appearance_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    input_name: str,
+) -> None:
+    """A path that appears after missing-parent capture is not certified absent."""
+    paths = _paths({"CODEX_HOME": str(tmp_path / "home")})
+    paths.codex_home.mkdir(parents=True)
+    target = (
+        paths.codex_home / "config.toml"
+        if input_name == "configuration"
+        else paths.codex_home / "plugins"
+    )
+    original_missing = fingerprinting._missing_generation
+
+    def appear_after_capture(path: Path) -> str:
+        generation = original_missing(path)
+        if path == target:
+            if input_name == "configuration":
+                path.write_text("", encoding="utf-8")
+            else:
+                path.mkdir()
+        return generation
+
+    monkeypatch.setattr(
+        fingerprinting,
+        "_missing_generation",
+        appear_after_capture,
+    )
+
+    with pytest.raises(fingerprinting.PluginSnapshotChangedError):
+        _plugin_configuration_snapshot(paths)
+
+
+@pytest.mark.parametrize("helper", ["absolute", "relative"])
+@pytest.mark.parametrize("error_number", [errno.ENOTDIR, errno.ESTALE])
+def test_missing_parent_race_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    helper: str,
+    error_number: int,
+) -> None:
+    """Parent traversal races use the same retryable mutation signal."""
+    root = tmp_path / "root"
+    root.mkdir()
+    original_open = os.open
+    root_fd = original_open(root, fingerprinting._directory_flags())
+
+    def racing_open(
+        path: os.PathLike[str] | str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        target = root / "missing" if helper == "absolute" else Path("missing")
+        if os.fspath(path) == os.fspath(target):
+            raise OSError(error_number, os.strerror(error_number))
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(fingerprinting.os, "open", racing_open)
+    try:
+        with pytest.raises(fingerprinting.PluginSnapshotChangedError):
+            if helper == "absolute":
+                fingerprinting._missing_generation(root / "missing/child")
+            else:
+                fingerprinting._missing_generation_at(root_fd, "missing/child")
+    finally:
+        os.close(root_fd)
+
+
+@pytest.mark.parametrize("helper", ["absolute", "relative"])
+def test_transient_missing_existing_parent_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    helper: str,
+) -> None:
+    """One false ENOENT cannot omit an existing nearest parent generation."""
+    root = tmp_path / "root"
+    existing = root / "existing"
+    existing.mkdir(parents=True)
+    original_open = os.open
+    root_fd = original_open(root, fingerprinting._directory_flags())
+    injected = False
+
+    def racing_open(
+        path: os.PathLike[str] | str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal injected
+        target = existing if helper == "absolute" else Path("existing")
+        if not injected and os.fspath(path) == os.fspath(target):
+            injected = True
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT))
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(fingerprinting.os, "open", racing_open)
+    try:
+        with pytest.raises(fingerprinting.PluginSnapshotChangedError):
+            if helper == "absolute":
+                fingerprinting._missing_generation(existing / "child")
+            else:
+                fingerprinting._missing_generation_at(
+                    root_fd,
+                    "existing/child",
+                )
+    finally:
+        os.close(root_fd)
+
+
+def test_absolute_missing_parent_replacement_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A replaced nearest parent cannot certify an absolute path as absent."""
+    root = tmp_path / "root"
+    replacement = tmp_path / "replacement"
+    displaced = tmp_path / "displaced"
+    root.mkdir()
+    replacement.mkdir()
+    original_require_missing = fingerprinting._require_missing_path
+
+    def replace_parent(path: Path, message: str) -> None:
+        original_require_missing(path, message)
+        root.rename(displaced)
+        replacement.rename(root)
+
+    monkeypatch.setattr(
+        fingerprinting,
+        "_require_missing_path",
+        replace_parent,
+    )
+
+    with pytest.raises(fingerprinting.PluginSnapshotChangedError):
+        fingerprinting._missing_generation(root / "missing")
+
+
+def test_relative_missing_parent_replacement_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A replaced nearest parent cannot certify a relative target as absent."""
+    root = tmp_path / "root"
+    parent = root / "parent"
+    replacement = root / "replacement"
+    displaced = root / "displaced"
+    parent.mkdir(parents=True)
+    replacement.mkdir()
+    root_fd = os.open(root, fingerprinting._directory_flags())
+    original_require_missing = fingerprinting._require_missing_path_at
+
+    def replace_parent(
+        directory_fd: int,
+        name: str,
+        message: str,
+        *,
+        follow_symlinks: bool = True,
+    ) -> None:
+        original_require_missing(
+            directory_fd,
+            name,
+            message,
+            follow_symlinks=follow_symlinks,
+        )
+        parent.rename(displaced)
+        replacement.rename(parent)
+
+    monkeypatch.setattr(
+        fingerprinting,
+        "_require_missing_path_at",
+        replace_parent,
+    )
+    try:
+        with pytest.raises(fingerprinting.PluginSnapshotChangedError):
+            fingerprinting._missing_generation_at(root_fd, "parent/missing")
+    finally:
+        os.close(root_fd)
+
+
+@pytest.mark.parametrize("helper", ["absolute", "relative"])
+def test_missing_parent_fstat_race_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    helper: str,
+) -> None:
+    """Descriptor metadata races use the bounded snapshot retry signal."""
+    root = tmp_path / "root"
+    root.mkdir()
+    root_fd = os.open(root, fingerprinting._directory_flags())
+
+    def stale_fstat(_fd: int) -> os.stat_result:
+        raise OSError(errno.ESTALE, os.strerror(errno.ESTALE))
+
+    monkeypatch.setattr(fingerprinting.os, "fstat", stale_fstat)
+    try:
+        with pytest.raises(fingerprinting.PluginSnapshotChangedError):
+            if helper == "absolute":
+                fingerprinting._missing_generation(root / "missing")
+            else:
+                fingerprinting._missing_generation_at(root_fd, "missing")
+    finally:
+        os.close(root_fd)
+
+
+def test_atomic_plugin_root_replacement_is_a_retryable_race(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A traversal cannot certify a plugin root replaced at its pathname."""
+    paths = _paths({"CODEX_HOME": str(tmp_path / "home")})
+    plugins = paths.codex_home / "plugins"
+    replacement = paths.codex_home / "replacement"
+    displaced = paths.codex_home / "displaced"
+    plugins.mkdir(parents=True)
+    replacement.mkdir()
+    original_hash = fingerprinting._hash_directory
+    replaced = False
+
+    def replace_after_hash(
+        directory_fd: int,
+        relative: Path,
+        digest: fingerprinting.HashWriter,
+        generation: fingerprinting.HashWriter,
+        budget: list[int],
+        depth: int,
+    ) -> None:
+        nonlocal replaced
+        original_hash(
+            directory_fd,
+            relative,
+            digest,
+            generation,
+            budget,
+            depth,
+        )
+        if not replaced:
+            replaced = True
+            plugins.rename(displaced)
+            replacement.rename(plugins)
+
+    monkeypatch.setattr(fingerprinting, "_hash_directory", replace_after_hash)
+
+    with pytest.raises(
+        fingerprinting.PluginSnapshotChangedError,
+        match="cache root changed",
+    ):
+        _plugin_configuration_snapshot(paths)
+
+
+def test_plugin_entry_removal_during_traversal_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An installer rename or removal enters the bounded snapshot retry path."""
+    paths = _paths({"CODEX_HOME": str(tmp_path / "home")})
+    artifact = paths.codex_home / "plugins/plugin.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("plugin", encoding="utf-8")
+    original_hash = fingerprinting._hash_regular_file
+
+    def remove_before_open(
+        directory_fd: int,
+        name: str,
+        relative: Path,
+        expected: os.stat_result,
+        digest: fingerprinting.HashWriter,
+        generation: fingerprinting.HashWriter,
+        budget: list[int],
+    ) -> None:
+        artifact.unlink()
+        original_hash(
+            directory_fd,
+            name,
+            relative,
+            expected,
+            digest,
+            generation,
+            budget,
+        )
+
+    monkeypatch.setattr(
+        fingerprinting,
+        "_hash_regular_file",
+        remove_before_open,
+    )
+
+    with pytest.raises(
+        fingerprinting.PluginSnapshotChangedError,
+        match="cache changed",
+    ):
+        _plugin_configuration_snapshot(paths)
+
+
+def test_atomic_symlink_target_replacement_is_retryable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An external target replacement cannot leave a stale plugin digest."""
+    paths = _paths({"CODEX_HOME": str(tmp_path / "home")})
+    target = tmp_path / "target.txt"
+    replacement = tmp_path / "replacement.txt"
+    link = paths.codex_home / "plugins/plugin.txt"
+    link.parent.mkdir(parents=True)
+    target.write_text("old", encoding="utf-8")
+    replacement.write_text("new", encoding="utf-8")
+    link.symlink_to(target)
+    original_hash = fingerprinting._hash_regular_descriptor
+    replaced = False
+
+    def replace_after_hash(
+        fd: int,
+        relative: Path,
+        initial_info: os.stat_result,
+        digest: fingerprinting.HashWriter,
+        generation: fingerprinting.HashWriter,
+        budget: list[int],
+    ) -> None:
+        nonlocal replaced
+        original_hash(
+            fd,
+            relative,
+            initial_info,
+            digest,
+            generation,
+            budget,
+        )
+        if not replaced:
+            replaced = True
+            replacement.replace(target)
+
+    monkeypatch.setattr(
+        fingerprinting,
+        "_hash_regular_descriptor",
+        replace_after_hash,
+    )
+
+    with pytest.raises(
+        fingerprinting.PluginSnapshotChangedError,
+        match="symlink target changed",
+    ):
+        _plugin_configuration_snapshot(paths)
 
 
 def test_wide_plugin_tree_respects_file_descriptor_limit(tmp_path: Path) -> None:

--- a/tests/test_codex_server_probe_safety.py
+++ b/tests/test_codex_server_probe_safety.py
@@ -14,6 +14,7 @@ from typing import NoReturn
 import pytest
 
 import claude_code_tools.codex_server as codex_server
+import claude_code_tools.codex_server_retry as codex_server_retry
 from claude_code_tools.codex_server import (
     CodexServerError,
     OwnedServer,
@@ -344,7 +345,7 @@ def test_plugin_change_during_reuse_probe_is_revalidated(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Reuse cannot return a server certified against a stale snapshot."""
+    """Reuse retries and certifies against the replacement snapshot."""
     environment, _sleeps, _commands = _arrange_live_helper(
         monkeypatch,
         tmp_path,
@@ -354,6 +355,9 @@ def test_plugin_change_during_reuse_probe_is_revalidated(
         [
             _snapshot(),
             _snapshot(),
+            _snapshot(generation="changed during probe"),
+            _snapshot(generation="changed during probe"),
+            _snapshot(generation="changed during probe"),
             _snapshot(generation="changed during probe"),
         ]
     )
@@ -373,12 +377,15 @@ def test_plugin_change_during_reuse_probe_is_revalidated(
         snapshot,
     )
 
-    with pytest.raises(CodexServerError, match="changed during app-server reuse"):
-        ensure_server(environment)
+    status = ensure_server(environment)
 
+    assert status.status == "running"
     assert observed == [
         "stable generation",
         "stable generation",
+        "changed during probe",
+        "changed during probe",
+        "changed during probe",
         "changed during probe",
     ]
 
@@ -518,21 +525,15 @@ def test_plugin_change_during_startup_is_not_certified(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A server cannot claim a plugin snapshot changed after it spawned."""
+    """Persistent startup churn cleans every attempt and remains bounded."""
     starting = replace(
         _live_state(),
         phase="starting",
         plugin_fingerprint="startup snapshot",
     )
-    snapshots = iter(
-        [
-            _snapshot("startup snapshot", "startup generation"),
-            _snapshot("startup snapshot", "startup generation"),
-            _snapshot("startup snapshot", "changed during startup"),
-        ]
-    )
+    snapshot_calls = 0
     observed: list[str] = []
-    states = iter([None, starting])
+    state_reads = 0
     terminated: list[OwnedServer] = []
     removals: list[object] = []
 
@@ -540,9 +541,21 @@ def test_plugin_change_during_startup_is_not_certified(
         _paths: object,
         _options: object = (),
     ) -> codex_server._PluginSnapshot:
-        value = next(snapshots)
+        nonlocal snapshot_calls
+        snapshot_calls += 1
+        generation = (
+            "changed during startup"
+            if snapshot_calls % 3 == 0
+            else "startup generation"
+        )
+        value = _snapshot("startup snapshot", generation)
         observed.append(value.generation)
         return value
+
+    def read_state(_paths: object) -> OwnedServer | None:
+        nonlocal state_reads
+        state_reads += 1
+        return None if state_reads % 2 == 1 else starting
 
     def spawn(*args: object) -> OwnedServer:
         assert args[-3] == "startup snapshot"
@@ -571,7 +584,7 @@ def test_plugin_change_during_startup_is_not_certified(
         "_plugin_configuration_snapshot",
         snapshot,
     )
-    monkeypatch.setattr(codex_server, "_read_state", lambda _paths: next(states))
+    monkeypatch.setattr(codex_server, "_read_state", read_state)
     monkeypatch.setattr(
         codex_server,
         "_probe_server",
@@ -596,17 +609,23 @@ def test_plugin_change_during_startup_is_not_certified(
         "_remove_state",
         lambda paths: removals.append(paths),
     )
+    monkeypatch.setattr(codex_server_retry.time, "sleep", lambda _delay: None)
 
     with pytest.raises(CodexServerError, match="changed during app-server startup"):
         ensure_server({"CODEX_HOME": str(tmp_path / "home")})
 
+    expected_attempts = codex_server_retry.PLUGIN_SNAPSHOT_ATTEMPTS
     assert observed == [
-        "startup generation",
-        "startup generation",
-        "changed during startup",
+        item
+        for _attempt in range(expected_attempts)
+        for item in (
+            "startup generation",
+            "startup generation",
+            "changed during startup",
+        )
     ]
-    assert terminated == [starting]
-    assert len(removals) == 1
+    assert terminated == [starting] * expected_attempts
+    assert len(removals) == expected_attempts
 
 
 def test_listener_replacement_during_startup_snapshot_is_not_certified(

--- a/tests/test_codex_server_upgrade_recovery.py
+++ b/tests/test_codex_server_upgrade_recovery.py
@@ -1,0 +1,396 @@
+"""Regression tests for app-server lifecycle behavior across upgrades."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from claude_code_tools import codex_server_legacy, codex_server_retry
+from claude_code_tools.codex_server_models import (
+    OwnedServer,
+    ServerPaths,
+    StateFileError,
+    read_state,
+    write_state,
+)
+
+
+def test_legacy_process_claim_matches_live_process() -> None:
+    """The old textual identity remains available only for reauthentication."""
+    pid = os.getpid()
+    legacy_identity = codex_server_legacy._legacy_process_identity(pid)
+
+    assert legacy_identity is not None
+    assert codex_server_legacy._legacy_process_matches(
+        pid,
+        os.getpgrp(),
+        legacy_identity,
+    )
+
+
+def test_legacy_state_reauthenticates_complete_process_chain(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Legacy state becomes signal-capable only after full listener validation."""
+    paths = _server_paths(tmp_path)
+    state = _legacy_state()
+    identities = {
+        state.pid: "darwin:100:1",
+        state.worker_pid: "darwin:100:2",
+        303: "darwin:100:3",
+    }
+    groups = {
+        state.pid: state.pgid,
+        state.worker_pid: state.worker_pgid,
+        303: state.worker_pgid,
+    }
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_legacy_processes_match",
+        lambda _state: True,
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_socket_identity",
+        lambda _path: (10, 20),
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_state_creation_barrier",
+        lambda _path: (30, 40, 101_000_000),
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_parent_pid",
+        lambda _pid: state.pid,
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "process_identity",
+        identities.get,
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "process_matches",
+        lambda pid, pgid, identity: (
+            identities.get(pid) == identity and groups.get(pid) == pgid
+        ),
+    )
+
+    recovered = codex_server_legacy.reauthenticate_legacy_state(
+        paths,
+        state,
+        lambda _path: 303,
+        lambda _paths: (state, (30, 40, 101_000_000)),
+    )
+
+    assert recovered is not None
+    assert recovered.process_started_at == "darwin:100:1"
+    assert recovered.worker_started_at == "darwin:100:2"
+
+
+def test_legacy_reauthentication_rejects_socket_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A replaced listener cannot authorize signals to old process groups."""
+    paths = _server_paths(tmp_path)
+    state = _legacy_state()
+    socket_identities = iter([(10, 20), (10, 21)])
+    identities = {
+        state.pid: "darwin:100:1",
+        state.worker_pid: "darwin:100:2",
+        303: "darwin:100:3",
+    }
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_socket_identity",
+        lambda _path: next(socket_identities),
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_state_creation_barrier",
+        lambda _path: (30, 40, 101_000_000),
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_legacy_processes_match",
+        lambda _state: True,
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_parent_pid",
+        lambda _pid: state.pid,
+    )
+    monkeypatch.setattr(codex_server_legacy, "process_identity", identities.get)
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "process_matches",
+        lambda _pid, _pgid, _identity: True,
+    )
+
+    recovered = codex_server_legacy.reauthenticate_legacy_state(
+        paths,
+        state,
+        lambda _path: 303,
+        lambda _paths: (state, (30, 40, 101_000_000)),
+    )
+
+    assert recovered == state
+
+
+@pytest.mark.parametrize(
+    "failure",
+    ["parent", "peer", "listener-group", "controller-identity"],
+)
+def test_legacy_reauthentication_rejects_process_chain_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure: str,
+) -> None:
+    """Every process-chain edge must remain stable through revalidation."""
+    paths = _server_paths(tmp_path)
+    state = _legacy_state()
+    identities = {
+        state.pid: "darwin:100:1",
+        state.worker_pid: "darwin:100:2",
+        303: "darwin:100:3",
+        304: "darwin:100:4",
+    }
+    groups = {
+        state.pid: state.pgid,
+        state.worker_pid: state.worker_pgid,
+        303: state.worker_pgid,
+        304: state.worker_pgid,
+    }
+    peer_values = iter([303, 304]) if failure == "peer" else None
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_socket_identity",
+        lambda _path: (10, 20),
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_state_creation_barrier",
+        lambda _path: (30, 40, 101_000_000),
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_legacy_processes_match",
+        lambda _state: True,
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_parent_pid",
+        lambda _pid: state.pid + 1 if failure == "parent" else state.pid,
+    )
+    monkeypatch.setattr(codex_server_legacy, "process_identity", identities.get)
+
+    def process_matches(pid: int, pgid: int, identity: str) -> bool:
+        if failure == "listener-group" and pid == 303:
+            return False
+        if failure == "controller-identity" and pid == state.pid:
+            return False
+        return identities.get(pid) == identity and groups.get(pid) == pgid
+
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "process_matches",
+        process_matches,
+    )
+
+    recovered = codex_server_legacy.reauthenticate_legacy_state(
+        paths,
+        state,
+        lambda _path: next(peer_values) if peer_values is not None else 303,
+        lambda _paths: (state, (30, 40, 101_000_000)),
+    )
+
+    assert recovered == state
+
+
+def test_legacy_reauthentication_rejects_chain_created_after_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A fully replaced pre-scan chain cannot inherit historical ownership."""
+    paths = _server_paths(tmp_path)
+    state = _legacy_state()
+    identities = {
+        state.pid: "darwin:100:1",
+        state.worker_pid: "darwin:100:2",
+        303: "darwin:100:3",
+    }
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_state_creation_barrier",
+        lambda _path: (30, 40, 99_999_999),
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_socket_identity",
+        lambda _path: (10, 20),
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_legacy_processes_match",
+        lambda _state: True,
+    )
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_parent_pid",
+        lambda _pid: state.pid,
+    )
+    monkeypatch.setattr(codex_server_legacy, "process_identity", identities.get)
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "process_matches",
+        lambda _pid, _pgid, _identity: True,
+    )
+
+    recovered = codex_server_legacy.reauthenticate_legacy_state(
+        paths,
+        state,
+        lambda _path: 303,
+        lambda _paths: (state, (30, 40, 99_999_999)),
+    )
+
+    assert recovered == state
+
+
+def test_partial_legacy_state_remains_unauthenticated(tmp_path: Path) -> None:
+    """Missing worker ownership can never authorize compatibility cleanup."""
+    state = replace(
+        _legacy_state(),
+        worker_pid=None,
+        worker_pgid=None,
+        worker_started_at=None,
+    )
+
+    recovered = codex_server_legacy.reauthenticate_legacy_state(
+        _server_paths(tmp_path),
+        state,
+        lambda _path: 303,
+    )
+
+    assert recovered == state
+
+
+def test_legacy_reauthentication_rejects_replaced_state_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """State content cannot inherit creation evidence from its replacement."""
+    paths = _server_paths(tmp_path)
+    write_state(paths, _legacy_state())
+    initial = read_state(paths)
+    assert initial is not None
+    write_state(paths, replace(initial, launch_token="replacement"))
+    monkeypatch.setattr(
+        codex_server_legacy,
+        "_socket_identity",
+        lambda _path: pytest.fail("process validation must not start"),
+    )
+
+    recovered = codex_server_legacy.reauthenticate_legacy_state(
+        paths,
+        initial,
+        lambda _path: 303,
+    )
+
+    assert recovered == initial
+
+
+def test_legacy_reauthentication_fails_closed_during_state_rewrite(
+    tmp_path: Path,
+) -> None:
+    """A concurrent malformed-state read cannot authorize process signals."""
+    state = _legacy_state()
+
+    def fail_read(
+        _paths: ServerPaths,
+    ) -> tuple[OwnedServer | None, tuple[int, int, int] | None]:
+        raise StateFileError("state changed")
+
+    recovered = codex_server_legacy.reauthenticate_legacy_state(
+        _server_paths(tmp_path),
+        state,
+        lambda _path: 303,
+        fail_read,
+    )
+
+    assert recovered == state
+
+
+def test_snapshot_retry_recovers_from_transient_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A short plugin-cache update no longer makes startup user-visible."""
+    calls = 0
+    delays: list[float] = []
+    monkeypatch.setattr(codex_server_retry.time, "sleep", delays.append)
+
+    @codex_server_retry.retry_plugin_snapshot_changes
+    def operation() -> str:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise codex_server_retry.PluginSnapshotChangedError("updating")
+        return "running"
+
+    assert operation() == "running"
+    assert calls == 3
+    assert delays == [0.05, 0.15]
+
+
+def test_snapshot_retry_remains_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Persistent plugin churn still fails after a small fixed attempt budget."""
+    calls = 0
+    monkeypatch.setattr(codex_server_retry.time, "sleep", lambda _delay: None)
+
+    @codex_server_retry.retry_plugin_snapshot_changes
+    def operation() -> None:
+        nonlocal calls
+        calls += 1
+        raise codex_server_retry.PluginSnapshotChangedError("still updating")
+
+    with pytest.raises(
+        codex_server_retry.PluginSnapshotChangedError,
+        match="still updating",
+    ):
+        operation()
+
+    assert calls == codex_server_retry.PLUGIN_SNAPSHOT_ATTEMPTS
+
+
+def _legacy_state() -> OwnedServer:
+    """Return ownership state written by the original callback helper."""
+    return OwnedServer(
+        pid=101,
+        pgid=101,
+        process_started_at="Tue Jul 14 10:09:10 2026",
+        codex_path="/fake/codex",
+        codex_version="codex-cli 0.144.4",
+        launched_at="2026-07-14T14:09:10.604461+00:00",
+        phase="running",
+        launch_token="launch-token",
+        worker_pid=202,
+        worker_pgid=202,
+        worker_started_at="Tue Jul 14 10:09:10 2026",
+    )
+
+
+def _server_paths(tmp_path: Path) -> ServerPaths:
+    """Return isolated legacy server paths."""
+    return ServerPaths(
+        codex_home=tmp_path,
+        runtime_dir=tmp_path / "runtime",
+        socket_path=tmp_path / "server.sock",
+        state_path=tmp_path / "state.json",
+        lock_path=tmp_path / "lock",
+        log_path=tmp_path / "server.log",
+    )


### PR DESCRIPTION
## What changed

- Reauthenticate app servers created with legacy textual process identities
  before allowing lifecycle commands to signal them.
- Bind ownership state and filesystem creation evidence to the same descriptor,
  then revalidate the socket, listener, parent edge, process groups, and native
  identities before cleanup.
- Retry bounded transient plugin and marketplace snapshot races during server
  startup.
- Reserve generation capacity with kernel-managed lifecycle locks so concurrent
  launches cannot exceed the retained-server limit.
- Detect atomic configuration, plugin-tree, symlink-target, missing-parent, and
  traversal replacements while building a server snapshot.
- Document how to run `/import` from plain Codex and safely retire an old helper
  occupying Codex's default socket.

## Why

Older releases stored process start times in a textual format. Current releases
use native identities, so an otherwise healthy old helper could not prove
ownership during `stop`. Separately, an old helper could still occupy Codex's
default local socket, making `/import` unavailable even from plain Codex.

Plugin installation could also rewrite the marketplace snapshot during startup,
and simultaneous launches could race past the generation cap. These cases now
retry or fail closed without disconnecting existing callback-ready sessions.

## User impact

Existing callbacks and dynamic TUIs remain untouched during ordinary upgrades.
After active callbacks finish and all dynamic TUIs have exited, users can run
`codex-server stop --force` to retire the legacy default-socket helper, then
start plain `codex` and use `/import`. New callback-ready servers continue to
use isolated generation-specific sockets.

## Validation

- Focused app-server suite: 177 passed, 2 skipped
- Hatch build-hook suite: 13 passed
- Ruff formatting and lint: passed
- Pyright: passed
- Starlight production build: passed
- Isolated wheel build and module-content checks: passed
- Detached adversarial review: GREEN with no blocking or important findings
- The live callback server was not stopped or modified during development
