### PR TITLE
voice-type: interactive setup wizard (voice-type setup)

### DIFF
--- a/claude_code_tools/voice_type/cli.py
+++ b/claude_code_tools/voice_type/cli.py
@@ -231,7 +231,12 @@ Accessibility (to type), Input Monitoring (global hotkeys).
         help="interactive walkthrough that writes your config",
     )
     p_setup.add_argument(
-        "--config", type=Path, default=None, help="destination path"
+        "--config",
+        type=Path,
+        # SUPPRESS so a --config given BEFORE the subcommand is not
+        # clobbered by the subparser's default (see the init parser).
+        default=argparse.SUPPRESS,
+        help="destination path",
     )
     p_setup.add_argument(
         "--force", action="store_true", help="overwrite existing config"

--- a/claude_code_tools/voice_type/cli.py
+++ b/claude_code_tools/voice_type/cli.py
@@ -157,6 +157,12 @@ def _cmd_hotkey() -> int:
     return 0
 
 
+def _cmd_setup(args: argparse.Namespace) -> int:
+    from .setup_wizard import run_setup
+
+    return run_setup(config_path=args.config, force=args.force)
+
+
 def _cmd_init(args: argparse.Namespace) -> int:
     try:
         path = write_sample_config(args.config, force=args.force)
@@ -164,6 +170,7 @@ def _cmd_init(args: argparse.Namespace) -> int:
         print(f"voice-type: {e}", file=sys.stderr)
         return 1
     print(f"wrote {path}")
+    print("(tip: `voice-type setup` walks you through it interactively)")
     return 0
 
 
@@ -179,6 +186,7 @@ examples:
   voice-type --engine parakeet-mlx --segmentation hold
                                  # best accuracy: whole-take dictation
   voice-type --mode wake         # hands-free with wake word "claude"
+  voice-type setup               # interactive walkthrough -> config
   voice-type init                # write a commented sample config
   voice-type hotkey              # record a chord, print the config line
 
@@ -218,12 +226,24 @@ Accessibility (to type), Input Monitoring (global hotkeys).
         "hotkey",
         help="press a key combo and print the matching config line",
     )
+    p_setup = sub.add_parser(
+        "setup",
+        help="interactive walkthrough that writes your config",
+    )
+    p_setup.add_argument(
+        "--config", type=Path, default=None, help="destination path"
+    )
+    p_setup.add_argument(
+        "--force", action="store_true", help="overwrite existing config"
+    )
 
     args = parser.parse_args()
     if args.command == "init":
         return _cmd_init(args)
     if args.command == "hotkey":
         return _cmd_hotkey()
+    if args.command == "setup":
+        return _cmd_setup(args)
     return _cmd_run(args)
 
 

--- a/claude_code_tools/voice_type/setup_wizard.py
+++ b/claude_code_tools/voice_type/setup_wizard.py
@@ -18,6 +18,24 @@ from .config import (
 )
 
 
+class _Cancelled(Exception):
+    """Raised when the user aborts a prompt (Ctrl-C / Esc)."""
+
+
+def _ask(prompt):  # noqa: ANN001, ANN202
+    """Return a prompt's answer, or raise ``_Cancelled`` if aborted.
+
+    questionary returns ``None`` when a prompt is cancelled; every
+    answer flows through here so an abort — at a required OR an optional
+    prompt — always cancels the whole wizard instead of being mistaken
+    for a "no"/default and writing a config anyway.
+    """
+    value = prompt.ask()
+    if value is None:
+        raise _Cancelled
+    return value
+
+
 def _toml_value(v: object) -> str:
     if isinstance(v, bool):
         return "true" if v else "false"
@@ -44,16 +62,14 @@ def _write_config(path: Path, answers: dict) -> None:
 
 def _ask_hotkey(q, label: str, default: str):  # noqa: ANN001, ANN202
     """Return a hotkey string via keep-default / record / type."""
-    how = q.select(
+    how = _ask(q.select(
         f"{label} hotkey:",
         choices=[
             f"Keep default ({default})",
             "Record one now (press the combo)",
             "Type it manually",
         ],
-    ).ask()
-    if how is None:
-        return None
+    ))
     if how.startswith("Keep"):
         return default
     if how.startswith("Record"):
@@ -78,11 +94,11 @@ def _ask_hotkey(q, label: str, default: str):  # noqa: ANN001, ANN202
         except ValueError as e:
             return str(e)
 
-    return q.text(
+    return _ask(q.text(
         'Hotkey (e.g. "<ctrl>+;" or "ctrl+;"):',
         default=default,
         validate=_valid,
-    ).ask()
+    ))
 
 
 def run_setup(config_path: Path | None = None, force: bool = False) -> int:
@@ -94,126 +110,114 @@ def run_setup(config_path: Path | None = None, force: bool = False) -> int:
         return 1
 
     path = config_path or DEFAULT_CONFIG_PATH
-    if path.exists() and not force:
-        if not q.confirm(
-            f"{path} exists — overwrite it?", default=False
-        ).ask():
-            print("setup cancelled.")
-            return 1
-
-    print("voice-type setup — a few questions, then you're ready.\n")
     ans: dict = {}
