### PR TITLE
voice-type: fix unbounded MLX GPU cache growth (multi-second stalls after long uptime)

### DIFF
--- a/claude_code_tools/voice_type/engine_parakeet_mlx.py
+++ b/claude_code_tools/voice_type/engine_parakeet_mlx.py
@@ -194,3 +194,24 @@ class ParakeetMlxEngine(ParakeetEngine):
             return text.strip() if isinstance(text, str) else ""
         finally:
             tmp.unlink(missing_ok=True)
+            self._release_gpu_cache()
+
+    @staticmethod
+    def _release_gpu_cache() -> None:
+        """Release MLX's buffer cache after a decode.
+
+        MLX caches every GPU buffer size it has ever allocated and
+        never frees them on its own. In a long-running dictation
+        process decoding takes of many different lengths, the cache
+        grows without bound — observed at 49 GB of dirty IOAccelerator
+        memory after two days of use, driving system-wide memory
+        pressure and multi-second paging stalls. Decodes happen at
+        human cadence, so re-allocating per take costs nothing
+        noticeable (~0.15 s decodes measured either way).
+        """
+        try:
+            import mlx.core as mx
+
+            mx.clear_cache()
+        except Exception:
+            pass

--- a/uv.lock
+++ b/uv.lock
@@ -443,7 +443,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.18.0"
+version = "1.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
## Summary

Long-running `parakeet-mlx` sessions degrade to multi-second transcription
stalls. Root cause: MLX's buffer cache retains every GPU buffer size ever
allocated; over days of dictating takes of varied lengths it grows without
bound — observed at **49 GB of dirty IOAccelerator memory** on a 2-day-old
process — causing system memory pressure and paging of the model weights.

Fix: release the cache (`mx.clear_cache()`) after every decode. Decodes
happen at human cadence, so the re-allocation cost is unmeasurable.

## Verification

- Before: cache 3.4 GB after ten 5s decodes, growing with each new take length
- After: cache 0 MB across 24 varied-length decodes; active memory steady at
  the model's 1.3 GB; decode latency unchanged (0.12–0.33 s)
- 171 voice-type tests pass