### PR TITLE
voxtype: make 'hold' the smart default segmentation

### DIFF
--- a/docs-site/src/content/docs/tools/voxtype/configuration.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/configuration.mdx
@@ -89,13 +89,19 @@ least immediate:
    transcription.
 
 Wake and vad **modes** always use per-pause typing
-(2); toggle mode lets you pick between (2) and (3).
+(2); toggle mode lets you pick between (2) and (3),
+and **defaults to (3), whole-take**, with a parakeet
+engine — so out of the box you get maximum-accuracy
+push-to-talk. Set `segmentation = "vad"` if you'd
+rather see text appear as you pause.
 
 ## Common setups
 
-**Push-to-talk dictation (recommended daily driver).**
-No wake word involved at all; maximum accuracy; text
-lands in one go (a single edit to undo, in most apps):
+**Push-to-talk dictation (the default, and the
+recommended daily driver).** No wake word involved at
+all; maximum accuracy; text lands in one go (a single
+edit to undo, in most apps). This is what you get out
+of the box on a parakeet engine — no config needed:
 
 ```toml
 mode = "toggle"
@@ -165,9 +171,10 @@ mode = "toggle"
 engine = "parakeet-mlx"
 
 # "vad" types each utterance when you pause; "hold" records everything
-# between toggle-on/off and transcribes the whole take at once
-# (parakeet engines + toggle mode only)
-segmentation = "vad"
+# between toggle-on/off and transcribes the whole take at once (parakeet
+# engines + toggle mode only). Default: "hold" with a parakeet engine in
+# toggle mode (the common case), otherwise "vad".
+segmentation = "hold"
 
 # parakeet (CPU) build: "v3-int8" | "v2-fp16"; and decode threads
 parakeet_model = "v3-int8"

--- a/packages/voxtype/src/voxtype/config.py
+++ b/packages/voxtype/src/voxtype/config.py
@@ -43,6 +43,29 @@ VALID_ENGINES = ("moonshine", "parakeet", "parakeet-mlx")
 
 VALID_SEGMENTATIONS = ("vad", "hold")
 
+# Parakeet engines support the "hold" (whole-take) segmentation; the
+# moonshine streaming engine does not.
+_PARAKEET_ENGINES = ("parakeet", "parakeet-mlx")
+
+# Sentinel `segmentation` default; resolved per engine/mode by
+# default_segmentation() in Config.__post_init__.
+_AUTO_SEGMENTATION = "auto"
+
+
+def default_segmentation(engine: str, mode: str) -> str:
+    """Best segmentation for an ``engine``/``mode`` combo.
+
+    "hold" (record the whole take, transcribe on toggle-off — maximum
+    accuracy, a single edit to undo) is the recommended default, but it
+    only works with a parakeet engine in toggle mode; every other
+    combination falls back to "vad" (per-pause typing), which is what the
+    moonshine, wake, and vad paths require anyway.
+    """
+    if engine in _PARAKEET_ENGINES and mode == "toggle":
+        return "hold"
+    return "vad"
+
+
 # Parakeet model builds published by k2-fsa (see engine_parakeet.MODELS).
 VALID_PARAKEET_MODELS = ("v3-int8", "v2-fp16")
 
@@ -72,7 +95,9 @@ class Config:
         segmentation: "vad" types each utterance when you pause;
             "hold" records everything between toggle-on and toggle-off
             and transcribes the whole take at once (full context, no
-            mid-sentence chopping; parakeet + toggle mode only).
+            mid-sentence chopping; parakeet + toggle mode only). Defaults
+            to "hold" when the engine is parakeet-family and mode is
+            "toggle" (see default_segmentation), else "vad".
         parakeet_model: Parakeet build: "v3-int8" (multilingual,
             ~490 MB) or "v2-fp16" (English, ~1.1 GB, higher precision).
         parakeet_threads: CPU threads for decoding (4 benchmarks
@@ -120,7 +145,10 @@ class Config:
 
     mode: str = "toggle"
     engine: str = field(default_factory=default_engine)
-    segmentation: str = "vad"
+    # "auto" is a sentinel resolved in __post_init__ to the best
+    # segmentation for the resolved engine/mode (hold for parakeet +
+    # toggle, else vad). An explicit "vad"/"hold" is left untouched.
+    segmentation: str = _AUTO_SEGMENTATION
     parakeet_model: str = "v3-int8"
     parakeet_threads: int = 4
     mlx_model: str = "mlx-community/parakeet-tdt-0.6b-v3"
@@ -146,6 +174,13 @@ class Config:
     paste_hotkey: str = ""
     cancel_hotkey: str = "<esc>"
 
+    def __post_init__(self) -> None:
+        # Resolve the smart segmentation default now that engine and mode
+        # are known (either may have been overridden). Leaves an explicit
+        # "vad"/"hold" from the config file or a flag untouched.
+        if self.segmentation == _AUTO_SEGMENTATION:
+            self.segmentation = default_segmentation(self.engine, self.mode)
+
     def validate(self) -> None:
         """Raise ``ValueError`` if any field has an invalid type or value.
 
@@ -168,7 +203,7 @@ class Config:
                 f"must be one of {VALID_SEGMENTATIONS}"
             )
         if self.segmentation == "hold" and (
-            self.engine not in ("parakeet", "parakeet-mlx")
+            self.engine not in _PARAKEET_ENGINES
             or self.mode != "toggle"
         ):
             raise ValueError(
@@ -332,10 +367,11 @@ engine = "{default_engine()}"
 mlx_model = "mlx-community/parakeet-tdt-0.6b-v3"
 
 # How speech becomes text (parakeet engine, toggle mode only):
-#   "vad"  - each utterance types when you pause (default)
+#   "vad"  - each utterance types when you pause
 #   "hold" - record from toggle-on to toggle-off, transcribe the whole
 #            take at once: full context, no mid-sentence chopping
-segmentation = "vad"
+#            (the default with a parakeet engine in toggle mode)
+segmentation = "{default_segmentation(default_engine(), "toggle")}"
 
 # Parakeet build: "v3-int8" (multilingual, ~490 MB download) or
 # "v2-fp16" (English-only, ~1.1 GB, higher precision = better accuracy)

--- a/packages/voxtype/src/voxtype/config.py
+++ b/packages/voxtype/src/voxtype/config.py
@@ -370,8 +370,12 @@ mlx_model = "mlx-community/parakeet-tdt-0.6b-v3"
 #   "vad"  - each utterance types when you pause
 #   "hold" - record from toggle-on to toggle-off, transcribe the whole
 #            take at once: full context, no mid-sentence chopping
-#            (the default with a parakeet engine in toggle mode)
-segmentation = "{default_segmentation(default_engine(), "toggle")}"
+# Left UNSET so the smart default applies: "hold" for a parakeet engine
+# in toggle mode, otherwise "vad" — this stays valid if you later change
+# mode/engine below. Uncomment one to pin it ("hold" needs a parakeet
+# engine + toggle mode):
+# segmentation = "hold"
+# segmentation = "vad"
 
 # Parakeet build: "v3-int8" (multilingual, ~490 MB download) or
 # "v2-fp16" (English-only, ~1.1 GB, higher precision = better accuracy)

--- a/packages/voxtype/tests/test_voxtype.py
+++ b/packages/voxtype/tests/test_voxtype.py
@@ -164,6 +164,31 @@ def test_default_config_is_valid() -> None:
     Config().validate()
 
 
+def test_segmentation_smart_default() -> None:
+    """segmentation defaults to 'hold' for parakeet+toggle, else 'vad',
+    and never resolves to an invalid engine/mode combo."""
+    from voxtype.config import default_segmentation
+
+    assert default_segmentation("parakeet-mlx", "toggle") == "hold"
+    assert default_segmentation("parakeet", "toggle") == "hold"
+    assert default_segmentation("moonshine", "toggle") == "vad"
+    assert default_segmentation("parakeet", "wake") == "vad"
+    assert default_segmentation("parakeet", "vad") == "vad"
+
+    # Config resolves the "auto" sentinel from the resolved engine/mode.
+    assert Config(engine="parakeet", mode="toggle").segmentation == "hold"
+    assert Config(engine="moonshine", mode="toggle").segmentation == "vad"
+    assert Config(engine="parakeet", mode="wake").segmentation == "vad"
+    # An explicit choice is left untouched...
+    assert Config(
+        engine="parakeet", mode="toggle", segmentation="vad"
+    ).segmentation == "vad"
+    # ...and every resolved default validates.
+    Config(engine="parakeet", mode="toggle").validate()
+    Config(engine="moonshine", mode="toggle").validate()
+    Config(engine="parakeet", mode="wake").validate()
+
+
 def test_load_config_missing_default_uses_defaults(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/packages/voxtype/tests/test_voxtype_engines.py
+++ b/packages/voxtype/tests/test_voxtype_engines.py
@@ -532,8 +532,11 @@ def _make_parakeet(monkeypatch, texts=("hello",)):  # noqa: ANN001, ANN202
     )
 
     statuses: list[str] = []
+    # These tests exercise the per-utterance VAD capture loop, so pin
+    # segmentation=vad (parakeet+toggle now defaults to hold, which has
+    # its own tests).
     eng = ParakeetEngine(
-        Config(engine="parakeet"), statuses.append
+        Config(engine="parakeet", segmentation="vad"), statuses.append
     )
     eng._recognizer = FakeRecognizer(texts)
     eng._vad = FakeVad()


### PR DESCRIPTION
Resolves the audit inconsistency: the overview marquee ("whole take typed in one go") and the config page's "recommended daily driver" both describe `hold`, but the shipped default was `vad` — so a fresh `voxtype` gave per-pause typing, not the advertised experience.

## Change
`Config.segmentation` now defaults to a sentinel (`"auto"`) that `__post_init__` resolves to:
- **`hold`** when the resolved engine is parakeet-family **and** mode is `toggle` (the common case — parakeet is the default engine, toggle the default mode), else
- **`vad`** (moonshine, wake, vad).

This is a *smart* default (via `default_segmentation(engine, mode)`) so it can never produce the invalid `hold`+moonshine / `hold`+wake combos the validator already rejects. An explicit `vad`/`hold` in the config file or a `--segmentation` flag is left untouched.

## Result
Out of the box on any Mac (Apple Silicon → parakeet-mlx, Intel → parakeet), plain `voxtype` now gives maximum-accuracy whole-take push-to-talk — matching the docs.

## Docs/tests
- Config page + sample config show `hold` as the default with the parakeet+toggle caveat.
- Engine VAD-loop tests pin `segmentation=vad` (they specifically exercise the per-utterance path; hold has its own tests).
- Added `test_segmentation_smart_default`. 198 tests pass.

Complements #128 (install-docs polish) — no file overlap.