+    try:
+        if path.exists() and not force:
+            if not _ask(
+                q.confirm(f"{path} exists — overwrite it?", default=False)
+            ):
+                print("setup cancelled.")
+                return 1
 
-    engine = q.select(
-        "Transcription engine:",
-        choices=[
-            q.Choice(
-                "parakeet-mlx — best accuracy + speed (Apple GPU; "
-                "needs the voice-mlx extra)",
-                value="parakeet-mlx",
-            ),
-            q.Choice(
-                "parakeet — Parakeet on CPU (needs voice-parakeet)",
-                value="parakeet",
-            ),
-            q.Choice(
-                "moonshine — small streaming models (needs voice)",
-                value="moonshine",
-            ),
-        ],
-    ).ask()
-    if engine is None:
-        return 1
-    ans["engine"] = engine
-    is_parakeet = engine in ("parakeet", "parakeet-mlx")
+        print("voice-type setup — a few questions, then you're ready.\n")
 
-    if engine == "parakeet":
-        pm = q.select(
-            "Parakeet build:",
-            choices=[
-                q.Choice("v3-int8 — multilingual, ~490 MB", "v3-int8"),
-                q.Choice("v2-fp16 — English, higher precision", "v2-fp16"),
-            ],
-        ).ask()
-        if pm is None:
-            return 1
-        ans["parakeet_model"] = pm
-    elif engine == "moonshine":
-        arch = q.select(
-            "Moonshine model:",
-            choices=list(VALID_MODEL_ARCHS),
-            default="medium-streaming",
-        ).ask()
-        if arch is None:
-            return 1
-        ans["model_arch"] = arch
-
-    mode = q.select(
-        "How should dictation activate?",
-        choices=[
-            q.Choice("toggle — a hotkey starts/stops", "toggle"),
-            q.Choice("wake — say a wake word (hands-free)", "wake"),
-            q.Choice("vad — always on while running", "vad"),
-        ],
-    ).ask()
-    if mode is None:
-        return 1
-    ans["mode"] = mode
-
-    if mode == "toggle" and is_parakeet:
-        seg = q.select(
-            "When should the text appear?",
+        engine = _ask(q.select(
+            "Transcription engine:",
             choices=[
                 q.Choice(
-                    "hold — whole take on toggle-off (most accurate)",
-                    "hold",
+                    "parakeet-mlx — best accuracy + speed (Apple GPU; "
+                    "needs the voice-mlx extra)",
+                    value="parakeet-mlx",
                 ),
-                q.Choice("vad — each utterance when you pause", "vad"),
+                q.Choice(
+                    "parakeet — Parakeet on CPU (needs voice-parakeet)",
+                    value="parakeet",
+                ),
+                q.Choice(
+                    "moonshine — small streaming models (needs voice)",
+                    value="moonshine",
+                ),
             ],
-        ).ask()
-        if seg is None:
-            return 1
-        ans["segmentation"] = seg
+        ))
+        ans["engine"] = engine
+        is_parakeet = engine in ("parakeet", "parakeet-mlx")
 
-    hotkey = _ask_hotkey(q, "Toggle-recording", "<ctrl>+;")
-    if hotkey is None:
-        return 1
-    ans["hotkey"] = hotkey
+        if engine == "parakeet":
+            ans["parakeet_model"] = _ask(q.select(
+                "Parakeet build:",
+                choices=[
+                    q.Choice("v3-int8 — multilingual, ~490 MB", "v3-int8"),
+                    q.Choice(
+                        "v2-fp16 — English, higher precision", "v2-fp16"
+                    ),
+                ],
+            ))
+        elif engine == "moonshine":
+            ans["model_arch"] = _ask(q.select(
+                "Moonshine model:",
+                choices=list(VALID_MODEL_ARCHS),
+                default="medium-streaming",
+            ))
 
-    if mode == "wake":
-        word = q.text("Wake word:", default="claude").ask()
-        if word is None:
-            return 1
-        ans["wake_word"] = word.strip() or "claude"
-        aliases = q.text(
-            "Wake-word aliases the model mishears "
-            "(comma-separated, optional):",
-            default="",
-        ).ask()
-        if aliases:
-            ans["wake_word_aliases"] = [
-                a.strip() for a in aliases.split(",") if a.strip()
-            ]
+        mode = _ask(q.select(
+            "How should dictation activate?",
+            choices=[
+                q.Choice("toggle — a hotkey starts/stops", "toggle"),
+                q.Choice("wake — say a wake word (hands-free)", "wake"),
+                q.Choice("vad — always on while running", "vad"),
+            ],
+        ))
+        ans["mode"] = mode
 
