### PR TITLE
fix(voxtype skill): refresh marketplace snapshot before install

### DIFF
--- a/packages/voxtype/src/voxtype/skill_install.py
+++ b/packages/voxtype/src/voxtype/skill_install.py
@@ -22,13 +22,20 @@ _PLUGIN = "voxtype"
 # (`cctools-codex-plugins`). Each agent also has its own install verb
 # (`plugin install` vs `plugin add`), so the selector must name that
 # agent's own marketplace or the install can't resolve the plugin.
+# Each agent caches a marketplace snapshot, so an already-added
+# marketplace is NOT re-fetched by `add` — without an explicit refresh a
+# machine that added the marketplace before voxtype was published can't
+# see the plugin. So we always refresh after add (Claude: `marketplace
+# update`; Codex: `marketplace upgrade`) before installing.
 _AGENTS: dict[str, dict[str, list[str]]] = {
     "claude": {
         "add": ["plugin", "marketplace", "add", _MARKETPLACE_REPO],
+        "refresh": ["plugin", "marketplace", "update", "cctools-plugins"],
         "install": ["plugin", "install", f"{_PLUGIN}@cctools-plugins"],
     },
     "codex": {
         "add": ["plugin", "marketplace", "add", _MARKETPLACE_REPO],
+        "refresh": ["plugin", "marketplace", "upgrade", "cctools-codex-plugins"],
         "install": ["plugin", "add", f"{_PLUGIN}@cctools-codex-plugins"],
     },
 }
@@ -47,11 +54,12 @@ def _run(argv: list[str]) -> int:
 
 
 def _install_for(agent: str) -> bool:
-    """Add the marketplace and install the voxtype plugin for ``agent``.
+    """Add + refresh the marketplace and install the plugin for ``agent``.
 
-    The marketplace-add is best-effort (it commonly "fails" only because
-    the marketplace is already added); success is decided by the install
-    step, which is what actually places the skill.
+    The add and refresh steps are best-effort (add commonly "fails" only
+    because the marketplace is already registered; refresh only matters
+    when it was); success is decided by the install step, which is what
+    actually places the skill.
     """
     verbs = _AGENTS[agent]
     print(f"voxtype: setting up the voxtype skill in {agent}…")
@@ -60,8 +68,11 @@ def _install_for(agent: str) -> bool:
         # Non-fatal: most often the marketplace is already registered.
         print(
             f"voxtype: '{agent} plugin marketplace add' returned {add_rc} "
-            "(already added?); continuing to install"
+            "(already added?); refreshing it"
         )
+    # Refresh the cached marketplace snapshot so a machine that added it
+    # before voxtype was published can see the plugin (non-fatal).
+    _run([agent, *verbs["refresh"]])
     install_rc = _run([agent, *verbs["install"]])
     if install_rc == 0:
         print(f"voxtype: installed the voxtype skill for {agent} ✓")

--- a/packages/voxtype/tests/test_voxtype.py
+++ b/packages/voxtype/tests/test_voxtype.py
@@ -1503,9 +1503,14 @@ def test_skill_install_targets_both_agents(monkeypatch, capsys) -> None:
         "codex", "plugin", "add", "voxtype@cctools-codex-plugins",
     ] in runs
     # marketplace add ran for both, from the repo
-    adds = [r for r in runs if "marketplace" in r]
+    adds = [r for r in runs if r[2:4] == ["marketplace", "add"]]
     assert all("pchalasani/claude-code-tools" in r for r in adds)
     assert len(adds) == 2
+    # and each cached marketplace was refreshed before install
+    assert ["claude", "plugin", "marketplace", "update",
+            "cctools-plugins"] in runs
+    assert ["codex", "plugin", "marketplace", "upgrade",
+            "cctools-codex-plugins"] in runs
 
 
 def test_skill_install_skips_absent_agent(monkeypatch) -> None:

--- a/plugins/voxtype/README.md
+++ b/plugins/voxtype/README.md
@@ -25,9 +25,15 @@ Or add it manually per agent — note the marketplace name differs
 ```bash
 # Claude Code
 claude plugin marketplace add pchalasani/claude-code-tools
+claude plugin marketplace update cctools-plugins   # refresh if already added
 claude plugin install voxtype@cctools-plugins
 
 # Codex
 codex plugin marketplace add pchalasani/claude-code-tools
+codex plugin marketplace upgrade cctools-codex-plugins  # refresh if already added
 codex plugin add voxtype@cctools-codex-plugins
 ```
+
+If you already had the marketplace added before voxtype was published,
+the `update`/`upgrade` step is what refreshes the cached snapshot so the
+plugin shows up (`voxtype skill` does this automatically).


### PR DESCRIPTION
`voxtype skill` failed with *"Plugin voxtype not found in marketplace"* on machines that had already added the `cctools-plugins` / `cctools-codex-plugins` marketplace before voxtype was published: the agents serve an already-added marketplace from a **cached snapshot**, and `marketplace add` is a no-op that doesn't re-fetch.

Fix: after `marketplace add`, `voxtype skill` now runs `claude plugin marketplace update cctools-plugins` / `codex plugin marketplace upgrade cctools-codex-plugins` (both best-effort, non-fatal) before the install, so the snapshot is current. Manual-install README updated with the refresh step. 197 tests pass (updated the both-agents test to assert the refresh commands run).