### PR TITLE
docs(voxtype): install polish — upgrade flag, voxtype skill, drop stray --segmentation

### DIFF
--- a/docs-site/src/content/docs/tools/voxtype/index.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/index.mdx
@@ -31,13 +31,28 @@ Intel-macOS build).
 
 :::note[Installation]
 ```bash
-uv tool install voxtype
+uv tool install voxtype                    # install
+uv tool install --force --refresh voxtype  # upgrade to the latest
 ```
 That's it — the install picks the best engine for
 your machine (Apple-GPU `parakeet-mlx` on Apple
 Silicon, CPU `parakeet` elsewhere) and it's the
-default at runtime too. See
-[Configuration & CLI](./configuration/) for all
+default at runtime too.
+
+**Using Claude Code or Codex?** Then run:
+
+```bash
+voxtype skill
+```
+
+It adds a voxtype guide skill to **both** agents, so
+you can just ask your agent *"help me install
+voxtype"* and it walks you through install,
+configuration, and the macOS permissions. See
+[Set it up from your coding agent](#set-it-up-from-your-coding-agent)
+below.
+
+See [Configuration & CLI](./configuration/) for all
 engines and options, or run `voxtype --help`.
 :::
 
@@ -102,12 +117,12 @@ engines and options, or run `voxtype --help`.
 3. Start dictating:
 
    ```bash
-   voxtype --segmentation hold
+   voxtype
    ```
 
-   Press `Ctrl+;`, speak (watch the ghost),
-   press `Ctrl+;` again -- the whole take types at
-   your cursor. `Esc` cancels a take.
+   Press `Ctrl+;` to start, speak (watch the ghost),
+   press `Ctrl+;` again to stop -- your speech is typed
+   at the cursor. `Esc` cancels a take.
 
 4. Make it yours: run `voxtype setup` for an
    interactive walkthrough — it asks a handful of

--- a/docs-site/src/content/docs/tools/voxtype/index.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/index.mdx
@@ -32,8 +32,8 @@ Intel-macOS build).
 
 :::note[Installation]
 ```bash
-uv tool install voxtype                    # install
-uv tool install --force --refresh voxtype  # upgrade to the latest
+uv tool install voxtype    # install
+uv tool upgrade voxtype     # upgrade to the latest (keeps any extras)
 ```
 That's it — the install picks the best engine for
 your machine (Apple-GPU `parakeet-mlx` on Apple

--- a/docs-site/src/content/docs/tools/voxtype/index.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/index.mdx
@@ -1,10 +1,11 @@
 ---
-title: "voxtype — Local Voice Dictation"
+title: "voxtype — Type with your voice"
 description: >
-  Fully on-device speech-to-text that types wherever
-  your cursor is. Parakeet/Moonshine engines, wake
-  word, spoken submit, filler removal, and a
-  talking-ghost recording indicator.
+  Local voice dictation for macOS: fully on-device
+  speech-to-text that types wherever your cursor is.
+  Parakeet/Moonshine engines, wake word, spoken
+  submit, filler removal, and a talking-ghost
+  recording indicator.
 ---
 
 import { Tabs, TabItem, Steps, Card, CardGrid } from

--- a/docs-site/src/content/docs/tools/voxtype/index.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/index.mdx
@@ -64,8 +64,9 @@ engines and options, or run `voxtype --help`.
     as long as you like, hit it again -- the whole
     take is transcribed with full sentence context
     and typed in one go (a single edit to undo, in
-    most apps). No chopping at pauses, sub-second
-    results.
+    most apps). No chopping at pauses; sub-second
+    results after a one-time warmup (the first take
+    loads the model onto the GPU).
   </Card>
   <Card title="Or go hands-free" icon="comment">
     Prefer no keys at all? Say "hey claude"


### PR DESCRIPTION
Overview-page install fixes:

- **Upgrade command**: installation note now shows `uv tool install --force --refresh voxtype` for upgrading, not just first install.
- **`voxtype skill` up front**: mentioned right after the install command — if you use Claude Code or Codex, run it to add the guide skill to both, then ask your agent to walk you through install + config.
- **Dropped the stray `--segmentation hold`** from the quick start; that's a config-page detail and looked awkward in first-run. Quick start is now plain `voxtype`, described mode-agnostically.

Full end-to-end audit of both voxtype doc pages against the current code is in the PR discussion.