-    if q.confirm(
-        "Configure extras (sounds, clipboard rescue, ghost)?",
-        default=False,
-    ).ask():
-        ans["sounds"] = q.confirm(
-            "Play start/stop chimes?", default=True
-        ).ask()
-        if q.confirm(
-            "Add a hotkey to re-type the last transcript "
-            "(wrong-window rescue)?",
+        if mode == "toggle" and is_parakeet:
+            ans["segmentation"] = _ask(q.select(
+                "When should the text appear?",
+                choices=[
+                    q.Choice(
+                        "hold — whole take on toggle-off (most accurate)",
+                        "hold",
+                    ),
+                    q.Choice("vad — each utterance when you pause", "vad"),
+                ],
+            ))
+
+        ans["hotkey"] = _ask_hotkey(q, "Toggle-recording", "<ctrl>+;")
+
+        if mode == "wake":
+            word = _ask(q.text("Wake word:", default="claude"))
+            ans["wake_word"] = word.strip() or "claude"
+            aliases = _ask(q.text(
+                "Wake-word aliases the model mishears "
+                "(comma-separated, optional):",
+                default="",
+            ))
+            if aliases.strip():
+                ans["wake_word_aliases"] = [
+                    a.strip() for a in aliases.split(",") if a.strip()
+                ]
+
+        if _ask(q.confirm(
+            "Configure extras (sounds, clipboard rescue, ghost)?",
             default=False,
-        ).ask():
-            paste = _ask_hotkey(q, "Paste-again", "<cmd>+<ctrl>+v")
-            if paste:
-                ans["paste_hotkey"] = paste
+        )):
+            ans["sounds"] = _ask(
+                q.confirm("Play start/stop chimes?", default=True)
+            )
+            if _ask(q.confirm(
+                "Add a hotkey to re-type the last transcript "
+                "(wrong-window rescue)?",
+                default=False,
+            )):
+                ans["paste_hotkey"] = _ask_hotkey(
+                    q, "Paste-again", "<cmd>+<ctrl>+v"
+                )
                 ans["copy_to_clipboard"] = True
-        ans["overlay"] = q.confirm(
-            "Show the floating ghost while recording?", default=True
-        ).ask()
+            ans["overlay"] = _ask(q.confirm(
+                "Show the floating ghost while recording?", default=True
+            ))
+    except _Cancelled:
+        print("\nsetup cancelled — nothing written.")
+        return 1
 
     # Validate the combination before writing.
     try:

--- a/claude_code_tools/voice_type/setup_wizard.py
+++ b/claude_code_tools/voice_type/setup_wizard.py
@@ -9,6 +9,9 @@ commented sample file to edit by hand), this asks questions.
 
 from __future__ import annotations
 
