### PR TITLE
voice-type: instant chimes + translucent vibrating-string overlay

### DIFF
--- a/claude_code_tools/voice_type/app.py
+++ b/claude_code_tools/voice_type/app.py
@@ -15,7 +15,7 @@ from enum import Enum
 from typing import Callable
 
 from .config import Config
-from .inject import Typist, copy_to_clipboard, play_sound
+from .inject import SoundPlayer, Typist, copy_to_clipboard
 from .logic import (
     collapse_repeats,
     contains_phrase,
@@ -44,6 +44,9 @@ class VoiceTypeApp:
     def __init__(self, cfg: Config) -> None:
         self.cfg = cfg
         self.typist = Typist()
+        # Preload the chimes so the first one is instant and in sync
+        # with the overlay (afplay would lag ~100 ms behind the pill).
+        self._sound = SoundPlayer(cfg.sound_start, cfg.sound_stop)
         self._lock = threading.Lock()
         self._state = (
             State.ACTIVE
@@ -140,7 +143,7 @@ class VoiceTypeApp:
             if pre_msg is not None:
                 self._status(pre_msg)
             if self.cfg.sounds and State.ACTIVE in (old, new):
-                play_sound(
+                self._sound.play(
                     self.cfg.sound_start
                     if new == State.ACTIVE
                     else self.cfg.sound_stop

--- a/claude_code_tools/voice_type/inject.py
+++ b/claude_code_tools/voice_type/inject.py
@@ -34,27 +34,125 @@ class Typist:
         self._keyboard.tap(Key.enter)
 
 
-def play_sound(name: str) -> None:
-    """Play a named macOS system sound or a sound file path.
+def _resolve_sound(name: str) -> Path | None:
+    """Map a sound name or path to an existing file, or None."""
+    if not name:
+        return None
+    p = Path(name) if "/" in name else _SYSTEM_SOUNDS / f"{name}.aiff"
+    return p if p.exists() else None
 
-    ``name`` is either a system sound name (e.g. "Glass", "Bottle" —
-    see /System/Library/Sounds) or an absolute path to an audio file.
-    Silently no-ops off macOS, on empty names, and on missing files.
+
+def play_sound(name: str) -> None:
+    """Play a sound by spawning ``afplay`` (the fallback path).
+
+    Higher-latency than :class:`SoundPlayer` because afplay's own
+    CoreAudio startup delays audio-out ~100 ms; used only when the
+    preloaded AudioServices path is unavailable. No-ops off macOS / on
+    missing files.
     """
-    if sys.platform != "darwin" or not name:
-        return
-    sound = (
-        Path(name)
-        if "/" in name
-        else _SYSTEM_SOUNDS / f"{name}.aiff"
-    )
-    if not sound.exists():
+    sound = _resolve_sound(name) if sys.platform == "darwin" else None
+    if sound is None:
         return
     subprocess.Popen(
         ["afplay", str(sound)],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
+
+
+class SoundPlayer:
+    """Instant start/stop sounds via CoreAudio ``AudioServices``.
+
+    Spawning ``afplay`` per sound delays audio-out ~100 ms behind the
+    in-process overlay, so the chime lands visibly after the waveform
+    pill. AudioServices plays a *preloaded* system-sound id in well
+    under a millisecond with no run loop, keeping sound and pill in
+    sync. Sounds are registered once at construction; playback is
+    thread-safe and asynchronous. Falls back to ``afplay`` when the
+    framework can't be loaded, and no-ops off macOS.
+    """
+
+    def __init__(self, *names: str) -> None:
+        self._ids: dict[str, int] = {}
+        self._at = None
+        self._cf = None
+        self._ctypes = None
+        if sys.platform == "darwin":
+            try:
+                import ctypes
+                import ctypes.util
+
+                self._ctypes = ctypes
+                at = ctypes.CDLL(ctypes.util.find_library("AudioToolbox"))
+                cf = ctypes.CDLL(
+                    ctypes.util.find_library("CoreFoundation")
+                )
+                cf.CFURLCreateFromFileSystemRepresentation.restype = (
+                    ctypes.c_void_p
+                )
+                cf.CFURLCreateFromFileSystemRepresentation.argtypes = [
+                    ctypes.c_void_p,
+                    ctypes.c_char_p,
+                    ctypes.c_long,
+                    ctypes.c_bool,
+                ]
+                cf.CFRelease.argtypes = [ctypes.c_void_p]
+                at.AudioServicesCreateSystemSoundID.restype = (
+                    ctypes.c_int32
+                )
+                at.AudioServicesCreateSystemSoundID.argtypes = [
+                    ctypes.c_void_p,
+                    ctypes.POINTER(ctypes.c_uint32),
+                ]
+                at.AudioServicesPlaySystemSound.argtypes = [
+                    ctypes.c_uint32
+                ]
+                self._at, self._cf = at, cf
+            except Exception:
+                self._at = None
+        for name in names:
+            self._sid(name)  # preload so the first play is instant
+
+    def _sid(self, name: str) -> int | None:
+        """Return the (cached) system-sound id for ``name``, or None."""
+        if not name or self._at is None:
+            return None
+        if name in self._ids:
+            return self._ids[name]
+        path = _resolve_sound(name)
+        if path is None:
+            return None
+        try:
+            raw = str(path).encode()
+            url = self._cf.CFURLCreateFromFileSystemRepresentation(
+                None, raw, len(raw), False
+            )
+            if not url:
+                return None
+            sid = self._ctypes.c_uint32(0)
+            err = self._at.AudioServicesCreateSystemSoundID(
+                url, self._ctypes.byref(sid)
+            )
+            self._cf.CFRelease(url)
+            if err != 0 or sid.value == 0:
+                return None
+            self._ids[name] = sid.value
+            return sid.value
+        except Exception:
+            return None
+
+    def play(self, name: str) -> None:
+        """Play ``name`` instantly; fall back to afplay if needed."""
+        if not name or sys.platform != "darwin":
+            return
+        sid = self._sid(name)
+        if sid is not None:
+            try:
+                self._at.AudioServicesPlaySystemSound(sid)
+                return
+            except Exception:
+                pass
+        play_sound(name)
 
 
 def copy_to_clipboard(text: str) -> None:

--- a/claude_code_tools/voice_type/overlay.py
+++ b/claude_code_tools/voice_type/overlay.py
@@ -21,11 +21,14 @@ from typing import Callable
 SampleFn = Callable[[], tuple[str, bool, float]]
 TickFn = Callable[[], None]
 
-_WIDTH = 280.0
-_HEIGHT = 46.0
-_MARGIN_BOTTOM = 96.0
-_BARS = 64
-_TICK_SECONDS = 0.05
+_WIDTH = 460.0
+_HEIGHT = 92.0
+_MARGIN_BOTTOM = 110.0
+# Recent audio-level history (drives the local vibration envelope) and
+# the number of points the string is rendered with (smoothness).
+_HISTORY = 96
+_RENDER = 190
+_TICK_SECONDS = 0.033  # ~30 fps, smooth string motion
 
 
 def overlay_available() -> bool:
@@ -66,60 +69,94 @@ def run_overlay(sample: SampleFn, tick: TickFn, stopped: Callable[[], bool]) -> 
     )
 
     class WaveView(AppKit.NSView):  # noqa: D401
-        """Draws the pill background, state dot, and scrolling bars."""
+        """A translucent string that lies flat and vibrates with the voice.
+
+        The line is pinned at both ends (like a plucked string) and its
+        oscillation amplitude tracks the live, gain-adjusted mic level:
+        silence reads as a near-flat line, speech makes it ripple. The
+        recent-level history modulates the amplitude ALONG the string
+        (and scrolls), so the shape reflects the actual audio rather
+        than a fixed animation.
+        """
 
         def initWithFrame_(self, frame):  # noqa: ANN001, ANN201, N802
             self = objc.super(WaveView, self).initWithFrame_(frame)
             if self is None:
                 return None
-            self.levels = [0.0] * _BARS
+            self.levels = [0.0] * _HISTORY
+            self.phase = 0.0
             self.recording = False
-            self.label = ""
             return self
 
         def push_(self, sample):  # noqa: ANN001, ANN201, N802
-            label, recording, level = sample
-            self.levels = self.levels[1:] + [max(0.0, min(1.0, level))]
+            _label, recording, level = sample
+            level = max(0.0, min(1.0, float(level)))
+            # Mild smoothing so the string settles rather than jitters.
+            prev = self.levels[-1]
+            smoothed = prev + 0.5 * (level - prev)
+            self.levels = self.levels[1:] + [smoothed]
+            self.phase += 0.42  # advance the travelling wave each frame
             self.recording = bool(recording)
-            self.label = str(label)
             self.setNeedsDisplay_(True)
+
+        def _string_path(self, width, mid, max_amp):  # noqa: ANN001, ANN202
+            import math
+
+            path = NSBezierPath.bezierPath()
+            path.setLineJoinStyle_(AppKit.NSLineJoinStyleRound)
+            path.setLineCapStyle_(AppKit.NSLineCapStyleRound)
+            n = len(self.levels)
+            for i in range(_RENDER + 1):
+                u = i / _RENDER  # 0..1 along the string
+                # local amplitude from the level history at this point
+                fpos = u * (n - 1)
+                lo = int(fpos)
+                frac = fpos - lo
+                lvl = self.levels[lo]
+                if lo + 1 < n:
+                    lvl += frac * (self.levels[lo + 1] - lvl)
+                window = math.sin(math.pi * u)  # pin both ends to flat
+                amp = lvl * max_amp * window
+                disp = amp * (
+                    math.sin(u * 7.0 * math.pi + self.phase)
+                    + 0.4 * math.sin(u * 13.0 * math.pi - 1.7 * self.phase)
+                ) / 1.4
+                x = u * width
+                y = mid + disp
+                if i == 0:
+                    path.moveToPoint_((x, y))
+                else:
+                    path.lineToPoint_((x, y))
+            return path
 
         def drawRect_(self, rect):  # noqa: ANN001, ANN201, N802
             b = self.bounds()
-            pill = NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
-                b, b.size.height / 2, b.size.height / 2
+            # Ultra-faint rounded backdrop: just enough to read the
+            # string over any wallpaper, without looking like a panel.
+            pad = 6.0
+            back = NSMakeRect(
+                pad, pad, b.size.width - 2 * pad, b.size.height - 2 * pad
             )
-            NSColor.colorWithCalibratedWhite_alpha_(0.08, 0.82).setFill()
-            pill.fill()
-            if self.recording:
-                bar_color = NSColor.colorWithCalibratedRed_green_blue_alpha_(
-                    1.0, 0.27, 0.23, 1.0
-                )
-            else:
-                bar_color = NSColor.colorWithCalibratedWhite_alpha_(
-                    0.62, 0.9
-                )
-            bar_color.setFill()
-            # state dot on the left
-            dot = 8.0
-            dot_rect = NSMakeRect(
-                14.0, (b.size.height - dot) / 2, dot, dot
-            )
-            NSBezierPath.bezierPathWithOvalInRect_(dot_rect).fill()
-            # scrolling waveform bars, mirrored around the centerline
-            left = 30.0
-            right = 14.0
-            span = b.size.width - left - right
-            bw = span / _BARS
+            r = back.size.height / 2
+            NSColor.colorWithCalibratedWhite_alpha_(0.0, 0.16).setFill()
+            NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
+                back, r, r
+            ).fill()
+
             mid = b.size.height / 2
-            max_half = b.size.height / 2 - 7.0
-            for i, level in enumerate(self.levels):
-                half = max(1.0, level * max_half)
-                x = left + i * bw
-                bar = NSMakeRect(x, mid - half, max(1.0, bw - 2.0), 2 * half)
-                NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
-                    bar, 1.0, 1.0
-                ).fill()
+            max_amp = b.size.height / 2 - 16.0
+            path = self._string_path(b.size.width, mid, max_amp)
+            # soft glow behind, then the crisp translucent string
+            NSColor.colorWithCalibratedRed_green_blue_alpha_(
+                1.0, 0.30, 0.26, 0.16
+            ).setStroke()
+            path.setLineWidth_(7.0)
+            path.stroke()
+            NSColor.colorWithCalibratedRed_green_blue_alpha_(
+                1.0, 0.42, 0.38, 0.55
+            ).setStroke()
+            path.setLineWidth_(2.0)
+            path.stroke()
 
     class Driver(AppKit.NSObject):
         """NSTimer target: samples audio, ticks the app, ends the loop.

--- a/tests/test_voice_type.py
+++ b/tests/test_voice_type.py
@@ -1716,3 +1716,13 @@ def test_startup_emits_permission_warnings_before_hotkeys(
         "WARNING: no accessibility",
     ]
     assert events[-1] == "start_hotkeys"
+
+
+def test_sound_player_constructs_and_plays_safely() -> None:
+    """SoundPlayer must never raise, even for bogus/empty sounds."""
+    from claude_code_tools.voice_type.inject import SoundPlayer
+
+    player = SoundPlayer("Glass", "Bottle", "")
+    player.play("Glass")          # real system sound (or afplay fallback)
+    player.play("")               # empty: no-op
+    player.play("/no/such.aiff")  # missing file: no-op, no raise

--- a/uv.lock
+++ b/uv.lock
@@ -443,7 +443,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.19.3"
+version = "1.19.4"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
Two UX polish items from field feedback.

**1. Sound was late relative to the overlay.** `afplay` spawns a process whose CoreAudio startup delays audio-out ~100ms behind the in-process pill. New `SoundPlayer` preloads start/stop sounds as CoreAudio AudioServices system-sound ids (stdlib ctypes, no dependency, no run loop) and plays them in **<1ms** (measured 0.09ms) — in sync with the visual. Falls back to afplay if the framework can't load; no-ops off macOS.

**2. Overlay redesign — bigger, translucent, livelier.** The opaque pill of vertical bars is now a faint red **string pinned at both ends** that lies flat in silence and vibrates with the live mic level; the recent-level history modulates amplitude along the string and scrolls, so it reflects the actual audio. ~30fps, ultra-faint backdrop, soft glow. Screenshot-verified.

177 tests pass.