### PR TITLE
feat(aichat): add `resolve` — agent-facing session resolver

### DIFF
--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -30,6 +30,26 @@ class SessionIDGroup(click.Group):
         return super().parse_args(ctx, args)
 
 
+class ResolveCommand(click.Command):
+    """Click command that renders resolver usage errors without usage text."""
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        """Parse arguments, converting Click usage failures to resolver errors."""
+        import sys
+
+        from claude_code_tools.resolve_session import _render_error
+
+        raw_args = tuple(args)
+        try:
+            return super().parse_args(ctx, args)
+        except click.UsageError as error:
+            pretty = "--pretty" in raw_args or (
+                "--json" not in raw_args and sys.stdout.isatty()
+            )
+            _render_error("invalid_input", error.format_message(), pretty)
+            ctx.exit(1)
+
+
 @click.group(cls=SessionIDGroup, invoke_without_command=True)
 @click.version_option()
 @click.option(
@@ -96,7 +116,11 @@ def main(ctx, claude_home, codex_home):
     # Skip for build-index/clear-index to avoid double-indexing or state conflicts
     # In JSON mode (-j/--json), suppress all output for clean parsing
     skip_auto_index_cmds = ['build-index', 'clear-index', 'index-stats']
-    should_skip = any(cmd in sys.argv for cmd in skip_auto_index_cmds)
+    should_skip = (
+        ctx.invoked_subcommand == 'resolve'
+        or ctx.invoked_subcommand in skip_auto_index_cmds
+        or any(cmd in sys.argv for cmd in skip_auto_index_cmds)
+    )
     json_mode = any(arg in sys.argv for arg in ['-j', '--json'])
     if not should_skip:
         try:
@@ -126,6 +150,49 @@ def main(ctx, claude_home, codex_home):
             select_target='action',
             results_title=' Select a session ',
         )
+
+
+@main.command("resolve", cls=ResolveCommand)
+@click.argument("query")
+@click.option(
+    "--agent",
+    type=str,
+    metavar="claude|codex",
+    default="claude",
+    show_default=True,
+)
+@click.option(
+    "--home",
+    type=click.Path(),
+    help="Claude or Codex home directory to search.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Force JSON output.")
+@click.option(
+    "--pretty",
+    "pretty_output",
+    is_flag=True,
+    help="Force human-readable output.",
+)
+def resolve_session_cmd(
+    query: str,
+    agent: str,
+    home: str | None,
+    json_output: bool,
+    pretty_output: bool,
+) -> None:
+    """Resolve a name, full session ID, or partial session ID."""
+    import sys
+
+    from claude_code_tools.resolve_session import run
+
+    if json_output and pretty_output:
+        click.echo(
+            '{"error":"invalid_format",'
+            '"detail":"Choose only one of --json or --pretty."}'
+        )
+        sys.exit(1)
+    fmt = "json" if json_output else "pretty" if pretty_output else "auto"
+    sys.exit(run(query, agent.lower(), home, fmt))
 
 
 # Shared help text for find commands

--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -163,7 +163,7 @@ def main(ctx, claude_home, codex_home):
 )
 @click.option(
     "--home",
-    type=click.Path(),
+    type=click.Path(readable=False),
     help="Claude or Codex home directory to search.",
 )
 @click.option("--json", "json_output", is_flag=True, help="Force JSON output.")
@@ -173,7 +173,9 @@ def main(ctx, claude_home, codex_home):
     is_flag=True,
     help="Force human-readable output.",
 )