+import os
+import tempfile
+import tomllib
 from pathlib import Path
 
 from .config import (
@@ -19,16 +22,21 @@ from .config import (
 
 
 class _Cancelled(Exception):
-    """Raised when the user aborts a prompt (Ctrl-C / Esc)."""
+    """Raised when the user aborts a prompt (Ctrl-C).
+
+    questionary 2.x turns Ctrl-C (and Ctrl-Q) into the ``None`` answer
+    that ``_ask`` maps to this exception; Escape is not a cancellation
+    key inside questionary prompts, so it is not advertised here.
+    """
 
 
 def _ask(prompt):  # noqa: ANN001, ANN202
     """Return a prompt's answer, or raise ``_Cancelled`` if aborted.
 
-    questionary returns ``None`` when a prompt is cancelled; every
-    answer flows through here so an abort — at a required OR an optional
-    prompt — always cancels the whole wizard instead of being mistaken
-    for a "no"/default and writing a config anyway.
+    questionary returns ``None`` when a prompt is cancelled (Ctrl-C);
+    every answer flows through here so an abort — at a required OR an
+    optional prompt — always cancels the whole wizard instead of being
+    mistaken for a "no"/default and writing a config anyway.
     """
     value = prompt.ask()
     if value is None:
@@ -36,11 +44,38 @@ def _ask(prompt):  # noqa: ANN001, ANN202
     return value
 
 
+# TOML basic-string escapes required by the spec; every other control
+# character (U+0000–U+001F and U+007F) is emitted as a \uXXXX escape so
+# a prompt answer with a newline/tab/etc. never produces invalid TOML.
+_TOML_STR_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\b": "\\b",
+    "\t": "\\t",
+    "\n": "\\n",
+    "\f": "\\f",
+    "\r": "\\r",
+}
+
+
+def _toml_string(s: str) -> str:
+    out: list[str] = []
+    for ch in s:
+        escaped = _TOML_STR_ESCAPES.get(ch)
+        if escaped is not None:
+            out.append(escaped)
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            out.append(f"\\u{ord(ch):04X}")
+        else:
+            out.append(ch)
+    return '"' + "".join(out) + '"'
+
+
 def _toml_value(v: object) -> str:
     if isinstance(v, bool):
         return "true" if v else "false"
     if isinstance(v, str):
-        return '"' + v.replace("\\", "\\\\").replace('"', '\\"') + '"'
+        return _toml_string(v)
     if isinstance(v, (int, float)):
         return repr(v)
     if isinstance(v, list):
@@ -48,7 +83,48 @@ def _toml_value(v: object) -> str:
     raise TypeError(f"cannot serialize {v!r} to TOML")
 
 
-def _write_config(path: Path, answers: dict) -> None:
+def _atomic_write(path: Path, text: str, overwrite: bool) -> None:
+    """Write ``text`` to ``path`` atomically.
+
+    Writes to a temporary file in the destination directory, flushes and
+    fsyncs it, then publishes it over the destination so an I/O failure or
+    interruption can never truncate or half-write an existing config. The
+    temporary file is removed on any failure.
+
+    When ``overwrite`` is true the publish is an unconditional
+    ``os.replace``. When it is false — the caller never authorized
+    clobbering an existing config — the publish is an atomic no-clobber
+    ``os.link``, which raises ``FileExistsError`` if the destination
+    appeared (e.g. another process created it) after the wizard's initial
+    existence check, so a config is never silently destroyed.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent), prefix=".config-", suffix=".toml.tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        if overwrite:
+            os.replace(tmp, path)
+        else:
+            # Atomic create-or-fail: link succeeds only if path is absent.
+            os.link(tmp, path)
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _write_config(path: Path, answers: dict, overwrite: bool) -> None:
     lines = [
         "# voice-type configuration — written by `voice-type setup`.",
         "# Run `voice-type init --force` for a fully commented sample.",
@@ -56,8 +132,29 @@ def _write_config(path: Path, answers: dict) -> None:
     ]
     for key, value in answers.items():
         lines.append(f"{key} = {_toml_value(value)}")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("\n".join(lines) + "\n")
+    text = "\n".join(lines) + "\n"
+    # Guard: never replace the destination with a document tomllib can't
+    # read back (the loader that voice-type itself uses).
+    tomllib.loads(text)
+    _atomic_write(path, text, overwrite)
+
+
+def _manual_hotkey(q, default: str):  # noqa: ANN001, ANN202
+    """Prompt for a hotkey typed by hand, validated by ``parse_hotkey``."""
+    from .hotkey import parse_hotkey
+
+    def _valid(text: str):  # noqa: ANN202
+        try:
+            parse_hotkey(text)
+            return True
+        except ValueError as e:
+            return str(e)
+
+    return _ask(q.text(
+        'Hotkey (e.g. "<ctrl>+;" or "ctrl+;"):',
+        default=default,
+        validate=_valid,
+    ))
 
 
 def _ask_hotkey(q, label: str, default: str):  # noqa: ANN001, ANN202
@@ -79,26 +176,39 @@ def _ask_hotkey(q, label: str, default: str):  # noqa: ANN001, ANN202
             print("  Press the key combo now (15s)...")
             chord = record_hotkey()
         except ImportError:
-            chord = None
-        if chord:
+            # Recording needs the optional voice dependency (pynput). Say
+            # so — rather than the ambiguous "nothing recorded" — and fall
+            # through to manual entry instead of silently keeping default.
+            print(
+                "  recording needs the voice dependency (pynput); "
+                "type the hotkey manually instead."
+            )
+            return _manual_hotkey(q, default)
+        except KeyboardInterrupt:
+            # Ctrl-C during the record window cancels the whole wizard,
+            # matching every other prompt — nothing gets written.
+            raise _Cancelled
+        if not chord:
+            print("  nothing recorded; keeping default.")
+            return default
+        # A recorded chord can contain keys the hotkey listener can't
+        # bind (e.g. <caps_lock>, media keys). Validate it the same way
+        # a manually typed one is validated, so the wizard never writes
+        # a config that later fails when the listeners start.
+        from .hotkey import parse_hotkey
+
+        try:
+            parse_hotkey(chord)
+        except ValueError as e:
+            print(
+                f"  recorded {chord!r} can't be used as a hotkey ({e}); "
+                "type one manually instead."
+            )
+        else:
             print(f"  recorded: {chord}")
             return chord
-        print("  nothing recorded; keeping default.")
-        return default
-    from .hotkey import parse_hotkey
-
-    def _valid(text: str):  # noqa: ANN202
-        try:
-            parse_hotkey(text)
-            return True
-        except ValueError as e:
-            return str(e)
-
-    return _ask(q.text(
-        'Hotkey (e.g. "<ctrl>+;" or "ctrl+;"):',
-        default=default,
-        validate=_valid,
-    ))
+        # fall through to manual entry (which retries / keeps the default)
+    return _manual_hotkey(q, default)
 
 
 def run_setup(config_path: Path | None = None, force: bool = False) -> int:
@@ -111,6 +221,11 @@ def run_setup(config_path: Path | None = None, force: bool = False) -> int:
 
     path = config_path or DEFAULT_CONFIG_PATH
     ans: dict = {}
+    # Whether clobbering an existing config was authorized: --force, or the
+    # user confirming the overwrite prompt below. If neither, the final
+    # write uses an atomic no-clobber publish so a config created by another
+    # process while the wizard runs is never silently overwritten.
+    overwrite_ok = force
     try:
         if path.exists() and not force:
             if not _ask(
@@ -118,6 +233,7 @@ def run_setup(config_path: Path | None = None, force: bool = False) -> int:
             ):
                 print("setup cancelled.")
                 return 1
+            overwrite_ok = True
 
         print("voice-type setup — a few questions, then you're ready.\n")
 
@@ -226,7 +342,16 @@ def run_setup(config_path: Path | None = None, force: bool = False) -> int:
         print(f"\nvoice-type: those choices don't combine ({e}).")
         return 1
 
-    _write_config(path, ans)
+    try:
+        _write_config(path, ans, overwrite_ok)
+    except FileExistsError:
+        # A config appeared after the initial existence check and the user
+        # never authorized an overwrite; refuse rather than clobber it.
+        print(
+            f"\nvoice-type: {path} was created while setup was running; "
+            "not overwriting it. Re-run with --force to replace it."
+        )
+        return 1
     print(f"\n✓ wrote {path}")
     print("\nStart dictating with:\n  voice-type")
     return 0

--- a/claude_code_tools/voice_type/setup_wizard.py
+++ b/claude_code_tools/voice_type/setup_wizard.py
@@ -1,0 +1,228 @@
+"""Interactive setup wizard for voice-type (``voice-type setup``).
+
+Walks a new user through the handful of choices that matter — engine,
+activation mode, segmentation, hotkey, wake word, and a few niceties —
+explaining each, then writes a valid ``config.toml`` and prints the
+command to run. Unlike ``voice-type init`` (which drops a fully
+commented sample file to edit by hand), this asks questions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .config import (
+    DEFAULT_CONFIG_PATH,
+    VALID_MODEL_ARCHS,
+    Config,
+)
+
+
+def _toml_value(v: object) -> str:
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, str):
+        return '"' + v.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    if isinstance(v, (int, float)):
+        return repr(v)
+    if isinstance(v, list):
+        return "[" + ", ".join(_toml_value(x) for x in v) + "]"
+    raise TypeError(f"cannot serialize {v!r} to TOML")
+
+
+def _write_config(path: Path, answers: dict) -> None:
+    lines = [
+        "# voice-type configuration — written by `voice-type setup`.",
+        "# Run `voice-type init --force` for a fully commented sample.",
+        "",
+    ]
+    for key, value in answers.items():
+        lines.append(f"{key} = {_toml_value(value)}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _ask_hotkey(q, label: str, default: str):  # noqa: ANN001, ANN202
+    """Return a hotkey string via keep-default / record / type."""
+    how = q.select(
+        f"{label} hotkey:",
+        choices=[
+            f"Keep default ({default})",
+            "Record one now (press the combo)",
+            "Type it manually",
+        ],
+    ).ask()
+    if how is None:
+        return None
+    if how.startswith("Keep"):
+        return default
+    if how.startswith("Record"):
+        try:
+            from .hotkey import record_hotkey
+
+            print("  Press the key combo now (15s)...")
+            chord = record_hotkey()
+        except ImportError:
+            chord = None
+        if chord:
+            print(f"  recorded: {chord}")
+            return chord
+        print("  nothing recorded; keeping default.")
+        return default
+    from .hotkey import parse_hotkey
+
+    def _valid(text: str):  # noqa: ANN202
+        try:
+            parse_hotkey(text)
+            return True
+        except ValueError as e:
+            return str(e)
+
+    return q.text(
+        'Hotkey (e.g. "<ctrl>+;" or "ctrl+;"):',
+        default=default,
+        validate=_valid,
+    ).ask()
+
+
+def run_setup(config_path: Path | None = None, force: bool = False) -> int:
+    """Run the interactive wizard; returns a process exit code."""
+    try:
+        import questionary as q
+    except ImportError as e:  # pragma: no cover - questionary is a base dep
+        print(f"voice-type: {e}; setup needs questionary")
+        return 1
+
+    path = config_path or DEFAULT_CONFIG_PATH
+    if path.exists() and not force:
+        if not q.confirm(
+            f"{path} exists — overwrite it?", default=False
+        ).ask():
+            print("setup cancelled.")
+            return 1
+
+    print("voice-type setup — a few questions, then you're ready.\n")
+    ans: dict = {}
+
+    engine = q.select(
+        "Transcription engine:",
+        choices=[
+            q.Choice(
+                "parakeet-mlx — best accuracy + speed (Apple GPU; "
+                "needs the voice-mlx extra)",
+                value="parakeet-mlx",
+            ),
+            q.Choice(
+                "parakeet — Parakeet on CPU (needs voice-parakeet)",
+                value="parakeet",
+            ),
+            q.Choice(
+                "moonshine — small streaming models (needs voice)",
+                value="moonshine",
+            ),
+        ],
+    ).ask()
+    if engine is None:
+        return 1
+    ans["engine"] = engine
+    is_parakeet = engine in ("parakeet", "parakeet-mlx")
+
+    if engine == "parakeet":
+        pm = q.select(
+            "Parakeet build:",
+            choices=[
+                q.Choice("v3-int8 — multilingual, ~490 MB", "v3-int8"),
+                q.Choice("v2-fp16 — English, higher precision", "v2-fp16"),
+            ],
+        ).ask()
+        if pm is None:
+            return 1
+        ans["parakeet_model"] = pm
+    elif engine == "moonshine":
+        arch = q.select(
+            "Moonshine model:",
+            choices=list(VALID_MODEL_ARCHS),
+            default="medium-streaming",
+        ).ask()
+        if arch is None:
+            return 1
+        ans["model_arch"] = arch
+
+    mode = q.select(
+        "How should dictation activate?",
+        choices=[
+            q.Choice("toggle — a hotkey starts/stops", "toggle"),
+            q.Choice("wake — say a wake word (hands-free)", "wake"),
+            q.Choice("vad — always on while running", "vad"),
+        ],
+    ).ask()
+    if mode is None:
+        return 1
+    ans["mode"] = mode
+
+    if mode == "toggle" and is_parakeet:
+        seg = q.select(
+            "When should the text appear?",
+            choices=[
+                q.Choice(
+                    "hold — whole take on toggle-off (most accurate)",
+                    "hold",
+                ),
+                q.Choice("vad — each utterance when you pause", "vad"),
+            ],
+        ).ask()
+        if seg is None:
+            return 1
+        ans["segmentation"] = seg
+
+    hotkey = _ask_hotkey(q, "Toggle-recording", "<ctrl>+;")
+    if hotkey is None:
+        return 1
+    ans["hotkey"] = hotkey
+
+    if mode == "wake":
+        word = q.text("Wake word:", default="claude").ask()
+        if word is None:
+            return 1
+        ans["wake_word"] = word.strip() or "claude"
+        aliases = q.text(
+            "Wake-word aliases the model mishears "
+            "(comma-separated, optional):",
+            default="",
+        ).ask()
+        if aliases:
+            ans["wake_word_aliases"] = [
+                a.strip() for a in aliases.split(",") if a.strip()
+            ]
+
+    if q.confirm(
+        "Configure extras (sounds, clipboard rescue, ghost)?",
+        default=False,
+    ).ask():
+        ans["sounds"] = q.confirm(
+            "Play start/stop chimes?", default=True
+        ).ask()
+        if q.confirm(
+            "Add a hotkey to re-type the last transcript "
+            "(wrong-window rescue)?",
+            default=False,
+        ).ask():
+            paste = _ask_hotkey(q, "Paste-again", "<cmd>+<ctrl>+v")
+            if paste:
+                ans["paste_hotkey"] = paste
+                ans["copy_to_clipboard"] = True
+        ans["overlay"] = q.confirm(
+            "Show the floating ghost while recording?", default=True
+        ).ask()
+
+    # Validate the combination before writing.
+    try:
+        Config(**ans).validate()
+    except (ValueError, TypeError) as e:
+        print(f"\nvoice-type: those choices don't combine ({e}).")
+        return 1
+
+    _write_config(path, ans)
+    print(f"\n✓ wrote {path}")
+    print("\nStart dictating with:\n  voice-type")
+    return 0

--- a/docs-site/src/content/docs/tools/voice-type/configuration.mdx
+++ b/docs-site/src/content/docs/tools/voice-type/configuration.mdx
@@ -205,10 +205,16 @@ overlay_speed = 1.0  # animation speed (lower = slower/gentler)
 
 ```
 voice-type [flags]           run with config + flag overrides
-voice-type init [--force]    write the commented sample config
+voice-type setup [--force]   interactive walkthrough -> writes config
+voice-type init [--force]    write the commented sample config to edit
 voice-type hotkey            press a chord; prints the config line
 voice-type --help            full flag reference
 ```
+
+New here? `voice-type setup` asks a handful of questions (engine,
+mode, hotkey, ...) — each explained, with sensible defaults — and
+writes a valid config for you. `init` instead drops a fully commented
+sample file to edit by hand.
 
 Flags mirror the config keys: `--mode`, `--engine`,
 `--segmentation`, `--parakeet-model`, `--model-arch`,

--- a/docs-site/src/content/docs/tools/voice-type/configuration.mdx
+++ b/docs-site/src/content/docs/tools/voice-type/configuration.mdx
@@ -19,10 +19,21 @@ also holds keys that have *no* flag at all
 `parakeet_threads`, ...), so the file is the
 complete interface; the flags are a subset.
 
