### PR TITLE
voice-type: log transcription decode time (realtime factor)

### DIFF
--- a/claude_code_tools/voice_type/engine_parakeet.py
+++ b/claude_code_tools/voice_type/engine_parakeet.py
@@ -525,6 +525,25 @@ class ParakeetEngine:
         except Exception:
             pass
 
+    def _report_decode_time(self, audio_secs: float, elapsed: float) -> None:
+        """Log how long a decode took, and its speed vs. real time.
+
+        Makes latency visible per utterance: a healthy MLX/CPU decode
+        runs at many times real time, so a drop toward 1x (or below) is
+        an at-a-glance signal that something — memory pressure, thermal
+        throttling — is slowing transcription down.
+        """
+        if elapsed > 0:
+            self._report(
+                f"transcribed {audio_secs:.1f}s of audio in "
+                f"{elapsed:.2f}s ({audio_secs / elapsed:.0f}x realtime)"
+            )
+        else:
+            self._report(
+                f"transcribed {audio_secs:.1f}s of audio in "
+                f"{elapsed:.2f}s"
+            )
+
     def _safe_call(self, fn: Callable[[], None], name: str) -> None:
         """Invoke a client callback; never let its exception escape.
 
@@ -843,11 +862,13 @@ class ParakeetEngine:
         """
         secs = len(take) / SAMPLE_RATE
         self._report(f"transcribing {secs:.1f}s take...")
+        t0 = time.monotonic()
         try:
             text = self.transcribe(take, SAMPLE_RATE)
         except Exception as e:
             self._report(f"parakeet decode error: {e}")
             return
+        self._report_decode_time(secs, time.monotonic() - t0)
         if text:
             if self._closed.is_set():
                 return
@@ -949,11 +970,14 @@ class ParakeetEngine:
             self._vad.pop()
             if segment is None or segment.ndim != 1 or segment.size == 0:
                 continue
+            seg_secs = segment.size / SAMPLE_RATE
+            t0 = time.monotonic()
             try:
                 text = self.transcribe(segment, SAMPLE_RATE)
             except Exception as e:
                 self._report(f"parakeet decode error: {e}")
                 continue
+            self._report_decode_time(seg_secs, time.monotonic() - t0)
             if text:
                 self._safe_call(
                     lambda t=text: on_utterance(t), "on_utterance"

--- a/tests/test_voice_type_engines.py
+++ b/tests/test_voice_type_engines.py
@@ -1151,3 +1151,16 @@ def test_autogain_output_is_finite_and_clipped_for_hostile_input() -> None:
         out = agc.process(hostile)
         assert np.isfinite(out).all()
         assert np.abs(out).max() <= 1.0
+
+
+def test_report_decode_time_formats(monkeypatch) -> None:
+    pytest.importorskip("sherpa_onnx")
+    from claude_code_tools.voice_type.config import Config
+    from claude_code_tools.voice_type.engine_parakeet import ParakeetEngine
+
+    msgs: list[str] = []
+    eng = ParakeetEngine(Config(engine="parakeet"), msgs.append)
+    eng._report_decode_time(4.0, 0.2)
+    assert msgs[-1] == "transcribed 4.0s of audio in 0.20s (20x realtime)"
+    eng._report_decode_time(1.0, 0.0)  # never divides by zero
+    assert msgs[-1] == "transcribed 1.0s of audio in 0.00s"

--- a/uv.lock
+++ b/uv.lock
@@ -443,7 +443,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.19.1"
+version = "1.19.2"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
After each decode (hold take or VAD segment), the engine now logs how long transcription took and its speed vs. real time:

```
[voice-type] transcribing 10.4s take...
[voice-type] transcribed 10.4s of audio in 0.28s (37x realtime)
```

Makes latency visible per utterance — a drop toward 1x realtime is an at-a-glance signal of memory pressure or thermal throttling (e.g. the MLX cache leak fixed in v1.19.1 would have shown up here). 176 tests pass.