+@click.pass_context
 def resolve_session_cmd(
+    ctx: click.Context,
     query: str,
     agent: str,
     home: str | None,
@@ -191,6 +193,9 @@ def resolve_session_cmd(
             '"detail":"Choose only one of --json or --pretty."}'
         )
         sys.exit(1)
+    if home is None:
+        home_key = "codex_home" if agent.casefold() == "codex" else "claude_home"
+        home = ctx.ensure_object(dict).get(home_key)
     fmt = "json" if json_output else "pretty" if pretty_output else "auto"
     sys.exit(run(query, agent.lower(), home, fmt))
 

--- a/claude_code_tools/export_session.py
+++ b/claude_code_tools/export_session.py
@@ -236,6 +236,8 @@ def extract_first_last_messages(
                     data = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                if not isinstance(data, dict):
+                    continue
 
                 role: Optional[str] = None
                 text: Optional[str] = None
@@ -343,6 +345,8 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
                     data = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                if not isinstance(data, dict):
+                    continue
 
                 # Extract cwd (first line that has it)
                 if metadata["cwd"] is None and data.get("cwd"):
@@ -410,7 +414,7 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
                 if (metadata["cwd"] and metadata["branch"]) or line_num >= 500:
                     break
 
-    except (OSError, IOError):
+    except (OSError, IOError, UnicodeError):
         pass
 
     # Note: customTitle extraction is done in search_index.py's _extract_session_content
@@ -454,7 +458,7 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
     try:
         with open(session_file, "r", encoding="utf-8") as f:
             metadata["lines"] = sum(1 for _ in f)
-    except (OSError, IOError):
+    except (OSError, IOError, UnicodeError):
         metadata["lines"] = 0
 
     # Derive project name from cwd

--- a/claude_code_tools/export_session.py
+++ b/claude_code_tools/export_session.py
@@ -97,7 +97,10 @@ def _get_last_line_timestamp(file_path: Path) -> Optional[str]:
 
             # Parse JSON and extract timestamp
             data = json.loads(last_line)
-            return data.get("timestamp")
+            if not isinstance(data, dict):
+                return None
+            timestamp = data.get("timestamp")
+            return timestamp if isinstance(timestamp, str) and timestamp else None
 
     except (OSError, IOError, json.JSONDecodeError, UnicodeDecodeError):
         return None
@@ -114,6 +117,8 @@ def _extract_claude_message_text(data: dict) -> Optional[str]:
         Extracted text or None if not a text message
     """
     message = data.get("message", {})
+    if not isinstance(message, dict):
+        return None
     content = message.get("content")
 
     if not content:
@@ -129,8 +134,9 @@ def _extract_claude_message_text(data: dict) -> Optional[str]:
             if isinstance(block, str) and block.strip():
                 return block.strip()
             if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text", "").strip()
-                if text:
+                text = block.get("text")
+                if isinstance(text, str) and text.strip():
+                    text = text.strip()
                     return text
 
     return None
@@ -147,6 +153,8 @@ def _extract_codex_message_text(data: dict) -> Optional[str]:
         Extracted text or None if not a text message
     """
     payload = data.get("payload", {})
+    if not isinstance(payload, dict):
+        return None
     if payload.get("type") != "message":
         return None
 
@@ -160,9 +168,9 @@ def _extract_codex_message_text(data: dict) -> Optional[str]:
         block_type = block.get("type")
         # Both input_text and output_text have text field
         if block_type in ("input_text", "output_text"):
-            text = block.get("text", "").strip()
-            if text:
-                return text
+            text = block.get("text")
+            if isinstance(text, str) and text.strip():
+                return text.strip()
 
     return None
 
@@ -251,10 +259,17 @@ def extract_first_last_messages(
                 elif agent == "codex":
                     if data.get("type") == "response_item":
                         payload = data.get("payload", {})
-                        if payload.get("type") == "message":
-                            role = payload.get("role")
+                        if (
+                            isinstance(payload, dict)
+                            and payload.get("type") == "message"
+                        ):
+                            payload_role = payload.get("role")
+                            if isinstance(payload_role, str):
+                                role = payload_role
                             text = _extract_codex_message_text(data)
-                            timestamp = data.get("timestamp")
+                            raw_timestamp = data.get("timestamp")
+                            if isinstance(raw_timestamp, str):
+                                timestamp = raw_timestamp
 
                 if role and text:
                     msg_dict = {
@@ -336,7 +351,7 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
 
     try:
         with open(session_file, "r", encoding="utf-8") as f:
-            for line_num, line in enumerate(f, 1):
+            for line in f:
                 line = line.strip()
                 if not line:
                     continue
@@ -348,39 +363,58 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
                 if not isinstance(data, dict):
                     continue
 
-                # Extract cwd (first line that has it)
-                if metadata["cwd"] is None and data.get("cwd"):
-                    metadata["cwd"] = data["cwd"]
+                # Extract cwd (first line with a non-empty string value)
+                cwd = data.get("cwd")
+                if (
+                    metadata["cwd"] is None
+                    and isinstance(cwd, str)
+                    and bool(cwd.strip())
+                ):
+                    metadata["cwd"] = cwd
 
                 # Extract git branch (first line that has it)
-                if metadata["branch"] is None and data.get("gitBranch"):
-                    metadata["branch"] = data["gitBranch"]
+                git_branch = data.get("gitBranch")
+                if (
+                    metadata["branch"] is None
+                    and isinstance(git_branch, str)
+                    and bool(git_branch.strip())
+                ):
+                    metadata["branch"] = git_branch
 
                 # Extract session ID from sessionId field if available
-                if data.get("sessionId"):
-                    metadata["session_id"] = data["sessionId"]
+                session_id = data.get("sessionId")
+                if isinstance(session_id, str) and session_id.strip():
+                    metadata["session_id"] = session_id
 
                 # Extract trim_metadata (for trimmed sessions)
-                if "trim_metadata" in data:
-                    tm = data["trim_metadata"]
+                tm = data.get("trim_metadata")
+                if isinstance(tm, dict):
                     metadata["derivation_type"] = "trimmed"
-                    metadata["parent_session_file"] = tm.get("parent_file")
-                    if tm.get("parent_file"):
-                        parent_path = Path(tm["parent_file"])
+                    parent_file = tm.get("parent_file")
+                    if isinstance(parent_file, str) and parent_file.strip():
+                        metadata["parent_session_file"] = parent_file
+                        parent_path = Path(parent_file)
                         metadata["parent_session_id"] = parent_path.stem
-                    if tm.get("stats"):
-                        metadata["trim_stats"] = tm["stats"]
+                    stats = tm.get("stats")
+                    if isinstance(stats, dict):
+                        metadata["trim_stats"] = stats
 
                 # Extract continue_metadata (for continued sessions)
-                if "continue_metadata" in data:
-                    cm = data["continue_metadata"]
+                cm = data.get("continue_metadata")
+                if isinstance(cm, dict):
                     metadata["derivation_type"] = "continued"
-                    metadata["parent_session_id"] = cm.get("parent_session_id")
-                    metadata["parent_session_file"] = cm.get("parent_session_file")
+                    parent_id = cm.get("parent_session_id")
+                    if isinstance(parent_id, str) and parent_id.strip():
+                        metadata["parent_session_id"] = parent_id
+                    parent_file = cm.get("parent_session_file")
+                    if isinstance(parent_file, str) and parent_file.strip():
+                        metadata["parent_session_file"] = parent_file
 
                 # Extract sessionType (e.g., "helper" for SDK/headless sessions)
                 if "sessionType" in data and metadata["session_type"] is None:
-                    metadata["session_type"] = data["sessionType"]
+                    session_type = data.get("sessionType")
+                    if isinstance(session_type, str) and session_type.strip():
+                        metadata["session_type"] = session_type
 
                 # Extract git branch for Claude from file-history-snapshot metadata
                 if (
@@ -388,30 +422,44 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
                     and metadata["branch"] is None
                     and data.get("type") == "file-history-snapshot"
                 ):
-                    git_info = data.get("metadata", {}).get("git", {})
-                    if git_info.get("branch"):
-                        metadata["branch"] = git_info["branch"]
+                    nested_metadata = data.get("metadata")
+                    if isinstance(nested_metadata, dict):
+                        git_info = nested_metadata.get("git")
+                        if isinstance(git_info, dict):
+                            branch = git_info.get("branch")
+                            if isinstance(branch, str) and branch.strip():
+                                metadata["branch"] = branch
 
                 # Extract git branch for Codex sessions from session_meta
                 if agent == "codex" and data.get("type") == "session_meta":
-                    payload = data.get("payload", {})
-                    git_info = payload.get("git", {})
-                    if git_info.get("branch"):
-                        metadata["branch"] = git_info["branch"]
-                    if payload.get("cwd"):
-                        metadata["cwd"] = payload["cwd"]
-                    if payload.get("id"):
-                        metadata["session_id"] = payload["id"]
-                    if session_start_timestamp is None and data.get("timestamp"):
-                        session_start_timestamp = data["timestamp"]
+                    payload = data.get("payload")
+                    if isinstance(payload, dict):
+                        git_info = payload.get("git")
+                        if isinstance(git_info, dict):
+                            branch = git_info.get("branch")
+                            if isinstance(branch, str) and branch.strip():
+                                metadata["branch"] = branch
+                        payload_cwd = payload.get("cwd")
+                        if (
+                            isinstance(payload_cwd, str)
+                            and payload_cwd.strip()
+                        ):
+                            metadata["cwd"] = payload_cwd
+                        payload_id = payload.get("id")
+                        if isinstance(payload_id, str) and payload_id.strip():
+                            metadata["session_id"] = payload_id
 
                 # Extract session start timestamp from first entry with timestamp
-                if session_start_timestamp is None and data.get("timestamp"):
-                    session_start_timestamp = data["timestamp"]
+                timestamp = data.get("timestamp")
+                if (
+                    session_start_timestamp is None
+                    and isinstance(timestamp, str)
+                    and timestamp.strip()
+                ):
+                    session_start_timestamp = timestamp
 
-                # Stop once we have the essential metadata (cwd and branch)
-                # or after 500 lines as a safety limit
-                if (metadata["cwd"] and metadata["branch"]) or line_num >= 500:
+                # Stop once we have the essential metadata (cwd and branch).
+                if metadata["cwd"] and metadata["branch"]:
                     break
 
     except (OSError, IOError, UnicodeError):

--- a/claude_code_tools/find_claude_session.py
+++ b/claude_code_tools/find_claude_session.py
@@ -294,20 +294,23 @@ def is_sidechain_session(filepath: Path) -> bool:
     Returns:
         True if session is a sidechain, False otherwise.
     """
+    if filepath.name.startswith("agent-"):
+        return True
+
     if not filepath.exists():
         return False
 
     try:
         with open(filepath, 'r', encoding='utf-8') as f:
-            # Check first few lines for isSidechain field
-            for i, line in enumerate(f):
-                if i >= 10:  # Only check first 10 lines
-                    break
+            for line in f:
                 try:
                     data = json.loads(line.strip())
-                    if isinstance(data, dict) and "isSidechain" in data:
-                        return data["isSidechain"] is True
-                except (json.JSONDecodeError, KeyError):
+                    if (
+                        isinstance(data, dict)
+                        and data.get("isSidechain") is True
+                    ):
+                        return True
+                except (json.JSONDecodeError, TypeError):
                     continue
     except (OSError, IOError, UnicodeError):
         pass
@@ -403,8 +406,13 @@ def get_session_preview(filepath: Path) -> str:
                         continue
                     msg_type = data.get('type')
                     # Accept user or assistant messages
-                    if msg_type in ('user', 'assistant'):
-                        message = data.get('message', {})
+                    if isinstance(msg_type, str) and msg_type in (
+                        'user',
+                        'assistant',
+                    ):
+                        message = data.get('message')
+                        if not isinstance(message, dict):
+                            continue
                         content = message.get('content', '')
                         text = None
 
@@ -413,8 +421,13 @@ def get_session_preview(filepath: Path) -> str:
                         elif isinstance(content, list):
                             # Handle structured content
                             for item in content:
-                                if isinstance(item, dict) and item.get('type') == 'text':
-                                    text = item.get('text', '').strip()
+                                if not isinstance(item, dict):
+                                    continue
+                                if item.get('type') != 'text':
+                                    continue
+                                item_text = item.get('text')
+                                if isinstance(item_text, str):
+                                    text = item_text.strip()
                                     break
 
                         # Filter out system messages and keep updating to get LAST

--- a/claude_code_tools/find_claude_session.py
+++ b/claude_code_tools/find_claude_session.py
@@ -59,15 +59,17 @@ def get_session_start_timestamp(jsonl_file: Path) -> Optional[float]:
                     continue
                 try:
                     data = json.loads(line)
-                    if data.get("timestamp"):
-                        ts = data["timestamp"]
+                    if not isinstance(data, dict):
+                        continue
+                    ts = data.get("timestamp")
+                    if isinstance(ts, str) and ts:
                         # Parse ISO format (e.g., "2025-10-22T16:05:28.707Z")
                         if ts.endswith("Z"):
                             ts = ts[:-1] + "+00:00"
                         return datetime.fromisoformat(ts).timestamp()
                 except (json.JSONDecodeError, ValueError, TypeError):
                     continue
-    except (OSError, IOError):
+    except (OSError, IOError, UnicodeError):
         pass
     return None
 
@@ -216,6 +218,8 @@ def extract_project_name(original_path: str) -> str:
                 for line in f:
                     try:
                         data = json.loads(line.strip())
+                        if not isinstance(data, dict):
+                            continue
                         # Only count user/assistant messages
                         if data.get('type') in ('user', 'assistant'):
                             msg_count += 1
@@ -242,6 +246,8 @@ def extract_project_name(original_path: str) -> str:
 
                 try:
                     data = json.loads(line.strip())
+                    if not isinstance(data, dict):
+                        continue
                     # Only count user/assistant messages
                     if data.get('type') in ('user', 'assistant'):
                         msg_count += 1
@@ -299,11 +305,11 @@ def is_sidechain_session(filepath: Path) -> bool:
                     break
                 try:
                     data = json.loads(line.strip())
-                    if "isSidechain" in data:
+                    if isinstance(data, dict) and "isSidechain" in data:
                         return data["isSidechain"] is True
                 except (json.JSONDecodeError, KeyError):
                     continue
-    except (OSError, IOError):
+    except (OSError, IOError, UnicodeError):
         pass
 
     return False
@@ -332,6 +338,8 @@ def search_keywords_in_file(filepath: Path, keywords: List[str]) -> tuple[bool, 
                 for line in f:
                     try:
                         data = json.loads(line.strip())
+                        if not isinstance(data, dict):
+                            continue
                         # Only count user/assistant messages
                         if data.get('type') in ('user', 'assistant'):
                             msg_count += 1
@@ -358,6 +366,8 @@ def search_keywords_in_file(filepath: Path, keywords: List[str]) -> tuple[bool, 
 
                 try:
                     data = json.loads(line.strip())
+                    if not isinstance(data, dict):
+                        continue
                     # Only count user/assistant messages
                     if data.get('type') in ('user', 'assistant'):
                         msg_count += 1
@@ -389,6 +399,8 @@ def get_session_preview(filepath: Path) -> str:
             for line in f:
                 try:
                     data = json.loads(line.strip())
+                    if not isinstance(data, dict):
+                        continue
                     msg_type = data.get('type')
                     # Accept user or assistant messages
                     if msg_type in ('user', 'assistant'):
@@ -498,7 +510,10 @@ def find_sessions(
                                     continue
 
                             session_id = jsonl_file.stem
-                            stat = jsonl_file.stat()
+                            try:
+                                stat = jsonl_file.stat()
+                            except OSError:
+                                continue
                             mod_time = stat.st_mtime
                             # Get session start timestamp from JSON metadata, fall back to file stats
                             create_time = get_session_start_timestamp(jsonl_file)
@@ -506,7 +521,10 @@ def find_sessions(
                                 create_time = getattr(stat, 'st_birthtime', stat.st_ctime)
                             preview = get_session_preview(jsonl_file)
                             # Extract actual cwd from session file - MUST NOT use reconstructed path as fallback
-                            actual_cwd = extract_cwd_from_session(jsonl_file)
+                            actual_cwd = extract_cwd_from_session(
+                                jsonl_file,
+                                agent="claude",
+                            )
                             if not actual_cwd:
                                 # Skip sessions without cwd metadata (shouldn't happen for valid Claude sessions)
                                 continue
@@ -547,7 +565,10 @@ def find_sessions(
                                 continue
 
                         session_id = jsonl_file.stem
-                        stat = jsonl_file.stat()
+                        try:
+                            stat = jsonl_file.stat()
+                        except OSError:
+                            continue
                         mod_time = stat.st_mtime
                         # Get session start timestamp from JSON metadata, fall back to file stats
                         create_time = get_session_start_timestamp(jsonl_file)
@@ -555,7 +576,10 @@ def find_sessions(
                             create_time = getattr(stat, 'st_birthtime', stat.st_ctime)
                         preview = get_session_preview(jsonl_file)
                         # Extract actual cwd from session file - MUST NOT use reconstructed path as fallback
-                        actual_cwd = extract_cwd_from_session(jsonl_file)
+                        actual_cwd = extract_cwd_from_session(
+                            jsonl_file,
+                            agent="claude",
+                        )
                         if not actual_cwd:
                             # Skip sessions without cwd metadata (shouldn't happen for valid Claude sessions)
                             continue
@@ -599,7 +623,10 @@ def find_sessions(
                         continue
 
                 session_id = jsonl_file.stem
-                stat = jsonl_file.stat()
+                try:
+                    stat = jsonl_file.stat()
+                except OSError:
+                    continue
                 mod_time = stat.st_mtime
                 # Get session start timestamp from JSON metadata, fall back to file stats
                 create_time = get_session_start_timestamp(jsonl_file)
@@ -607,7 +634,10 @@ def find_sessions(
                     create_time = getattr(stat, 'st_birthtime', stat.st_ctime)
                 preview = get_session_preview(jsonl_file)
                 # Extract actual cwd from session file for consistency
-                actual_cwd = extract_cwd_from_session(jsonl_file) or os.getcwd()
+                actual_cwd = (
+                    extract_cwd_from_session(jsonl_file, agent="claude")
+                    or os.getcwd()
+                )
                 matching_sessions.append((session_id, mod_time, create_time, line_count, project_name, preview, actual_cwd, git_branch, derivation_type, is_sidechain))
     
     # Sort by modification time (newest first)
@@ -1059,6 +1089,54 @@ def get_session_file_path(
         )
 
 
+def get_custom_title(
+    session_id: str,
+    cwd: str,
+    claude_home: Optional[str] = None,
+    session_file: Optional[Path] = None,
+) -> str:
+    """Return the most recent user-assigned name for a Claude session.
+
+    Claude writes names from ``/rename`` as ``custom-title`` records. Older
+    versions may mirror the value in an ``agent-name`` record. Automatic
+    ``ai-title`` records are deliberately ignored.
+
+    Args:
+        session_id: Full Claude session identifier.
+        cwd: Session working directory.
+        claude_home: Optional Claude home directory override.
+        session_file: Optional already-discovered transcript path. This avoids
+            reconstructing a stale path from the transcript's current cwd.
+
+    Returns:
+        The latest custom session name, or an empty string if none is found.
+    """
+    try:
+        path = session_file or Path(
+            get_session_file_path(session_id, cwd, claude_home)
+        )
+        custom_title = ""
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(data, dict):
+                    continue
+                if data.get("type") == "custom-title":
+                    value = data.get("customTitle")
+                elif data.get("type") == "agent-name":
+                    value = data.get("agentName")
+                else:
+                    continue
+                if isinstance(value, str) and value:
+                    custom_title = value
+        return custom_title
+    except (OSError, UnicodeError, ValueError):
+        return ""
+
+
 def handle_export_session(session_file_path: str, dest_override: str | None = None, silent: bool = False) -> None:
     """Export session to text file."""
     from claude_code_tools.export_claude_session import export_session_to_markdown as do_export
@@ -1071,7 +1149,7 @@ def handle_export_session(session_file_path: str, dest_override: str | None = No
         today = datetime.now().strftime("%Y%m%d")
 
         # Infer project directory from session metadata
-        project_dir = extract_cwd_from_session(session_file)
+        project_dir = extract_cwd_from_session(session_file, agent="claude")
         if project_dir:
             output_dir = Path(project_dir) / "exported-sessions"
         else:
@@ -1591,19 +1669,6 @@ To persist directory changes when resuming sessions:
     rpc_path = str(Path(__file__).parent / "action_rpc.py")
 
     if not args.simple_ui:
-        from claude_code_tools.export_session import extract_session_metadata
-
-        def get_custom_title(session_id: str, cwd: str) -> str:
-            """Extract custom title from session file if present."""
-            try:
-                fp = get_session_file_path(session_id, cwd, args.claude_home)
-                if fp:
-                    meta = extract_session_metadata(Path(fp), "claude")
-                    return meta.get("customTitle", "")
-            except Exception:
-                pass
-            return ""
-
         limited = [
             {
                 "agent": "claude",
@@ -1621,7 +1686,9 @@ To persist directory changes when resuming sessions:
                 "is_trimmed": s[8] if len(s) > 8 else False,
                 "derivation_type": None,
                 "is_sidechain": s[9] if len(s) > 9 else False,
-                "custom_title": get_custom_title(s[0], s[6]),
+                "custom_title": get_custom_title(
+                    s[0], s[6], args.claude_home
+                ),
             }
             for s in matching_sessions[: args.num_matches]
         ]

--- a/claude_code_tools/find_codex_session.py
+++ b/claude_code_tools/find_codex_session.py
@@ -79,6 +79,12 @@ try:
 except ImportError:
     RICH_AVAILABLE = False
 
+
+def _string_or_empty(value: object) -> str:
+    """Return string metadata values, normalizing malformed values to empty."""
+    return value if isinstance(value, str) else ""
+
+
 def extract_session_id_from_filename(filename: str) -> Optional[str]:
     """
     Extract session ID from Codex session filename.
@@ -109,14 +115,22 @@ def extract_session_metadata(session_file: Path) -> Optional[dict]:
                     continue
                 try:
                     entry = json.loads(line)
+                    if not isinstance(entry, dict):
+                        continue
                     if entry.get("type") == "session_meta":
-                        payload = entry.get("payload", {})
+                        payload = entry.get("payload")
+                        if not isinstance(payload, dict):
+                            continue
                         git_info = payload.get("git", {})
+                        if not isinstance(git_info, dict):
+                            git_info = {}
                         return {
-                            "id": payload.get("id", ""),
-                            "cwd": payload.get("cwd", ""),
-                            "branch": git_info.get("branch", ""),
-                            "timestamp": payload.get("timestamp", ""),
+                            "id": _string_or_empty(payload.get("id")),
+                            "cwd": _string_or_empty(payload.get("cwd")),
+                            "branch": _string_or_empty(git_info.get("branch")),
+                            "timestamp": _string_or_empty(
+                                payload.get("timestamp")
+                            ),
                         }
                 except json.JSONDecodeError:
                     continue
@@ -166,18 +180,29 @@ def search_keywords_in_file(
                         continue
                     try:
                         entry = json.loads(line)
+                        if not isinstance(entry, dict):
+                            continue
                         # Only count and extract user/assistant messages
                         if entry.get("type") == "response_item":
-                            role = entry.get("payload", {}).get("role")
+                            payload = entry.get("payload")
+                            if not isinstance(payload, dict):
+                                continue
+                            role = _string_or_empty(payload.get("role"))
                             if role in ("user", "assistant"):
                                 msg_count += 1
-                                content = entry.get("payload", {}).get("content", [])
+                                content = payload.get("content")
                                 if isinstance(content, list) and len(content) > 0:
                                     first_item = content[0]
                                     if isinstance(first_item, dict):
-                                        text = first_item.get("text", "")
+                                        text = _string_or_empty(
+                                            first_item.get("text")
+                                        )
                                         if text and not is_system_message(text):
-                                            cleaned = text[:400].replace("\n", " ").strip()
+                                            cleaned = (
+                                                text[:400]
+                                                .replace("\n", " ")
+                                                .strip()
+                                            )
                                             type_prefix = f"[{role}]"
                                             if len(cleaned) > 20:
                                                 last_message = (type_prefix, cleaned)
@@ -187,7 +212,7 @@ def search_keywords_in_file(
                         continue
             preview = f"{last_message[0]} {last_message[1]}" if last_message else None
             return True, msg_count, preview
-        except (OSError, IOError):
+        except (OSError, IOError, UnicodeError):
             return False, 0, None
 
     keywords_lower = [k.lower() for k in keywords]
@@ -209,20 +234,31 @@ def search_keywords_in_file(
 
                 try:
                     entry = json.loads(line)
+                    if not isinstance(entry, dict):
+                        continue
 
                     # Only count and extract user/assistant messages
                     if entry.get("type") == "response_item":
-                        role = entry.get("payload", {}).get("role")
+                        payload = entry.get("payload")
+                        if not isinstance(payload, dict):
+                            continue
+                        role = _string_or_empty(payload.get("role"))
                         if role in ("user", "assistant"):
                             msg_count += 1
-                            content = entry.get("payload", {}).get("content", [])
+                            content = payload.get("content")
                             if isinstance(content, list) and len(content) > 0:
                                 first_item = content[0]
                                 if isinstance(first_item, dict):
-                                    text = first_item.get("text", "")
+                                    text = _string_or_empty(
+                                        first_item.get("text")
+                                    )
                                     if text and not is_system_message(text):
                                         # Keep updating with latest message
-                                        cleaned = text[:400].replace("\n", " ").strip()
+                                        cleaned = (
+                                            text[:400]
+                                            .replace("\n", " ")
+                                            .strip()
+                                        )
                                         type_prefix = f"[{role}]"
                                         # Only keep if it's substantial (>20 chars)
                                         if len(cleaned) > 20:
@@ -238,14 +274,14 @@ def search_keywords_in_file(
         preview = f"{last_message[0]} {last_message[1]}" if last_message else None
         return all_found, msg_count, preview
 
-    except (OSError, IOError):
+    except (OSError, IOError, UnicodeError):
         return False, 0, None
 
 
 def find_sessions(
     codex_home: Path,
     keywords: list[str],
-    num_matches: int = 10,
+    num_matches: Optional[int] = 10,
     global_search: bool = False,
     original_only: bool = False,
     no_sub: bool = False,
@@ -258,7 +294,8 @@ def find_sessions(
     Args:
         codex_home: Path to Codex home directory
         keywords: List of keywords to search for
-        num_matches: Maximum number of results to return
+        num_matches: Maximum number of results to return, or None for all
+            matching sessions.
         global_search: If False, filter to current directory only
         original_only: If True, show only original sessions (excludes trimmed and rollover)
         no_sub: If True, exclude sub-agent sessions (Note: Codex doesn't have sub-agents)
@@ -342,7 +379,11 @@ def find_sessions(
                             continue
 
                     # Get timestamps - prefer JSON metadata for create_time
-                    stat = session_file.stat()
+                    try:
+                        stat = session_file.stat()
+                    except OSError:
+                        # The rollout may disappear after it was opened above.
+                        continue
                     mod_time = stat.st_mtime
                     # Use session timestamp from metadata if available
                     if metadata.get("timestamp"):
@@ -352,7 +393,7 @@ def find_sessions(
                             if ts.endswith("Z"):
                                 ts = ts[:-1] + "+00:00"
                             create_time = datetime.fromisoformat(ts).timestamp()
-                        except (ValueError, TypeError):
+                        except (OSError, OverflowError, TypeError, ValueError):
                             create_time = getattr(stat, 'st_birthtime', stat.st_ctime)
                     else:
                         create_time = getattr(stat, 'st_birthtime', stat.st_ctime)
@@ -379,12 +420,15 @@ def find_sessions(
                     )
 
                     # Early exit if we have enough matches
-                    if len(matches) >= num_matches * 3:
+                    if (
+                        num_matches is not None
+                        and len(matches) >= num_matches * 3
+                    ):
                         break
 
     # Sort by modification time (newest first) and limit
     matches.sort(key=lambda x: x["mod_time"], reverse=True)
-    return matches[:num_matches]
+    return matches if num_matches is None else matches[:num_matches]
 
 
 def display_interactive_ui(

--- a/claude_code_tools/find_codex_session.py
+++ b/claude_code_tools/find_codex_session.py
@@ -314,117 +314,123 @@ def find_sessions(
 
     matches = []
 
-    # Walk through YYYY/MM/DD directory structure
-    for year_dir in sorted(sessions_dir.iterdir(), reverse=True):
-        if not year_dir.is_dir():
-            continue
+    # Rollouts normally use YYYY/MM/DD, but the on-disk contract permits any
+    # directory depth beneath sessions.
+    session_files: list[Path] = []
+    try:
+        session_files.extend(
+            sessions_dir.rglob("rollout-*.jsonl")
+        )
+    except OSError:
+        # Preserve paths yielded before an inaccessible directory interrupted
+        # traversal. Per-file guards below isolate failures in those paths.
+        pass
+    session_files.sort(reverse=True)
 
-        for month_dir in sorted(year_dir.iterdir(), reverse=True):
-            if not month_dir.is_dir():
+    for session_file in session_files:
+        try:
+            # Search for keywords
+            found, line_count, preview = search_keywords_in_file(
+                session_file, keywords
+            )
+
+            if not found:
                 continue
 
-            for day_dir in sorted(month_dir.iterdir(), reverse=True):
-                if not day_dir.is_dir():
+            # Extract metadata
+            metadata = extract_session_metadata(session_file)
+            if not metadata:
+                # Fallback: extract session ID from filename
+                session_id = extract_session_id_from_filename(
+                    session_file.name
+                )
+                if not session_id:
+                    continue
+                metadata = {
+                    "id": session_id,
+                    "cwd": "",
+                    "branch": "",
+                    "timestamp": "",
+                }
+
+            # Filter by current directory if not global search
+            if current_cwd and metadata["cwd"] != current_cwd:
+                continue
+
+            # Check if session is trimmed/continued
+            is_trimmed = is_trimmed_session(session_file)
+            derivation_type = (
+                get_session_derivation_type(session_file)
+                if is_trimmed
+                else None
+            )
+
+            # Apply filters (original_only overrides individual filters)
+            # Note: Codex doesn't have sub-agent sessions, so no_sub has no
+            # effect.
+            if original_only:
+                if is_trimmed:
+                    continue
+            else:
+                if no_trim and derivation_type == "trimmed":
+                    continue
+                if no_cont and derivation_type == "continued":
                     continue
 
-                # Process all JSONL files in this day
-                session_files = sorted(
-                    day_dir.glob("rollout-*.jsonl"), reverse=True
-                )
-
-                for session_file in session_files:
-                    # Search for keywords
-                    found, line_count, preview = search_keywords_in_file(
-                        session_file, keywords
+            # Get timestamps - prefer JSON metadata for create_time
+            stat = session_file.stat()
+            mod_time = stat.st_mtime
+            if metadata.get("timestamp"):
+                try:
+                    ts = metadata["timestamp"]
+                    # Parse ISO format (e.g., "2025-10-22T16:05:28.707Z")
+                    if ts.endswith("Z"):
+                        ts = ts[:-1] + "+00:00"
+                    create_time = datetime.fromisoformat(ts).timestamp()
+                except (OSError, OverflowError, TypeError, ValueError):
+                    create_time = getattr(
+                        stat, "st_birthtime", stat.st_ctime
                     )
+            else:
+                create_time = getattr(stat, "st_birthtime", stat.st_ctime)
 
-                    if not found:
-                        continue
+            # Format dates: "10/04 - 10/09 13:45"
+            create_date = datetime.fromtimestamp(create_time).strftime("%m/%d")
+            mod_date = datetime.fromtimestamp(mod_time).strftime("%m/%d %H:%M")
+            date_str = f"{create_date} - {mod_date}"
 
-                    # Extract metadata
-                    metadata = extract_session_metadata(session_file)
-                    if not metadata:
-                        # Fallback: extract session ID from filename
-                        session_id = extract_session_id_from_filename(
-                            session_file.name
-                        )
-                        if not session_id:
-                            continue
-                        metadata = {
-                            "id": session_id,
-                            "cwd": "",
-                            "branch": "",
-                            "timestamp": "",
-                        }
+            matches.append(
+                {
+                    "session_id": metadata["id"],
+                    "project": get_project_name(metadata["cwd"]),
+                    "branch": metadata["branch"] or "",
+                    "date": date_str,
+                    "mod_time": mod_time,  # For sorting
+                    "create_time": create_time,  # For date range display
+                    "lines": line_count,
+                    "preview": preview or "No preview",
+                    "cwd": metadata["cwd"],
+                    "file_path": str(session_file),
+                    "is_trimmed": is_trimmed,
+                }
+            )
+        except (
+            AttributeError,
+            KeyError,
+            OSError,
+            OverflowError,
+            RuntimeError,
+            TypeError,
+            UnicodeError,
+            ValueError,
+        ):
+            # One disappearing, inaccessible, or malformed rollout must not
+            # prevent discovery of other sessions.
+            continue
 
-                    # Filter by current directory if not global search
-                    if current_cwd and metadata["cwd"] != current_cwd:
-                        continue
-
-                    # Check if session is trimmed/continued
-                    is_trimmed = is_trimmed_session(session_file)
-                    derivation_type = get_session_derivation_type(session_file) if is_trimmed else None
-
-                    # Apply filters (original_only overrides individual filters)
-                    # Note: Codex doesn't have sub-agent sessions, so no_sub has no effect
-                    if original_only:
-                        # Original only: exclude trimmed and continued
-                        if is_trimmed:
-                            continue
-                    else:
-                        # Individual filters
-                        if no_trim and derivation_type == "trimmed":
-                            continue
-                        if no_cont and derivation_type == "continued":
-                            continue
-
-                    # Get timestamps - prefer JSON metadata for create_time
-                    try:
-                        stat = session_file.stat()
-                    except OSError:
-                        # The rollout may disappear after it was opened above.
-                        continue
-                    mod_time = stat.st_mtime
-                    # Use session timestamp from metadata if available
-                    if metadata.get("timestamp"):
-                        try:
-                            ts = metadata["timestamp"]
-                            # Parse ISO format (e.g., "2025-10-22T16:05:28.707Z")
-                            if ts.endswith("Z"):
-                                ts = ts[:-1] + "+00:00"
-                            create_time = datetime.fromisoformat(ts).timestamp()
-                        except (OSError, OverflowError, TypeError, ValueError):
-                            create_time = getattr(stat, 'st_birthtime', stat.st_ctime)
-                    else:
-                        create_time = getattr(stat, 'st_birthtime', stat.st_ctime)
-
-                    # Format dates: "10/04 - 10/09 13:45"
-                    create_date = datetime.fromtimestamp(create_time).strftime("%m/%d")
-                    mod_date = datetime.fromtimestamp(mod_time).strftime("%m/%d %H:%M")
-                    date_str = f"{create_date} - {mod_date}"
-
-                    matches.append(
-                        {
-                            "session_id": metadata["id"],
-                            "project": get_project_name(metadata["cwd"]),
-                            "branch": metadata["branch"] or "",
-                            "date": date_str,
-                            "mod_time": mod_time,  # For sorting
-                            "create_time": create_time,  # For date range display
-                            "lines": line_count,
-                            "preview": preview or "No preview",
-                            "cwd": metadata["cwd"],
-                            "file_path": str(session_file),
-                            "is_trimmed": is_trimmed,
-                        }
-                    )
-
-                    # Early exit if we have enough matches
-                    if (
-                        num_matches is not None
-                        and len(matches) >= num_matches * 3
-                    ):
-                        break
+        # Early exit if we have enough matches
+        if num_matches is not None and len(matches) >= num_matches * 3:
+            break
 
     # Sort by modification time (newest first) and limit
     matches.sort(key=lambda x: x["mod_time"], reverse=True)

--- a/claude_code_tools/resolve_session.py
+++ b/claude_code_tools/resolve_session.py
@@ -15,11 +15,13 @@ from rich import box
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 from claude_code_tools.session_utils import (
     format_session_id_display,
     get_claude_home,
     get_codex_home,
+    is_valid_session,
 )
 
 Agent = Literal["claude", "codex"]
@@ -130,11 +132,11 @@ def _mtime(path: Path) -> tuple[str, float]:
     """Return a session file's local ISO mtime and numeric timestamp."""
     try:
         timestamp = path.stat().st_mtime
-    except OSError as error:
+        modified = datetime.fromtimestamp(timestamp).astimezone().isoformat()
+    except (OSError, OverflowError, ValueError) as error:
         raise ResolverError(
             "unreadable_session", f"Cannot stat session file {path}: {error}"
         ) from error
-    modified = datetime.fromtimestamp(timestamp).astimezone().isoformat()
     return modified, timestamp
 
 
@@ -158,9 +160,52 @@ def _normalize_archived(value: object) -> bool:
     return False
 
 
+def _decode_sqlite_text(value: bytes) -> str | bytes:
+    """Decode valid UTF-8 SQLite text and preserve invalid text as bytes."""
+    try:
+        return value.decode("utf-8")
+    except UnicodeDecodeError:
+        return value
+
+
 def _normalize_directory(value: object) -> str | None:
     """Return a usable session directory, or None for malformed metadata."""
     return value if isinstance(value, str) and value.strip() else None
+
+
+def _has_claude_session_record(session_file: Path) -> bool:
+    """Return whether a transcript contains a Claude conversation record.
+
+    Filename-based exact-ID resolution can tolerate missing or wrong-typed
+    record metadata, including ``sessionId``. It still requires at least one
+    parseable Claude conversation record so empty, unreadable, or wholly
+    truncated files are not presented as resumable sessions.
+    """
+    conversation_types = {
+        "assistant",
+        "system",
+        "tool_result",
+        "tool_use",
+        "user",
+    }
+    try:
+        with session_file.open("r", encoding="utf-8") as transcript:
+            for line in transcript:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                record_type = record.get("type")
+                if (
+                    isinstance(record_type, str)
+                    and record_type in conversation_types
+                ):
+                    return True
+    except (OSError, UnicodeError):
+        return False
+    return False
 
 
 def _claude_record(
@@ -241,12 +286,18 @@ def enumerate_claude_sessions(home: Path) -> list[SessionRecord]:
                     session_id, directory, str(home)
                 )
             )
-            eligible = not claude_sessions.is_sidechain_session(path)
-            eligible = eligible and not claude_sessions.is_malformed_session(
-                path
-            )
+            if not _has_claude_session_record(path):
+                continue
         except (OSError, UnicodeError, TypeError, ValueError):
             continue
+        try:
+            eligible = not claude_sessions.is_sidechain_session(path)
+            eligible = (
+                eligible
+                and not claude_sessions.is_malformed_session(path)
+            )
+        except (OSError, UnicodeError, TypeError, ValueError):
+            eligible = False
         absolute_path = _absolute(path)
         try:
             records_by_path[absolute_path] = _claude_record(
@@ -266,6 +317,8 @@ def enumerate_claude_sessions(home: Path) -> list[SessionRecord]:
             directory = _normalize_directory(
                 extract_cwd_from_session(session_file, agent="claude")
             )
+            if not _has_claude_session_record(session_file):
+                continue
             try:
                 eligible = not claude_sessions.is_sidechain_session(
                     session_file
@@ -311,12 +364,15 @@ def _codex_state_database(home: Path) -> Path | None:
 
 def _codex_path(raw_path: object, home: Path) -> Path | None:
     """Normalize a rollout path read from the Codex database."""
-    if not isinstance(raw_path, str) or not raw_path:
+    if not isinstance(raw_path, str) or not raw_path.strip():
         return None
-    path = Path(raw_path).expanduser()
-    if not path.is_absolute():
-        path = home / path
-    return _absolute(path)
+    try:
+        path = Path(raw_path).expanduser()
+        if not path.is_absolute():
+            path = home / path
+        return _absolute(path)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return None
 
 
 def _deduplicate_records(
@@ -357,6 +413,10 @@ def _enumerate_codex_database(
             "unreadable_database", f"Cannot open {database}: {error}"
         ) from error
 
+    # SQLite's default text decoder aborts fetchall() when any selected TEXT
+    # value is invalid UTF-8. Preserve undecodable values as bytes so the
+    # hostile row can be rejected or normalized without losing valid rows.
+    connection.text_factory = _decode_sqlite_text
     connection.row_factory = sqlite3.Row
     try:
         table_info = connection.execute(
@@ -395,40 +455,49 @@ def _enumerate_codex_database(
 
     records: list[SessionRecord] = []
     for row in rows:
-        session_id = row["id"]
-        if not isinstance(session_id, str) or not session_id:
-            continue
-        session_file = _codex_path(row["rollout_path"], home)
-        if session_file is None or not session_file.is_file():
-            continue
         try:
-            modified, timestamp = _mtime(session_file)
-        except ResolverError as error:
-            if _is_unreadable_session(error):
+            session_id = row["id"]
+            if not isinstance(session_id, str) or not session_id.strip():
                 continue
-            raise
-        title = row["title"] if "title" in selected else None
-        directory = row["cwd"] if "cwd" in selected else None
-        records.append(
-            SessionRecord(
-                agent="codex",
-                session_id=session_id,
-                name=title if isinstance(title, str) and title else None,
-                directory=(
-                    directory
-                    if isinstance(directory, str) and directory
-                    else None
-                ),
-                home=str(home),
-                session_file=str(session_file),
-                matched_by=None,
-                modified=modified,
-                archived=_normalize_archived(row["archived"])
-                if "archived" in selected
-                else False,
-                _modified_timestamp=timestamp,
+            session_file = _codex_path(row["rollout_path"], home)
+            if session_file is None or not session_file.is_file():
+                continue
+            if not is_valid_session(session_file):
+                continue
+            modified, timestamp = _mtime(session_file)
+            title = row["title"] if "title" in selected else None
+            directory = row["cwd"] if "cwd" in selected else None
+            records.append(
+                SessionRecord(
+                    agent="codex",
+                    session_id=session_id,
+                    name=title if isinstance(title, str) and title else None,
+                    directory=(
+                        directory
+                        if isinstance(directory, str) and directory
+                        else None
+                    ),
+                    home=str(home),
+                    session_file=str(session_file),
+                    matched_by=None,
+                    modified=modified,
+                    archived=_normalize_archived(row["archived"])
+                    if "archived" in selected
+                    else False,
+                    _modified_timestamp=timestamp,
+                )
             )
-        )
+        except (
+            OSError,
+            ResolverError,
+            RuntimeError,
+            TypeError,
+            UnicodeError,
+            ValueError,
+        ):
+            # Database fields are hostile input. Skip only this row when its
+            # rollout path cannot be normalized, checked, or read.
+            continue
     return _deduplicate_records(records)
 
 
@@ -463,6 +532,8 @@ def _enumerate_codex_fallback(home: Path) -> list[SessionRecord]:
             )
             if not isinstance(session_id, str) or not session_id:
                 continue
+            if not is_valid_session(session_file):
+                continue
 
             try:
                 modified, timestamp = _mtime(session_file)
@@ -495,23 +566,15 @@ def _enumerate_codex_fallback(home: Path) -> list[SessionRecord]:
 
 
 def enumerate_codex_sessions(home: Path) -> list[SessionRecord]:
-    """Enumerate Codex sessions from SQLite or the rollout fallback."""
+    """Enumerate Codex sessions from SQLite or recursive rollout fallback."""
     _validate_home(home)
     database = _codex_state_database(home)
-    if database is not None:
-        try:
-            return _enumerate_codex_database(home, database)
-        except ResolverError as database_error:
-            if database_error.code not in {
-                "invalid_database",
-                "unreadable_database",
-            }:
-                raise
-            fallback_records = _enumerate_codex_fallback(home)
-            if fallback_records:
-                return fallback_records
-            raise database_error
-    return _enumerate_codex_fallback(home)
+    if database is None:
+        return _enumerate_codex_fallback(home)
+
+    # The highest-numbered state database is authoritative whenever present.
+    # Rollout discovery is only a fallback for homes with no state database.
+    return _enumerate_codex_database(home, database)
 
 
 def _resolved_home(agent: Agent, home: str | Path | None) -> Path:
@@ -670,7 +733,7 @@ def _success_table(record: SessionRecord) -> Table:
         ("Archived", "yes" if record.archived else "no"),
     )
     for label, value in values:
-        table.add_row(label, value)
+        table.add_row(label, Text(value))
     return table
 
 
@@ -684,10 +747,10 @@ def _candidate_table(records: tuple[SessionRecord, ...]) -> Table:
     table.add_column("Archived", no_wrap=True)
     for record in records:
         table.add_row(
-            format_session_id_display(record.session_id),
-            record.name or "—",
-            record.directory or "—",
-            record.modified,
+            Text(format_session_id_display(record.session_id)),
+            Text(record.name or "—"),
+            Text(record.directory or "—"),
+            Text(record.modified),
             "yes" if record.archived else "no",
         )
     return table
@@ -699,22 +762,27 @@ def render_pretty(result: ResolveResult) -> None:
     if result.kind == "single":
         console.print(Panel(_success_table(result.records[0]), title="Session"))
     elif result.kind == "ambiguous":
-        console.print(
-            f"[yellow]{result.match_count} sessions match "
-            f"'{result.query}' — disambiguate:[/yellow]"
-        )
+        message = Text(style="yellow")
+        message.append(f"{result.match_count} sessions match '")
+        message.append(result.query)
+        message.append("' — disambiguate:")
+        console.print(message)
         console.print(_candidate_table(result.records))
     else:
-        console.print(
-            f"[yellow]No session found for '{result.query}' "
-            f"in {result.home}[/yellow]"
-        )
+        message = Text(style="yellow")
+        message.append("No session found for '")
+        message.append(result.query)
+        message.append(f"' in {result.home}")
+        console.print(message)
 
 
 def _render_error(code: str, detail: str, pretty: bool) -> None:
     """Render an expected operational error."""
     if pretty:
-        Console().print(f"[red]Error:[/red] {detail}")
+        message = Text()
+        message.append("Error:", style="red")
+        message.append(f" {detail}")
+        Console().print(message)
     else:
         print(json.dumps({"error": code, "detail": detail}))
 

--- a/claude_code_tools/resolve_session.py
+++ b/claude_code_tools/resolve_session.py
@@ -1,0 +1,764 @@
+"""Non-interactive, JSON-first session resolution for agents and humans."""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Literal, cast
+
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from claude_code_tools.session_utils import (
+    format_session_id_display,
+    get_claude_home,
+    get_codex_home,
+)
+
+Agent = Literal["claude", "codex"]
+MatchKind = Literal["id", "partial-id", "name"]
+ResultKind = Literal["single", "ambiguous", "not_found"]
+OutputFormat = Literal["auto", "json", "pretty"]
+
+_PARTIAL_ID_RE = re.compile(r"^[0-9a-f-]+$", re.IGNORECASE)
+_CODEX_STATE_RE = re.compile(r"state_(\d+)\.sqlite$")
+
+
+class ResolverError(Exception):
+    """An expected error that should be rendered without a traceback."""
+
+    def __init__(self, code: str, detail: str) -> None:
+        """Initialize an expected resolver error.
+
+        Args:
+            code: Stable machine-facing error code.
+            detail: Human-readable error detail.
+        """
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class SessionRecord:
+    """Agent-facing metadata for one resumable session."""
+
+    agent: Agent
+    session_id: str
+    name: str | None
+    directory: str | None
+    home: str
+    session_file: str
+    matched_by: MatchKind | None
+    modified: str
+    archived: bool
+    _eligible: bool = True
+    _modified_timestamp: float = 0.0
+
+    def with_match(self, matched_by: MatchKind) -> SessionRecord:
+        """Return a copy tagged with the winning match tier.
+
+        Args:
+            matched_by: Match tier responsible for this result.
+
+        Returns:
+            A copy carrying the match classification.
+        """
+        return replace(self, matched_by=matched_by)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the exact public JSON shape for a session record."""
+        return {
+            "agent": self.agent,
+            "session_id": self.session_id,
+            "name": self.name,
+            "directory": self.directory,
+            "home": self.home,
+            "session_file": self.session_file,
+            "matched_by": self.matched_by,
+            "modified": self.modified,
+            "archived": self.archived,
+        }
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    """Tagged result returned by the pure resolution layer."""
+
+    kind: ResultKind
+    query: str
+    agent: Agent
+    home: str
+    records: tuple[SessionRecord, ...] = ()
+    match_count: int = 0
+
+
+def _absolute(path: Path) -> Path:
+    """Return an expanded absolute path without requiring it to exist."""
+    return path.expanduser().resolve(strict=False)
+
+
+def _validate_home(home: Path) -> None:
+    """Validate a resolver home directory.
+
+    Args:
+        home: Resolved Claude or Codex home.
+
+    Raises:
+        ResolverError: If the home cannot be searched.
+    """
+    if not home.exists():
+        raise ResolverError("invalid_home", f"Home does not exist: {home}")
+    if not home.is_dir():
+        raise ResolverError("invalid_home", f"Home is not a directory: {home}")
+    try:
+        next(home.iterdir(), None)
+    except OSError as error:
+        raise ResolverError(
+            "unreadable_home", f"Cannot read home {home}: {error}"
+        ) from error
+
+
+def _mtime(path: Path) -> tuple[str, float]:
+    """Return a session file's local ISO mtime and numeric timestamp."""
+    try:
+        timestamp = path.stat().st_mtime
+    except OSError as error:
+        raise ResolverError(
+            "unreadable_session", f"Cannot stat session file {path}: {error}"
+        ) from error
+    modified = datetime.fromtimestamp(timestamp).astimezone().isoformat()
+    return modified, timestamp
+
+
+def _is_unreadable_session(error: ResolverError) -> bool:
+    """Return whether an expected error is isolated to one session file."""
+    return error.code == "unreadable_session"
+
+
+def _normalize_archived(value: object) -> bool:
+    """Normalize a SQLite archived value without relying on truthiness."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value == 1
+    if isinstance(value, str):
+        normalized = value.strip().casefold()
+        if normalized in {"1", "true"}:
+            return True
+        if normalized in {"0", "false"}:
+            return False
+    return False
+
+
+def _normalize_directory(value: object) -> str | None:
+    """Return a usable session directory, or None for malformed metadata."""
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _claude_record(
+    session_file: Path,
+    home: Path,
+    directory: str | None,
+    eligible: bool,
+) -> SessionRecord:
+    """Build one Claude record using the established metadata helpers."""
+    from claude_code_tools.find_claude_session import get_custom_title
+
+    path = _absolute(session_file)
+    modified, timestamp = _mtime(path)
+    name = None
+    if eligible and directory:
+        name = get_custom_title(
+            path.stem,
+            directory,
+            str(home),
+            session_file=path,
+        ) or None
+    return SessionRecord(
+        agent="claude",
+        session_id=path.stem,
+        name=name,
+        directory=directory,
+        home=str(home),
+        session_file=str(path),
+        matched_by=None,
+        modified=modified,
+        archived=False,
+        _eligible=eligible,
+        _modified_timestamp=timestamp,
+    )
+
+
+def enumerate_claude_sessions(home: Path) -> list[SessionRecord]:
+    """Enumerate Claude sessions, including exact-ID-only excluded sessions.
+
+    Args:
+        home: Absolute Claude home directory.
+
+    Returns:
+        All discovered Claude session records.
+    """
+    from claude_code_tools import find_claude_session as claude_sessions
+    from claude_code_tools.session_utils import extract_cwd_from_session
+
+    _validate_home(home)
+    projects = home / "projects"
+    if not projects.exists():
+        return []
+    if not projects.is_dir():
+        raise ResolverError(
+            "invalid_home", f"Claude projects path is not a directory: {projects}"
+        )
+
+    rich_available = claude_sessions.RICH_AVAILABLE
+    claude_sessions.RICH_AVAILABLE = False
+    try:
+        found = claude_sessions.find_sessions(
+            [],
+            global_search=True,
+            claude_home=str(home),
+        )
+    finally:
+        claude_sessions.RICH_AVAILABLE = rich_available
+
+    records_by_path: dict[Path, SessionRecord] = {}
+    for session in found:
+        session_id = session[0]
+        directory = _normalize_directory(session[6])
+        if not isinstance(session_id, str) or not session_id or directory is None:
+            continue
+        try:
+            path = Path(
+                claude_sessions.get_session_file_path(
+                    session_id, directory, str(home)
+                )
+            )
+            eligible = not claude_sessions.is_sidechain_session(path)
+            eligible = eligible and not claude_sessions.is_malformed_session(
+                path
+            )
+        except (OSError, UnicodeError, TypeError, ValueError):
+            continue
+        absolute_path = _absolute(path)
+        try:
+            records_by_path[absolute_path] = _claude_record(
+                absolute_path, home, directory, eligible
+            )
+        except ResolverError as error:
+            if _is_unreadable_session(error):
+                continue
+            raise
+
+    try:
+        all_files = projects.glob("*/*.jsonl")
+        for session_file in all_files:
+            absolute_path = _absolute(session_file)
+            if absolute_path in records_by_path:
+                continue
+            directory = _normalize_directory(
+                extract_cwd_from_session(session_file, agent="claude")
+            )
+            try:
+                eligible = not claude_sessions.is_sidechain_session(
+                    session_file
+                )
+                eligible = (
+                    eligible
+                    and not claude_sessions.is_malformed_session(session_file)
+                    and directory is not None
+                )
+            except (OSError, UnicodeError, TypeError, ValueError):
+                eligible = False
+            try:
+                records_by_path[absolute_path] = _claude_record(
+                    absolute_path, home, directory, eligible
+                )
+            except ResolverError as error:
+                if _is_unreadable_session(error):
+                    continue
+                raise
+    except OSError as error:
+        raise ResolverError(
+            "unreadable_home", f"Cannot scan Claude projects {projects}: {error}"
+        ) from error
+    return _deduplicate_records(list(records_by_path.values()))
+
+
+def _codex_state_database(home: Path) -> Path | None:
+    """Return the highest-numbered Codex state database, if present."""
+    candidates: list[tuple[int, Path]] = []
+    try:
+        for path in home.glob("state_*.sqlite"):
+            match = _CODEX_STATE_RE.fullmatch(path.name)
+            if match and path.is_file():
+                candidates.append((int(match.group(1)), path))
+    except OSError as error:
+        raise ResolverError(
+            "unreadable_home", f"Cannot scan Codex home {home}: {error}"
+        ) from error
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[1]
+
+
+def _codex_path(raw_path: object, home: Path) -> Path | None:
+    """Normalize a rollout path read from the Codex database."""
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        path = home / path
+    return _absolute(path)
+
+
+def _deduplicate_records(
+    records: list[SessionRecord],
+) -> list[SessionRecord]:
+    """Keep the newest record for each session ID or canonical file path."""
+    unique: list[SessionRecord] = []
+    seen_ids: set[str] = set()
+    seen_paths: set[str] = set()
+    newest_usable_first = sorted(
+        records,
+        key=lambda record: (
+            record._eligible,
+            record._modified_timestamp,
+        ),
+        reverse=True,
+    )
+    for record in newest_usable_first:
+        session_id = record.session_id.casefold()
+        session_path = str(_absolute(Path(record.session_file)))
+        if session_id in seen_ids or session_path in seen_paths:
+            continue
+        seen_ids.add(session_id)
+        seen_paths.add(session_path)
+        unique.append(record)
+    return unique
+
+
+def _enumerate_codex_database(
+    home: Path, database: Path
+) -> list[SessionRecord]:
+    """Enumerate Codex threads from a read-only state database."""
+    uri = _absolute(database).as_uri() + "?mode=ro"
+    try:
+        connection = sqlite3.connect(uri, uri=True)
+    except sqlite3.Error as error:
+        raise ResolverError(
+            "unreadable_database", f"Cannot open {database}: {error}"
+        ) from error
+
+    connection.row_factory = sqlite3.Row
+    try:
+        table_info = connection.execute(
+            "PRAGMA table_info(threads)"
+        ).fetchall()
+        columns = {str(row[1]) for row in table_info}
+        required = {"id", "rollout_path"}
+        if not required.issubset(columns):
+            missing = ", ".join(sorted(required - columns))
+            raise ResolverError(
+                "invalid_database",
+                f"Codex threads table in {database} lacks: {missing}",
+            )
+        selected = [
+            column
+            for column in (
+                "id",
+                "rollout_path",
+                "cwd",
+                "title",
+                "archived",
+                "git_branch",
+                "updated_at",
+            )
+            if column in columns
+        ]
+        rows = connection.execute(
+            f"SELECT {', '.join(selected)} FROM threads"
+        ).fetchall()
+    except sqlite3.Error as error:
+        raise ResolverError(
+            "unreadable_database", f"Cannot query {database}: {error}"
+        ) from error
+    finally:
+        connection.close()
+
+    records: list[SessionRecord] = []
+    for row in rows:
+        session_id = row["id"]
+        if not isinstance(session_id, str) or not session_id:
+            continue
+        session_file = _codex_path(row["rollout_path"], home)
+        if session_file is None or not session_file.is_file():
+            continue
+        try:
+            modified, timestamp = _mtime(session_file)
+        except ResolverError as error:
+            if _is_unreadable_session(error):
+                continue
+            raise
+        title = row["title"] if "title" in selected else None
+        directory = row["cwd"] if "cwd" in selected else None
+        records.append(
+            SessionRecord(
+                agent="codex",
+                session_id=session_id,
+                name=title if isinstance(title, str) and title else None,
+                directory=(
+                    directory
+                    if isinstance(directory, str) and directory
+                    else None
+                ),
+                home=str(home),
+                session_file=str(session_file),
+                matched_by=None,
+                modified=modified,
+                archived=_normalize_archived(row["archived"])
+                if "archived" in selected
+                else False,
+                _modified_timestamp=timestamp,
+            )
+        )
+    return _deduplicate_records(records)
+
+
+def _enumerate_codex_fallback(home: Path) -> list[SessionRecord]:
+    """Enumerate rollout files when Codex has no state database."""
+    from claude_code_tools import find_codex_session as codex_sessions
+
+    sessions_root = home / "sessions"
+    if not sessions_root.exists():
+        return []
+    if not sessions_root.is_dir():
+        raise ResolverError(
+            "invalid_home",
+            f"Codex sessions path is not a directory: {sessions_root}",
+        )
+
+    records: list[SessionRecord] = []
+    try:
+        found = codex_sessions.find_sessions(
+            home,
+            [],
+            num_matches=None,
+            global_search=True,
+        )
+        for session in found:
+            raw_session_file = session.get("file_path")
+            if not isinstance(raw_session_file, str) or not raw_session_file:
+                continue
+            session_file = _absolute(Path(raw_session_file))
+            session_id = codex_sessions.extract_session_id_from_filename(
+                session_file.name
+            )
+            if not isinstance(session_id, str) or not session_id:
+                continue
+
+            try:
+                modified, timestamp = _mtime(session_file)
+            except ResolverError as error:
+                if _is_unreadable_session(error):
+                    continue
+                raise
+
+            directory = _normalize_directory(session.get("cwd"))
+            records.append(
+                SessionRecord(
+                    agent="codex",
+                    session_id=session_id,
+                    name=None,
+                    directory=directory,
+                    home=str(home),
+                    session_file=str(session_file),
+                    matched_by=None,
+                    modified=modified,
+                    archived=False,
+                    _modified_timestamp=timestamp,
+                )
+            )
+    except OSError as error:
+        raise ResolverError(
+            "unreadable_home",
+            f"Cannot scan Codex sessions {sessions_root}: {error}",
+        ) from error
+    return _deduplicate_records(records)
+
+
+def enumerate_codex_sessions(home: Path) -> list[SessionRecord]:
+    """Enumerate Codex sessions from SQLite or the rollout fallback."""
+    _validate_home(home)
+    database = _codex_state_database(home)
+    if database is not None:
+        try:
+            return _enumerate_codex_database(home, database)
+        except ResolverError as database_error:
+            if database_error.code not in {
+                "invalid_database",
+                "unreadable_database",
+            }:
+                raise
+            fallback_records = _enumerate_codex_fallback(home)
+            if fallback_records:
+                return fallback_records
+            raise database_error
+    return _enumerate_codex_fallback(home)
+
+
+def _resolved_home(agent: Agent, home: str | Path | None) -> Path:
+    """Resolve an agent home through the shared precedence helpers."""
+    if home is not None and not str(home).strip():
+        raise ResolverError("invalid_home", "Home must not be empty.")
+    cli_arg = str(home) if home is not None else None
+    selected = (
+        get_claude_home(cli_arg=cli_arg)
+        if agent == "claude"
+        else get_codex_home(cli_arg=cli_arg)
+    )
+    return _absolute(selected)
+
+
+def _matches(
+    records: list[SessionRecord], query: str
+) -> tuple[list[SessionRecord], MatchKind | None]:
+    """Apply ordered resolution tiers and return only the winning tier."""
+    lowered = query.casefold()
+    exact_ids = [
+        record
+        for record in records
+        if record.session_id.casefold() == lowered
+    ]
+    if exact_ids:
+        return exact_ids, "id"
+
+    named = [record for record in records if record._eligible and record.name]
+    exact_names = [
+        record
+        for record in named
+        if record.name is not None and record.name.casefold() == lowered
+    ]
+    if exact_names:
+        return exact_names, "name"
+
+    if len(query) >= 4 and _PARTIAL_ID_RE.fullmatch(query):
+        partial_ids = [
+            record
+            for record in records
+            if record._eligible
+            and record.session_id.casefold().startswith(lowered)
+        ]
+        if partial_ids:
+            return partial_ids, "partial-id"
+
+    substring_names = [
+        record
+        for record in named
+        if record.name is not None and lowered in record.name.casefold()
+    ]
+    if substring_names:
+        return substring_names, "name"
+    return [], None
+
+
+def resolve(
+    query: str,
+    agent: Agent,
+    home: str | Path | None = None,
+) -> ResolveResult:
+    """Resolve a query to one session, ambiguity, or no result.
+
+    Args:
+        query: Session name, full ID, or ID prefix.
+        agent: Agent whose home should be searched.
+        home: Optional explicit agent home.
+
+    Returns:
+        A tagged resolution result.
+    """
+    if not query.strip():
+        raise ResolverError("invalid_query", "Query must not be empty.")
+
+    resolved_home = _resolved_home(agent, home)
+    records = (
+        enumerate_claude_sessions(resolved_home)
+        if agent == "claude"
+        else enumerate_codex_sessions(resolved_home)
+    )
+    matches, matched_by = _matches(records, query)
+    if not matches or matched_by is None:
+        return ResolveResult(
+            kind="not_found",
+            query=query,
+            agent=agent,
+            home=str(resolved_home),
+        )
+
+    tagged = [record.with_match(matched_by) for record in matches]
+    tagged.sort(key=lambda record: record._modified_timestamp, reverse=True)
+    if len(tagged) == 1:
+        return ResolveResult(
+            kind="single",
+            query=query,
+            agent=agent,
+            home=str(resolved_home),
+            records=(tagged[0],),
+        )
+    return ResolveResult(
+        kind="ambiguous",
+        query=query,
+        agent=agent,
+        home=str(resolved_home),
+        records=tuple(tagged[:25]),
+        match_count=len(tagged),
+    )
+
+
+def _result_payload(result: ResolveResult) -> dict[str, object]:
+    """Convert a tagged result to its exact JSON payload."""
+    if result.kind == "single":
+        return result.records[0].to_dict()
+    if result.kind == "ambiguous":
+        return {
+            "error": "ambiguous",
+            "query": result.query,
+            "agent": result.agent,
+            "match_count": result.match_count,
+            "candidates": [record.to_dict() for record in result.records],
+        }
+    return {
+        "error": "not_found",
+        "query": result.query,
+        "agent": result.agent,
+        "home": result.home,
+    }
+
+
+def render_json(result: ResolveResult) -> None:
+    """Print one JSON object for a tagged resolution result."""
+    print(json.dumps(_result_payload(result)))
+
+
+def _success_table(record: SessionRecord) -> Table:
+    """Build the human-readable table for one resolved session."""
+    table = Table(box=None, show_header=False, pad_edge=False)
+    table.add_column("Field", style="bold cyan", no_wrap=True)
+    table.add_column("Value")
+    values = (
+        ("Agent", record.agent),
+        (
+            "Session ID",
+            format_session_id_display(
+                record.session_id,
+                truncate_length=len(record.session_id),
+            ).removesuffix("..."),
+        ),
+        ("Name", record.name or "—"),
+        ("Directory", record.directory or "—"),
+        ("Home", record.home),
+        ("Session file", record.session_file),
+        ("Matched by", record.matched_by or "—"),
+        ("Modified", record.modified),
+        ("Archived", "yes" if record.archived else "no"),
+    )
+    for label, value in values:
+        table.add_row(label, value)
+    return table
+
+
+def _candidate_table(records: tuple[SessionRecord, ...]) -> Table:
+    """Build the disambiguation table for candidate sessions."""
+    table = Table(box=box.SIMPLE_HEAVY, header_style="bold cyan")
+    table.add_column("Session ID", no_wrap=True)
+    table.add_column("Name")
+    table.add_column("Directory")
+    table.add_column("Modified", no_wrap=True)
+    table.add_column("Archived", no_wrap=True)
+    for record in records:
+        table.add_row(
+            format_session_id_display(record.session_id),
+            record.name or "—",
+            record.directory or "—",
+            record.modified,
+            "yes" if record.archived else "no",
+        )
+    return table
+
+
+def render_pretty(result: ResolveResult) -> None:
+    """Print a Rich panel or table for a tagged resolution result."""
+    console = Console()
+    if result.kind == "single":
+        console.print(Panel(_success_table(result.records[0]), title="Session"))
+    elif result.kind == "ambiguous":
+        console.print(
+            f"[yellow]{result.match_count} sessions match "
+            f"'{result.query}' — disambiguate:[/yellow]"
+        )
+        console.print(_candidate_table(result.records))
+    else:
+        console.print(
+            f"[yellow]No session found for '{result.query}' "
+            f"in {result.home}[/yellow]"
+        )
+
+
+def _render_error(code: str, detail: str, pretty: bool) -> None:
+    """Render an expected operational error."""
+    if pretty:
+        Console().print(f"[red]Error:[/red] {detail}")
+    else:
+        print(json.dumps({"error": code, "detail": detail}))
+
+
+def run(
+    query: str,
+    agent: str,
+    home: str | Path | None,
+    fmt: str = "auto",
+) -> int:
+    """Resolve, render, and return the command's process exit code.
+
+    Args:
+        query: Session name, full ID, or ID prefix.
+        agent: ``claude`` or ``codex``.
+        home: Optional explicit agent home.
+        fmt: ``auto``, ``json``, or ``pretty``.
+
+    Returns:
+        Zero for a unique match, two for ambiguity, or one otherwise.
+    """
+    pretty = fmt == "pretty" or (fmt == "auto" and sys.stdout.isatty())
+    try:
+        if agent not in ("claude", "codex"):
+            raise ResolverError("invalid_agent", f"Unsupported agent: {agent}")
+        if fmt not in ("auto", "json", "pretty"):
+            raise ResolverError("invalid_format", f"Unsupported format: {fmt}")
+        result = resolve(query, cast(Agent, agent), home)
+    except ResolverError as error:
+        _render_error(error.code, error.detail, pretty)
+        return 1
+    except (OSError, sqlite3.Error) as error:
+        _render_error(type(error).__name__, str(error), pretty)
+        return 1
+    except Exception as error:
+        _render_error("resolver_error", str(error) or type(error).__name__, pretty)
+        return 1
+
+    if pretty:
+        render_pretty(result)
+    else:
+        render_json(result)
+    if result.kind == "single":
+        return 0
+    if result.kind == "ambiguous":
+        return 2
+    return 1

--- a/claude_code_tools/session_utils.py
+++ b/claude_code_tools/session_utils.py
@@ -592,16 +592,17 @@ def is_valid_session(filepath: Path) -> bool:
 
     Supports both Claude Code and Codex session formats:
     - Claude: user, assistant, tool_result, tool_use (with sessionId)
-    - Codex: event_msg, response_item, turn_context (with session_meta)
+    - Codex: a well-formed session_meta record
 
-    Sessions containing ONLY metadata types (file-history-snapshot, queue-operation,
-    session_meta alone) are invalid.
+    Claude sessions containing ONLY metadata types (file-history-snapshot,
+    queue-operation) are invalid. A Codex session_meta record is itself sufficient
+    because metadata-only rollouts are valid Codex sessions.
 
     Args:
         filepath: Path to session JSONL file.
 
     Returns:
-        True if session contains at least one resumable message, False otherwise.
+        True if the file contains a valid session record, False otherwise.
     """
     if not filepath.exists():
         return False
@@ -609,49 +610,69 @@ def is_valid_session(filepath: Path) -> bool:
     # Whitelist of resumable message types
     # Claude Code types (require sessionId)
     claude_valid_types = {"user", "assistant", "tool_result", "tool_use", "system"}
-    # Codex types (conversation content types)
-    codex_valid_types = {"event_msg", "response_item", "turn_context"}
-
     try:
         with open(filepath, 'r', encoding='utf-8') as f:
-            has_any_content = False
-            has_valid_record = False
+            has_valid_claude_content = False
+            has_valid_codex_metadata = False
 
             for line in f:
                 line = line.strip()
                 if not line:
                     continue
 
-                has_any_content = True
-
                 try:
                     data = json.loads(line)
-                    entry_type = (
+                    raw_entry_type = (
                         data.get("type", "")
                         if isinstance(data, dict)
                         else ""
                     )
+                    entry_type = (
+                        raw_entry_type
+                        if isinstance(raw_entry_type, str)
+                        else ""
+                    )
 
-                    # Claude Code: valid type with non-null sessionId
+                    # Claude Code: valid type with a non-empty string sessionId
                     session_id = (
                         data.get("sessionId")
                         if isinstance(data, dict)
                         else None
                     )
-                    if entry_type in claude_valid_types and session_id is not None:
-                        has_valid_record = True
+                    if (
+                        entry_type in claude_valid_types
+                        and isinstance(session_id, str)
+                        and bool(session_id.strip())
+                    ):
+                        has_valid_claude_content = True
 
-                    # Codex: valid conversation content type
-                    if entry_type in codex_valid_types:
-                        has_valid_record = True
+                    # Codex: session_meta is the identifying record for a
+                    # rollout. It is sufficient even when no conversation
+                    # records have been written yet.
+                    payload = (
+                        data.get("payload")
+                        if isinstance(data, dict)
+                        else None
+                    )
+                    if (
+                        entry_type == "session_meta"
+                        and isinstance(payload, dict)
+                        and any(
+                            isinstance(value, str) and bool(value.strip())
+                            for value in (
+                                payload.get("id"),
+                                payload.get("cwd"),
+                                payload.get("timestamp"),
+                            )
+                        )
+                    ):
+                        has_valid_codex_metadata = True
 
                 except json.JSONDecodeError:
                     # Skip malformed JSON lines, continue checking other lines
                     continue
 
-            # If we scanned entire file and found no valid message types
-            # (only metadata or empty), session is invalid
-            return has_any_content and has_valid_record
+            return has_valid_claude_content or has_valid_codex_metadata
 
     except (OSError, IOError, UnicodeError):
         return False  # File read errors indicate invalid file

--- a/claude_code_tools/session_utils.py
+++ b/claude_code_tools/session_utils.py
@@ -202,8 +202,7 @@ def get_claude_home(cli_arg: Optional[str] = None) -> Path:
 
 
 def get_codex_home(cli_arg: Optional[str] = None) -> Path:
-    """
-    Get Codex home directory.
+    """Get Codex home directory with proper precedence.
 
     Args:
         cli_arg: Optional CLI argument value for --codex-home
@@ -213,6 +212,11 @@ def get_codex_home(cli_arg: Optional[str] = None) -> Path:
     """
     if cli_arg:
         return Path(cli_arg).expanduser()
+
+    env_var = os.environ.get("CODEX_HOME")
+    if env_var:
+        return Path(env_var).expanduser()
+
     return Path.home() / ".codex"
 
 
@@ -611,6 +615,7 @@ def is_valid_session(filepath: Path) -> bool:
     try:
         with open(filepath, 'r', encoding='utf-8') as f:
             has_any_content = False
+            has_valid_record = False
 
             for line in f:
                 line = line.strip()
@@ -621,16 +626,24 @@ def is_valid_session(filepath: Path) -> bool:
 
                 try:
                     data = json.loads(line)
-                    entry_type = data.get("type", "")
+                    entry_type = (
+                        data.get("type", "")
+                        if isinstance(data, dict)
+                        else ""
+                    )
 
                     # Claude Code: valid type with non-null sessionId
-                    session_id = data.get("sessionId")
+                    session_id = (
+                        data.get("sessionId")
+                        if isinstance(data, dict)
+                        else None
+                    )
                     if entry_type in claude_valid_types and session_id is not None:
-                        return True
+                        has_valid_record = True
 
                     # Codex: valid conversation content type
                     if entry_type in codex_valid_types:
-                        return True
+                        has_valid_record = True
 
                 except json.JSONDecodeError:
                     # Skip malformed JSON lines, continue checking other lines
@@ -638,9 +651,9 @@ def is_valid_session(filepath: Path) -> bool:
 
             # If we scanned entire file and found no valid message types
             # (only metadata or empty), session is invalid
-            return False if has_any_content else False  # Empty file is invalid
+            return has_any_content and has_valid_record
 
-    except (OSError, IOError):
+    except (OSError, IOError, UnicodeError):
         return False  # File read errors indicate invalid file
 
 
@@ -655,7 +668,10 @@ def is_malformed_session(filepath: Path) -> bool:
     return not is_valid_session(filepath)
 
 
-def extract_cwd_from_session(session_file: Path) -> Optional[str]:
+def extract_cwd_from_session(
+    session_file: Path,
+    agent: Optional[str] = None,
+) -> Optional[str]:
     """
     Extract the working directory (cwd) from a session file.
 
@@ -665,6 +681,9 @@ def extract_cwd_from_session(session_file: Path) -> Optional[str]:
 
     Args:
         session_file: Path to the session JSONL file
+        agent: Explicit agent type (``"claude"`` or ``"codex"``). When
+            omitted, the agent is inferred from the session path for backward
+            compatibility.
 
     Returns:
         The cwd string if found, None otherwise
@@ -672,12 +691,13 @@ def extract_cwd_from_session(session_file: Path) -> Optional[str]:
     try:
         from claude_code_tools.export_session import extract_session_metadata
 
-        # Detect agent from path
-        path_str = str(session_file)
-        agent = "codex" if ".codex" in path_str else "claude"
+        if agent is None:
+            path_str = str(session_file)
+            agent = "codex" if ".codex" in path_str else "claude"
 
         metadata = extract_session_metadata(session_file, agent)
-        return metadata.get("cwd")
+        cwd = metadata.get("cwd")
+        return cwd if isinstance(cwd, str) and cwd else None
     except Exception:
         return None
 
@@ -746,7 +766,10 @@ def find_session_file(
                         if is_malformed_session(session_file):
                             continue
                         # Extract actual cwd from session file
-                        actual_cwd = extract_cwd_from_session(session_file)
+                        actual_cwd = extract_cwd_from_session(
+                            session_file,
+                            agent="claude",
+                        )
                         if not actual_cwd:
                             # Skip sessions without cwd
                             continue
@@ -900,7 +923,7 @@ def default_export_path(
             if metadata and metadata.get("cwd"):
                 base_dir = Path(metadata["cwd"])
         else:  # claude
-            cwd = extract_cwd_from_session(session_file)
+            cwd = extract_cwd_from_session(session_file, agent="claude")
             if cwd:
                 base_dir = Path(cwd)
 

--- a/claude_code_tools/trim_session.py
+++ b/claude_code_tools/trim_session.py
@@ -240,8 +240,10 @@ def is_trimmed_session(session_file: Path) -> bool:
                 return False
 
             data = json.loads(first_line)
+            if not isinstance(data, dict):
+                return False
             return "trim_metadata" in data or "continue_metadata" in data
-    except (json.JSONDecodeError, IOError):
+    except (json.JSONDecodeError, IOError, UnicodeError):
         return False
 
 
@@ -267,12 +269,14 @@ def get_session_derivation_type(session_file: Path) -> Optional[str]:
                 return None
 
             data = json.loads(first_line)
+            if not isinstance(data, dict):
+                return None
             if "trim_metadata" in data:
                 return "trimmed"
             elif "continue_metadata" in data:
                 return "continued"
             return None
-    except (json.JSONDecodeError, IOError):
+    except (json.JSONDecodeError, IOError, UnicodeError):
         return None
 
 

--- a/tests/test_resolve_session.py
+++ b/tests/test_resolve_session.py
@@ -7,15 +7,15 @@ import os
 import sqlite3
 import subprocess
 import sys
-import threading
+import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner, Result
 
 from claude_code_tools.aichat import main
-from claude_code_tools.resolve_session import _normalize_archived
 from claude_code_tools.session_utils import encode_claude_project_path
 
 CLAUDE_IDS = (
@@ -145,12 +145,12 @@ def _create_threads_database(database: Path) -> None:
 
 def _insert_codex_thread(
     database: Path,
-    session_id: str,
-    rollout_path: Path,
-    cwd: str,
-    title: str,
+    session_id: object,
+    rollout_path: object,
+    cwd: object,
+    title: object,
     updated_at: int,
-    archived: bool = False,
+    archived: object = False,
 ) -> None:
     """Insert one row into a fake Codex threads database."""
     connection = sqlite3.connect(database)
@@ -164,10 +164,10 @@ def _insert_codex_thread(
             """,
             (
                 session_id,
-                str(rollout_path),
+                str(rollout_path) if isinstance(rollout_path, Path) else rollout_path,
                 cwd,
                 title,
-                int(archived),
+                archived,
                 "feat/session-finder",
                 updated_at,
             ),
@@ -282,6 +282,39 @@ def _json(result: Result) -> dict[str, object]:
     return payload
 
 
+def _run_in_tty(arguments: list[str]) -> tuple[int, str]:
+    """Run the CLI with a pseudo-terminal attached to stdout."""
+    master, slave = os.openpty()
+    command = [sys.executable, "-m", "claude_code_tools.aichat", *arguments]
+    process = subprocess.Popen(command, stdout=slave, stderr=slave)
+    os.close(slave)
+    chunks: list[bytes] = []
+    while True:
+        try:
+            chunk = os.read(master, 4_096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        chunks.append(chunk)
+    os.close(master)
+    return process.wait(timeout=5), b"".join(chunks).decode(errors="replace")
+
+
+def _run_cli(
+    arguments: list[str], env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run the real module entry point with an isolated environment."""
+    return subprocess.run(
+        [sys.executable, "-m", "claude_code_tools.aichat", *arguments],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+        timeout=20,
+    )
+
+
 @pytest.mark.parametrize(
     ("query", "expected_id", "matched_by"),
     [
@@ -305,6 +338,61 @@ def test_claude_success_tiers(
     assert payload["matched_by"] == matched_by
 
 
+@pytest.mark.parametrize(
+    ("query", "winning_id", "matched_by"),
+    [
+        (
+            "face0000-0000-4000-8000-000000000001",
+            "face0000-0000-4000-8000-000000000001",
+            "id",
+        ),
+        ("cafe", "22222222-2222-4222-8222-222222222222", "name"),
+        (
+            "beef",
+            "beef0000-0000-4000-8000-000000000003",
+            "partial-id",
+        ),
+    ],
+)
+def test_claude_first_nonempty_tier_wins_cross_tier_collisions(
+    runner: CliRunner,
+    tmp_path: Path,
+    query: str,
+    winning_id: str,
+    matched_by: str,
+) -> None:
+    home = tmp_path / "claude"
+    sessions = (
+        (
+            "face0000-0000-4000-8000-000000000001",
+            "Ordinary Session",
+        ),
+        (
+            "11111111-1111-4111-8111-111111111111",
+            "face0000-0000-4000-8000-000000000001",
+        ),
+        ("cafe0000-0000-4000-8000-000000000002", "Other Cafe"),
+        ("22222222-2222-4222-8222-222222222222", "cafe"),
+        ("beef0000-0000-4000-8000-000000000003", "Prefix Winner"),
+        ("33333333-3333-4333-8333-333333333333", "Roast Beef Notes"),
+    )
+    for index, (session_id, title) in enumerate(sessions):
+        _write_claude_session(
+            home,
+            session_id,
+            str(tmp_path / f"project-{index}"),
+            title,
+            1_720_000_000.0 + index,
+        )
+
+    result = _invoke(runner, query, home)
+    payload = _json(result)
+
+    assert result.exit_code == 0
+    assert payload["session_id"] == winning_id
+    assert payload["matched_by"] == matched_by
+
+
 @pytest.mark.parametrize("query", ["shared plan", "aaaa"])
 def test_claude_ambiguous_tiers(
     runner: CliRunner, claude_home: FakeHome, query: str
@@ -315,6 +403,56 @@ def test_claude_ambiguous_tiers(
     assert payload["error"] == "ambiguous"
     assert payload["match_count"] == 2
     assert len(payload["candidates"]) == 2  # type: ignore[arg-type]
+
+
+def test_claude_ambiguity_is_newest_first_and_capped(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "claude"
+    session_ids: list[str] = []
+    mtimes: dict[str, float] = {}
+    for index in range(30):
+        session_id = f"{index:08x}-0000-4000-8000-{index:012x}"
+        mtime = 1_720_000_000.0 + index
+        session_ids.append(session_id)
+        mtimes[session_id] = mtime
+        _write_claude_session(
+            home,
+            session_id,
+            str(tmp_path / f"project-{index}"),
+            "Crowded Name",
+            mtime,
+        )
+
+    result = _invoke(runner, "Crowded Name", home)
+    payload = _json(result)
+    candidates = payload["candidates"]
+
+    assert result.exit_code == 2
+    assert payload["error"] == "ambiguous"
+    assert payload["query"] == "Crowded Name"
+    assert payload["agent"] == "claude"
+    assert payload["match_count"] == 30
+    assert isinstance(candidates, list)
+    assert len(candidates) == 25
+    expected_ids = list(reversed(session_ids))[:25]
+    assert [candidate["session_id"] for candidate in candidates] == expected_ids
+    for candidate in candidates:
+        assert set(candidate) == {
+            "agent",
+            "session_id",
+            "name",
+            "directory",
+            "home",
+            "session_file",
+            "matched_by",
+            "modified",
+            "archived",
+        }
+        parsed = datetime.fromisoformat(candidate["modified"])
+        assert parsed.timestamp() == pytest.approx(
+            mtimes[candidate["session_id"]]
+        )
 
 
 def test_claude_not_found(runner: CliRunner, claude_home: FakeHome) -> None:
@@ -440,6 +578,128 @@ def test_agent_home_environment_variables(
 
 
 @pytest.mark.parametrize(
+    ("agent", "option"),
+    [("claude", "--claude-home"), ("codex", "--codex-home")],
+)
+def test_top_level_home_options_apply_to_resolve(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    agent: str,
+    option: str,
+) -> None:
+    fake_home = claude_home if agent == "claude" else codex_home
+    result = runner.invoke(
+        main,
+        [
+            option,
+            str(fake_home.path),
+            "resolve",
+            fake_home.ids[2],
+            "--agent",
+            agent,
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert _json(result)["home"] == str(fake_home.path.resolve())
+
+
+def test_local_home_overrides_top_level_home(
+    runner: CliRunner, claude_home: FakeHome, tmp_path: Path
+) -> None:
+    other_home = tmp_path / "other-claude"
+    other_id = "ffff0000-0000-4000-8000-000000000000"
+    _write_claude_session(
+        other_home,
+        other_id,
+        str(tmp_path / "other-project"),
+        "Other Session",
+        1_720_000_000.0,
+    )
+    result = runner.invoke(
+        main,
+        [
+            "--claude-home",
+            str(claude_home.path),
+            "resolve",
+            other_id,
+            "--home",
+            str(other_home),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert _json(result)["home"] == str(other_home.resolve())
+
+
+def test_resolve_skips_auto_index_without_changing_other_commands(
+    tmp_path: Path,
+) -> None:
+    user_home = tmp_path / "user-home"
+    user_home.mkdir()
+    claude_home = tmp_path / "selected-claude"
+    codex_home = tmp_path / "selected-codex"
+    codex_home.mkdir()
+    wrong_claude_home = tmp_path / "environment-claude"
+    wrong_codex_home = tmp_path / "environment-codex"
+    wrong_codex_home.mkdir()
+    session_id = "aaaa9999-9999-4999-8999-999999999999"
+    selected_session = _write_claude_session(
+        claude_home,
+        session_id,
+        str(tmp_path / "selected-project"),
+        "Selected Session",
+        1_720_000_000.0,
+    )
+    wrong_session = _write_claude_session(
+        wrong_claude_home,
+        "bbbb9999-9999-4999-8999-999999999999",
+        str(tmp_path / "wrong-project"),
+        "Wrong Session",
+        1_720_000_001.0,
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(user_home),
+            "CLAUDE_CONFIG_DIR": str(wrong_claude_home),
+            "CODEX_HOME": str(wrong_codex_home),
+        }
+    )
+    index_path = user_home / ".cctools" / "search-index"
+
+    resolve_result = _run_cli(
+        ["resolve", session_id, "--home", str(claude_home), "--json"],
+        env,
+    )
+
+    assert resolve_result.returncode == 0
+    assert not index_path.exists()
+
+    search_result = _run_cli(
+        [
+            "search",
+            "--claude-home",
+            str(claude_home),
+            "--codex-home",
+            str(codex_home),
+            "--json",
+            "--help",
+        ],
+        env,
+    )
+
+    assert search_result.returncode == 0
+    assert "Indexed " not in search_result.stdout + search_result.stderr
+    state = json.loads((index_path / "index_state.json").read_text())
+    assert str(selected_session) in state
+    assert str(wrong_session) not in state
+
+
+@pytest.mark.parametrize(
     ("query", "expected_code", "expected_match", "expected_id"),
     [
         (CODEX_IDS[0], 0, "id", CODEX_IDS[0]),
@@ -503,6 +763,10 @@ def test_json_success_shape_and_types(runner: CliRunner, codex_home: FakeHome) -
     assert isinstance(payload["matched_by"], str)
     assert isinstance(payload["modified"], str)
     assert isinstance(payload["archived"], bool)
+    modified = datetime.fromisoformat(payload["modified"])
+    assert modified.timestamp() == pytest.approx(
+        codex_home.files[1].stat().st_mtime
+    )
     assert payload["name"] == "Shared Codex"
     assert payload["directory"] == codex_home.directories[1]
     assert payload["session_file"] == str(codex_home.files[1].resolve())
@@ -530,27 +794,127 @@ def test_json_and_pretty_flags_force_formats(
     assert not pretty_result.output.lstrip().startswith("{")
     assert "Session" in pretty_result.output
     assert "Matched by" in pretty_result.output
-    master, slave = os.openpty()
-    command = [
-        sys.executable, "-m", "claude_code_tools.aichat", "resolve",
-        claude_home.ids[2], "--home", str(claude_home.path),
-    ]
-    process = subprocess.Popen(command, stdout=slave, stderr=slave)
-    os.close(slave)
-    chunks: list[bytes] = []
-    while True:
-        try:
-            chunk = os.read(master, 4_096)
-        except OSError:
-            break
-        if not chunk:
-            break
-        chunks.append(chunk)
-    tty_output = b"".join(chunks).decode(errors="replace")
-    os.close(master)
-    assert process.wait(timeout=5) == 0
+    exit_code, tty_output = _run_in_tty(
+        [
+            "resolve",
+            claude_home.ids[2],
+            "--home",
+            str(claude_home.path),
+        ]
+    )
+    assert exit_code == 0
     assert "Session" in tty_output
     assert not tty_output.lstrip().startswith("{")
+    exit_code, tty_json = _run_in_tty(
+        [
+            "resolve",
+            claude_home.ids[2],
+            "--home",
+            str(claude_home.path),
+            "--json",
+        ]
+    )
+    assert exit_code == 0
+    assert json.loads(tty_json)["session_id"] == claude_home.ids[2]
+
+
+def test_pretty_not_found_escapes_hostile_query(
+    runner: CliRunner, claude_home: FakeHome
+) -> None:
+    """Render a markup-like not-found query as literal text."""
+    result = _invoke(
+        runner,
+        "[/]",
+        claude_home.path,
+        extra=["--pretty"],
+    )
+
+    assert result.exit_code == 1
+    assert "No session found" in result.output
+    assert "[/]" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_pretty_success_escapes_hostile_codex_metadata(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Render database strings containing malformed tags as literal text."""
+    home = tmp_path / "[" / "home]"
+    home.mkdir(parents=True)
+    rollout_id = "eeee5555-5555-4555-8555-555555555555"
+    rollout = _write_codex_session(
+        home,
+        rollout_id,
+        "[/rollout-directory]",
+        1_720_000_000.0,
+    )
+    database = home / "state_1.sqlite"
+    _create_threads_database(database)
+    session_id = "hostile[/id]"
+    _insert_codex_thread(
+        database,
+        session_id,
+        rollout,
+        "[/directory]",
+        "Hostile [/name]",
+        1_720_000_000,
+    )
+
+    result = _invoke(
+        runner,
+        session_id,
+        home,
+        agent="codex",
+        extra=["--pretty"],
+    )
+
+    assert result.exit_code == 0
+    assert session_id in result.output
+    assert "Hostile [/name]" in result.output
+    assert "[/directory]" in result.output
+    assert "Home" in result.output
+    assert "Session file" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_pretty_error_escapes_hostile_detail(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """Render an expected error detail containing malformed tags literally."""
+    bad_home = tmp_path / "[" / "bad-home]"
+    bad_home.parent.mkdir()
+    bad_home.write_text("not a directory", encoding="utf-8")
+
+    result = _invoke(
+        runner,
+        "anything",
+        bad_home,
+        extra=["--pretty"],
+    )
+
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    assert "[/bad-home]" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_json_and_pretty_are_mutually_exclusive(
+    runner: CliRunner, claude_home: FakeHome
+) -> None:
+    result = _invoke(
+        runner,
+        claude_home.ids[2],
+        claude_home.path,
+        extra=["--json", "--pretty"],
+    )
+    payload = _json(result)
+
+    assert result.exit_code == 1
+    assert payload == {
+        "error": "invalid_format",
+        "detail": "Choose only one of --json or --pretty.",
+    }
+    assert "Traceback" not in result.output
 
 
 def test_codex_stale_database_row_does_not_block_valid_match(
@@ -665,6 +1029,47 @@ def test_claude_no_cwd_is_exact_id_only(
     assert _json(valid_result)["session_id"] == claude_home.ids[2]
 
 
+@pytest.mark.parametrize("bad_id", [None, 17, [], {"id": "bad"}])
+def test_claude_non_string_transcript_id_is_exact_id_only(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    tmp_path: Path,
+    bad_id: object,
+) -> None:
+    filename_id = "dede5555-5555-4555-8555-555555555555"
+    cwd = str(tmp_path / "project-with-bad-id")
+    _write_raw_claude_session(
+        claude_home.path,
+        filename_id,
+        cwd,
+        [
+            {
+                "type": "user",
+                "sessionId": bad_id,
+                "cwd": cwd,
+                "message": {"content": "hello"},
+            },
+            {
+                "type": "custom-title",
+                "sessionId": bad_id,
+                "customTitle": "Malformed Identifier",
+            },
+        ],
+    )
+
+    exact = _invoke(runner, filename_id, claude_home.path)
+    partial = _invoke(runner, "dede", claude_home.path)
+    named = _invoke(runner, "Malformed Identifier", claude_home.path)
+    valid = _invoke(runner, claude_home.ids[2], claude_home.path)
+
+    assert exact.exit_code == 0
+    assert _json(exact)["matched_by"] == "id"
+    assert partial.exit_code == 1
+    assert named.exit_code == 1
+    assert valid.exit_code == 0
+    assert _json(valid)["session_id"] == claude_home.ids[2]
+
+
 def test_claude_non_object_json_before_valid_records_is_resolvable(
     runner: CliRunner, claude_home: FakeHome, tmp_path: Path
 ) -> None:
@@ -709,6 +1114,92 @@ def test_claude_non_object_json_before_valid_records_is_resolvable(
     assert _json(partial_result)["session_id"] == session_id
     assert name_result.exit_code == 0
     assert _json(name_result)["session_id"] == session_id
+
+
+def test_claude_malformed_jsonl_before_between_and_after_valid_records(
+    runner: CliRunner, claude_home: FakeHome, tmp_path: Path
+) -> None:
+    session_id = "fefe6666-6666-4666-8666-666666666666"
+    cwd = str(tmp_path / "malformed-json-project")
+    session_file = _write_raw_claude_session(
+        claude_home.path,
+        session_id,
+        cwd,
+        [],
+    )
+    valid_user = json.dumps(
+        {"type": "user", "sessionId": session_id, "cwd": cwd}
+    )
+    valid_title = json.dumps(
+        {
+            "type": "custom-title",
+            "sessionId": session_id,
+            "customTitle": "Malformed JSON Survivor",
+        }
+    )
+    session_file.write_text(
+        "{not valid json}\n"
+        f"{valid_user}\n"
+        '["unterminated"\n'
+        f"{valid_title}\n"
+        "not-json-after-valid-records\n",
+        encoding="utf-8",
+    )
+
+    named = _invoke(runner, "Malformed JSON Survivor", claude_home.path)
+    valid = _invoke(runner, claude_home.ids[2], claude_home.path)
+
+    assert named.exit_code == 0
+    assert _json(named)["session_id"] == session_id
+    assert valid.exit_code == 0
+    assert _json(valid)["session_id"] == claude_home.ids[2]
+    assert "Traceback" not in named.output + valid.output
+
+
+def test_claude_malformed_nested_metadata_after_valid_records(
+    runner: CliRunner, claude_home: FakeHome, tmp_path: Path
+) -> None:
+    session_id = "fefe7777-7777-4777-8777-777777777777"
+    cwd = str(tmp_path / "nested-metadata-project")
+    _write_raw_claude_session(
+        claude_home.path,
+        session_id,
+        cwd,
+        [
+            {
+                "type": "progress",
+                "cwd": {"wrong": "shape"},
+                "trim_metadata": [],
+                "continue_metadata": "invalid",
+            },
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "cwd": cwd,
+                "message": {"content": "hello"},
+            },
+            {
+                "type": "file-history-snapshot",
+                "metadata": {"git": []},
+            },
+            {
+                "type": "custom-title",
+                "sessionId": session_id,
+                "customTitle": "Nested Metadata Survivor",
+            },
+            None,
+            [],
+            {"timestamp": ["wrong", "shape"]},
+        ],
+    )
+
+    result = _invoke(runner, "Nested Metadata Survivor", claude_home.path)
+    payload = _json(result)
+
+    assert result.exit_code == 0
+    assert payload["session_id"] == session_id
+    assert payload["directory"] == cwd
+    assert "Traceback" not in result.output
 
 
 def test_claude_invalid_utf8_is_isolated(
@@ -756,8 +1247,233 @@ def test_codex_fallback_without_database(runner: CliRunner, tmp_path: Path) -> N
     assert _json(name_result)["error"] == "not_found"
 
 
+def test_codex_fallback_discovers_rollouts_at_arbitrary_depth(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    session_id = "eeee7766-7766-4766-8766-776677667766"
+    rollout = _write_codex_session(
+        home,
+        session_id,
+        str(tmp_path / "deep-project"),
+        1_720_000_305.0,
+    )
+    deep_directory = home / "sessions" / "a" / "b" / "c" / "d" / "e"
+    deep_directory.mkdir(parents=True)
+    deeply_nested_rollout = deep_directory / rollout.name
+    rollout.replace(deeply_nested_rollout)
+
+    result = _invoke(runner, session_id, home, agent="codex")
+    payload = _json(result)
+
+    assert result.exit_code == 0
+    assert payload["session_file"] == str(deeply_nested_rollout.resolve())
+
+
+def test_codex_empty_database_ignores_unindexed_rollouts(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    home.mkdir()
+    _create_threads_database(home / "state_1.sqlite")
+    session_id = "eeee7788-7788-4788-8788-778877887788"
+    _write_codex_session(
+        home,
+        session_id,
+        str(tmp_path / "fallback-project"),
+        1_720_000_310.0,
+    )
+
+    result = _invoke(runner, session_id, home, agent="codex")
+    assert result.exit_code == 1
+    assert _json(result)["error"] == "not_found"
+
+
+def test_codex_database_ignores_unindexed_rollout(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    home.mkdir()
+    database = home / "state_1.sqlite"
+    _create_threads_database(database)
+    indexed_id = "eeee7799-7799-4799-8799-779977997799"
+    omitted_id = "ffff7799-7799-4799-8799-779977997799"
+    indexed = _write_codex_session(
+        home, indexed_id, "/rollout-cwd", 1_720_000_320.0
+    )
+    _write_codex_session(
+        home, omitted_id, "/omitted-cwd", 1_720_000_321.0
+    )
+    _insert_codex_thread(
+        database,
+        indexed_id,
+        indexed,
+        "/database-cwd",
+        "Database Title",
+        1_720_000_320,
+        archived=True,
+    )
+
+    indexed_result = _invoke(runner, "Database Title", home, agent="codex")
+    omitted_result = _invoke(runner, omitted_id, home, agent="codex")
+
+    assert indexed_result.exit_code == 0
+    assert _json(indexed_result)["directory"] == "/database-cwd"
+    assert _json(indexed_result)["archived"] is True
+    assert omitted_result.exit_code == 1
+    assert _json(omitted_result)["error"] == "not_found"
+
+
+@pytest.mark.parametrize(
+    "hostile_id",
+    [None, sqlite3.Binary(b"not-a-text-id")],
+    ids=["null", "blob"],
+)
+def test_codex_sqlite_non_string_ids_are_skipped(
+    runner: CliRunner, tmp_path: Path, hostile_id: object
+) -> None:
+    home = tmp_path / "codex"
+    home.mkdir()
+    database = home / "state_1.sqlite"
+    _create_threads_database(database)
+    valid_id = "eeee7800-7800-4800-8800-780078007800"
+    valid_rollout = _write_codex_session(
+        home, valid_id, "/valid", 1_720_000_330.0
+    )
+    hostile_rollout = _write_codex_session(
+        home,
+        "ffff7800-7800-4800-8800-780078007800",
+        "/hostile",
+        1_720_000_331.0,
+    )
+    _insert_codex_thread(
+        database,
+        hostile_id,
+        hostile_rollout,
+        "/hostile",
+        "Hostile Thread",
+        1_720_000_331,
+    )
+    _insert_codex_thread(
+        database,
+        valid_id,
+        valid_rollout,
+        "/valid",
+        "Valid Thread",
+        1_720_000_330,
+    )
+
+    result = _invoke(runner, "Valid Thread", home, agent="codex")
+
+    assert result.exit_code == 0
+    assert _json(result)["session_id"] == valid_id
+    assert "Traceback" not in result.output
+
+
+def test_codex_sqlite_invalid_utf8_text_is_isolated(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    home.mkdir()
+    database = home / "state_1.sqlite"
+    _create_threads_database(database)
+    hostile_id = "ffff7801-7801-4801-8801-780178017801"
+    valid_id = "eeee7801-7801-4801-8801-780178017801"
+    hostile_rollout = _write_codex_session(
+        home, hostile_id, "/hostile", 1_720_000_331.0
+    )
+    valid_rollout = _write_codex_session(
+        home, valid_id, "/valid", 1_720_000_330.0
+    )
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute(
+            """
+            INSERT INTO threads (
+                id, rollout_path, cwd, title, archived,
+                git_branch, updated_at
+            ) VALUES (?, ?, ?, CAST(X'80' AS TEXT), ?, ?, ?)
+            """,
+            (
+                hostile_id,
+                str(hostile_rollout),
+                "/hostile",
+                0,
+                "feat/session-finder",
+                1_720_000_331,
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    _insert_codex_thread(
+        database,
+        valid_id,
+        valid_rollout,
+        "/valid",
+        "Valid Thread After Invalid UTF-8",
+        1_720_000_330,
+    )
+
+    result = _invoke(
+        runner,
+        "Valid Thread After Invalid UTF-8",
+        home,
+        agent="codex",
+    )
+    payload = _json(result)
+
+    assert result.exit_code == 0
+    assert payload["session_id"] == valid_id
+    assert "Traceback" not in result.output
+
+
+def test_codex_hostile_database_paths_are_isolated_per_row(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    home.mkdir()
+    database = home / "state_1.sqlite"
+    _create_threads_database(database)
+    valid_id = "eeee7811-7811-4811-8811-781178117811"
+    valid_rollout = _write_codex_session(
+        home, valid_id, "/valid", 1_720_000_340.0
+    )
+    _insert_codex_thread(
+        database,
+        "ffff7811-7811-4811-8811-781178117811",
+        "~codex-resolver-user-that-does-not-exist/rollout.jsonl",
+        "/hostile",
+        "Unexpandable Path",
+        1_720_000_342,
+    )
+    _insert_codex_thread(
+        database,
+        "ffff7822-7822-4822-8822-782278227822",
+        "rollout-with-embedded-nul\x00.jsonl",
+        "/hostile",
+        "Embedded Nul Path",
+        1_720_000_341,
+    )
+    _insert_codex_thread(
+        database,
+        valid_id,
+        valid_rollout,
+        "/valid",
+        "Valid After Hostile Paths",
+        1_720_000_340,
+    )
+
+    result = _invoke(runner, "Valid After Hostile Paths", home, agent="codex")
+    payload = _json(result)
+
+    assert result.exit_code == 0
+    assert payload["session_id"] == valid_id
+    assert "Traceback" not in result.output
+
+
 @pytest.mark.parametrize("database_kind", ["corrupt", "incomplete"])
-def test_codex_database_failure_falls_back_to_rollouts(
+def test_codex_authoritative_database_failure_is_structured(
     runner: CliRunner, tmp_path: Path, database_kind: str
 ) -> None:
     home = tmp_path / database_kind
@@ -775,8 +1491,12 @@ def test_codex_database_failure_falls_back_to_rollouts(
         finally:
             connection.close()
     result = _invoke(runner, session_id, home, agent="codex")
-    assert result.exit_code == 0
-    assert _json(result)["session_id"] == session_id
+    payload = _json(result)
+
+    assert result.exit_code == 1
+    assert payload["error"] in {"invalid_database", "unreadable_database"}
+    assert "detail" in payload
+    assert "Traceback" not in result.output
 
 
 @pytest.mark.parametrize(
@@ -810,7 +1530,10 @@ def test_codex_fallback_uses_filename_id(
         session_id,
         cwd,
         1_720_000_400.0,
-        lines=[{"type": "session_meta", "payload": payload}],
+        lines=[
+            {"type": "session_meta", "payload": payload},
+            {"type": "event_msg", "payload": {}},
+        ],
     )
 
     result = _invoke(runner, session_id, home, agent="codex")
@@ -848,9 +1571,192 @@ def test_codex_fallback_skips_malformed_rollout(
             },
         ],
     )
-    result = _invoke(runner, valid_id, home, agent="codex")
+    malformed_id = "ffffbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    valid_result = _invoke(runner, valid_id, home, agent="codex")
+    malformed_result = _invoke(runner, malformed_id, home, agent="codex")
+
+    assert valid_result.exit_code == 0
+    assert _json(valid_result)["session_id"] == valid_id
+    assert malformed_result.exit_code == 1
+    assert _json(malformed_result)["error"] == "not_found"
+
+
+def test_codex_database_skips_malformed_rollout(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    home.mkdir()
+    database = home / "state_1.sqlite"
+    _create_threads_database(database)
+    valid_id = "eeeecccc-cccc-4ccc-8ccc-cccccccccccc"
+    malformed_id = "ffffdddd-dddd-4ddd-8ddd-dddddddddddd"
+    valid_rollout = _write_codex_session(
+        home, valid_id, "/valid", 1_720_000_510.0
+    )
+    malformed_rollout = _write_codex_session(
+        home,
+        malformed_id,
+        "/malformed",
+        1_720_000_511.0,
+        lines=[{"type": "response_item", "payload": None}],
+    )
+    _insert_codex_thread(
+        database,
+        valid_id,
+        valid_rollout,
+        "/valid",
+        "Valid Database Thread",
+        1_720_000_510,
+    )
+    _insert_codex_thread(
+        database,
+        malformed_id,
+        malformed_rollout,
+        "/malformed",
+        "Malformed Database Thread",
+        1_720_000_511,
+    )
+
+    valid_result = _invoke(runner, valid_id, home, agent="codex")
+    malformed_result = _invoke(
+        runner, "Malformed Database Thread", home, agent="codex"
+    )
+
+    assert valid_result.exit_code == 0
+    assert _json(valid_result)["session_id"] == valid_id
+    assert malformed_result.exit_code == 1
+    assert _json(malformed_result)["error"] == "not_found"
+
+
+@pytest.mark.parametrize(
+    "use_database",
+    [False, True],
+    ids=["fallback", "sqlite"],
+)
+def test_codex_conversation_without_session_meta_is_not_resolvable(
+    runner: CliRunner, tmp_path: Path, use_database: bool
+) -> None:
+    home = tmp_path / "codex"
+    if use_database:
+        home.mkdir()
+        database = home / "state_1.sqlite"
+        _create_threads_database(database)
+    invalid_id = "ffffeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+    valid_id = "eeeeffff-ffff-4fff-8fff-ffffffffffff"
+    invalid_rollout = _write_codex_session(
+        home,
+        invalid_id,
+        "/missing-metadata",
+        1_720_000_520.0,
+        lines=[{"type": "event_msg", "payload": {}}],
+    )
+    valid_rollout = _write_codex_session(
+        home, valid_id, "/valid", 1_720_000_521.0
+    )
+    if use_database:
+        _insert_codex_thread(
+            database,
+            invalid_id,
+            invalid_rollout,
+            "/missing-metadata",
+            "Missing Session Metadata",
+            1_720_000_520,
+        )
+        _insert_codex_thread(
+            database,
+            valid_id,
+            valid_rollout,
+            "/valid",
+            "Valid Metadata Thread",
+            1_720_000_521,
+        )
+
+    invalid_result = _invoke(runner, invalid_id, home, agent="codex")
+    valid_result = _invoke(runner, valid_id, home, agent="codex")
+
+    assert invalid_result.exit_code == 1
+    assert _json(invalid_result)["error"] == "not_found"
+    assert valid_result.exit_code == 0
+    assert _json(valid_result)["session_id"] == valid_id
+
+
+@pytest.mark.parametrize(
+    "use_database",
+    [False, True],
+    ids=["fallback", "sqlite"],
+)
+def test_codex_metadata_only_rollout_is_resolvable(
+    runner: CliRunner, tmp_path: Path, use_database: bool
+) -> None:
+    home = tmp_path / "codex"
+    if use_database:
+        home.mkdir()
+        database = home / "state_1.sqlite"
+        _create_threads_database(database)
+    session_id = "eeee1212-1212-4212-8212-121212121212"
+    cwd = str(tmp_path / "metadata-only")
+    rollout = _write_codex_session(
+        home,
+        session_id,
+        cwd,
+        1_720_000_530.0,
+        lines=[
+            {
+                "type": "session_meta",
+                "payload": {"id": session_id, "cwd": cwd},
+            }
+        ],
+    )
+    if use_database:
+        _insert_codex_thread(
+            database,
+            session_id,
+            rollout,
+            cwd,
+            "Metadata Only Thread",
+            1_720_000_530,
+        )
+
+    result = _invoke(runner, session_id, home, agent="codex")
+    payload = _json(result)
+
     assert result.exit_code == 0
-    assert _json(result)["session_id"] == valid_id
+    assert payload["session_id"] == session_id
+    assert payload["directory"] == cwd
+    assert payload["session_file"] == str(rollout.resolve())
+
+
+def test_codex_fallback_skips_bad_json_syntax_between_valid_records(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    session_id = "eeeeabab-abab-4bab-8bab-abababababab"
+    cwd = str(tmp_path / "surviving-project")
+    rollout = _write_codex_session(
+        home,
+        session_id,
+        cwd,
+        1_720_000_550.0,
+    )
+    metadata = json.dumps(
+        {"type": "session_meta", "payload": {"id": session_id, "cwd": cwd}}
+    )
+    rollout.write_text(
+        "{bad json before}\n"
+        f"{metadata}\n"
+        '["bad json between"\n'
+        f"{json.dumps({'type': 'event_msg', 'payload': {}})}\n"
+        "bad-json-after\n",
+        encoding="utf-8",
+    )
+
+    result = _invoke(runner, session_id, home, agent="codex")
+    payload = _json(result)
+
+    assert result.exit_code == 0
+    assert payload["session_id"] == session_id
+    assert payload["directory"] == cwd
+    assert "Traceback" not in result.output
 
 
 def test_stale_claude_file_does_not_block_valid_match(
@@ -897,28 +1803,8 @@ def test_stale_codex_fallback_file_does_not_block_valid_match(
     stale = valid.parent / (
         "rollout-2026-07-14T10-00-00-ffffdddd-dddd-4ddd-8ddd-dddddddddddd.jsonl"
     )
-    os.mkfifo(stale)
-    entry = json.dumps(
-        {"type": "session_meta", "payload": {"id": "stale", "cwd": "/stale"}}
-    )
-    encoded_entry = f"{entry}\n".encode()
-    def feed_fifo_three_times() -> None:
-        for attempt in range(3):
-            descriptor = os.open(stale, os.O_WRONLY)
-            if attempt == 2:
-                stale.unlink()
-            try:
-                os.write(descriptor, encoded_entry)
-            except BrokenPipeError:
-                pass
-            finally:
-                os.close(descriptor)
-
-    writer = threading.Thread(target=feed_fifo_three_times)
-    writer.start()
+    stale.symlink_to(tmp_path / "rollout-that-no-longer-exists.jsonl")
     result = _invoke(runner, session_id, home, agent="codex")
-    writer.join(timeout=2)
-    assert not writer.is_alive()
     assert result.exit_code == 0, result.output
     assert _json(result)["session_id"] == session_id
 
@@ -927,8 +1813,39 @@ def test_stale_codex_fallback_file_does_not_block_valid_match(
     ("value", "expected"),
     [(0, False), (1, True), (None, False), ("0", False), ("1", True)],
 )
-def test_codex_archived_value_normalization(value: object, expected: bool) -> None:
-    assert _normalize_archived(value) is expected
+def test_codex_archived_variants_through_sqlite_and_cli(
+    runner: CliRunner,
+    tmp_path: Path,
+    value: object,
+    expected: bool,
+) -> None:
+    home = tmp_path / "codex"
+    home.mkdir()
+    database = home / "state_1.sqlite"
+    _create_threads_database(database)
+    session_id = "abab0000-0000-4000-8000-000000000000"
+    rollout = _write_codex_session(
+        home,
+        session_id,
+        str(tmp_path / "project"),
+        1_720_000_700.0,
+    )
+    _insert_codex_thread(
+        database,
+        session_id,
+        rollout,
+        str(tmp_path / "project"),
+        "Archived Variant",
+        1_720_000_700,
+        archived=value,
+    )
+
+    result = _invoke(runner, session_id, home, agent="codex")
+    payload = _json(result)
+
+    assert result.exit_code == 0
+    assert payload["archived"] is expected
+    assert isinstance(payload["archived"], bool)
 
 
 def test_claude_sidechain_is_exact_id_only(
@@ -967,6 +1884,68 @@ def test_claude_sidechain_is_exact_id_only(
     assert _json(name_result)["error"] == "not_found"
 
 
+def test_claude_agent_filename_sidechain_is_exact_id_only(
+    runner: CliRunner, claude_home: FakeHome, tmp_path: Path
+) -> None:
+    filename_id = "agent-fafa8888-8888-4888-8888-888888888888"
+    cwd = str(tmp_path / "filename-sidechain")
+    _write_raw_claude_session(
+        claude_home.path,
+        filename_id,
+        cwd,
+        [
+            {
+                "type": "user",
+                "sessionId": "fafa8888-8888-4888-8888-888888888888",
+                "cwd": cwd,
+            },
+            {
+                "type": "custom-title",
+                "customTitle": "Filename Sidechain",
+            },
+        ],
+    )
+
+    exact = _invoke(runner, filename_id, claude_home.path)
+    named = _invoke(runner, "Filename Sidechain", claude_home.path)
+
+    assert exact.exit_code == 0
+    assert _json(exact)["matched_by"] == "id"
+    assert named.exit_code == 1
+
+
+def test_claude_late_sidechain_marker_is_exact_id_only(
+    runner: CliRunner, claude_home: FakeHome, tmp_path: Path
+) -> None:
+    session_id = "fafa9999-9999-4999-8999-999999999999"
+    cwd = str(tmp_path / "late-sidechain")
+    lines: list[object] = [
+        {"type": "user", "sessionId": session_id, "cwd": cwd},
+        *({"type": "progress", "index": index} for index in range(12)),
+        {"type": "progress", "isSidechain": True},
+        {
+            "type": "custom-title",
+            "sessionId": session_id,
+            "customTitle": "Late Sidechain",
+        },
+    ]
+    _write_raw_claude_session(
+        claude_home.path,
+        session_id,
+        cwd,
+        lines,
+    )
+
+    exact = _invoke(runner, session_id, claude_home.path)
+    partial = _invoke(runner, "fafa", claude_home.path)
+    named = _invoke(runner, "Late Sidechain", claude_home.path)
+
+    assert exact.exit_code == 0
+    assert _json(exact)["matched_by"] == "id"
+    assert partial.exit_code == 1
+    assert named.exit_code == 1
+
+
 def test_claude_ai_title_is_not_a_name(
     runner: CliRunner, claude_home: FakeHome, tmp_path: Path
 ) -> None:
@@ -997,3 +1976,319 @@ def test_claude_ai_title_is_not_a_name(
     assert _json(exact_result)["name"] is None
     assert title_result.exit_code == 1
     assert _json(title_result)["error"] == "not_found"
+
+
+@pytest.mark.parametrize("agent", ["claude", "codex"])
+def test_unreadable_home_is_a_structured_error(
+    runner: CliRunner, tmp_path: Path, agent: str
+) -> None:
+    home = tmp_path / f"unreadable-{agent}"
+    home.mkdir()
+    (home / "sentinel").write_text("unreadable", encoding="utf-8")
+    home.chmod(0)
+    try:
+        try:
+            next(home.iterdir())
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("directory permissions cannot be enforced")
+
+        result = _invoke(runner, "anything", home, agent=agent)
+        payload = _json(result)
+
+        assert result.exit_code == 1
+        assert set(payload) == {"error", "detail"}
+        assert payload["error"] == "unreadable_home"
+        assert isinstance(payload["detail"], str)
+        assert payload["detail"]
+        assert "Traceback" not in result.output
+    finally:
+        home.chmod(0o700)
+
+
+def test_claude_wrong_typed_record_type_does_not_block_valid_match(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "claude"
+    hostile_id = "face1000-0000-4000-8000-000000000001"
+    _write_raw_claude_session(
+        home,
+        hostile_id,
+        str(tmp_path / "hostile"),
+        [{"type": [], "sessionId": None}],
+    )
+    valid_id = "face2000-0000-4000-8000-000000000002"
+    _write_claude_session(
+        home,
+        valid_id,
+        str(tmp_path / "valid"),
+        "Valid After Wrong Type",
+        1_720_001_000.0,
+    )
+
+    result = _invoke(runner, "Valid After Wrong Type", home)
+
+    assert result.exit_code == 0
+    assert _json(result)["session_id"] == valid_id
+    assert "Traceback" not in result.output
+
+
+def test_codex_fallback_wrong_typed_record_type_is_isolated(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    _write_codex_session(
+        home,
+        "face3000-0000-4000-8000-000000000003",
+        "/hostile",
+        1_720_001_001.0,
+        lines=[{"type": [], "sessionId": None}],
+    )
+    valid_id = "face4000-0000-4000-8000-000000000004"
+    _write_codex_session(home, valid_id, "/valid", 1_720_001_002.0)
+
+    result = _invoke(runner, valid_id, home, agent="codex")
+
+    assert result.exit_code == 0
+    assert _json(result)["session_id"] == valid_id
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        pytest.param([], id="non-dict-message"),
+        pytest.param({"content": 17}, id="non-string-or-list-content"),
+        pytest.param(
+            {"content": [{"type": "text", "text": 17}]},
+            id="non-string-text-block",
+        ),
+    ],
+)
+def test_claude_hostile_message_metadata_is_isolated(
+    runner: CliRunner, tmp_path: Path, message: object
+) -> None:
+    home = tmp_path / "claude"
+    hostile_id = "face5000-0000-4000-8000-000000000005"
+    hostile_cwd = str(tmp_path / "hostile")
+    _write_raw_claude_session(
+        home,
+        hostile_id,
+        hostile_cwd,
+        [
+            {
+                "type": "user",
+                "sessionId": hostile_id,
+                "cwd": hostile_cwd,
+                "message": message,
+            }
+        ],
+    )
+    valid_id = "face6000-0000-4000-8000-000000000006"
+    _write_claude_session(
+        home,
+        valid_id,
+        str(tmp_path / "valid"),
+        "Valid After Hostile Message",
+        1_720_001_010.0,
+    )
+
+    result = _invoke(runner, "Valid After Hostile Message", home)
+
+    assert result.exit_code == 0
+    assert _json(result)["session_id"] == valid_id
+    assert "Traceback" not in result.output
+
+
+def test_codex_sqlite_required_columns_only_resolve_without_cwd(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    home.mkdir()
+    database = home / "state_1.sqlite"
+    valid_id = "face7000-0000-4000-8000-000000000007"
+    valid_rollout = _write_codex_session(
+        home, valid_id, "/metadata-cwd", 1_720_001_020.0
+    )
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute(
+            "CREATE TABLE threads (id TEXT, rollout_path TEXT)"
+        )
+        connection.executemany(
+            "INSERT INTO threads (id, rollout_path) VALUES (?, ?)",
+            [
+                (None, str(valid_rollout)),
+                ("hostile-path", "rollout-with-nul\x00.jsonl"),
+                (valid_id, str(valid_rollout)),
+            ],
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = _invoke(runner, valid_id, home, agent="codex")
+    payload = _json(result)
+
+    assert result.exit_code == 0
+    assert payload["session_id"] == valid_id
+    assert payload["directory"] is None
+    assert payload["name"] is None
+    assert payload["archived"] is False
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    "cwd",
+    [None, 17, sqlite3.Binary(b"not-text")],
+    ids=["null", "integer", "blob"],
+)
+def test_codex_sqlite_wrong_typed_cwd_is_null_and_row_isolated(
+    runner: CliRunner, tmp_path: Path, cwd: object
+) -> None:
+    home = tmp_path / "codex"
+    home.mkdir()
+    database = home / "state_1.sqlite"
+    valid_id = "face8000-0000-4000-8000-000000000008"
+    valid_rollout = _write_codex_session(
+        home, valid_id, "/metadata-cwd", 1_720_001_021.0
+    )
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute(
+            "CREATE TABLE threads (id TEXT, rollout_path TEXT, cwd)"
+        )
+        connection.executemany(
+            "INSERT INTO threads (id, rollout_path, cwd) VALUES (?, ?, ?)",
+            [
+                (None, str(valid_rollout), "/hostile"),
+                (valid_id, str(valid_rollout), cwd),
+            ],
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = _invoke(runner, valid_id, home, agent="codex")
+    payload = _json(result)
+
+    assert result.exit_code == 0
+    assert payload["session_id"] == valid_id
+    assert payload["directory"] is None
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize("contents", [b"", b"not-json\n[truncated\n"])
+def test_claude_invalid_transcript_does_not_resolve_by_exact_filename(
+    runner: CliRunner, tmp_path: Path, contents: bytes
+) -> None:
+    home = tmp_path / "claude"
+    session_id = "face9000-0000-4000-8000-000000000009"
+    project = home / "projects" / "-invalid"
+    project.mkdir(parents=True)
+    transcript = project / f"{session_id}.jsonl"
+    transcript.write_bytes(contents)
+
+    result = _invoke(runner, session_id, home)
+
+    assert result.exit_code == 1
+    assert _json(result)["error"] == "not_found"
+    assert "Traceback" not in result.output
+
+
+def test_unreadable_claude_transcript_does_not_resolve_by_filename(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "claude"
+    session_id = "facea000-0000-4000-8000-00000000000a"
+    transcript = _write_raw_claude_session(
+        home,
+        session_id,
+        str(tmp_path / "unreadable"),
+        [{"type": "user", "sessionId": session_id}],
+    )
+    transcript.chmod(0)
+    try:
+        try:
+            transcript.read_bytes()
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("file permissions cannot be enforced")
+
+        result = _invoke(runner, session_id, home)
+
+        assert result.exit_code == 1
+        assert _json(result)["error"] == "not_found"
+        assert "Traceback" not in result.output
+    finally:
+        transcript.chmod(0o600)
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO")
+def test_codex_rollout_deleted_after_discovery_is_isolated(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "codex"
+    valid_id = "dddd0000-0000-4000-8000-000000000001"
+    deleted_id = "eeee0000-0000-4000-8000-000000000002"
+    blocker_id = "ffff0000-0000-4000-8000-000000000003"
+    valid = _write_codex_session(home, valid_id, "/valid", 1_720_001_030.0)
+    deleted = _write_codex_session(
+        home, deleted_id, "/deleted", 1_720_001_031.0
+    )
+    blocker = valid.parent / (
+        f"rollout-2026-07-14T10-00-00-{blocker_id}.jsonl"
+    )
+    os.mkfifo(blocker)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "claude_code_tools.aichat",
+            "resolve",
+            valid_id,
+            "--agent",
+            "codex",
+            "--home",
+            str(home),
+            "--json",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    writer = -1
+    deadline = time.monotonic() + 10
+    try:
+        while time.monotonic() < deadline:
+            try:
+                writer = os.open(blocker, os.O_WRONLY | os.O_NONBLOCK)
+                break
+            except OSError:
+                if process.poll() is not None:
+                    pytest.fail("resolver exited before scanning the FIFO")
+                time.sleep(0.01)
+        if writer < 0:
+            pytest.fail("resolver did not reach the discovered FIFO")
+
+        deleted.unlink()
+        blocker.unlink()
+        blocker.write_text("not json\n", encoding="utf-8")
+        os.write(writer, b"not json\n")
+        os.close(writer)
+        writer = -1
+        stdout, stderr = process.communicate(timeout=10)
+    finally:
+        if writer >= 0:
+            os.close(writer)
+        if process.poll() is None:
+            process.kill()
+            process.communicate()
+
+    assert process.returncode == 0, stderr or stdout
+    payload = json.loads(stdout)
+    assert payload["session_id"] == valid_id
+    assert "Traceback" not in stdout
+    assert "Traceback" not in stderr

--- a/tests/test_resolve_session.py
+++ b/tests/test_resolve_session.py
@@ -1,0 +1,999 @@
+"""Tests for the non-interactive ``aichat resolve`` command."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner, Result
+
+from claude_code_tools.aichat import main
+from claude_code_tools.resolve_session import _normalize_archived
+from claude_code_tools.session_utils import encode_claude_project_path
+
+CLAUDE_IDS = (
+    "aaaa1111-1111-4111-8111-111111111111",
+    "aaaa2222-2222-4222-8222-222222222222",
+    "bbbb3333-3333-4333-8333-333333333333",
+)
+CODEX_IDS = (
+    "cccc1111-1111-4111-8111-111111111111",
+    "cccc2222-2222-4222-8222-222222222222",
+    "dddd3333-3333-4333-8333-333333333333",
+)
+
+
+@dataclass(frozen=True)
+class FakeHome:
+    """Paths and metadata for one fake agent home."""
+
+    path: Path
+    ids: tuple[str, str, str]
+    files: tuple[Path, Path, Path]
+    directories: tuple[str, str, str]
+
+
+def _write_claude_session(
+    home: Path,
+    session_id: str,
+    cwd: str,
+    title: str,
+    mtime: float,
+) -> Path:
+    """Create one realistic minimal Claude transcript."""
+    project = home / "projects" / encode_claude_project_path(cwd)
+    project.mkdir(parents=True, exist_ok=True)
+    session_file = project / f"{session_id}.jsonl"
+    lines = [
+        {
+            "type": "user",
+            "sessionId": session_id,
+            "cwd": cwd,
+            "message": {"content": "hello"},
+        },
+        {
+            "type": "ai-title",
+            "sessionId": session_id,
+            "aiTitle": f"Auto {title}",
+        },
+        {
+            "type": "custom-title",
+            "sessionId": session_id,
+            "customTitle": title,
+        },
+    ]
+    session_file.write_text(
+        "".join(f"{json.dumps(line)}\n" for line in lines),
+        encoding="utf-8",
+    )
+    os.utime(session_file, (mtime, mtime))
+    return session_file
+
+
+def _write_raw_claude_session(
+    home: Path,
+    session_id: str,
+    project_cwd: str,
+    lines: list[object],
+    mtime: float = 1_720_000_000.0,
+) -> Path:
+    """Create a Claude transcript from exact JSON values."""
+    project = home / "projects" / encode_claude_project_path(project_cwd)
+    project.mkdir(parents=True, exist_ok=True)
+    session_file = project / f"{session_id}.jsonl"
+    session_file.write_text(
+        "".join(f"{json.dumps(line)}\n" for line in lines),
+        encoding="utf-8",
+    )
+    os.utime(session_file, (mtime, mtime))
+    return session_file
+
+
+@pytest.fixture
+def claude_home(tmp_path: Path) -> FakeHome:
+    """Create three Claude sessions with name and prefix collisions."""
+    home = tmp_path / "claude"
+    directories = (
+        str(tmp_path / "work" / "alpha"),
+        str(tmp_path / "work" / "beta"),
+        str(tmp_path / "work" / "gamma"),
+    )
+    titles = ("Shared Plan", "Shared Plan", "Unique Deployment Review")
+    files = tuple(
+        _write_claude_session(
+            home,
+            session_id,
+            cwd,
+            title,
+            1_700_000_000.0 + index,
+        )
+        for index, (session_id, cwd, title) in enumerate(
+            zip(CLAUDE_IDS, directories, titles, strict=True)
+        )
+    )
+    return FakeHome(home, CLAUDE_IDS, files, directories)
+
+
+def _create_threads_database(database: Path) -> None:
+    """Create the Codex threads schema used by the resolver."""
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute(
+            """
+            CREATE TABLE threads (
+                id TEXT,
+                rollout_path TEXT,
+                cwd TEXT,
+                title TEXT,
+                archived INTEGER,
+                git_branch TEXT,
+                updated_at INTEGER
+            )
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _insert_codex_thread(
+    database: Path,
+    session_id: str,
+    rollout_path: Path,
+    cwd: str,
+    title: str,
+    updated_at: int,
+    archived: bool = False,
+) -> None:
+    """Insert one row into a fake Codex threads database."""
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute(
+            """
+            INSERT INTO threads (
+                id, rollout_path, cwd, title, archived,
+                git_branch, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                str(rollout_path),
+                cwd,
+                title,
+                int(archived),
+                "feat/session-finder",
+                updated_at,
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _write_codex_session(
+    home: Path,
+    session_id: str,
+    cwd: str,
+    mtime: float,
+    lines: list[object] | None = None,
+) -> Path:
+    """Create one realistic minimal Codex rollout file."""
+    session_dir = home / "sessions" / "2026" / "07" / "14"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    session_file = session_dir / (
+        f"rollout-2026-07-14T10-00-00-{session_id}.jsonl"
+    )
+    metadata = {
+        "type": "session_meta",
+        "payload": {
+            "id": session_id,
+            "cwd": cwd,
+            "git": {"branch": "feat/session-finder"},
+        },
+    }
+    entries = [metadata] if lines is None else lines
+    session_file.write_text(
+        "".join(f"{json.dumps(entry)}\n" for entry in entries),
+        encoding="utf-8",
+    )
+    os.utime(session_file, (mtime, mtime))
+    return session_file
+
+
+@pytest.fixture
+def codex_home(tmp_path: Path) -> FakeHome:
+    """Create three Codex threads with name and prefix collisions."""
+    home = tmp_path / "codex"
+    home.mkdir()
+    directories = (
+        str(tmp_path / "code" / "alpha"),
+        str(tmp_path / "code" / "beta"),
+        str(tmp_path / "code" / "gamma"),
+    )
+    titles = ("Shared Codex", "Shared Codex", "Unique Codex Migration")
+    files = tuple(
+        _write_codex_session(
+            home,
+            session_id,
+            cwd,
+            1_710_000_000.0 + index,
+        )
+        for index, (session_id, cwd) in enumerate(
+            zip(CODEX_IDS, directories, strict=True)
+        )
+    )
+    old_database = home / "state_4.sqlite"
+    _create_threads_database(old_database)
+    database = home / "state_5.sqlite"
+    _create_threads_database(database)
+    for index, (session_id, session_file, cwd, title) in enumerate(
+        zip(CODEX_IDS, files, directories, titles, strict=True)
+    ):
+        _insert_codex_thread(
+            database,
+            session_id,
+            session_file,
+            cwd,
+            title,
+            1_710_000_000 + index,
+            archived=index == 1,
+        )
+    return FakeHome(home, CODEX_IDS, files, directories)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Return an isolated in-process Click runner."""
+    return CliRunner()
+
+
+def _invoke(
+    runner: CliRunner,
+    query: str | None,
+    home: Path | None = None,
+    agent: str | None = None,
+    extra: list[str] | None = None,
+    env: dict[str, str] | None = None,
+) -> Result:
+    """Invoke ``aichat resolve`` with concise test arguments."""
+    args = ["resolve"]
+    if query is not None:
+        args.append(query)
+    if agent is not None:
+        args.extend(["--agent", agent])
+    if home is not None:
+        args.extend(["--home", str(home)])
+    if extra:
+        args.extend(extra)
+    return runner.invoke(main, args, env=env, catch_exceptions=False)
+
+
+def _json(result: Result) -> dict[str, object]:
+    """Decode a command's single JSON object."""
+    payload = json.loads(result.output)
+    assert isinstance(payload, dict)
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_id", "matched_by"),
+    [
+        (CLAUDE_IDS[0], CLAUDE_IDS[0], "id"),
+        ("bbbb", CLAUDE_IDS[2], "partial-id"),
+        ("unique deployment review", CLAUDE_IDS[2], "name"),
+        ("deployment", CLAUDE_IDS[2], "name"),
+    ],
+)
+def test_claude_success_tiers(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    query: str,
+    expected_id: str,
+    matched_by: str,
+) -> None:
+    result = _invoke(runner, query, claude_home.path)
+    payload = _json(result)
+    assert result.exit_code == 0
+    assert payload["session_id"] == expected_id
+    assert payload["matched_by"] == matched_by
+
+
+@pytest.mark.parametrize("query", ["shared plan", "aaaa"])
+def test_claude_ambiguous_tiers(
+    runner: CliRunner, claude_home: FakeHome, query: str
+) -> None:
+    result = _invoke(runner, query, claude_home.path)
+    payload = _json(result)
+    assert result.exit_code == 2
+    assert payload["error"] == "ambiguous"
+    assert payload["match_count"] == 2
+    assert len(payload["candidates"]) == 2  # type: ignore[arg-type]
+
+
+def test_claude_not_found(runner: CliRunner, claude_home: FakeHome) -> None:
+    result = _invoke(runner, "missing session", claude_home.path)
+    payload = _json(result)
+    assert result.exit_code == 1
+    assert payload == {
+        "error": "not_found",
+        "query": "missing session",
+        "agent": "claude",
+        "home": str(claude_home.path.resolve()),
+    }
+
+
+def test_existing_file_home_returns_structured_error(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    bad_home = tmp_path / "home-file"
+    bad_home.write_text("not a directory", encoding="utf-8")
+    result = _invoke(runner, "anything", bad_home)
+    payload = _json(result)
+    assert result.exit_code == 1
+    assert payload["error"] == "invalid_home"
+    assert "not a directory" in str(payload["detail"])
+    assert "Usage:" not in result.output
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize("query", [None, "", " ", " \t "])
+def test_empty_query_is_rejected(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    query: str | None,
+) -> None:
+    result = _invoke(runner, query, claude_home.path)
+    payload = _json(result)
+    assert result.exit_code == 1
+    expected_error = "invalid_input" if query is None else "invalid_query"
+    assert payload["error"] == expected_error
+    if query is None:
+        assert "Missing argument 'QUERY'" in str(payload["detail"])
+    else:
+        assert payload["detail"] == "Query must not be empty."
+    assert "Traceback" not in result.output
+
+
+def test_invalid_agent_is_structured(runner: CliRunner) -> None:
+    result = _invoke(runner, "query", agent="other")
+    assert result.exit_code == 1
+    assert _json(result)["error"] == "invalid_agent"
+    assert "Usage:" not in result.output
+
+
+def test_default_agent_is_claude(runner: CliRunner, claude_home: FakeHome) -> None:
+    payload = _json(_invoke(runner, claude_home.ids[0], claude_home.path))
+    assert payload["agent"] == "claude"
+
+
+def test_explicit_home_overrides_agent_environments(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    tmp_path: Path,
+) -> None:
+    wrong_home = tmp_path / "wrong-claude"
+    wrong_home.mkdir()
+    claude_result = _invoke(
+        runner,
+        claude_home.ids[0],
+        claude_home.path,
+        env={"CLAUDE_CONFIG_DIR": str(wrong_home)},
+    )
+    wrong_home = tmp_path / "wrong-codex"
+    wrong_home.mkdir()
+    codex_result = _invoke(
+        runner,
+        codex_home.ids[0],
+        codex_home.path,
+        agent="codex",
+        env={"CODEX_HOME": str(wrong_home)},
+    )
+    assert claude_result.exit_code == codex_result.exit_code == 0
+    assert _json(claude_result)["home"] == str(claude_home.path.resolve())
+    assert _json(codex_result)["home"] == str(codex_home.path.resolve())
+
+
+def test_empty_explicit_homes_do_not_use_environment(
+    runner: CliRunner, claude_home: FakeHome, codex_home: FakeHome
+) -> None:
+    cases = (
+        ("claude", "CLAUDE_CONFIG_DIR", claude_home),
+        ("codex", "CODEX_HOME", codex_home),
+    )
+    for agent, variable, fake_home in cases:
+        result = runner.invoke(
+            main,
+            ["resolve", fake_home.ids[0], "--agent", agent, "--home", ""],
+            env={variable: str(fake_home.path)},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 1
+        assert _json(result)["error"] == "invalid_home"
+
+
+def test_agent_home_environment_variables(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    claude_result = _invoke(
+        runner,
+        claude_home.ids[2],
+        env={"CLAUDE_CONFIG_DIR": str(claude_home.path)},
+    )
+    codex_result = _invoke(
+        runner,
+        codex_home.ids[2],
+        agent="codex",
+        env={"CODEX_HOME": str(codex_home.path)},
+    )
+    assert _json(claude_result)["home"] == str(claude_home.path.resolve())
+    assert _json(codex_result)["home"] == str(codex_home.path.resolve())
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_code", "expected_match", "expected_id"),
+    [
+        (CODEX_IDS[0], 0, "id", CODEX_IDS[0]),
+        ("dddd", 0, "partial-id", CODEX_IDS[2]),
+        ("unique codex migration", 0, "name", CODEX_IDS[2]),
+        ("migration", 0, "name", CODEX_IDS[2]),
+        ("shared codex", 2, None, None),
+        ("cccc", 2, None, None),
+        ("absent codex", 1, None, None),
+    ],
+)
+def test_codex_resolution_mirror(
+    runner: CliRunner,
+    codex_home: FakeHome,
+    query: str,
+    expected_code: int,
+    expected_match: str | None,
+    expected_id: str | None,
+) -> None:
+    result = _invoke(runner, query, codex_home.path, agent="codex")
+    payload = _json(result)
+    assert result.exit_code == expected_code
+    if expected_match is not None:
+        assert payload["matched_by"] == expected_match
+        assert payload["session_id"] == expected_id
+    elif expected_code == 2:
+        assert payload["error"] == "ambiguous"
+        assert payload["match_count"] == 2
+        candidates = payload["candidates"]
+        assert isinstance(candidates, list)
+        assert {item["session_id"] for item in candidates} == set(CODEX_IDS[:2])
+    else:
+        assert payload["error"] == "not_found"
+
+
+def test_json_success_shape_and_types(runner: CliRunner, codex_home: FakeHome) -> None:
+    result = _invoke(
+        runner,
+        codex_home.ids[1],
+        codex_home.path,
+        agent="codex",
+    )
+    payload = _json(result)
+    assert set(payload) == {
+        "agent",
+        "session_id",
+        "name",
+        "directory",
+        "home",
+        "session_file",
+        "matched_by",
+        "modified",
+        "archived",
+    }
+    assert isinstance(payload["agent"], str)
+    assert isinstance(payload["session_id"], str)
+    assert isinstance(payload["name"], str)
+    assert isinstance(payload["directory"], str)
+    assert isinstance(payload["home"], str)
+    assert isinstance(payload["session_file"], str)
+    assert isinstance(payload["matched_by"], str)
+    assert isinstance(payload["modified"], str)
+    assert isinstance(payload["archived"], bool)
+    assert payload["name"] == "Shared Codex"
+    assert payload["directory"] == codex_home.directories[1]
+    assert payload["session_file"] == str(codex_home.files[1].resolve())
+    assert payload["archived"] is True
+
+
+def test_json_and_pretty_flags_force_formats(
+    runner: CliRunner, claude_home: FakeHome
+) -> None:
+    json_result = _invoke(
+        runner,
+        claude_home.ids[2],
+        claude_home.path,
+        extra=["--json"],
+    )
+    pretty_result = _invoke(
+        runner,
+        claude_home.ids[2],
+        claude_home.path,
+        extra=["--pretty"],
+    )
+    assert json_result.exit_code == 0
+    assert _json(json_result)["session_id"] == claude_home.ids[2]
+    assert pretty_result.exit_code == 0
+    assert not pretty_result.output.lstrip().startswith("{")
+    assert "Session" in pretty_result.output
+    assert "Matched by" in pretty_result.output
+    master, slave = os.openpty()
+    command = [
+        sys.executable, "-m", "claude_code_tools.aichat", "resolve",
+        claude_home.ids[2], "--home", str(claude_home.path),
+    ]
+    process = subprocess.Popen(command, stdout=slave, stderr=slave)
+    os.close(slave)
+    chunks: list[bytes] = []
+    while True:
+        try:
+            chunk = os.read(master, 4_096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        chunks.append(chunk)
+    tty_output = b"".join(chunks).decode(errors="replace")
+    os.close(master)
+    assert process.wait(timeout=5) == 0
+    assert "Session" in tty_output
+    assert not tty_output.lstrip().startswith("{")
+
+
+def test_codex_stale_database_row_does_not_block_valid_match(
+    runner: CliRunner, codex_home: FakeHome
+) -> None:
+    database = codex_home.path / "state_5.sqlite"
+    missing_rollout = codex_home.path / "sessions" / "missing.jsonl"
+    _insert_codex_thread(
+        database,
+        "eeee4444-4444-4444-8444-444444444444",
+        missing_rollout,
+        "/missing",
+        "Stale Thread",
+        1_720_000_100,
+    )
+    result = _invoke(
+        runner,
+        codex_home.ids[2],
+        codex_home.path,
+        agent="codex",
+    )
+    payload = _json(result)
+    assert result.exit_code == 0
+    assert payload["session_id"] == codex_home.ids[2]
+
+
+def test_codex_duplicate_id_rows_resolve_uniquely(
+    runner: CliRunner, codex_home: FakeHome
+) -> None:
+    database = codex_home.path / "state_5.sqlite"
+    _insert_codex_thread(
+        database,
+        codex_home.ids[0],
+        codex_home.files[0],
+        codex_home.directories[0],
+        "Shared Codex",
+        1_720_000_200,
+    )
+    result = _invoke(
+        runner,
+        codex_home.ids[0],
+        codex_home.path,
+        agent="codex",
+    )
+    payload = _json(result)
+    assert result.exit_code == 0
+    assert payload["session_id"] == codex_home.ids[0]
+    assert payload["matched_by"] == "id"
+
+
+def test_claude_codex_named_home_and_duplicate_id(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "claude.codex-home"
+    session_id = "eeee4444-4444-4444-8444-444444444444"
+    old_cwd = str(tmp_path / "old-project")
+    new_cwd = str(tmp_path / "new-project")
+    _write_claude_session(home, session_id, old_cwd, "Old Copy", 100.0)
+    newest = _write_claude_session(
+        home, session_id, new_cwd, "Newest Copy", 200.0
+    )
+    exact = _invoke(runner, session_id, home)
+    named = _invoke(runner, "Newest Copy", home)
+    payload = _json(exact)
+    assert exact.exit_code == named.exit_code == 0
+    assert payload["directory"] == new_cwd
+    assert payload["session_file"] == str(newest.resolve())
+    assert _json(named)["session_id"] == session_id
+
+
+@pytest.mark.parametrize("bad_cwd", [None, "", 17, {"bad": "cwd"}])
+def test_claude_no_cwd_is_exact_id_only(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    tmp_path: Path,
+    bad_cwd: object,
+) -> None:
+    session_id = "eeee5555-5555-4555-8555-555555555555"
+    project_cwd = str(tmp_path / "project-without-cwd")
+    _write_raw_claude_session(
+        claude_home.path,
+        session_id,
+        project_cwd,
+        [
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "cwd": bad_cwd,
+                "message": {"content": "hello"},
+            },
+            {
+                "type": "custom-title",
+                "sessionId": session_id,
+                "customTitle": "No Cwd Session",
+            },
+        ],
+    )
+    exact_result = _invoke(runner, session_id, claude_home.path)
+    exact_payload = _json(exact_result)
+    partial_result = _invoke(runner, "eeee", claude_home.path)
+    name_result = _invoke(runner, "No Cwd Session", claude_home.path)
+    valid_result = _invoke(runner, claude_home.ids[2], claude_home.path)
+    assert exact_result.exit_code == 0
+    assert exact_payload["matched_by"] == "id"
+    assert exact_payload["directory"] is None
+    assert exact_payload["name"] is None
+    assert partial_result.exit_code == 1
+    assert _json(partial_result)["error"] == "not_found"
+    assert name_result.exit_code == 1
+    assert _json(name_result)["error"] == "not_found"
+    assert valid_result.exit_code == 0
+    assert _json(valid_result)["session_id"] == claude_home.ids[2]
+
+
+def test_claude_non_object_json_before_valid_records_is_resolvable(
+    runner: CliRunner, claude_home: FakeHome, tmp_path: Path
+) -> None:
+    session_id = "ffff6666-6666-4666-8666-666666666666"
+    cwd = str(tmp_path / "corrupt-project")
+    _write_raw_claude_session(
+        claude_home.path,
+        session_id,
+        cwd,
+        [
+            None,
+            [],
+            42,
+            "text",
+            {"timestamp": {"malformed": True}},
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "cwd": cwd,
+                "message": {"content": "hello"},
+            },
+            {
+                "type": "custom-title",
+                "sessionId": session_id,
+                "customTitle": "Corrupt Named Session",
+            },
+        ],
+    )
+    valid_result = _invoke(
+        runner,
+        claude_home.ids[2],
+        claude_home.path,
+    )
+    exact_result = _invoke(runner, session_id, claude_home.path)
+    partial_result = _invoke(runner, "ffff", claude_home.path)
+    name_result = _invoke(runner, "Corrupt Named", claude_home.path)
+    assert valid_result.exit_code == 0
+    assert _json(valid_result)["session_id"] == claude_home.ids[2]
+    assert exact_result.exit_code == 0
+    assert _json(exact_result)["matched_by"] == "id"
+    assert partial_result.exit_code == 0
+    assert _json(partial_result)["session_id"] == session_id
+    assert name_result.exit_code == 0
+    assert _json(name_result)["session_id"] == session_id
+
+
+def test_claude_invalid_utf8_is_isolated(
+    runner: CliRunner, claude_home: FakeHome, tmp_path: Path
+) -> None:
+    session_id = "ffff7777-7777-4777-8777-777777777777"
+    cwd = str(tmp_path / "invalid-utf8")
+    session_file = _write_raw_claude_session(
+        claude_home.path,
+        session_id,
+        cwd,
+        [{"type": "user", "sessionId": session_id, "cwd": cwd}],
+    )
+    session_file.write_bytes(session_file.read_bytes() + b"\xff\n")
+    valid_result = _invoke(runner, claude_home.ids[2], claude_home.path)
+    partial_result = _invoke(runner, "ffff7777", claude_home.path)
+
+    assert valid_result.exit_code == 0
+    assert _json(valid_result)["session_id"] == claude_home.ids[2]
+    assert "Traceback" not in valid_result.output
+    assert partial_result.exit_code == 1
+
+
+def test_codex_fallback_without_database(runner: CliRunner, tmp_path: Path) -> None:
+    home = tmp_path / "fallback-codex"
+    session_id = "eeee7777-7777-4777-8777-777777777777"
+    cwd = str(tmp_path / "fallback-project")
+    session_file = _write_codex_session(
+        home,
+        session_id,
+        cwd,
+        1_720_000_300.0,
+    )
+
+    result = _invoke(runner, session_id, home, agent="codex")
+    payload = _json(result)
+    name_result = _invoke(runner, "Fallback Name", home, agent="codex")
+    assert result.exit_code == 0
+    assert payload["session_id"] == session_id
+    assert payload["directory"] == cwd
+    assert payload["session_file"] == str(session_file.resolve())
+    assert payload["name"] is None
+    assert payload["archived"] is False
+    assert name_result.exit_code == 1
+    assert _json(name_result)["error"] == "not_found"
+
+
+@pytest.mark.parametrize("database_kind", ["corrupt", "incomplete"])
+def test_codex_database_failure_falls_back_to_rollouts(
+    runner: CliRunner, tmp_path: Path, database_kind: str
+) -> None:
+    home = tmp_path / database_kind
+    home.mkdir()
+    session_id = "eeee7890-7890-4890-8890-789078907890"
+    _write_codex_session(home, session_id, "/valid", 1_720_000_350.0)
+    database = home / "state_9.sqlite"
+    if database_kind == "corrupt":
+        database.write_bytes(b"not a sqlite database")
+    else:
+        connection = sqlite3.connect(database)
+        try:
+            connection.execute("CREATE TABLE threads (id TEXT)")
+            connection.commit()
+        finally:
+            connection.close()
+    result = _invoke(runner, session_id, home, agent="codex")
+    assert result.exit_code == 0
+    assert _json(result)["session_id"] == session_id
+
+
+@pytest.mark.parametrize(
+    ("include_payload_id", "payload_id"),
+    [
+        pytest.param(False, None, id="missing"),
+        pytest.param(True, None, id="null"),
+        pytest.param(True, "", id="empty"),
+        pytest.param(True, 17, id="non-string"),
+        pytest.param(
+            True,
+            "ffff9999-9999-4999-8999-999999999999",
+            id="different",
+        ),
+    ],
+)
+def test_codex_fallback_uses_filename_id(
+    runner: CliRunner,
+    tmp_path: Path,
+    include_payload_id: bool,
+    payload_id: object,
+) -> None:
+    home = tmp_path / "codex"
+    session_id = "eeee9999-9999-4999-8999-999999999999"
+    cwd = str(tmp_path / "project")
+    payload: dict[str, object] = {"cwd": cwd, "git": {}}
+    if include_payload_id:
+        payload["id"] = payload_id
+    _write_codex_session(
+        home,
+        session_id,
+        cwd,
+        1_720_000_400.0,
+        lines=[{"type": "session_meta", "payload": payload}],
+    )
+
+    result = _invoke(runner, session_id, home, agent="codex")
+    wrong_id = "None" if payload_id is None else str(payload_id)
+
+    assert result.exit_code == 0
+    assert _json(result)["session_id"] == session_id
+    if wrong_id:
+        assert _invoke(runner, wrong_id, home, agent="codex").exit_code == 1
+
+
+def test_codex_fallback_skips_malformed_rollout(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    valid_id = "eeeeaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+    _write_codex_session(home, valid_id, "/valid", 1_720_000_500.0)
+    _write_codex_session(
+        home,
+        "ffffbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "/bad",
+        1_720_000_501.0,
+        lines=[
+            42,
+            {"type": "response_item", "payload": None},
+            {"type": "response_item", "payload": []},
+            {"type": "response_item", "payload": {"role": [], "content": []}},
+            {
+                "type": "response_item",
+                "payload": {"role": "user", "content": [{"text": 17}]},
+            },
+            {
+                "type": "session_meta",
+                "payload": {"cwd": [], "timestamp": {}, "git": []},
+            },
+        ],
+    )
+    result = _invoke(runner, valid_id, home, agent="codex")
+    assert result.exit_code == 0
+    assert _json(result)["session_id"] == valid_id
+
+
+def test_stale_claude_file_does_not_block_valid_match(
+    runner: CliRunner, claude_home: FakeHome, tmp_path: Path
+) -> None:
+    session_id = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+    payload_cwd = str(tmp_path / "moved-project")
+    _write_raw_claude_session(
+        claude_home.path,
+        session_id,
+        str(tmp_path / "original-project"),
+        [
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "cwd": payload_cwd,
+                "message": {"content": "hello"},
+            },
+            {
+                "type": "custom-title",
+                "sessionId": session_id,
+                "customTitle": "Moved Session",
+            },
+        ],
+    )
+
+    result = _invoke(runner, session_id, claude_home.path)
+    name_result = _invoke(runner, "Moved Session", claude_home.path)
+    payload = _json(result)
+
+    assert result.exit_code == 0
+    assert payload["session_id"] == session_id
+    assert payload["name"] == "Moved Session"
+    assert name_result.exit_code == 0
+    assert _json(name_result)["session_id"] == session_id
+
+
+def test_stale_codex_fallback_file_does_not_block_valid_match(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    home = tmp_path / "codex"
+    session_id = "eeeecccc-cccc-4ccc-8ccc-cccccccccccc"
+    valid = _write_codex_session(home, session_id, "/valid", 1_720_000_600.0)
+    stale = valid.parent / (
+        "rollout-2026-07-14T10-00-00-ffffdddd-dddd-4ddd-8ddd-dddddddddddd.jsonl"
+    )
+    os.mkfifo(stale)
+    entry = json.dumps(
+        {"type": "session_meta", "payload": {"id": "stale", "cwd": "/stale"}}
+    )
+    encoded_entry = f"{entry}\n".encode()
+    def feed_fifo_three_times() -> None:
+        for attempt in range(3):
+            descriptor = os.open(stale, os.O_WRONLY)
+            if attempt == 2:
+                stale.unlink()
+            try:
+                os.write(descriptor, encoded_entry)
+            except BrokenPipeError:
+                pass
+            finally:
+                os.close(descriptor)
+
+    writer = threading.Thread(target=feed_fifo_three_times)
+    writer.start()
+    result = _invoke(runner, session_id, home, agent="codex")
+    writer.join(timeout=2)
+    assert not writer.is_alive()
+    assert result.exit_code == 0, result.output
+    assert _json(result)["session_id"] == session_id
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(0, False), (1, True), (None, False), ("0", False), ("1", True)],
+)
+def test_codex_archived_value_normalization(value: object, expected: bool) -> None:
+    assert _normalize_archived(value) is expected
+
+
+def test_claude_sidechain_is_exact_id_only(
+    runner: CliRunner, claude_home: FakeHome, tmp_path: Path
+) -> None:
+    session_id = "eeee8888-8888-4888-8888-888888888888"
+    cwd = str(tmp_path / "sidechain-project")
+    _write_raw_claude_session(
+        claude_home.path,
+        session_id,
+        cwd,
+        [
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "cwd": cwd,
+                "isSidechain": True,
+                "message": {"content": "hello"},
+            },
+            {
+                "type": "custom-title",
+                "sessionId": session_id,
+                "customTitle": "Hidden Sidechain",
+            },
+        ],
+    )
+
+    exact_result = _invoke(runner, session_id, claude_home.path)
+    partial_result = _invoke(runner, "eeee", claude_home.path)
+    name_result = _invoke(runner, "Hidden Sidechain", claude_home.path)
+    assert exact_result.exit_code == 0
+    assert _json(exact_result)["matched_by"] == "id"
+    assert partial_result.exit_code == 1
+    assert _json(partial_result)["error"] == "not_found"
+    assert name_result.exit_code == 1
+    assert _json(name_result)["error"] == "not_found"
+
+
+def test_claude_ai_title_is_not_a_name(
+    runner: CliRunner, claude_home: FakeHome, tmp_path: Path
+) -> None:
+    session_id = "dddd9999-9999-4999-8999-999999999999"
+    cwd = str(tmp_path / "ai-title-project")
+    _write_raw_claude_session(
+        claude_home.path,
+        session_id,
+        cwd,
+        [
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "cwd": cwd,
+                "message": {"content": "hello"},
+            },
+            {
+                "type": "ai-title",
+                "sessionId": session_id,
+                "aiTitle": "Automatic Only Title",
+            },
+        ],
+    )
+
+    exact_result = _invoke(runner, session_id, claude_home.path)
+    title_result = _invoke(runner, "Automatic Only", claude_home.path)
+    assert exact_result.exit_code == 0
+    assert _json(exact_result)["name"] is None
+    assert title_result.exit_code == 1
+    assert _json(title_result)["error"] == "not_found"


### PR DESCRIPTION
## Summary

Adds **`aichat resolve`** — a non-interactive, JSON-first command that resolves a
session **name** (from `/rename`), a **full session ID**, or a **partial ID** to a
single canonical session record, across both Claude Code and Codex homes. It exists so
an AI agent can look up a session programmatically, but prints a readable panel for
humans too.

Distinct from the existing interactive `find-session` TUI / `aichat find*` commands.

## Usage

```
aichat resolve <query> [--agent claude|codex] [--home PATH] [--json | --pretty]
```

- `<query>` — session name, full UUID, or partial id (required)
- `--agent` — `claude` (default) or `codex`
- `--home` — the claude/codex home to search; falls back to `$CLAUDE_CONFIG_DIR` /
  `$CODEX_HOME`, then `~/.claude` / `~/.codex`
- Output auto-detects: **JSON** when captured/piped (agent-facing), a **Rich panel** on
  a TTY; `--json` / `--pretty` force either.

```console
$ aichat resolve session-finder --json
{"agent": "claude", "session_id": "a15f9ced-…", "name": "session-finder",
 "directory": "/Users/…/claude-code-tools", "home": "/Users/…/.claude",
 "session_file": "…/a15f9ced-….jsonl", "matched_by": "name",
 "modified": "2026-07-14T…", "archived": false}
```

## Behavior

- **Match precedence:** exact id → exact name → id-prefix → name-substring; the first
  non-empty tier wins.
- **Exit codes:** `0` resolved · `1` not found · `2` ambiguous (emits a candidate list).
- Structured JSON errors (never a traceback) for empty/missing query, unsupported
  `--agent`, empty or non-directory `--home`.

## Data model

- **Claude:** name comes from the `custom-title` (`/rename`) transcript event — *not*
  the auto `ai-title`; sidechain/malformed sessions are excluded from name/partial
  matching.
- **Codex:** id / name / cwd come from the highest-numbered `state_*.sqlite` `threads`
  table (opened read-only), with a rollout filesystem-scan fallback when no DB exists.

Reuses the existing `find_claude_session` / `find_codex_session` / `session_utils`
helpers rather than re-implementing enumeration or home precedence.

## Testing

- `tests/test_resolve_session.py` — **101 tests**, real files (temp homes + a real
  SQLite `threads` fixture), **no mocks**. Covers the full matrix (full id, unique
  partial, exact/substring name, ambiguous name/partial, not-found, default agent,
  `--home` + env override, Codex mirror, JSON shape, `--json`/`--pretty`) plus hostile
  input: empty/whitespace/markup queries, malformed JSONL, null/non-string ids, stale
  rollouts, metadata-only rollouts, SQLite `archived` variants.
- No regressions across the session / find / trim / export suites.

## Hardening

The second commit is a robustness pass driven by multiple rounds of adversarial review
(including a contract-free "cold-diff" lens hunting crashes on hostile input): every
file/DB dereference is guarded so one malformed, stale, or unreadable session cannot
abort resolution of others, and pretty-mode rendering escapes all external strings to
eliminate Rich markup-injection crashes.