+Two ways to create that file:
+
 ```bash
-voice-type init          # write a fully commented sample config
-voice-type init --force  # overwrite an existing one
+voice-type setup         # interactive walkthrough — asks, then writes
+voice-type init          # write a fully commented sample to edit by hand
+voice-type init --force  # overwrite an existing sample
 ```
+
+`voice-type setup` is the quickest start: it asks a
+short series of explained questions (engine, mode,
+segmentation, hotkey, wake word, and optional extras),
+validates your choices, and writes a ready-to-use
+config — you can record the hotkey live during the
+walkthrough. `init` instead drops the fully commented
+template below for hand-editing.
 
 ## The three independent axes
 

--- a/docs-site/src/content/docs/tools/voice-type/index.mdx
+++ b/docs-site/src/content/docs/tools/voice-type/index.mdx
@@ -104,10 +104,13 @@ engines and options, or run `voice-type --help`.
    press `Ctrl+;` again -- the whole take types at
    your cursor. `Esc` cancels a take.
 
-4. Make it yours: `voice-type init` writes a fully
-   commented config to
-   `~/.config/voice-type/config.toml`; after that,
-   plain `voice-type` starts with your settings.
+4. Make it yours: run `voice-type setup` for an
+   interactive walkthrough — it asks a handful of
+   explained questions (engine, mode, hotkey, ...)
+   and writes your `~/.config/voice-type/config.toml`.
+   (Prefer editing by hand? `voice-type init` drops a
+   fully commented sample instead.) After that, plain
+   `voice-type` starts with your settings.
 
 </Steps>
 

