### PR TITLE
docs: slim README to card grid; de-stale voxtype overlay copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,42 +15,10 @@ CLI tools, skills, agents, hooks, and plugins for enhancing productivity with Cl
 
 </div>
 
-## [Full Documentation](https://pchalasani.github.io/claude-code-tools/)
+## [Full Documentation →](https://pchalasani.github.io/claude-code-tools/)
 
-## Install
-
-```bash
-# Core package
-uv tool install claude-code-tools
-
-# With Google Docs/Sheets extras
-uv tool install "claude-code-tools[gdocs]"
-
-# Upgrade an existing installation
-uv tool install --force claude-code-tools
-```
-
-The search engine (`aichat search`) requires a
-separate Rust binary:
-
-- **Homebrew** (macOS/Linux):
-  `brew install pchalasani/tap/aichat-search`
-- **Cargo**: `cargo install aichat-search`
-- **Pre-built binary**:
-  [Releases](https://github.com/pchalasani/claude-code-tools/releases)
-  (look for `rust-v*`)
-
-Install the Claude Code
-[plugins](https://pchalasani.github.io/claude-code-tools/getting-started/plugins/)
-for hooks, skills, and agents:
-
-```bash
-claude plugin marketplace add pchalasani/claude-code-tools
-```
-
----
-
-Click a card to jump to that feature, or
+Everything — installation, every tool, plugins, and guides — lives in the
+docs. Click a card below to jump to a feature, or
 **[read the full docs](https://pchalasani.github.io/claude-code-tools/)**.
 
 <div align="center">
@@ -181,44 +149,3 @@ Click a card to jump to that feature, or
 </table>
 
 </div>
-
----
-
-> **Legacy links** — The sections below exist to
-> preserve links shared in earlier discussions.
-> For current documentation, visit the
-> [full docs site](https://pchalasani.github.io/claude-code-tools/).
-
-<a id="aichat-session-management"></a>
-## aichat — Session Management
-See [aichat](https://pchalasani.github.io/claude-code-tools/tools/aichat/) in the full documentation.
-
-<a id="tmux-cli-terminal-automation"></a>
-## tmux-cli — Terminal Automation
-See [tmux-cli](https://pchalasani.github.io/claude-code-tools/tools/tmux-cli/) in the full documentation.
-
-<a id="voice"></a>
-## Voice Plugin
-See [Voice](https://pchalasani.github.io/claude-code-tools/plugins-detail/voice/) in the full documentation.
-
-<a id="voice-type"></a>
-<a id="voxtype"></a>
-## voxtype — Local Voice Dictation
-**macOS only** (Intel and Apple Silicon). Fully on-device speech-to-text
-(Parakeet on the Apple GPU or CPU, or Moonshine; + VAD) that types wherever
-your cursor is, with a configurable toggle hotkey and optional wake word.
-It is its own standalone package — install it directly, no need for the
-rest of this suite:
-
-```bash
-uv tool install voxtype
-```
-
-That picks the best engine for your machine automatically (Apple-GPU
-`parakeet-mlx` on Apple Silicon, CPU `parakeet` on Intel).
-See [voxtype](https://pchalasani.github.io/claude-code-tools/tools/voxtype/) in the full documentation.
-
-<a id="license"></a>
-## License
-
-MIT

--- a/docs-site/src/content/docs/tools/voxtype/configuration.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/configuration.mdx
@@ -77,8 +77,8 @@ least immediate:
    each fragment with only that fragment's context,
    so accuracy is a notch lower.
 3. **Whole-take** — `segmentation = "hold"`.
-   Nothing appears while you speak (the waveform
-   pill is your feedback); on toggle-off the entire
+   Nothing appears while you speak (the ghost
+   indicator is your feedback); on toggle-off the entire
    take is transcribed as one segment and typed in
    one go. Maximum accuracy — the model sees full
    sentence context — and most apps undo it as a

--- a/docs-site/src/content/docs/tools/voxtype/index.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/index.mdx
@@ -3,8 +3,8 @@ title: "voxtype — Local Voice Dictation"
 description: >
   Fully on-device speech-to-text that types wherever
   your cursor is. Parakeet/Moonshine engines, wake
-  word, spoken submit, filler removal, and a live
-  waveform recording indicator.
+  word, spoken submit, filler removal, and a
+  talking-ghost recording indicator.
 ---
 
 import { Tabs, TabItem, Steps, Card, CardGrid } from
@@ -70,9 +70,9 @@ engines and options, or run `voxtype --help`.
     "I think") -- on-device regex, no LLM involved.
   </Card>
   <Card title="Visible when it matters" icon="magnifier">
-    A floating waveform pill appears ONLY while
-    recording -- red waves as you speak. Pill on
-    screen = mic live; no pill = not listening.
+    A little glowing-blue ghost appears ONLY while
+    recording -- its mouth opens as you speak. Ghost
+    on screen = mic live; no ghost = not listening.
   </Card>
   <Card title="Nothing is ever lost" icon="random">
     Dictated into the wrong window? A paste-again
@@ -105,7 +105,7 @@ engines and options, or run `voxtype --help`.
    voxtype --segmentation hold
    ```
 
-   Press `Ctrl+;`, speak (watch the waveform pill),
+   Press `Ctrl+;`, speak (watch the ghost),
    press `Ctrl+;` again -- the whole take types at
    your cursor. `Esc` cancels a take.
 


### PR DESCRIPTION
Two doc cleanups.

## README → card grid + docs pointer only
Removed **all** installation instructions and the per-tool/legacy prose sections (aichat, tmux-cli, voice, voxtype, License). The README is now just: title/badges, a "Full Documentation →" link, and the card grid. The Starlight site is the single source of truth (net −73 lines).

## voxtype docs: overlay copy was stale
The recording indicator is the **talking-blue-ghost** overlay now, but the docs still described a "floating waveform pill / red waves". Fixed in:
- the "Visible when it matters" overview card
- the quick-start step ("watch the ghost")
- the page frontmatter description
- the `segmentation = "hold"` feedback note (configuration page)

## voice-type mentions
None remain in docs **content**. The only `voice-type` strings left are the URL redirects in `astro.config.mjs` (`/tools/voice-type` → `/tools/voxtype/`), kept so old links from the v1.19.x release notes still resolve. Say the word if you want those dropped too.

Docs build clean; rendered voxtype page shows "ghost" and no "waveform pill".