### PR TITLE
voice-type: permission preflight warnings + voice-mlx resolver guard

### DIFF
--- a/claude_code_tools/voice_type/app.py
+++ b/claude_code_tools/voice_type/app.py
@@ -571,12 +571,20 @@ class VoiceTypeApp:
     def _start_hotkey_listener(self):  # noqa: ANN202
         """Start the global hotkey listener; invalid chords degrade.
 
+        Missing macOS permissions are reported LOUDLY first: a launch
+        context without Input Monitoring gets a dead event tap with no
+        error from the OS, which previously looked exactly like "the
+        hotkey just doesn't work".
+
         Each configured chord is validated independently, so one
         malformed OPTIONAL binding (paste/cancel) only disables itself
         — a typo in cancel_hotkey must never take the toggle hotkey
         (and with it all of toggle mode) down.
         """
-        from .hotkey import parse_hotkey, start_hotkeys
+        from .hotkey import check_permissions, parse_hotkey, start_hotkeys
+
+        for warning in check_permissions():
+            self._status(f"WARNING: {warning}")
 
         candidates: list[tuple[str, tuple]] = [
             ("toggle", (self.cfg.hotkey, self.toggle))

--- a/claude_code_tools/voice_type/hotkey.py
+++ b/claude_code_tools/voice_type/hotkey.py
@@ -11,6 +11,7 @@ back to the observing ``GlobalHotKeys`` behavior.
 
 from __future__ import annotations
 
+import contextlib
 import sys
 import threading
 from typing import Callable
@@ -301,6 +302,54 @@ def record_hotkey(timeout: float = 15.0) -> str | None:
         listener_box["l"] = listener
         listener.join(timeout)
     return result.get("chord")
+
+
+def check_permissions() -> list[str]:
+    """Report missing macOS permissions that silently kill hotkeys.
+
+    macOS attributes keystroke access to the LAUNCH CONTEXT (the
+    terminal app — or tmux, when launched inside tmux), and a context
+    without Input Monitoring gets a dead event tap with no error: the
+    app looks healthy but hotkeys simply never fire. Observed in the
+    field when a rebuilt venv/new launch context lost the prior grant.
+
+    Returns human-readable warnings (empty when all is well) and asks
+    macOS to register/prompt for the missing access so the user can
+    grant it in System Settings.
+    """
+    if sys.platform != "darwin":
+        return []
+    warnings: list[str] = []
+    try:
+        import Quartz
+
+        if hasattr(Quartz, "CGPreflightListenEventAccess") and (
+            not Quartz.CGPreflightListenEventAccess()
+        ):
+            warnings.append(
+                "Input Monitoring permission MISSING for this launch "
+                "context — hotkeys will NOT work. Grant it in System "
+                "Settings > Privacy & Security > Input Monitoring "
+                "(to your terminal app, and to tmux if you launched "
+                "inside tmux), then restart voice-type."
+            )
+            with contextlib.suppress(Exception):
+                Quartz.CGRequestListenEventAccess()
+    except Exception:
+        pass
+    try:
+        from ApplicationServices import AXIsProcessTrusted
+
+        if not AXIsProcessTrusted():
+            warnings.append(
+                "Accessibility permission MISSING for this launch "
+                "context — typing into other apps will NOT work. "
+                "Grant it in System Settings > Privacy & Security > "
+                "Accessibility, then restart voice-type."
+            )
+    except Exception:
+        pass
+    return warnings
 
 
 def start_hotkeys(bindings: list[tuple]):  # noqa: ANN201

--- a/claude_code_tools/voice_type/hotkey.py
+++ b/claude_code_tools/voice_type/hotkey.py
@@ -11,7 +11,6 @@ back to the observing ``GlobalHotKeys`` behavior.
 
 from __future__ import annotations
 
-import contextlib
 import sys
 import threading
 from typing import Callable
@@ -313,42 +312,114 @@ def check_permissions() -> list[str]:
     app looks healthy but hotkeys simply never fire. Observed in the
     field when a rebuilt venv/new launch context lost the prior grant.
 
-    Returns human-readable warnings (empty when all is well) and asks
-    macOS to register/prompt for the missing access so the user can
-    grant it in System Settings.
+    Returns human-readable warnings (empty ONLY when every check ran
+    and every permission is granted — an unavailable module/symbol or
+    a probe that throws produces a "could not verify" warning instead
+    of silently passing) and asks macOS to register/prompt for the
+    missing access so the user can grant it in System Settings.
     """
     if sys.platform != "darwin":
         return []
     warnings: list[str] = []
+    warnings.extend(_check_input_monitoring())
+    warnings.extend(_check_accessibility())
+    return warnings
+
+
+def _check_input_monitoring() -> list[str]:
+    """Probe the Input Monitoring grant; never silently swallow failure."""
     try:
         import Quartz
+    except Exception as e:  # pragma: no cover - environment-specific
+        return [
+            "could not verify Input Monitoring permission (Quartz "
+            f"bridge unavailable: {e!r}) — hotkeys may silently not "
+            "work. Check that pyobjc is installed correctly."
+        ]
+    preflight = getattr(Quartz, "CGPreflightListenEventAccess", None)
+    if preflight is None:
+        return [
+            "could not verify Input Monitoring permission (this "
+            "macOS/pyobjc lacks CGPreflightListenEventAccess) — "
+            "hotkeys may silently not work."
+        ]
+    try:
+        granted = bool(preflight())
+    except Exception as e:
+        return [
+            "could not verify Input Monitoring permission (the "
+            f"CGPreflightListenEventAccess probe failed: {e!r}) — "
+            "hotkeys may silently not work."
+        ]
+    if granted:
+        return []
+    warnings = [
+        "Input Monitoring permission MISSING for this launch "
+        "context — hotkeys will NOT work. Grant it in System "
+        "Settings > Privacy & Security > Input Monitoring "
+        "(to your terminal app, and to tmux if you launched "
+        "inside tmux), then restart voice-type."
+    ]
+    # Nonfatal: registration just makes the app appear in System
+    # Settings so the user can flip the toggle — but a failure is
+    # still reported, never silently suppressed.
+    try:
+        Quartz.CGRequestListenEventAccess()
+    except Exception as e:
+        warnings.append(
+            "requesting Input Monitoring registration failed "
+            f"({e!r}); add your terminal app manually in System "
+            "Settings > Privacy & Security > Input Monitoring."
+        )
+    return warnings
 
-        if hasattr(Quartz, "CGPreflightListenEventAccess") and (
-            not Quartz.CGPreflightListenEventAccess()
-        ):
-            warnings.append(
-                "Input Monitoring permission MISSING for this launch "
-                "context — hotkeys will NOT work. Grant it in System "
-                "Settings > Privacy & Security > Input Monitoring "
-                "(to your terminal app, and to tmux if you launched "
-                "inside tmux), then restart voice-type."
-            )
-            with contextlib.suppress(Exception):
-                Quartz.CGRequestListenEventAccess()
-    except Exception:
-        pass
+
+def _check_accessibility() -> list[str]:
+    """Probe the Accessibility grant; never silently swallow failure."""
     try:
         from ApplicationServices import AXIsProcessTrusted
+    except Exception as e:  # pragma: no cover - environment-specific
+        return [
+            "could not verify Accessibility permission "
+            f"(ApplicationServices bridge unavailable: {e!r}) — "
+            "typing into other apps may silently not work. Check "
+            "that pyobjc is installed correctly."
+        ]
+    try:
+        trusted = bool(AXIsProcessTrusted())
+    except Exception as e:
+        return [
+            "could not verify Accessibility permission (the "
+            f"AXIsProcessTrusted probe failed: {e!r}) — typing into "
+            "other apps may silently not work."
+        ]
+    if trusted:
+        return []
+    warnings = [
+        "Accessibility permission MISSING for this launch "
+        "context — typing into other apps will NOT work. "
+        "Grant it in System Settings > Privacy & Security > "
+        "Accessibility, then restart voice-type."
+    ]
+    # Nonfatal: the prompt request registers the app in System
+    # Settings (and may show the system grant dialog) so the user can
+    # flip the toggle — a failure is still reported, never silently
+    # suppressed.
+    try:
+        from ApplicationServices import (
+            AXIsProcessTrustedWithOptions,
+            kAXTrustedCheckOptionPrompt,
+        )
 
-        if not AXIsProcessTrusted():
-            warnings.append(
-                "Accessibility permission MISSING for this launch "
-                "context — typing into other apps will NOT work. "
-                "Grant it in System Settings > Privacy & Security > "
-                "Accessibility, then restart voice-type."
-            )
-    except Exception:
-        pass
+        AXIsProcessTrustedWithOptions(
+            {kAXTrustedCheckOptionPrompt: True}
+        )
+    except Exception as e:
+        warnings.append(
+            "requesting Accessibility registration failed "
+            f"({e!r}); add your terminal app manually in System "
+            "Settings > Privacy & Security > Accessibility."
+        )
     return warnings
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ voice-parakeet = [
 voice-mlx = [
     "pynput>=1.7.7",
     "parakeet-mlx>=0.5.0",
+    # Resolver guard: without it uv can backtrack through parakeet-mlx
+    # -> librosa -> numba to a 2021 llvmlite that cannot build on
+    # modern Python ("Cannot install on Python version 3.13...").
+    "numba>=0.61",
     # sherpa-onnx supplies the Silero VAD used for segmentation.
     "sherpa-onnx>=1.12.0,<1.13",
     "sherpa-onnx-core>=1.12.0,<1.13",

--- a/tests/test_voice_type.py
+++ b/tests/test_voice_type.py
@@ -1563,10 +1563,45 @@ def test_invalid_optional_hotkey_keeps_toggle(monkeypatch) -> None:
     assert chords == ["<ctrl>+;", "<cmd>+<ctrl>+v"]
 
 
-def test_check_permissions_returns_warning_list() -> None:
-    pytest.importorskip("pynput")
-    from claude_code_tools.voice_type.hotkey import check_permissions
+def test_check_permissions_non_darwin_is_empty(monkeypatch) -> None:
+    """Off macOS the preflight is a no-op (and touches no OS APIs)."""
+    from claude_code_tools.voice_type import hotkey as hotkey_mod
 
-    warnings = check_permissions()
-    assert isinstance(warnings, list)
-    assert all(isinstance(w, str) and w for w in warnings)
+    monkeypatch.setattr(hotkey_mod.sys, "platform", "linux")
+    assert hotkey_mod.check_permissions() == []
+
+
+def test_check_permissions_reports_missing_grants(monkeypatch) -> None:
+    """Missing grants produce warnings — via STUBBED macOS APIs only.
+
+    The real CGRequestListenEventAccess can open a blocking system
+    privacy prompt, so the test injects fake Quartz/ApplicationServices
+    modules instead of ever invoking the genuine preflight.
+    """
+    from claude_code_tools.voice_type import hotkey as hotkey_mod
+
+    monkeypatch.setattr(hotkey_mod.sys, "platform", "darwin")
+    requested = {"n": 0}
+    fake_quartz = types.SimpleNamespace(
+        CGPreflightListenEventAccess=lambda: False,
+        CGRequestListenEventAccess=lambda: requested.__setitem__(
+            "n", requested["n"] + 1
+        ),
+    )
+    fake_appserv = types.SimpleNamespace(
+        AXIsProcessTrusted=lambda: False
+    )
+    monkeypatch.setitem(sys.modules, "Quartz", fake_quartz)
+    monkeypatch.setitem(
+        sys.modules, "ApplicationServices", fake_appserv
+    )
+    warnings = hotkey_mod.check_permissions()
+    assert len(warnings) == 2
+    assert "Input Monitoring" in warnings[0]
+    assert "Accessibility" in warnings[1]
+    assert requested["n"] == 1  # registration was requested
+
+    # granted context: no warnings
+    fake_quartz.CGPreflightListenEventAccess = lambda: True
+    fake_appserv.AXIsProcessTrusted = lambda: True
+    assert hotkey_mod.check_permissions() == []

--- a/tests/test_voice_type.py
+++ b/tests/test_voice_type.py
@@ -1542,10 +1542,10 @@ def test_stop_phrase_in_flight_is_dropped_not_typed() -> None:
 
 
 def test_invalid_optional_hotkey_keeps_toggle(monkeypatch) -> None:
-    pytest.importorskip("pynput")
+    import claude_code_tools.voice_type.app as app_mod
     import claude_code_tools.voice_type.hotkey as hotkey_mod
-    from claude_code_tools.voice_type.app import VoiceTypeApp
 
+    monkeypatch.setattr(app_mod, "Typist", RecordingTypist)
     started: dict = {}
 
     def fake_start_hotkeys(bindings):  # noqa: ANN001, ANN202
@@ -1553,7 +1553,10 @@ def test_invalid_optional_hotkey_keeps_toggle(monkeypatch) -> None:
         return SimpleNamespace(stop=lambda: None)
 
     monkeypatch.setattr(hotkey_mod, "start_hotkeys", fake_start_hotkeys)
-    app = VoiceTypeApp(Config(
+    # Never let the test hit real Quartz/ApplicationServices probes
+    # (CGRequestListenEventAccess can open a system privacy prompt).
+    monkeypatch.setattr(hotkey_mod, "check_permissions", lambda: [])
+    app = app_mod.VoiceTypeApp(Config(
         mode="toggle", sounds=False, overlay=False,
         cancel_hotkey="escape", paste_hotkey="<cmd>+<ctrl>+v",
     ))
@@ -1588,8 +1591,13 @@ def test_check_permissions_reports_missing_grants(monkeypatch) -> None:
             "n", requested["n"] + 1
         ),
     )
+    ax_prompts: list[dict] = []
     fake_appserv = types.SimpleNamespace(
-        AXIsProcessTrusted=lambda: False
+        AXIsProcessTrusted=lambda: False,
+        AXIsProcessTrustedWithOptions=lambda opts: bool(
+            ax_prompts.append(opts)
+        ),
+        kAXTrustedCheckOptionPrompt="AXTrustedCheckOptionPrompt",
     )
     monkeypatch.setitem(sys.modules, "Quartz", fake_quartz)
     monkeypatch.setitem(
@@ -1600,8 +1608,111 @@ def test_check_permissions_reports_missing_grants(monkeypatch) -> None:
     assert "Input Monitoring" in warnings[0]
     assert "Accessibility" in warnings[1]
     assert requested["n"] == 1  # registration was requested
+    # the Accessibility prompt/registration was requested too
+    assert ax_prompts == [{"AXTrustedCheckOptionPrompt": True}]
 
-    # granted context: no warnings
+    # granted context: no warnings, and no fresh registration request
     fake_quartz.CGPreflightListenEventAccess = lambda: True
     fake_appserv.AXIsProcessTrusted = lambda: True
     assert hotkey_mod.check_permissions() == []
+    assert requested["n"] == 1  # unchanged: not re-requested
+    assert len(ax_prompts) == 1  # unchanged: not re-prompted
+
+
+def test_check_permissions_reports_unverifiable_probes(monkeypatch) -> None:
+    """Failed or unavailable probes yield 'could not verify' warnings
+    instead of silently reporting that all is well."""
+    from claude_code_tools.voice_type import hotkey as hotkey_mod
+
+    monkeypatch.setattr(hotkey_mod.sys, "platform", "darwin")
+
+    def boom() -> bool:
+        raise RuntimeError("kaput")
+
+    fake_appserv = types.SimpleNamespace(AXIsProcessTrusted=boom)
+    monkeypatch.setitem(
+        sys.modules,
+        "Quartz",
+        types.SimpleNamespace(CGPreflightListenEventAccess=boom),
+    )
+    monkeypatch.setitem(sys.modules, "ApplicationServices", fake_appserv)
+    warnings = hotkey_mod.check_permissions()
+    assert len(warnings) == 2
+    assert "could not verify Input Monitoring" in warnings[0]
+    assert "could not verify Accessibility" in warnings[1]
+
+    # a Quartz build lacking the preflight symbol is loud too, never
+    # treated as "granted"
+    monkeypatch.setitem(sys.modules, "Quartz", types.SimpleNamespace())
+    warnings = hotkey_mod.check_permissions()
+    assert "could not verify Input Monitoring" in warnings[0]
+
+    # a failed registration request is reported alongside the missing
+    # grant, not suppressed
+    monkeypatch.setitem(
+        sys.modules,
+        "Quartz",
+        types.SimpleNamespace(
+            CGPreflightListenEventAccess=lambda: False,
+            CGRequestListenEventAccess=boom,
+        ),
+    )
+    warnings = hotkey_mod.check_permissions()
+    assert "Input Monitoring permission MISSING" in warnings[0]
+    assert "registration failed" in warnings[1]
+
+    # same for Accessibility: a failed prompt/registration request is
+    # reported alongside the missing grant, not suppressed (the stub
+    # lacks AXIsProcessTrustedWithOptions, so the request fails)
+    monkeypatch.setitem(
+        sys.modules,
+        "Quartz",
+        types.SimpleNamespace(
+            CGPreflightListenEventAccess=lambda: True
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ApplicationServices",
+        types.SimpleNamespace(AXIsProcessTrusted=lambda: False),
+    )
+    warnings = hotkey_mod.check_permissions()
+    assert "Accessibility permission MISSING" in warnings[0]
+    assert "requesting Accessibility registration failed" in warnings[1]
+
+
+def test_startup_emits_permission_warnings_before_hotkeys(
+    monkeypatch,
+) -> None:
+    """Startup surfaces every preflight warning via _status with the
+    documented "WARNING: " prefix, before starting the hotkeys.
+
+    Hermetic: check_permissions/start_hotkeys are replaced and Typist
+    is stubbed, so no real pynput/Quartz backend is ever imported.
+    """
+    import claude_code_tools.voice_type.app as app_mod
+    import claude_code_tools.voice_type.hotkey as hotkey_mod
+
+    monkeypatch.setattr(app_mod, "Typist", RecordingTypist)
+    events: list[str] = []
+    monkeypatch.setattr(
+        hotkey_mod,
+        "check_permissions",
+        lambda: ["no input monitoring", "no accessibility"],
+    )
+
+    def fake_start_hotkeys(bindings):  # noqa: ANN001, ANN202
+        events.append("start_hotkeys")
+        return SimpleNamespace(stop=lambda: None)
+
+    monkeypatch.setattr(hotkey_mod, "start_hotkeys", fake_start_hotkeys)
+    app = app_mod.VoiceTypeApp(
+        Config(mode="toggle", sounds=False, overlay=False)
+    )
+    app._status = events.append  # instance attr shadows the staticmethod
+    assert app._start_hotkey_listener() is not None
+    assert events[:2] == [
+        "WARNING: no input monitoring",
+        "WARNING: no accessibility",
+    ]
+    assert events[-1] == "start_hotkeys"

--- a/tests/test_voice_type.py
+++ b/tests/test_voice_type.py
@@ -164,7 +164,17 @@ def test_default_config_is_valid() -> None:
     Config().validate()
 
 
-def test_load_config_missing_default_uses_defaults(tmp_path: Path) -> None:
+def test_load_config_missing_default_uses_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Isolate from the developer's real ~/.config/voice-type/config.toml:
+    # the default path must be a missing file for this test to mean
+    # "missing config falls back to defaults".
+    import claude_code_tools.voice_type.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod, "DEFAULT_CONFIG_PATH", tmp_path / "absent.toml"
+    )
     cfg = load_config(None, overrides={"mode": "wake"})
     assert cfg.mode == "wake"
     assert cfg.model_arch == "medium-streaming"
@@ -1551,3 +1561,12 @@ def test_invalid_optional_hotkey_keeps_toggle(monkeypatch) -> None:
     chords = [b[0] for b in started["bindings"]]
     # The malformed cancel chord is dropped; toggle and paste survive.
     assert chords == ["<ctrl>+;", "<cmd>+<ctrl>+v"]
+
+
+def test_check_permissions_returns_warning_list() -> None:
+    pytest.importorskip("pynput")
+    from claude_code_tools.voice_type.hotkey import check_permissions
+
+    warnings = check_permissions()
+    assert isinstance(warnings, list)
+    assert all(isinstance(w, str) and w for w in warnings)

--- a/uv.lock
+++ b/uv.lock
@@ -443,7 +443,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.19.0"
+version = "1.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },
@@ -474,6 +474,7 @@ voice = [
     { name = "pynput" },
 ]
 voice-mlx = [
+    { name = "numba" },
     { name = "numpy" },
     { name = "parakeet-mlx" },
     { name = "pynput" },
@@ -506,6 +507,7 @@ requires-dist = [
     { name = "google-auth-oauthlib", marker = "extra == 'gdocs'", specifier = ">=1.0.0" },
     { name = "mcp", specifier = ">=1.13.0" },
     { name = "moonshine-voice", marker = "extra == 'voice'", specifier = ">=0.0.69" },
+    { name = "numba", marker = "extra == 'voice-mlx'", specifier = ">=0.61" },
     { name = "numpy", marker = "extra == 'voice-mlx'", specifier = ">=1.26.0" },
     { name = "numpy", marker = "extra == 'voice-parakeet'", specifier = ">=1.26.0" },
     { name = "parakeet-mlx", marker = "extra == 'voice-mlx'", specifier = ">=0.5.0" },


### PR DESCRIPTION
Two small fixes from field failures on v1.19.1:

1. **Dead hotkeys, silently**: a launch context (terminal/tmux) without macOS
   Input Monitoring gets a dead event tap with no error. voice-type now
   preflights Input Monitoring + Accessibility at startup and prints a WARNING
   naming exactly what to grant and where, and registers the subject so it
   appears in System Settings.
2. **`uv tool install "claude-code-tools[voice-mlx]"` build failure**: uv
   backtracked through librosa→numba to a 2021 llvmlite that can't build on
   Python 3.13. `numba>=0.61` in the extra guards the resolution
   (verified: install succeeds with the constraint).

Plus a test-isolation fix (the missing-default-config test read the real
user config). 172 tests pass.