--- a/tests/test_voice_type.py
+++ b/tests/test_voice_type.py
@@ -1726,3 +1726,108 @@ def test_sound_player_constructs_and_plays_safely() -> None:
     player.play("Glass")          # real system sound (or afplay fallback)
     player.play("")               # empty: no-op
     player.play("/no/such.aiff")  # missing file: no-op, no raise
+
+
+# -- setup wizard ---------------------------------------------------------
+
+
+def _fake_questionary(script):
+    """Build a fake questionary module that returns scripted answers."""
+    it = iter(script)
+
+    class _Ans:
+        def __init__(self, v):
+            self._v = v
+
+        def ask(self):
+            return self._v
+
+    def _select(msg, choices=None, default=None):  # noqa: ANN001, ANN202
+        return _Ans(next(it))
+
+    def _confirm(msg, default=None):  # noqa: ANN001, ANN202
+        return _Ans(next(it))
+
+    def _text(msg, default="", validate=None):  # noqa: ANN001, ANN202
+        return _Ans(next(it))
+
+    class _Choice:
+        def __init__(self, title, value=None):  # noqa: ANN001
+            self.title, self.value = title, value
+
+    return types.SimpleNamespace(
+        select=_select, confirm=_confirm, text=_text, Choice=_Choice
+    )
+
+
+def test_toml_value_serialization() -> None:
+    from claude_code_tools.voice_type.setup_wizard import _toml_value
+
+    assert _toml_value(True) == "true"
+    assert _toml_value("<ctrl>+;") == '"<ctrl>+;"'
+    assert _toml_value(["a", "b"]) == '["a", "b"]'
+    assert _toml_value('say "go"') == '"say \\"go\\""'
+
+
+def test_setup_wizard_writes_valid_config(monkeypatch, tmp_path) -> None:
+    monkeypatch.setitem(
+        sys.modules,
+        "questionary",
+        _fake_questionary(
+            [
+                "parakeet-mlx",             # engine
+                "toggle",                   # mode
+                "hold",                     # segmentation
+                "Keep default (<ctrl>+;)",  # hotkey
+                False,                      # extras?
+            ]
+        ),
+    )
+    from claude_code_tools.voice_type.config import load_config
+    from claude_code_tools.voice_type.setup_wizard import run_setup
+
+    out = tmp_path / "c.toml"
+    assert run_setup(config_path=out, force=True) == 0
+    cfg = load_config(out)
+    assert (cfg.engine, cfg.mode, cfg.segmentation) == (
+        "parakeet-mlx",
+        "toggle",
+        "hold",
+    )
+
+
+def test_setup_wizard_wake_mode(monkeypatch, tmp_path) -> None:
+    monkeypatch.setitem(
+        sys.modules,
+        "questionary",
+        _fake_questionary(
+            [
+                "moonshine",                # engine
+                "medium-streaming",         # model_arch
+                "wake",                     # mode
+                "Keep default (<ctrl>+;)",  # hotkey
+                "claude",                   # wake word
+                "hey cloud, claud",         # aliases
+                False,                      # extras?
+            ]
+        ),
+    )
+    from claude_code_tools.voice_type.config import load_config
+    from claude_code_tools.voice_type.setup_wizard import run_setup
+
+    out = tmp_path / "c.toml"
+    assert run_setup(config_path=out, force=True) == 0
+    cfg = load_config(out)
+    assert cfg.mode == "wake"
+    assert cfg.wake_word_aliases == ["hey cloud", "claud"]
+
+
+def test_setup_wizard_cancel_leaves_no_file(monkeypatch, tmp_path) -> None:
+    monkeypatch.setitem(
+        sys.modules, "questionary", _fake_questionary([None])  # engine=None
+    )
+    from claude_code_tools.voice_type.setup_wizard import run_setup
+
+    out = tmp_path / "c.toml"
+    assert run_setup(config_path=out, force=True) == 1
+    assert not out.exists()

