### PR TITLE
voxtype: warm up the MLX decoder at startup (fix slow first take)

### DIFF
--- a/packages/voxtype/src/voxtype/engine_parakeet_mlx.py
+++ b/packages/voxtype/src/voxtype/engine_parakeet_mlx.py
@@ -89,6 +89,7 @@ class ParakeetMlxEngine(ParakeetEngine):
     ) -> None:
         try:
             self._load_models_with_repair()
+            self._warmup()
         except Exception as e:
             self.fatal_error = f"model load failed: {e}"
             self._report(self.fatal_error)
@@ -96,6 +97,28 @@ class ParakeetMlxEngine(ParakeetEngine):
         finally:
             self._ready.set()
         self._loop(on_utterance, on_activity)
+
+    def _warmup(self) -> None:
+        """Compile MLX kernels at startup, not on the first real take.
+
+        The first decode on a fresh process compiles the model's Metal
+        kernels — measured ~3-10s — while every decode after is
+        sub-second (verified: decode 0 ~3s, decodes 1+ ~0.12s). Doing a
+        throwaway decode of a short silent clip HERE, on the worker
+        thread while the user still sees "loading ...", moves that
+        one-time cost off their first dictation. Warming up on one
+        length makes other lengths fast too. Non-fatal: on any failure
+        the first real decode simply pays the cost as before.
+        """
+        import numpy as np
+
+        try:
+            self._status("warming up the GPU decoder...")
+            self.transcribe(
+                np.zeros(SAMPLE_RATE * 2, dtype=np.float32), SAMPLE_RATE
+            )
+        except Exception:
+            pass
 
     def _load_models_with_repair(self) -> None:
         """Load the MLX model (HF-cached) and the Silero VAD.


### PR DESCRIPTION
## Symptom
On the parakeet-mlx engine, the first take(s) after launching took several seconds ('11, 3, 2s'), then it sped up.

## Root cause
MLX compiles the model's Metal kernels on the **first decode** of a fresh process (~3-10s). Every decode after is sub-second. Benchmarks:
- decode 0: ~3s; decodes 1+: ~0.12s (16-52x realtime), across audio lengths
- **identical with and without `clear_cache`** — the v1.19.1 memory-leak fix is NOT the cause

So it was cold-start kernel compilation being paid on the user's first real dictation.

## Fix
`_warmup()` does a throwaway decode of a short silent clip on the worker thread right after the model loads — while the user still sees "loading ..." — so the one-time compile lands there, not on their first take. Warming up on one length makes other lengths fast too. Non-fatal (any failure just reverts to paying the cost on the first real decode).

## Verified
End-to-end on the real engine: model load 2.1s, warmup 1.16s (the compile), then the **first real decode is 0.15s** (was ~3s). 198 tests pass.