### PR TITLE
docs(voxtype): dedup overview + accuracy fixes (codex docs review)

### DIFF
--- a/docs-site/src/content/docs/tools/voxtype/configuration.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/configuration.mdx
@@ -5,10 +5,16 @@ description: >
   hotkey — the complete reference.
 ---
 
-Configuration lives at `~/.config/voxtype/config.toml`.
+Configuration lives at `~/.config/voxtype/config.toml`
+(voxtype also reads a legacy
+`~/.config/voice-type/config.toml` if it exists and the
+voxtype one doesn't — a carryover from when the tool
+shipped as `voice-type`).
 
-**You never need CLI flags.** Every flag is just an
-override of a config key, so the intended workflow
+**You rarely need CLI flags.** Every *runtime* flag is
+just an override of a config key (the exceptions are
+`--config`, which points at a different file, and the
+`setup`/`init` `--force` flag), so the intended workflow
 is: put your preferences in the config once, then
 your daily command is plain `voxtype` — flags
 exist for one-off experiments (e.g. trying another
@@ -32,8 +38,8 @@ short series of explained questions (engine, mode,
 segmentation, hotkey, wake word, and optional extras),
 validates your choices, and writes a ready-to-use
 config — you can record the hotkey live during the
-walkthrough. `init` instead drops the fully commented
-template below for hand-editing.
+walkthrough. `init` instead drops a fully commented
+sample (like the reference below) for hand-editing.
 
 ## The three independent axes
 
@@ -48,7 +54,9 @@ behaves, and they answer different questions:
 - **`segmentation`** — *when does text appear?* See
   ["When does the text appear?"](#when-does-the-text-appear)
   below — this is the axis people mean when they ask
-  about "streaming" dictation.
+  about "streaming" dictation. (Mostly independent, with
+  one tie: `hold` needs a parakeet engine in toggle mode;
+  otherwise voxtype uses `vad`.)
 - **`engine`** — *what transcribes it?* Pure
   speed/accuracy/platform trade-off; see the
   [engine table](#engines) below. Any engine works
@@ -100,13 +108,17 @@ rather see text appear as you pause.
 **Push-to-talk dictation (the default, and the
 recommended daily driver).** No wake word involved at
 all; maximum accuracy; text lands in one go (a single
-edit to undo, in most apps). This is what you get out
-of the box on a parakeet engine — no config needed:
+edit to undo, in most apps). This is exactly what you
+get out of the box — **no config needed** — since
+`mode` defaults to `toggle`, the engine is auto-selected
+(a parakeet engine), and `segmentation` then defaults to
+`hold`. Spelled out, that is:
 
 ```toml
 mode = "toggle"
 segmentation = "hold"
-engine = "parakeet-mlx"
+# engine is auto-selected: parakeet-mlx on Apple Silicon,
+# parakeet on Intel — you normally leave it unset
 ```
 
 **Toggle with live feedback.** Same hotkey workflow,
@@ -117,7 +129,6 @@ dictating something long, at some cost in accuracy:
 ```toml
 mode = "toggle"
 segmentation = "vad"
-engine = "parakeet-mlx"
 ```
 
 **Hands-free with a wake word.** Say "hey claude
@@ -127,7 +138,6 @@ Per-pause typing is inherent to this mode:
 
 ```toml
 mode = "wake"
-engine = "parakeet-mlx"
 wake_word_aliases = ["hey cloud"]  # add what the model mishears
 ```
 
@@ -137,8 +147,11 @@ short bursts of use:
 
 ```toml
 mode = "vad"
-engine = "parakeet-mlx"
 ```
+
+(These recipes leave `engine` unset so it auto-selects
+for your machine; set it explicitly only to force a
+specific engine.)
 
 ## Engines
 
@@ -161,13 +174,15 @@ for CPU tuning.
 ## Config reference
 
 ```toml
-# ~/.config/voxtype/config.toml — all keys optional; these are defaults
+# ~/.config/voxtype/config.toml — all keys optional; the values shown
+# are the defaults (except `engine`, which is auto-selected per machine)
 
 # Activation: "toggle" (hotkey), "vad" (hands-free), "wake" (wake word)
 mode = "toggle"
 
-# Engine: "parakeet-mlx" | "parakeet" | "moonshine"
-# (default: parakeet-mlx on Apple Silicon, parakeet elsewhere)
+# Engine: "parakeet-mlx" | "parakeet" | "moonshine". Auto-selected when
+# unset: parakeet-mlx on Apple Silicon, parakeet on Intel. Set it only to
+# force a choice; the value below is just the Apple-Silicon case.
 engine = "parakeet-mlx"
 
 # "vad" types each utterance when you pause; "hold" records everything
@@ -229,18 +244,13 @@ overlay_speed = 1.0  # animation speed (lower = slower/gentler)
 ## CLI
 
 ```
-voxtype [flags]           run with config + flag overrides
-voxtype setup [--force]   interactive walkthrough -> writes config
-voxtype init [--force]    write the commented sample config to edit
-voxtype hotkey            press a chord; prints the config line
-voxtype skill             install the voxtype skill into Claude + Codex
-voxtype --help            full flag reference
+voxtype [flags]                    run with config + flag overrides
+voxtype setup [--config PATH] [--force]  interactive walkthrough -> writes config
+voxtype init  [--config PATH] [--force]  write the commented sample config to edit
+voxtype hotkey                     press a chord; prints the config line
+voxtype skill                      install the voxtype skill into Claude + Codex
+voxtype --help                     full flag reference (per-subcommand: e.g. voxtype setup --help)
 ```
-
-New here? `voxtype setup` asks a handful of questions (engine,
-mode, hotkey, ...) — each explained, with sensible defaults — and
-writes a valid config for you. `init` instead drops a fully commented
-sample file to edit by hand.
 
 Flags mirror the config keys: `--mode`, `--engine`,
 `--segmentation`, `--parakeet-model`, `--model-arch`,

--- a/docs-site/src/content/docs/tools/voxtype/index.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/index.mdx
@@ -8,7 +8,7 @@ description: >
   recording indicator.
 ---
 
-import { Tabs, TabItem, Steps, Card, CardGrid } from
+import { Steps, Card, CardGrid } from
   "@astrojs/starlight/components";
 
 `voxtype` turns speech into text in whatever app
@@ -30,32 +30,48 @@ the `parakeet` CPU engine (`moonshine` ships no
 Intel-macOS build).
 :::
 
-:::note[Installation]
-```bash
-uv tool install voxtype    # install
-uv tool upgrade voxtype     # upgrade to the latest (keeps any extras)
-```
-That's it — the install picks the best engine for
-your machine (Apple-GPU `parakeet-mlx` on Apple
-Silicon, CPU `parakeet` elsewhere) and it's the
-default at runtime too.
+## Quick start
 
-**Using Claude Code or Codex?** Then run:
+<Steps>
 
-```bash
-voxtype skill
-```
+1. Install — the best engine for your machine comes
+   bundled automatically (Apple-GPU `parakeet-mlx` on
+   Apple Silicon, CPU `parakeet` on Intel):
 
-It adds a voxtype guide skill to **both** agents, so
-you can just ask your agent *"help me install
-voxtype"* and it walks you through install,
-configuration, and the macOS permissions. See
+   ```bash
+   uv tool install voxtype
+   ```
+
+   Upgrade later with `uv tool upgrade voxtype` (it
+   keeps any extras).
+
+2. Grant your terminal **Microphone**,
+   **Accessibility**, and **Input Monitoring**
+   permissions (System Settings → Privacy &
+   Security) when prompted.
+
+3. Start dictating:
+
+   ```bash
+   voxtype
+   ```
+
+   Press `Ctrl+;` to start, speak (watch the ghost),
+   press `Ctrl+;` again to stop -- your speech is typed
+   at the cursor. `Esc` cancels a take.
+
+4. Configure it: run `voxtype setup` for an
+   interactive walkthrough — it asks a handful of
+   explained questions (engine, mode, hotkey, ...) and
+   writes your `~/.config/voxtype/config.toml`. (Prefer
+   editing by hand? `voxtype init` drops a fully
+   commented sample instead.)
+
+</Steps>
+
+Rather have your coding agent do all of this? See
 [Set it up from your coding agent](#set-it-up-from-your-coding-agent)
 below.
-
-See [Configuration & CLI](./configuration/) for all
-engines and options, or run `voxtype --help`.
-:::
 
 ## Why it's different
 
@@ -67,7 +83,7 @@ engines and options, or run `voxtype --help`.
     and typed in one go (a single edit to undo, in
     most apps). No chopping at pauses; sub-second
     results after a one-time warmup (the first take
-    loads the model onto the GPU).
+    loads the model).
   </Card>
   <Card title="Or go hands-free" icon="comment">
     Prefer no keys at all? Say "hey claude"
@@ -89,70 +105,25 @@ engines and options, or run `voxtype --help`.
   <Card title="Visible when it matters" icon="magnifier">
     A little glowing-blue ghost appears ONLY while
     recording -- its mouth opens as you speak. Ghost
-    on screen = mic live; no ghost = not listening.
+    on screen = actively recording; no ghost = not
+    recording (paused, or waiting for the wake word).
   </Card>
   <Card title="Nothing is ever lost" icon="random">
-    Dictated into the wrong window? A paste-again
-    hotkey re-types the last session's transcript at
-    the cursor; optional clipboard mirroring too.
-    Escape cancels a recording outright.
+    `Esc` cancels a recording outright (the default
+    `cancel_hotkey`). Two optional rescues, **both off
+    by default**: bind a
+    paste-again hotkey (`paste_hotkey`) to re-type the
+    last session's transcript at your cursor, and/or
+    enable clipboard mirroring (`copy_to_clipboard`) to
+    echo each session to the clipboard.
   </Card>
 </CardGrid>
 
-## Quick start
-
-<Steps>
-
-1. Install (the best engine for your machine is
-   included automatically — see
-   [engines](./configuration/#engines)):
-
-   ```bash
-   uv tool install voxtype
-   ```
-
-2. Grant your terminal **Microphone**,
-   **Accessibility**, and **Input Monitoring**
-   permissions (System Settings → Privacy &
-   Security) when prompted.
-
-3. Start dictating:
-
-   ```bash
-   voxtype
-   ```
-
-   Press `Ctrl+;` to start, speak (watch the ghost),
-   press `Ctrl+;` again to stop -- your speech is typed
-   at the cursor. `Esc` cancels a take.
-
-4. Make it yours: run `voxtype setup` for an
-   interactive walkthrough — it asks a handful of
-   explained questions (engine, mode, hotkey, ...)
-   and writes your `~/.config/voxtype/config.toml`.
-   (Prefer editing by hand? `voxtype init` drops a
-   fully commented sample instead.) After that, plain
-   `voxtype` starts with your settings.
-
-</Steps>
-
-## Make it yours
-
-Everything above is a choice, not a default you're
-stuck with: how dictation activates (hotkey, wake
-word, or always-on), how speech becomes text
-(whole-take vs. per-pause), which local engine runs
-it (Apple-GPU Parakeet, CPU Parakeet, or Moonshine),
-plus hotkeys, sounds, clipboard behavior, and more.
-The complete reference -- every config key with its
-default, the engine comparison, and all CLI flags --
-lives in **[Configuration & CLI](./configuration/)**.
-
 ## Set it up from your coding agent
 
-Prefer to have your agent do the install? `voxtype skill`
-installs a short guide skill into **both** Claude Code
-and Codex (each reads its own marketplace in this repo):
+`voxtype skill` installs a short guide skill into your
+coding agents — Claude Code, Codex, or both (each reads
+its own marketplace in this repo):
 
 ```bash
 voxtype skill
@@ -165,6 +136,18 @@ dictation"*) and it walks you through
 `uv tool install voxtype` → `voxtype setup` → launch,
 including the macOS permission steps.
 
+## Make it yours
+
+Almost everything is a choice: how dictation activates
+(hotkey, wake word, or always-on), how speech becomes
+text (whole-take vs. per-pause), which local engine
+runs it (Apple-GPU Parakeet, CPU Parakeet, or
+Moonshine), plus hotkeys, sounds, optional clipboard
+mirroring, and more. The complete reference -- every
+config key with its default, the engine comparison, and
+all CLI flags -- lives in
+**[Configuration & CLI](./configuration/)**.
+
 ## Hotkey & voice vocabulary
 
 | Action | Default | Configurable as |
@@ -173,11 +156,16 @@ including the macOS permission steps.
 | Cancel recording (discard) | `Esc` (only while recording) | `cancel_hotkey` |
 | Re-type last transcript | off | `paste_hotkey` |
 | Submit (press Enter) | say "go" / "over" / "submit" | `submit_phrases` |
-| Stop dictating | say "stop listening" | `stop_phrase` |
+| Stop dictating (vad segmentation) | say "stop listening" | `stop_phrase` |
 
-Not sure how to spell a chord for the three hotkey
-settings above? Run `voxtype hotkey`, press the
-combo you want, and it prints the exact line to put
-in your config (e.g. `hotkey = "<ctrl>+;"`).
+In the default toggle + `hold` setup you stop by pressing the toggle
+hotkey again; the spoken `stop_phrase` only applies to per-utterance
+(vad) transcription — i.e. wake mode or `segmentation = "vad"`.
+
+Not sure how to spell a chord for the hotkey settings
+above? Run `voxtype hotkey`, press the combo you want,
+and it prints a ready-to-paste `hotkey = "..."` line
+(use the same chord string for `cancel_hotkey` /
+`paste_hotkey`).
 
 Full reference: [Configuration & CLI](./configuration/).


### PR DESCRIPTION
You flagged the Installation-vs-Quick-start redundancy on the voxtype overview. Fixing that, then a local **codex docs-review pass** (cross-checking both pages against `config.py`/`cli.py`) surfaced several accuracy issues I'd missed.

## Dedup (overview)
- Removed the standalone `:::note[Installation]` block — install now lives only in **Quick start** (moved up under the macOS caution).
- `voxtype skill` and the Configuration & CLI pointer each appear once now (were duplicated).

## Accuracy fixes (from the codex review)
Overview:
- Warmup card no longer says the model always loads "onto the GPU" (Intel/CPU engines exist).
- Ghost card no longer equates "no ghost" with "not listening" — wake mode listens passively with no ghost.
- `Esc`-cancel noted as the default `cancel_hotkey` (configurable/disable-able), not "always."
- Vocab table: **"say 'stop listening'" is vad-segmentation only** — in the default toggle+`hold` you stop with the hotkey (this one mattered once `hold` became the default).
- `voxtype hotkey` prints a `hotkey = "..."` line (note to reuse the chord for `cancel_hotkey`/`paste_hotkey`).

Config page:
- Documents the legacy `~/.config/voice-type/config.toml` fallback.
- Qualifies "every flag overrides a config key" (`--config` and `setup`/`init --force` are exceptions).
- Stops presenting `engine = "parakeet-mlx"` as a universal default (it's auto-selected; parakeet on Intel) in the recipes and the reference block.
- Adds `--config PATH` to the `setup`/`init` CLI synopsis; drops the duplicated setup/init paragraph.

## Process
Ran the codex docs-review loop 3× locally, fixing each round until the remaining findings were cross-page redundancy (by design — the overview is brief, the config page is the full reference) and synthetic pedantry. Docs build clean.