--- a/tests/test_voice_type.py
+++ b/tests/test_voice_type.py
@@ -1831,3 +1831,52 @@ def test_setup_wizard_cancel_leaves_no_file(monkeypatch, tmp_path) -> None:
     out = tmp_path / "c.toml"
     assert run_setup(config_path=out, force=True) == 1
     assert not out.exists()
+
+
+def test_setup_wizard_cancel_at_optional_prompt_keeps_file(
+    monkeypatch, tmp_path
+) -> None:
+    """Aborting an OPTIONAL prompt cancels — never overwrites a config."""
+    out = tmp_path / "c.toml"
+    out.write_text('engine = "moonshine"\n')  # pre-existing config
+    monkeypatch.setitem(
+        sys.modules,
+        "questionary",
+        _fake_questionary(
+            [
+                "parakeet-mlx",             # engine
+                "toggle",                   # mode
+                "hold",                     # segmentation
+                "Keep default (<ctrl>+;)",  # hotkey
+                None,                       # extras? -> CANCEL (Esc)
+            ]
+        ),
+    )
+    from claude_code_tools.voice_type.setup_wizard import run_setup
+
+    assert run_setup(config_path=out, force=True) == 1
+    assert out.read_text() == 'engine = "moonshine"\n'  # untouched
+
+
+def test_setup_config_flag_before_subcommand_preserved(
+    monkeypatch, tmp_path
+) -> None:
+    """`voice-type --config X setup` must target X, not the default."""
+    import claude_code_tools.voice_type.cli as cli_mod
+
+    target = tmp_path / "chosen.toml"
+    seen = {}
+
+    def _fake_run_setup(config_path=None, force=False):  # noqa: ANN001
+        seen["path"] = config_path
+        return 0
+
+    monkeypatch.setattr(
+        "claude_code_tools.voice_type.setup_wizard.run_setup",
+        _fake_run_setup,
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["voice-type", "--config", str(target), "setup"]
+    )
+    assert cli_mod.main() == 0
+    assert seen["path"] == target  # global --config survived the subparser

--- a/tests/test_voice_type.py
+++ b/tests/test_voice_type.py
@@ -1848,7 +1848,7 @@ def test_setup_wizard_cancel_at_optional_prompt_keeps_file(
                 "toggle",                   # mode
                 "hold",                     # segmentation
                 "Keep default (<ctrl>+;)",  # hotkey
-                None,                       # extras? -> CANCEL (Esc)
+                None,                       # extras? -> CANCEL (Ctrl-C)
             ]
         ),
     )
@@ -1880,3 +1880,89 @@ def test_setup_config_flag_before_subcommand_preserved(
     )
     assert cli_mod.main() == 0
     assert seen["path"] == target  # global --config survived the subparser
+
+
+def test_toml_value_escapes_control_chars() -> None:
+    """A string with newlines/tabs/etc. serializes to valid TOML.
+
+    The old serializer escaped only backslashes and quotes, so a value
+    with a control character produced a document tomllib rejected.
+    """
+    import tomllib
+
+    from claude_code_tools.voice_type.setup_wizard import _toml_value
+
+    value = "line1\nline2\ttab\rreturn\x00nul"
+    rendered = _toml_value(value)
+    assert tomllib.loads(f"x = {rendered}")["x"] == value
+
+
+def test_setup_wizard_rejects_unsupported_recorded_hotkey(
+    monkeypatch, tmp_path
+) -> None:
+    """A recorded chord that ``parse_hotkey`` can't accept is refused,
+    falling through to manual entry instead of being written blindly."""
+    import claude_code_tools.voice_type.hotkey as hotkey_mod
+
+    monkeypatch.setattr(
+        hotkey_mod, "record_hotkey", lambda *a, **k: "<caps_lock>"
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "questionary",
+        _fake_questionary(
+            [
+                "parakeet-mlx",                      # engine
+                "toggle",                            # mode
+                "hold",                              # segmentation
+                "Record one now (press the combo)",  # hotkey: record
+                "<ctrl>+<alt>+d",                    # manual fallback
+                False,                               # extras?
+            ]
+        ),
+    )
+    from claude_code_tools.voice_type.config import load_config
+    from claude_code_tools.voice_type.setup_wizard import run_setup
+
+    out = tmp_path / "c.toml"
+    assert run_setup(config_path=out, force=True) == 0
+    cfg = load_config(out)
+    # The unsupported recorded <caps_lock> was refused; the manually
+    # typed chord was written instead.
+    assert cfg.hotkey == "<ctrl>+<alt>+d"
+
+
+def test_setup_wizard_atomic_write_preserves_existing_on_failure(
+    monkeypatch, tmp_path
+) -> None:
+    """A write interrupted mid-flight never truncates the old config.
+
+    An fsync failure must leave the pre-existing file byte-for-byte
+    intact and leave no temporary litter behind.
+    """
+    import claude_code_tools.voice_type.setup_wizard as sw
+
+    out = tmp_path / "c.toml"
+    out.write_text('engine = "moonshine"\n')
+    monkeypatch.setitem(
+        sys.modules,
+        "questionary",
+        _fake_questionary(
+            [
+                "parakeet-mlx",             # engine
+                "toggle",                   # mode
+                "hold",                     # segmentation
+                "Keep default (<ctrl>+;)",  # hotkey
+                False,                      # extras?
+            ]
+        ),
+    )
+
+    def boom(_fd: int) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(sw.os, "fsync", boom)
+    with pytest.raises(OSError):
+        sw.run_setup(config_path=out, force=True)
+    assert out.read_text() == 'engine = "moonshine"\n'  # untouched
+    assert list(tmp_path.glob(".config-*")) == []  # temp cleaned up

--- a/uv.lock
+++ b/uv.lock
@@ -443,7 +443,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.19.6"
+version = "1.19.7"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
Adds `voice-type setup` — a guided onboarding walkthrough, as a friendlier alternative to hand-editing the config.

It asks a short series of **explained** questions and writes a valid `config.toml`:
- **Engine** (with the 'needs voice-mlx extra / Apple Silicon only' notes inline)
- **Mode** (toggle / wake / vad), and **segmentation** when applicable
- **Toggle hotkey** — keep default, *record one live* (reuses `record_hotkey`), or type it (validated)
- **Wake word** + aliases in wake mode
- Optional **extras**: chimes, clipboard-rescue paste hotkey, the ghost overlay

The combination is validated via `Config.validate()` before writing, and it prints the run command at the end. `voice-type init` still writes the commented sample to edit by hand and now points at `setup`.

**Why questionary:** already a base dependency and used elsewhere in the repo; uniquely suited to arrow-key select menus (rich has no select widget; textual is overkill for a linear Q&A).

4 new tests (mocked questionary) cover a toggle/hold run, wake-mode with aliases, cancel-leaves-no-file, and TOML serialization. 181 tests pass.