### PR TITLE
feat(aichat): resolve sessions by name or partial id in every session command

### DIFF
--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -19,6 +19,110 @@ etc.) are still available.
 import click
 
 
+def _session_homes() -> tuple[str | None, str | None]:
+    """Return agent homes configured on the root Click context."""
+    context = click.get_current_context(silent=True)
+    if context is None:
+        return None, None
+    root_obj = context.find_root().obj or {}
+    return root_obj.get("claude_home"), root_obj.get("codex_home")
+
+
+def _resolve_cli_session(
+    session: str,
+    agent: str | None = None,
+    *,
+    claude_home: str | None = None,
+    codex_home: str | None = None,
+) -> "ResolvedSessionQuery":
+    """Resolve a CLI session query or print its user-facing error."""
+    import sys
+
+    from claude_code_tools.session_resolution import (
+        ResolvedSessionQuery,
+        SessionQueryError,
+        resolve_session_query,
+    )
+
+    root_claude_home, root_codex_home = _session_homes()
+    effective_claude_home = claude_home or root_claude_home
+    effective_codex_home = codex_home or root_codex_home
+    try:
+        return resolve_session_query(
+            session,
+            agent=agent,
+            claude_home=effective_claude_home,
+            codex_home=effective_codex_home,
+        )
+    except SessionQueryError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _resolve_export_session(
+    session: str,
+    agent: str | None = None,
+) -> "ResolvedSessionQuery":
+    """Resolve export input and surface shared resolver failures."""
+    import sys
+
+    from claude_code_tools.session_resolution import (
+        ResolvedSessionQuery,
+        SessionQueryError,
+        resolve_session_query,
+    )
+
+    claude_home, codex_home = _session_homes()
+    try:
+        return resolve_session_query(
+            session,
+            agent=agent,
+            claude_home=claude_home,
+            codex_home=codex_home,
+        )
+    except SessionQueryError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _consume_export_agent(
+    args: list[str], parsed_agent: str | None
+) -> tuple[str | None, list[str]]:
+    """Consume ``--agent`` from exporter passthrough arguments."""
+    agent = parsed_agent
+    remaining: list[str] = []
+    index = 0
+    while index < len(args):
+        argument = args[index]
+        if argument == "--agent":
+            if index + 1 >= len(args):
+                raise click.UsageError("Option '--agent' requires an argument.")
+            value = args[index + 1].lower()
+            if value not in ("claude", "codex"):
+                raise click.BadParameter(
+                    value,
+                    param_hint="--agent",
+                    param_type_hint="choice",
+                )
+            agent = value
+            index += 2
+            continue
+        if argument.startswith("--agent="):
+            value = argument.partition("=")[2].lower()
+            if value not in ("claude", "codex"):
+                raise click.BadParameter(
+                    value,
+                    param_hint="--agent",
+                    param_type_hint="choice",
+                )
+            agent = value
+            index += 1
+            continue
+        remaining.append(argument)
+        index += 1
+    return agent, remaining
+
+
 class SessionIDGroup(click.Group):
     """Custom group that treats unknown commands as session IDs for menu."""
 
@@ -273,6 +377,7 @@ def _find_and_run_session_ui(
     from claude_code_tools.search_index import SessionIndex
     from claude_code_tools.session_menu_cli import execute_action
     from claude_code_tools.session_utils import default_export_path
+    claude_home, codex_home = _session_homes()
 
     if session_id:
         if direct_action:
@@ -280,25 +385,20 @@ def _find_and_run_session_ui(
             # This allows direct_action to be passed to Node UI for correct
             # escape behavior (exit to shell vs. go to resume menu)
             from claude_code_tools.session_utils import (
-                find_session_file,
                 default_export_path,
-                detect_agent_from_path,
                 get_session_uuid,
             )
 
-            # Find session file
-            input_path = Path(session_id).expanduser()
-            if input_path.exists() and input_path.is_file():
-                session_file = input_path
-                agent = detect_agent_from_path(session_file)
-                project_path = str(session_file.parent)
-                git_branch = None
-            else:
-                result = find_session_file(session_id)
-                if not result:
-                    print(f"Error: Session not found: {session_id}", file=sys.stderr)
-                    sys.exit(1)
-                agent, session_file, project_path, git_branch = result
+            constraint = (
+                agent_constraint
+                if agent_constraint in ("claude", "codex")
+                else None
+            )
+            resolved = _resolve_cli_session(session_id, constraint)
+            agent = resolved.agent
+            session_file = resolved.session_file
+            project_path = resolved.directory or str(session_file.parent)
+            git_branch = resolved.git_branch
 
             # Build session dict for Node UI
             session_dict = {
@@ -327,6 +427,8 @@ def _find_and_run_session_ui(
                     sess["agent"],
                     Path(sess["file_path"]),
                     sess["cwd"],
+                    claude_home=claude_home,
+                    codex_home=codex_home,
                     action_kwargs=merged_kwargs if merged_kwargs else None,
                     session_id=sess.get("session_id"),
                 )
@@ -500,6 +602,8 @@ def _find_and_run_session_ui(
             sess["agent"],
             session_file,
             sess["cwd"],
+            claude_home=claude_home,
+            codex_home=codex_home,
             action_kwargs=merged_kwargs if merged_kwargs else None,
             session_id=sess.get("session_id"),
         )
@@ -886,7 +990,11 @@ def smart_trim(session, instructions, exclude_types, preserve_recent, content_th
     be safely trimmed while preserving important context. Creates a new
     trimmed session with lineage metadata.
 
-    If no session ID provided, finds latest session for current project/branch.
+    SESSION may be a full session id, a partial id (prefix, middle,
+    or suffix fragment), a session name (set with /rename), a
+    rollout filename fragment (e.g. 2026-03-25T14-50), or a session
+    file path. If omitted, finds the latest session in the current
+    project.
 
     \b
     Examples:
@@ -908,31 +1016,27 @@ def smart_trim(session, instructions, exclude_types, preserve_recent, content_th
     import sys
     from pathlib import Path
 
-    from claude_code_tools.session_utils import (
-        find_session_file, detect_agent_from_path, get_session_uuid,
-    )
+    from claude_code_tools.session_utils import get_session_uuid
 
     # If --instructions provided, use the handler function (same as TUI)
     if instructions and session:
-        input_path = Path(session).expanduser()
-        if input_path.exists() and input_path.is_file():
-            session_file = input_path
-            detected_agent = detect_agent_from_path(session_file)
-            session_id = get_session_uuid(session_file.stem)
-            project_path = str(session_file.parent)
-        else:
-            result = find_session_file(session)
-            if not result:
-                print(f"Error: Session not found: {session}", file=sys.stderr)
-                sys.exit(1)
-            detected_agent, session_file, project_path, _ = result
-            session_id = get_session_uuid(session_file.stem)
+        root_claude_home, root_codex_home = _session_homes()
+        effective_claude_home = claude_home or root_claude_home
+        resolved = _resolve_cli_session(
+            session,
+            claude_home=effective_claude_home,
+            codex_home=root_codex_home,
+        )
+        session_file = resolved.session_file
+        detected_agent = resolved.agent
+        session_id = get_session_uuid(session_file.stem)
+        project_path = resolved.directory or str(session_file.parent)
 
         # Use the handler function which supports custom_instructions
         if detected_agent == "claude":
             from claude_code_tools.find_claude_session import handle_smart_trim_resume_claude
             handle_smart_trim_resume_claude(
-                session_id, project_path, claude_home,
+                session_id, project_path, effective_claude_home,
                 custom_instructions=instructions,
             )
         else:
@@ -940,7 +1044,7 @@ def smart_trim(session, instructions, exclude_types, preserve_recent, content_th
             from claude_code_tools.session_utils import get_codex_home
             handle_smart_trim_resume_codex(
                 {"file_path": str(session_file), "cwd": project_path, "session_id": session_id},
-                Path(get_codex_home(cli_arg=None)),
+                Path(get_codex_home(cli_arg=root_codex_home)),
                 custom_instructions=instructions,
             )
         return
@@ -952,8 +1056,16 @@ def smart_trim(session, instructions, exclude_types, preserve_recent, content_th
             print("Use 'aichat smart-trim' without options for interactive mode", file=sys.stderr)
             sys.exit(1)
 
+        root_claude_home, root_codex_home = _session_homes()
+        effective_claude_home = claude_home or root_claude_home
+        resolved = _resolve_cli_session(
+            session,
+            claude_home=effective_claude_home,
+            codex_home=root_codex_home,
+        )
+
         # Build args for smart-trim CLI
-        args = [session]
+        args = [str(resolved.session_file)]
         if exclude_types:
             args.extend(["--exclude-types", exclude_types])
         if preserve_recent != 10:
@@ -964,8 +1076,8 @@ def smart_trim(session, instructions, exclude_types, preserve_recent, content_th
             args.extend(["--output-dir", output_dir])
         if dry_run:
             args.append("--dry-run")
-        if claude_home:
-            args.extend(["--claude-home", claude_home])
+        if effective_claude_home:
+            args.extend(["--claude-home", effective_claude_home])
 
         sys.argv = [sys.argv[0].replace('aichat', 'smart-trim')] + args
         from claude_code_tools.smart_trim import main as smart_trim_main
@@ -984,75 +1096,67 @@ def smart_trim(session, instructions, exclude_types, preserve_recent, content_th
 
 
 @main.command("export", context_settings={"ignore_unknown_options": True, "allow_extra_args": True, "allow_interspersed_args": False})
-@click.option("--agent", type=click.Choice(["claude", "codex"], case_sensitive=False), help="Force export with specific agent")
+@click.option(
+    "--agent",
+    type=click.Choice(["claude", "codex"], case_sensitive=False),
+    help="Restrict the search to this agent's home",
+)
 @click.argument("session", required=False)
 @click.pass_context
 def export_session(ctx, agent, session):
     """Export session to text/markdown format.
 
-    If no session ID provided, finds latest session for current project/branch.
-    Auto-detects session type and uses matching export command.
-    Use --agent to override and force export with a specific agent.
+    SESSION may be a full session id, a partial id (prefix, middle,
+    or suffix fragment), a session name (set with /rename), a
+    rollout filename fragment (e.g. 2026-03-25T14-50), or a session
+    file path.
+    If no session is provided, searches the current project, preferring
+    the current branch.
+    Auto-detects session type and uses the matching export command.
+    Use --agent to restrict the search to that agent's home.
     """
     import sys
-    from pathlib import Path
-    from claude_code_tools.session_utils import detect_agent_from_path, find_session_file
+
+    agent, passthrough_args = _consume_export_agent(ctx.args, agent)
 
     if not session:
         # No session provided - find latest and export directly
         _find_and_run_session_ui(
             session_id=None,
-            agent_constraint='both',
+            agent_constraint=agent or 'both',
             start_screen='action',
             results_title=' Which session to export? ',
             direct_action='export',
         )
         return
 
-    # Session provided - existing behavior
-    # Try to detect session type
-    detected_agent = None
-    session_file = None
+    resolved = _resolve_export_session(
+        session, agent.lower() if agent is not None else None
+    )
+    detected_agent = resolved.agent
+    session_file = resolved.session_file
 
-    # First check if it's a file path
-    input_path = Path(session).expanduser()
-    if input_path.exists() and input_path.is_file():
-        session_file = input_path
-        detected_agent = detect_agent_from_path(session_file)
-    else:
-        # Try to find by session ID
-        result = find_session_file(session)
-        if result:
-            detected_agent, session_file, _, _ = result
-
-    # Determine which agent to use
-    if agent:
-        # User explicitly specified agent
-        export_agent = agent.lower()
-        if detected_agent and detected_agent != export_agent:
-            print(f"\nDetected {detected_agent.upper()} session")
-            print(f"Exporting with {export_agent.upper()} (user specified)")
-        else:
-            print(f"\nExporting with {export_agent.upper()} (user specified)")
-    elif detected_agent:
-        # Use detected agent
-        export_agent = detected_agent
-        print(f"\nDetected {detected_agent.upper()} session")
-        print(f"Exporting with {export_agent.upper()}")
-    else:
-        # Default to Claude if cannot detect
-        export_agent = "claude"
-        print(f"\nCould not detect session type, defaulting to CLAUDE")
+    export_agent = detected_agent
+    print(f"\nDetected {detected_agent.upper()} session")
+    print(f"Exporting with {export_agent.upper()}")
 
     print()
 
-    # Route to appropriate export command
+    resolved_argument = str(session_file)
     if export_agent == "claude":
-        sys.argv = [sys.argv[0].replace('aichat', 'export-claude-session'), session] + ctx.args
+        sys.argv = [
+            sys.argv[0].replace("aichat", "export-claude-session"),
+            resolved_argument,
+            *passthrough_args,
+        ]
         from claude_code_tools.export_claude_session import main as export_main
         export_main()
     else:
-        sys.argv = [sys.argv[0].replace('aichat', 'export-codex-session'), session] + ctx.args
+        sys.argv = [
+            sys.argv[0].replace("aichat", "export-codex-session"),
+            resolved_argument,
+            *passthrough_args,
+        ]
         from claude_code_tools.export_codex_session import main as export_main
         export_main()
 
@@ -1130,7 +1234,7 @@ def delete(ctx):
 @main.command("info")
 @click.argument("session", required=False)
 @click.option("--agent", type=click.Choice(["claude", "codex"], case_sensitive=False),
-              help="Force agent type (auto-detected if not specified)")
+              help="Restrict the search to this agent's home")
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 def info(session, agent, json_output):
     """Show information about a session.
@@ -1138,8 +1242,11 @@ def info(session, agent, json_output):
     Displays session metadata including file path, agent type, project,
     branch, timestamps, message counts, and lineage (parent sessions).
 
-    If no session ID provided, shows info for latest session in current
-    project/branch.
+    SESSION may be a full session id, a partial id (prefix, middle,
+    or suffix fragment), a session name (set with /rename), a
+    rollout filename fragment (e.g. 2026-03-25T14-50), or a session
+    file path. If omitted, shows the latest session in the current
+    project.
 
     \b
     Examples:
@@ -1148,13 +1255,10 @@ def info(session, agent, json_output):
         aichat info --json abc123       # Output as JSON
     """
     import json as json_lib
-    import sys
     from pathlib import Path
     from datetime import datetime
 
     from claude_code_tools.session_utils import (
-        find_session_file,
-        detect_agent_from_path,
         extract_cwd_from_session,
         count_user_messages,
         default_export_path,
@@ -1164,23 +1268,14 @@ def info(session, agent, json_output):
 
     # Find session file
     if session:
-        input_path = Path(session).expanduser()
-        if input_path.exists() and input_path.is_file():
-            session_file = input_path
-            detected_agent = agent or detect_agent_from_path(session_file)
-        else:
-            result = find_session_file(session)
-            if not result:
-                print(f"Error: Session not found: {session}", file=sys.stderr)
-                sys.exit(1)
-            detected_agent, session_file, _, _ = result
-            if agent:
-                detected_agent = agent
+        resolved = _resolve_cli_session(session, agent)
+        session_file = resolved.session_file
+        detected_agent = resolved.agent
     else:
         # No session provided - find latest
         _find_and_run_session_ui(
             session_id=None,
-            agent_constraint='both',
+            agent_constraint=agent or 'both',
             start_screen='action',
             direct_action='path',  # Just show path for now
         )
@@ -1255,11 +1350,15 @@ def info(session, agent, json_output):
 @click.argument("session", required=False)
 @click.option("--dest", "-d", help="Destination path (default: prompted)")
 @click.option("--agent", type=click.Choice(["claude", "codex"], case_sensitive=False),
-              help="Force agent type (auto-detected if not specified)")
+              help="Restrict the search to this agent's home")
 def copy_session(session, dest, agent):
     """Copy a session file to a new location.
 
-    If no session ID provided, finds latest session for current project/branch.
+    SESSION may be a full session id, a partial id (prefix, middle,
+    or suffix fragment), a session name (set with /rename), a
+    rollout filename fragment (e.g. 2026-03-25T14-50), or a session
+    file path. If omitted, searches the current project, preferring
+    the current branch.
 
     \b
     Examples:
@@ -1267,33 +1366,18 @@ def copy_session(session, dest, agent):
         aichat copy abc123 -d ~/backups/       # Copy to specific directory
         aichat copy abc123 -d ./my-session.jsonl  # Copy with specific filename
     """
-    import sys
-    from pathlib import Path
-
-    from claude_code_tools.session_utils import find_session_file, detect_agent_from_path
-
     if not session:
         _find_and_run_session_ui(
             session_id=None,
-            agent_constraint='both',
+            agent_constraint=agent or 'both',
             start_screen='action',
             direct_action='copy',
         )
         return
 
-    # Find session file
-    input_path = Path(session).expanduser()
-    if input_path.exists() and input_path.is_file():
-        session_file = input_path
-        detected_agent = agent or detect_agent_from_path(session_file)
-    else:
-        result = find_session_file(session)
-        if not result:
-            print(f"Error: Session not found: {session}", file=sys.stderr)
-            sys.exit(1)
-        detected_agent, session_file, _, _ = result
-        if agent:
-            detected_agent = agent
+    resolved = _resolve_cli_session(session, agent)
+    session_file = resolved.session_file
+    detected_agent = agent or resolved.agent
 
     # Import agent-specific copy function
     if detected_agent == "claude":
@@ -1308,25 +1392,31 @@ def copy_session(session, dest, agent):
 @click.argument("session", required=True)
 @click.argument("new_project", required=True)
 @click.option("--agent", type=click.Choice(["claude", "codex"], case_sensitive=False),
-              help="Force agent type (auto-detected if not specified)")
-def move_session(session, new_project, agent):
+              help="Restrict the search to this agent's home")
+def move_session(
+    session: str, new_project: str, agent: str | None
+) -> None:
     """Move a session to a different project directory.
 
     Updates the cwd metadata in all lines and moves the session file
     to the appropriate project directory.
+    SESSION may be a full session id, a partial id (prefix, middle,
+    or suffix fragment), a session name (set with /rename), a
+    rollout filename fragment (e.g. 2026-03-25T14-50), or a session
+    file path.
 
     \b
     Examples:
         aichat move abc123 /path/to/new/project
-        aichat move abc123 ~/Git/other-repo
+        aichat move my-session-name ~/Git/other-repo
+        aichat move 2026-03-25T14-50 ~/Git/other-repo --agent codex
     """
     import json
     import sys
     from pathlib import Path
 
     from claude_code_tools.session_utils import (
-        find_session_file,
-        detect_agent_from_path,
+        encode_claude_project_path,
         get_claude_home,
         get_session_uuid,
     )
@@ -1341,19 +1431,9 @@ def move_session(session, new_project, agent):
         print(f"Error: Not a directory: {new_project_path}", file=sys.stderr)
         sys.exit(1)
 
-    # Find session file
-    input_path = Path(session).expanduser()
-    if input_path.exists() and input_path.is_file():
-        session_file = input_path
-        detected_agent = agent or detect_agent_from_path(session_file)
-    else:
-        result = find_session_file(session)
-        if not result:
-            print(f"Error: Session not found: {session}", file=sys.stderr)
-            sys.exit(1)
-        detected_agent, session_file, _, _ = result
-        if agent:
-            detected_agent = agent
+    resolved = _resolve_cli_session(session, agent)
+    session_file = resolved.session_file
+    detected_agent = resolved.agent
 
     # Read and update the session file
     print(f"Reading session: {session_file}")
@@ -1363,6 +1443,9 @@ def move_session(session, new_project, agent):
         for line in f:
             try:
                 data = json.loads(line)
+                if not isinstance(data, dict):
+                    lines.append(line)
+                    continue
                 if detected_agent == "claude":
                     # Claude: cwd is at top level
                     if old_cwd is None and "cwd" in data:
@@ -1370,16 +1453,23 @@ def move_session(session, new_project, agent):
                     if "cwd" in data:
                         data["cwd"] = str(new_project_path)
                 else:
-                    # Codex: cwd is in session_meta payload or response_item payload
-                    if data.get("type") == "session_meta":
-                        payload = data.get("payload", {})
+                    # Codex: cwd is stored in several payload record types.
+                    record_type = data.get("type")
+                    payload = data.get("payload")
+                    if (
+                        isinstance(record_type, str)
+                        and record_type in {"session_meta", "turn_context"}
+                        and isinstance(payload, dict)
+                    ):
                         if old_cwd is None and "cwd" in payload:
                             old_cwd = payload["cwd"]
                         if "cwd" in payload:
                             payload["cwd"] = str(new_project_path)
                     # Also check response_item with message payloads
-                    elif data.get("type") == "response_item":
-                        payload = data.get("payload", {})
+                    elif (
+                        record_type == "response_item"
+                        and isinstance(payload, dict)
+                    ):
                         if "cwd" in payload:
                             payload["cwd"] = str(new_project_path)
                 lines.append(json.dumps(data) + "\n")
@@ -1388,9 +1478,11 @@ def move_session(session, new_project, agent):
 
     if detected_agent == "claude":
         # Claude: move file to new project directory
-        # Claude stores sessions in: ~/.claude/projects/<encoded-path>/<session-id>.jsonl
-        encoded_path = str(new_project_path).replace("/", "-").replace("_", "-").replace(".", "-")
-        claude_home = get_claude_home()
+        # Claude stores sessions under:
+        # ~/.claude/projects/<encoded-path>/<session-id>.jsonl
+        encoded_path = encode_claude_project_path(str(new_project_path))
+        configured_claude_home, _ = _session_homes()
+        claude_home = get_claude_home(cli_arg=configured_claude_home)
         new_project_dir = claude_home / "projects" / encoded_path
         new_project_dir.mkdir(parents=True, exist_ok=True)
         new_file_path = new_project_dir / session_file.name
@@ -1403,8 +1495,7 @@ def move_session(session, new_project, agent):
 
         # Write updated content to new location
         print(f"Moving session to: {new_file_path}")
-        with open(new_file_path, "w") as f:
-            f.writelines(lines)
+        _write_lines_atomically(new_file_path, lines)
 
         # Remove old file if different location
         if new_file_path != session_file:
@@ -1415,19 +1506,16 @@ def move_session(session, new_project, agent):
         print(f"  From: {old_cwd}")
         print(f"  To:   {new_project_path}")
         session_id = session_file.stem
-        agent_cmd = "claude"
         resume_cmd = f"cd {new_project_path} && claude --resume {session_id}"
     else:
         # Codex: just update file in place (sessions organized by date, not project)
         print(f"Updating session in place: {session_file}")
-        with open(session_file, "w") as f:
-            f.writelines(lines)
+        _write_lines_atomically(session_file, lines)
 
         print(f"\n[green]Session updated successfully![/green]")
         print(f"  From: {old_cwd}")
         print(f"  To:   {new_project_path}")
         session_id = get_session_uuid(session_file.stem)
-        agent_cmd = "codex"
         resume_cmd = f"cd {new_project_path} && codex resume {session_id}"
 
     # Ask user if they want to switch directory and resume
@@ -1439,7 +1527,6 @@ def move_session(session, new_project, agent):
     if Confirm.ask(f"[cyan]Switch to {new_project_path} and resume session?[/cyan]",
                    default=True):
         import os
-        import subprocess
         os.chdir(new_project_path)
         console.print(f"\n[green]Switching to {new_project_path}...[/green]")
         if detected_agent == "claude":
@@ -1449,6 +1536,34 @@ def move_session(session, new_project, agent):
     else:
         console.print(f"\n[dim]To resume later:[/dim]")
         console.print(f"  [cyan]{resume_cmd}[/cyan]")
+
+
+def _write_lines_atomically(path: "Path", lines: list[str]) -> None:
+    """Atomically replace a path with the supplied transcript lines.
+
+    Args:
+        path: Destination transcript path.
+        lines: Complete serialized transcript lines.
+    """
+    import os
+    import tempfile
+    from pathlib import Path
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.stem}.",
+        suffix=".tmp",
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as transcript:
+            transcript.writelines(lines)
+            transcript.flush()
+            os.fsync(transcript.fileno())
+        os.replace(temporary_path, path)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
 
 
 @main.command("port")
@@ -1553,12 +1668,16 @@ def port_session(
 @click.argument("session", required=False)
 @click.argument("question", required=False)
 @click.option("--agent", type=click.Choice(["claude", "codex"], case_sensitive=False),
-              help="Force agent type (auto-detected if not specified)")
+              help="Restrict the search to this agent's home")
 def query_session(session, question, agent):
     """Query a session with a question using an AI agent.
 
     Exports the session and uses Claude to answer questions about its content.
     If no question provided, opens interactive query mode.
+    SESSION may be a full session id, a partial id (prefix, middle,
+    or suffix fragment), a session name (set with /rename), a
+    rollout filename fragment (e.g. 2026-03-25T14-50), or a session
+    file path.
 
     \b
     Examples:
@@ -1566,35 +1685,23 @@ def query_session(session, question, agent):
         aichat query abc123 "Summarize the changes made"
         aichat query                           # Interactive mode for latest session
     """
-    import sys
     from pathlib import Path
 
-    from claude_code_tools.session_utils import (
-        find_session_file, detect_agent_from_path, get_session_uuid,
-    )
+    from claude_code_tools.session_utils import get_session_uuid
 
     if not session:
         _find_and_run_session_ui(
             session_id=None,
-            agent_constraint='both',
+            agent_constraint=agent or 'both',
             start_screen='query',
             direct_action='query',
         )
         return
 
-    # Find session file
-    input_path = Path(session).expanduser()
-    if input_path.exists() and input_path.is_file():
-        session_file = input_path
-        detected_agent = agent or detect_agent_from_path(session_file)
-    else:
-        result = find_session_file(session)
-        if not result:
-            print(f"Error: Session not found: {session}", file=sys.stderr)
-            sys.exit(1)
-        detected_agent, session_file, cwd, _ = result
-        if agent:
-            detected_agent = agent
+    resolved = _resolve_cli_session(session, agent)
+    session_file = resolved.session_file
+    detected_agent = resolved.agent
+    cwd = resolved.directory or str(session_file.parent)
 
     # If no question, show interactive query UI
     if not question:
@@ -1606,13 +1713,17 @@ def query_session(session, question, agent):
             "session_id": get_session_uuid(session_file.stem),
             "agent": detected_agent,
             "file_path": str(session_file),
-            "cwd": str(session_file.parent),
+            "cwd": cwd,
         }
 
         def handler(sess, action, kwargs=None):
+            claude_home, codex_home = _session_homes()
             return execute_action(
                 action, sess["agent"], Path(sess["file_path"]),
-                sess["cwd"], action_kwargs=kwargs
+                sess["cwd"],
+                claude_home=claude_home,
+                codex_home=codex_home,
+                action_kwargs=kwargs,
             )
 
         run_node_menu_ui(
@@ -1643,60 +1754,62 @@ def query_session(session, question, agent):
 @main.command("clone")
 @click.argument("session", required=False)
 @click.option("--agent", type=click.Choice(["claude", "codex"], case_sensitive=False),
-              help="Force agent type (auto-detected if not specified)")
+              help="Restrict the search to this agent's home")
 def clone_session_cmd(session, agent):
     """Clone a session and resume the clone.
 
     Creates a copy of the session with a new ID and resumes it,
     leaving the original session untouched.
 
-    If no session ID provided, finds latest session for current project/branch.
+    SESSION may be a full session id, a partial id (prefix, middle,
+    or suffix fragment), a session name (set with /rename), a
+    rollout filename fragment (e.g. 2026-03-25T14-50), or a session
+    file path. If omitted, finds the latest session in the current
+    project.
 
     \b
     Examples:
         aichat clone abc123-def456    # Clone specific session
         aichat clone                  # Clone latest session
     """
-    import sys
-    from pathlib import Path
-
-    from claude_code_tools.session_utils import (
-        find_session_file, detect_agent_from_path, get_session_uuid,
-    )
+    from claude_code_tools.session_utils import get_session_uuid
 
     if not session:
         _find_and_run_session_ui(
             session_id=None,
-            agent_constraint='both',
+            agent_constraint=agent or 'both',
             start_screen='resume',
             direct_action='clone',
         )
         return
 
-    # Find session file
-    input_path = Path(session).expanduser()
-    if input_path.exists() and input_path.is_file():
-        session_file = input_path
-        detected_agent = agent or detect_agent_from_path(session_file)
-        cwd = str(session_file.parent)
-    else:
-        result = find_session_file(session)
-        if not result:
-            print(f"Error: Session not found: {session}", file=sys.stderr)
-            sys.exit(1)
-        detected_agent, session_file, cwd, _ = result
-        if agent:
-            detected_agent = agent
+    resolved = _resolve_cli_session(session, agent)
+    session_file = resolved.session_file
+    detected_agent = resolved.agent
+    cwd = resolved.directory or str(session_file.parent)
 
     session_id = get_session_uuid(session_file.stem)
 
     # Execute clone
     if detected_agent == "claude":
         from claude_code_tools.find_claude_session import clone_session
-        clone_session(session_id, cwd, shell_mode=False)
+        claude_home, _ = _session_homes()
+        clone_session(
+            session_id,
+            cwd,
+            shell_mode=False,
+            claude_home=claude_home,
+        )
     else:
         from claude_code_tools.find_codex_session import clone_session
-        clone_session(str(session_file), session_id, cwd, shell_mode=False)
+        _, codex_home = _session_homes()
+        clone_session(
+            str(session_file),
+            session_id,
+            cwd,
+            shell_mode=False,
+            codex_home=codex_home,
+        )
 
 
 @main.command("rollover")
@@ -1705,13 +1818,17 @@ def clone_session_cmd(session, agent):
               help="Quick rollover without context extraction (just preserve lineage)")
 @click.option("--prompt", "-p", help="Custom prompt for context extraction")
 @click.option("--agent", type=click.Choice(["claude", "codex"], case_sensitive=False),
-              help="Force agent type (auto-detected if not specified)")
+              help="Restrict the search to this agent's home")
 def rollover(session, quick, prompt, agent):
     """Rollover: hand off work to a fresh session with preserved lineage.
 
     Creates a new session with a summary of the current work and links back
     to the parent session. The new session starts with full context available
     while the parent session is preserved intact.
+    SESSION may be a full session id, a partial id (prefix, middle,
+    or suffix fragment), a session name (set with /rename), a
+    rollout filename fragment (e.g. 2026-03-25T14-50), or a session
+    file path.
 
     \b
     Options:
@@ -1726,42 +1843,29 @@ def rollover(session, quick, prompt, agent):
         aichat rollover                     # Rollover latest session
     """
     import sys
-    from pathlib import Path
-
-    from claude_code_tools.session_utils import (
-        find_session_file,
-        detect_agent_from_path,
-        continue_with_options,
-    )
+    from claude_code_tools.session_utils import continue_with_options
 
     # If CLI options provided, use direct handler (backward compatible)
-    if quick or prompt or agent:
+    if quick or prompt or (agent and session):
         if not session:
-            print("Error: --quick, --prompt, or --agent require a session ID",
+            print("Error: --quick or --prompt require a session ID",
                   file=sys.stderr)
             print("Use 'aichat rollover' without options for interactive mode",
                   file=sys.stderr)
             sys.exit(1)
 
-        # Find session file
-        input_path = Path(session).expanduser()
-        if input_path.exists() and input_path.is_file():
-            session_file = input_path
-            detected_agent = agent or detect_agent_from_path(session_file)
-        else:
-            result = find_session_file(session)
-            if not result:
-                print(f"Error: Session not found: {session}", file=sys.stderr)
-                sys.exit(1)
-            detected_agent, session_file, _, _ = result
-            if agent:
-                detected_agent = agent
+        resolved = _resolve_cli_session(session, agent)
+        session_file = resolved.session_file
+        detected_agent = resolved.agent
 
         # Execute rollover directly
         rollover_type = "quick" if quick else "context"
+        claude_home, codex_home = _session_homes()
         continue_with_options(
             str(session_file),
             detected_agent,
+            claude_home=claude_home,
+            codex_home=codex_home,
             preset_prompt=prompt,
             rollover_type=rollover_type,
         )
@@ -1772,7 +1876,7 @@ def rollover(session, quick, prompt, agent):
     # Start at lineage screen, with direct_action for proper escape behavior
     _find_and_run_session_ui(
         session_id=session,
-        agent_constraint='both',
+        agent_constraint=agent or 'both',
         start_screen='lineage',
         select_target='lineage',
         results_title=' Which session to rollover? ',
@@ -1783,13 +1887,17 @@ def rollover(session, quick, prompt, agent):
 @main.command("lineage")
 @click.argument("session", required=False)
 @click.option("--agent", type=click.Choice(["claude", "codex"], case_sensitive=False),
-              help="Force agent type (auto-detected if not specified)")
+              help="Restrict the search to this agent's home")
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 def lineage(session, agent, json_output):
     """Show the parent lineage chain of a session.
 
     Traces back through continue_metadata and trim_metadata to find
     all ancestor sessions, from the current session back to the original.
+    SESSION may be a full session id, a partial id (prefix, middle,
+    or suffix fragment), a session name (set with /rename), a
+    rollout filename fragment (e.g. 2026-03-25T14-50), or a session
+    file path.
 
     \b
     Examples:
@@ -1798,36 +1906,22 @@ def lineage(session, agent, json_output):
         aichat lineage abc123 --json    # Output as JSON
     """
     import json as json_lib
-    import sys
     from pathlib import Path
     from datetime import datetime
 
-    from claude_code_tools.session_utils import (
-        find_session_file, detect_agent_from_path, get_session_uuid,
-    )
+    from claude_code_tools.session_utils import get_session_uuid
     from claude_code_tools.session_lineage import get_full_lineage_chain
 
     if not session:
         _find_and_run_session_ui(
             session_id=None,
-            agent_constraint='both',
+            agent_constraint=agent or 'both',
             start_screen='lineage',
         )
         return
 
-    # Find session file
-    input_path = Path(session).expanduser()
-    if input_path.exists() and input_path.is_file():
-        session_file = input_path
-        detected_agent = agent or detect_agent_from_path(session_file)
-    else:
-        result = find_session_file(session)
-        if not result:
-            print(f"Error: Session not found: {session}", file=sys.stderr)
-            sys.exit(1)
-        detected_agent, session_file, _, _ = result
-        if agent:
-            detected_agent = agent
+    resolved = _resolve_cli_session(session, agent)
+    session_file = resolved.session_file
 
     # Get lineage (returns newest-first, ending with original)
     lineage_chain = get_full_lineage_chain(session_file)

--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -45,8 +45,12 @@ def _resolve_cli_session(
     )
 
     root_claude_home, root_codex_home = _session_homes()
-    effective_claude_home = claude_home or root_claude_home
-    effective_codex_home = codex_home or root_codex_home
+    effective_claude_home = (
+        root_claude_home if claude_home is None else claude_home
+    )
+    effective_codex_home = (
+        root_codex_home if codex_home is None else codex_home
+    )
     try:
         return resolve_session_query(
             session,
@@ -352,6 +356,9 @@ def _find_and_run_session_ui(
     results_title: str | None = None,
     direct_action: str | None = None,
     action_kwargs: dict | None = None,
+    *,
+    claude_home: str | None = None,
+    codex_home: str | None = None,
 ) -> None:
     """
     Find session(s) and run Node UI for the specified action.
@@ -367,6 +374,8 @@ def _find_and_run_session_ui(
         results_title: Title for selection screen
         direct_action: If set, execute this action directly instead of showing UI
         action_kwargs: Optional kwargs to pass to action
+        claude_home: Optional Claude home override
+        codex_home: Optional Codex home override
     """
     import os
     import subprocess
@@ -377,7 +386,11 @@ def _find_and_run_session_ui(
     from claude_code_tools.search_index import SessionIndex
     from claude_code_tools.session_menu_cli import execute_action
     from claude_code_tools.session_utils import default_export_path
-    claude_home, codex_home = _session_homes()
+    root_claude_home, root_codex_home = _session_homes()
+    if claude_home is None:
+        claude_home = root_claude_home
+    if codex_home is None:
+        codex_home = root_codex_home
 
     if session_id:
         if direct_action:
@@ -394,7 +407,12 @@ def _find_and_run_session_ui(
                 if agent_constraint in ("claude", "codex")
                 else None
             )
-            resolved = _resolve_cli_session(session_id, constraint)
+            resolved = _resolve_cli_session(
+                session_id,
+                constraint,
+                claude_home=claude_home,
+                codex_home=codex_home,
+            )
             agent = resolved.agent
             session_file = resolved.session_file
             project_path = resolved.directory or str(session_file.parent)
@@ -447,11 +465,28 @@ def _find_and_run_session_ui(
             return
 
         # Normal mode (no direct_action): route through session_menu_cli
-        sys.argv = [
+        constraint = (
+            agent_constraint
+            if agent_constraint in ("claude", "codex")
+            else None
+        )
+        resolved = _resolve_cli_session(
+            session_id,
+            constraint,
+            claude_home=claude_home,
+            codex_home=codex_home,
+        )
+        menu_args = [
             sys.argv[0].replace('aichat', 'session-menu'),
             '--start-screen', start_screen,
-            session_id,
+            '--agent', resolved.agent,
+            str(resolved.session_file),
         ]
+        if claude_home:
+            menu_args.extend(["--claude-home", claude_home])
+        if codex_home:
+            menu_args.extend(["--codex-home", codex_home])
+        sys.argv = menu_args
         from claude_code_tools.session_menu_cli import main as menu_main
         menu_main()
         return
@@ -799,8 +834,14 @@ def trim(session, tools, threshold, trim_assistant, output_dir, agent, claude_ho
             print("Use 'aichat trim' without options for interactive mode", file=sys.stderr)
             sys.exit(1)
 
+        resolved = _resolve_cli_session(
+            session,
+            agent,
+            claude_home=claude_home,
+        )
+
         # Build args for trim-session CLI
-        args = [session]
+        args = [str(resolved.session_file)]
         if tools:
             args.extend(["--tools", tools])
         if threshold != 500:
@@ -809,8 +850,7 @@ def trim(session, tools, threshold, trim_assistant, output_dir, agent, claude_ho
             args.extend(["--trim-assistant-messages", str(trim_assistant)])
         if output_dir:
             args.extend(["--output-dir", output_dir])
-        if agent:
-            args.extend(["--agent", agent])
+        args.extend(["--agent", resolved.agent])
         if claude_home:
             args.extend(["--claude-home", claude_home])
 
@@ -821,10 +861,11 @@ def trim(session, tools, threshold, trim_assistant, output_dir, agent, claude_ho
 
     _find_and_run_session_ui(
         session_id=session,
-        agent_constraint='both',
+        agent_constraint=agent or 'both',
         start_screen='trim_menu',
         select_target='trim_menu',
         results_title=' Which session to trim? ',
+        claude_home=claude_home,
     )
 
 
@@ -982,8 +1023,22 @@ def trim_in_place_cmd(session, tools, threshold, trim_assistant, dry_run,
 @click.option("--dry-run", "-n", is_flag=True,
               help="Show what would be trimmed without doing it")
 @click.option("--claude-home", help="Path to Claude home directory")
-def smart_trim(session, instructions, exclude_types, preserve_recent, content_threshold,
-               output_dir, dry_run, claude_home):
+@click.option(
+    "--agent",
+    type=click.Choice(["claude", "codex"], case_sensitive=False),
+    help="Restrict the search to this agent's home",
+)
+def smart_trim(
+    session,
+    instructions,
+    exclude_types,
+    preserve_recent,
+    content_threshold,
+    output_dir,
+    dry_run,
+    claude_home,
+    agent,
+):
     """Smart trim using Claude SDK agents (EXPERIMENTAL).
 
     Uses an LLM to intelligently analyze the session and decide what can
@@ -1021,9 +1076,12 @@ def smart_trim(session, instructions, exclude_types, preserve_recent, content_th
     # If --instructions provided, use the handler function (same as TUI)
     if instructions and session:
         root_claude_home, root_codex_home = _session_homes()
-        effective_claude_home = claude_home or root_claude_home
+        effective_claude_home = (
+            root_claude_home if claude_home is None else claude_home
+        )
         resolved = _resolve_cli_session(
             session,
+            agent,
             claude_home=effective_claude_home,
             codex_home=root_codex_home,
         )
@@ -1057,9 +1115,12 @@ def smart_trim(session, instructions, exclude_types, preserve_recent, content_th
             sys.exit(1)
 
         root_claude_home, root_codex_home = _session_homes()
-        effective_claude_home = claude_home or root_claude_home
+        effective_claude_home = (
+            root_claude_home if claude_home is None else claude_home
+        )
         resolved = _resolve_cli_session(
             session,
+            agent,
             claude_home=effective_claude_home,
             codex_home=root_codex_home,
         )
@@ -1088,10 +1149,11 @@ def smart_trim(session, instructions, exclude_types, preserve_recent, content_th
     # (whether session provided or not - find latest if not)
     _find_and_run_session_ui(
         session_id=session,
-        agent_constraint='both',
+        agent_constraint=agent or 'both',
         start_screen='smart_trim_form',
         select_target='smart_trim_form',
         results_title=' Which session to smart-trim? ',
+        claude_home=claude_home,
     )
 
 
@@ -1286,7 +1348,8 @@ def info(session, agent, json_output):
     mod_time = datetime.fromtimestamp(session_file.stat().st_mtime)
     create_time = datetime.fromtimestamp(session_file.stat().st_ctime)
     file_size = session_file.stat().st_size
-    line_count = sum(1 for _ in open(session_file))
+    with session_file.open("rb") as transcript:
+        line_count = sum(1 for _ in transcript)
 
     # Extract metadata from session
     from claude_code_tools.export_session import extract_session_metadata
@@ -1413,6 +1476,7 @@ def move_session(
     """
     import json
     import sys
+    import uuid
     from pathlib import Path
 
     from claude_code_tools.session_utils import (
@@ -1439,15 +1503,34 @@ def move_session(
     print(f"Reading session: {session_file}")
     lines = []
     old_cwd = None
-    with open(session_file, "r") as f:
+    content_session_id = None
+    with open(
+        session_file,
+        "r",
+        encoding="utf-8",
+        errors="surrogateescape",
+    ) as f:
         for line in f:
             try:
-                data = json.loads(line)
+                parseable_line, raw_byte_markers = (
+                    _protect_surrogateescape_bytes(
+                        line,
+                        reserved_text=str(new_project_path),
+                    )
+                )
+                data = json.loads(parseable_line)
                 if not isinstance(data, dict):
                     lines.append(line)
                     continue
                 if detected_agent == "claude":
                     # Claude: cwd is at top level
+                    record_session_id = data.get("sessionId")
+                    if (
+                        content_session_id is None
+                        and isinstance(record_session_id, str)
+                        and record_session_id.strip()
+                    ):
+                        content_session_id = record_session_id.strip()
                     if old_cwd is None and "cwd" in data:
                         old_cwd = data["cwd"]
                     if "cwd" in data:
@@ -1472,8 +1555,11 @@ def move_session(
                     ):
                         if "cwd" in payload:
                             payload["cwd"] = str(new_project_path)
-                lines.append(json.dumps(data) + "\n")
-            except json.JSONDecodeError:
+                serialized = json.dumps(data)
+                for marker, raw_byte in raw_byte_markers.items():
+                    serialized = serialized.replace(marker, raw_byte)
+                lines.append(serialized + "\n")
+            except (ValueError, RecursionError):
                 lines.append(line)
 
     if detected_agent == "claude":
@@ -1484,8 +1570,20 @@ def move_session(
         configured_claude_home, _ = _session_homes()
         claude_home = get_claude_home(cli_arg=configured_claude_home)
         new_project_dir = claude_home / "projects" / encoded_path
+        if content_session_id is not None:
+            try:
+                session_id = str(uuid.UUID(content_session_id))
+            except ValueError:
+                print(
+                    "Error: Invalid sessionId in Claude transcript: "
+                    f"{content_session_id}",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        else:
+            session_id = session_file.stem
         new_project_dir.mkdir(parents=True, exist_ok=True)
-        new_file_path = new_project_dir / session_file.name
+        new_file_path = new_project_dir / f"{session_id}.jsonl"
 
         # Check if destination already exists
         if new_file_path.exists() and new_file_path != session_file:
@@ -1495,7 +1593,11 @@ def move_session(
 
         # Write updated content to new location
         print(f"Moving session to: {new_file_path}")
-        _write_lines_atomically(new_file_path, lines)
+        _write_lines_atomically(
+            new_file_path,
+            lines,
+            mode_source=session_file,
+        )
 
         # Remove old file if different location
         if new_file_path != session_file:
@@ -1505,7 +1607,6 @@ def move_session(
         print(f"\n[green]Session moved successfully![/green]")
         print(f"  From: {old_cwd}")
         print(f"  To:   {new_project_path}")
-        session_id = session_file.stem
         resume_cmd = f"cd {new_project_path} && claude --resume {session_id}"
     else:
         # Codex: just update file in place (sessions organized by date, not project)
@@ -1538,16 +1639,78 @@ def move_session(
         console.print(f"  [cyan]{resume_cmd}[/cyan]")
 
 
-def _write_lines_atomically(path: "Path", lines: list[str]) -> None:
+def _protect_surrogateescape_bytes(
+    line: str,
+    *,
+    reserved_text: str,
+) -> tuple[str, dict[str, str]]:
+    """Replace raw undecodable bytes with JSON-safe temporary markers.
+
+    Args:
+        line: Transcript line decoded with ``surrogateescape``.
+        reserved_text: Replacement text that markers must not collide with.
+
+    Returns:
+        The parseable line and a mapping from markers to surrogate characters.
+    """
+    import json
+
+    protected = line
+    markers: dict[str, str] = {}
+    decoded_serialization = json.dumps(json.loads(line))
+    raw_bytes = sorted(
+        {
+            character
+            for character in line
+            if "\udc80" <= character <= "\udcff"
+        }
+    )
+    for index, raw_byte in enumerate(raw_bytes):
+        marker = f"__aichat_raw_byte_{ord(raw_byte):04x}_{index}__"
+        while (
+            marker in protected
+            or marker in decoded_serialization
+            or marker in reserved_text
+        ):
+            marker = f"_{marker}"
+        protected = protected.replace(raw_byte, marker)
+        markers[marker] = raw_byte
+    return protected, markers
+
+
+def _write_lines_atomically(
+    path: "Path",
+    lines: list[str],
+    *,
+    mode_source: "Path | None" = None,
+) -> None:
     """Atomically replace a path with the supplied transcript lines.
 
     Args:
         path: Destination transcript path.
         lines: Complete serialized transcript lines.
+        mode_source: Existing transcript whose mode should be preserved when
+            the destination does not exist.
     """
     import os
+    import stat
     import tempfile
     from pathlib import Path
+
+    existing_mode = None
+    try:
+        existing_status = path.lstat()
+        if stat.S_ISREG(existing_status.st_mode):
+            existing_mode = stat.S_IMODE(existing_status.st_mode)
+    except FileNotFoundError:
+        pass
+    if existing_mode is None and mode_source is not None:
+        try:
+            source_status = mode_source.stat()
+            if stat.S_ISREG(source_status.st_mode):
+                existing_mode = stat.S_IMODE(source_status.st_mode)
+        except FileNotFoundError:
+            pass
 
     descriptor, temporary_name = tempfile.mkstemp(
         dir=path.parent,
@@ -1556,7 +1719,14 @@ def _write_lines_atomically(path: "Path", lines: list[str]) -> None:
     )
     temporary_path = Path(temporary_name)
     try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as transcript:
+        if existing_mode is not None:
+            os.fchmod(descriptor, existing_mode)
+        with os.fdopen(
+            descriptor,
+            "w",
+            encoding="utf-8",
+            errors="surrogateescape",
+        ) as transcript:
             transcript.writelines(lines)
             transcript.flush()
             os.fsync(transcript.fileno())
@@ -1799,6 +1969,7 @@ def clone_session_cmd(session, agent):
             cwd,
             shell_mode=False,
             claude_home=claude_home,
+            source_path=session_file,
         )
     else:
         from claude_code_tools.find_codex_session import clone_session
@@ -1846,7 +2017,7 @@ def rollover(session, quick, prompt, agent):
     from claude_code_tools.session_utils import continue_with_options
 
     # If CLI options provided, use direct handler (backward compatible)
-    if quick or prompt or (agent and session):
+    if quick or prompt:
         if not session:
             print("Error: --quick or --prompt require a session ID",
                   file=sys.stderr)
@@ -1978,8 +2149,13 @@ def lineage(session, agent, json_output):
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
     help='Codex home directory (default: ~/.codex or CODEX_HOME)',
 )
+@click.option(
+    "--agent",
+    type=click.Choice(["claude", "codex"], case_sensitive=False),
+    help="Restrict the search to this agent's home",
+)
 @click.pass_context
-def resume_session(ctx, claude_home, codex_home):
+def resume_session(ctx, claude_home, codex_home, agent):
     """Resume a session with various options (resume, clone, trim, continue).
 
     If no session ID provided, finds latest session for current project/branch.
@@ -1992,17 +2168,21 @@ def resume_session(ctx, claude_home, codex_home):
         CODEX_HOME         - Default Codex home (overridden by --codex-home)
     """
     # Merge with parent context options (CLI arg takes precedence)
-    claude_home = claude_home or (ctx.obj or {}).get('claude_home')
-    codex_home = codex_home or (ctx.obj or {}).get('codex_home')
+    if claude_home is None:
+        claude_home = (ctx.obj or {}).get('claude_home')
+    if codex_home is None:
+        codex_home = (ctx.obj or {}).get('codex_home')
 
-    args = ctx.args
+    agent, args = _consume_export_agent(ctx.args, agent)
     session_id = args[0] if args and not args[0].startswith('-') else None
     _find_and_run_session_ui(
         session_id=session_id,
-        agent_constraint='both',
+        agent_constraint=agent or 'both',
         start_screen='resume',
         select_target='resume',
         results_title=' Which session to resume? ',
+        claude_home=claude_home,
+        codex_home=codex_home,
     )
 
 

--- a/claude_code_tools/find_claude_session.py
+++ b/claude_code_tools/find_claude_session.py
@@ -1263,25 +1263,47 @@ def copy_session_file(session_file_path: str, dest_override: str | None = None, 
         print(f"\nError copying file: {e}")
 
 
-def clone_session(session_id: str, project_path: str, shell_mode: bool = False, claude_home: Optional[str] = None):
-    """Clone a Claude session to a new file with new UUID and resume it."""
+def clone_session(
+    session_id: str,
+    project_path: str,
+    shell_mode: bool = False,
+    claude_home: Optional[str] = None,
+    source_path: Optional[Path] = None,
+) -> None:
+    """Clone a Claude session to a new file with new UUID and resume it.
+
+    Args:
+        session_id: UUID of the session being cloned.
+        project_path: Working directory used when resuming the clone.
+        shell_mode: Whether to emit shell commands instead of resuming.
+        claude_home: Optional configured Claude home.
+        source_path: Exact resolved transcript to clone. When omitted, retain
+            the legacy path reconstruction behavior.
+    """
     import shutil
     import uuid
 
-    # Get the original session file path
-    source_path = Path(get_session_file_path(session_id, project_path, claude_home))
+    if source_path is None:
+        source_path = Path(
+            get_session_file_path(session_id, project_path, claude_home)
+        )
 
     if not source_path.exists():
         print(f"\nError: Session file not found: {source_path}")
         return
 
-    # Generate new UUID for cloned session
-    new_session_id = str(uuid.uuid4())
-
-    # Create destination path with new UUID in same directory
-    dest_path = source_path.parent / f"{new_session_id}.jsonl"
-
     try:
+        destination_dir = Path(
+            get_session_file_path(session_id, project_path, claude_home)
+        ).parent
+        destination_dir.mkdir(parents=True, exist_ok=True)
+
+        # Generate new UUID for cloned session
+        new_session_id = str(uuid.uuid4())
+
+        # Claude discovers sessions only inside the configured project home.
+        dest_path = destination_dir / f"{new_session_id}.jsonl"
+
         # Copy the file
         shutil.copy2(source_path, dest_path)
 
@@ -1299,8 +1321,8 @@ def clone_session(session_id: str, project_path: str, shell_mode: bool = False, 
         resume_session(new_session_id, project_path, shell_mode=shell_mode, claude_home=claude_home)
 
     except Exception as e:
-        print(f"\nError cloning session: {e}")
-        return
+        print(f"\nError cloning session: {e}", file=sys.stderr)
+        raise SystemExit(1) from None
 
 
 def resume_session(session_id: str, project_path: str, shell_mode: bool = False, claude_home: Optional[str] = None):

--- a/claude_code_tools/port_service.py
+++ b/claude_code_tools/port_service.py
@@ -27,16 +27,11 @@ from typing import TYPE_CHECKING, Optional, Union
 if TYPE_CHECKING:
     from claude_code_tools.resolve_session import ResolveResult
 
-from claude_code_tools.session_utils import (
-    detect_agent_from_content,
-    detect_agent_from_path,
-    get_claude_home,
-    get_codex_home,
-    is_valid_session,
+from claude_code_tools.session_resolution import (
+    _detect_direct_path_agent,
+    _resolve_query_for_agent,
+    build_ambiguity_message,
 )
-
-_MAX_AMBIGUITY_LINES = 25
-_MAX_AMBIGUITY_NAME_CHARS = 60
 
 
 class PortSessionError(Exception):
@@ -75,138 +70,6 @@ class PortResult:
     output_file: Path
     cwd: str
     resume_hint: str
-
-
-def _detect_direct_path_agent(
-    session_file: Path,
-    claude_home: Optional[str],
-    codex_home: Optional[str],
-) -> Optional[str]:
-    """Detect the source agent of an explicitly given session file.
-
-    Content is authoritative: the file's own JSONL records are
-    sniffed first, so a Codex rollout copied under the Claude home
-    (or vice versa) is classified by what it IS, not where it sits.
-    Only when content detection is inconclusive does the file's
-    location decide -- and a location-derived Claude classification
-    must additionally pass :func:`is_valid_session`, mirroring the
-    validation applied to id-based lookups.
-
-    Args:
-        session_file: Existing session file path.
-        claude_home: Optional custom Claude home directory.
-        codex_home: Optional custom Codex home directory.
-
-    Returns:
-        ``"claude"``, ``"codex"``, or None when undetectable.
-    """
-    # Stream the ENTIRE file (memory-bounded): a rollout whose
-    # leading records are unrecognized or oversized must still be
-    # classified by its later recognizable records.
-    agent = detect_agent_from_content(session_file, max_lines=None)
-    if agent is not None:
-        return agent
-
-    # Content inconclusive: fall back to the file's location
-    # (configured homes first, then default path conventions).
-    resolved = session_file.resolve()
-    claude_root = get_claude_home(claude_home).resolve()
-    codex_root = get_codex_home(codex_home).resolve()
-    if resolved.is_relative_to(claude_root):
-        located: Optional[str] = "claude"
-    elif resolved.is_relative_to(codex_root):
-        located = "codex"
-    else:
-        located = detect_agent_from_path(session_file)
-
-    # A location-only Claude claim must be backed by valid content;
-    # otherwise a malformed file inside the Claude home would be
-    # misreported as portable and silently exit 0.
-    if located == "claude" and not is_valid_session(session_file):
-        return None
-    return located
-
-
-def _resolve_query_for_agent(
-    query: str, agent: str, home: Optional[str]
-) -> "Optional[ResolveResult]":
-    """Resolve a query through the shared resolver for one agent.
-
-    Expected resolver errors (empty query, missing or unreadable
-    home) are treated as "no match for this agent" so a broken codex
-    home never blocks a valid claude lookup, mirroring the tolerant
-    behavior of the old glob path. A corrupt or incomplete Codex
-    state database additionally degrades to direct on-disk rollout
-    enumeration (``fallback_on_database_error``), so valid rollouts
-    still port during database damage or migration.
-
-    Args:
-        query: Session id, name, or filename fragment.
-        agent: ``"claude"`` or ``"codex"``.
-        home: Optional custom home directory for the agent.
-
-    Returns:
-        A ``ResolveResult`` or None when resolution failed outright.
-    """
-    from typing import cast
-
-    from claude_code_tools.resolve_session import (
-        Agent,
-        ResolverError,
-        resolve,
-    )
-
-    try:
-        return resolve(
-            query,
-            cast(Agent, agent),
-            home,
-            fallback_on_database_error=True,
-        )
-    except ResolverError:
-        return None
-
-
-def _ambiguity_error(
-    session: str, results: "list[ResolveResult]"
-) -> PortSessionError:
-    """Build the multi-candidate rejection error for a port lookup.
-
-    Args:
-        session: The original session query.
-        results: Non-empty resolver results (single or ambiguous).
-
-    Returns:
-        A user-facing error listing every candidate from both agents.
-    """
-    records = [record for result in results for record in result.records]
-    records.sort(key=lambda record: record._modified_timestamp, reverse=True)
-    total = sum(
-        1 if result.kind == "single" else result.match_count
-        for result in results
-    )
-    lines = []
-    for record in records[:_MAX_AMBIGUITY_LINES]:
-        name = record.name or ""
-        # Codex auto-titles can be entire prompts: keep lines readable.
-        name = " ".join(name.split())
-        if len(name) > _MAX_AMBIGUITY_NAME_CHARS:
-            name = name[: _MAX_AMBIGUITY_NAME_CHARS - 3] + "..."
-        name_part = f" ({name})" if name else ""
-        lines.append(
-            f"  [{record.agent}] {record.session_id}{name_part}"
-            f"  modified {record.modified}"
-        )
-    remaining = total - len(records[:_MAX_AMBIGUITY_LINES])
-    if remaining > 0:
-        lines.append(f"  ... and {remaining} more")
-    listing = "\n".join(lines)
-    return PortSessionError(
-        f"Ambiguous session '{session}' matches {total} sessions:\n"
-        f"{listing}\n"
-        "Use a longer unique id, the exact session name, or the "
-        "full file path."
-    )
 
 
 def resolve_port_session(
@@ -274,7 +137,7 @@ def resolve_port_session(
         return ResolvedSession(
             agent=record.agent, session_file=Path(record.session_file)
         )
-    raise _ambiguity_error(session, results)
+    raise PortSessionError(build_ambiguity_message(session, results))
 
 
 def _read_output_cwd(output_file: Path) -> str:

--- a/claude_code_tools/session_lineage.py
+++ b/claude_code_tools/session_lineage.py
@@ -53,7 +53,12 @@ def get_parent_info(session_file: Path) -> Tuple[
         return None, None, None
 
     try:
-        with open(session_file) as f:
+        with open(
+            session_file,
+            "r",
+            encoding="utf-8",
+            errors="replace",
+        ) as f:
             first_line = f.readline().strip()
 
         if not first_line:

--- a/claude_code_tools/session_menu_cli.py
+++ b/claude_code_tools/session_menu_cli.py
@@ -123,7 +123,11 @@ def execute_action(
         if agent == "claude":
             from claude_code_tools.find_claude_session import clone_session
             clone_session(
-                session_id, project_path, shell_mode=False, claude_home=claude_home
+                session_id,
+                project_path,
+                shell_mode=False,
+                claude_home=claude_home,
+                source_path=session_file,
             )
         else:
             from claude_code_tools.find_codex_session import clone_session

--- a/claude_code_tools/session_resolution.py
+++ b/claude_code_tools/session_resolution.py
@@ -10,13 +10,14 @@ Symlinked in-home transcripts are only partially handled. One discovered link
 to an external transcript is preserved and several are ambiguous, but exotic
 topologies may resolve to the canonical target. This is a known, accepted
 limitation because agent homes are not expected to contain such links.
+Fast-candidate validation also retains legacy unbounded physical-line reads.
 """
 
 from __future__ import annotations
 
 import re
 import sqlite3
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, cast
 
@@ -567,6 +568,98 @@ def _fast_candidate_ambiguity(
     )
 
 
+def _result_tier(result: ResolveResult, query: str) -> int:
+    """Return the global precedence tier for one agent resolver result."""
+    matched_by = result.records[0].matched_by
+    if matched_by == "id":
+        return 0
+    if matched_by == "name":
+        name = result.records[0].name
+        if name is not None and name.casefold() == query.casefold():
+            return 1
+        return 5
+    return {
+        "partial-id": 2,
+        "id-substring": 3,
+        "filename": 4,
+    }[matched_by]
+
+
+def _retain_winning_tier(
+    results: list[ResolveResult], query: str
+) -> list[ResolveResult]:
+    """Discard cross-agent results weaker than the best resolver tier."""
+    if not results:
+        return results
+    winning_tier = min(_result_tier(result, query) for result in results)
+    return [
+        result
+        for result in results
+        if _result_tier(result, query) == winning_tier
+    ]
+
+
+def _validate_resolver_content_ids(
+    result: ResolveResult,
+    claude_home: str | None,
+    codex_home: str | None,
+    *,
+    fast_candidates_overflowed: bool,
+) -> ResolveResult | None:
+    """Remove resolver records whose content contradicts their filename."""
+    valid_records = []
+    for record in result.records:
+        path = Path(record.session_file)
+        discovered_path = _restore_discovered_path(
+            result.query,
+            record.agent,
+            path,
+            claude_home,
+            codex_home,
+        )
+        content_id = _session_id_from_content(record.agent, path)
+        filename_id = get_session_uuid(discovered_path.stem)
+        if (
+            content_id is not None
+            and content_id.casefold() != filename_id.casefold()
+        ):
+            continue
+        valid_records.append(record)
+
+    removed_count = len(result.records) - len(valid_records)
+    remaining_count = (
+        result.match_count - removed_count
+        if result.kind == "ambiguous"
+        else len(valid_records)
+    )
+    if remaining_count <= 0:
+        if fast_candidates_overflowed:
+            return replace(
+                result,
+                kind="ambiguous",
+                match_count=_MAX_FAST_PATH_CANDIDATES + 1,
+            )
+        return None
+    if not valid_records:
+        # ResolveResult retains at most 25 ambiguity records. If additional
+        # records were truncated, their content identities are unknown here,
+        # so preserve the ambiguity rather than reporting a false not-found.
+        return result
+    if remaining_count == 1:
+        return replace(
+            result,
+            kind="single",
+            records=(valid_records[0],),
+            match_count=0,
+        )
+    return replace(
+        result,
+        kind="ambiguous",
+        records=tuple(valid_records),
+        match_count=remaining_count,
+    )
+
+
 def resolve_session_query(
     session: str,
     *,
@@ -588,6 +681,13 @@ def resolve_session_query(
     Raises:
         SessionQueryError: If no unique eligible session can be selected.
     """
+    for home_name, home in (
+        ("Claude", claude_home),
+        ("Codex", codex_home),
+    ):
+        if home is not None and not home.strip():
+            raise SessionQueryError(f"{home_name} home must not be empty.")
+
     try:
         input_path: Path | None = Path(session).expanduser()
         is_direct_file = input_path.is_file()
@@ -598,6 +698,15 @@ def resolve_session_query(
         detected = _detect_direct_path_agent(
             input_path, claude_home, codex_home
         )
+        if detected == "codex":
+            from claude_code_tools.resolve_session import (
+                _is_legacy_codex_rollout,
+            )
+
+            if not is_valid_session(input_path) and not (
+                _is_legacy_codex_rollout(input_path)
+            ):
+                detected = None
         if detected not in ("claude", "codex"):
             raise SessionQueryError(
                 f"Could not detect agent for session file: {input_path}"
@@ -614,15 +723,27 @@ def resolve_session_query(
         )
 
     fast_candidates: list[_ValidatedFastCandidate] = []
+    fast_candidates_overflowed = False
     if _ID_FRAGMENT_RE.fullmatch(session):
         bounded = _validated_fast_candidates(
             session, agent, claude_home, codex_home
         )
+        fast_candidates_overflowed = bounded is None
         if bounded is not None:
             fast_candidates = bounded
             if len(fast_candidates) == 1:
                 if _FULL_ID_RE.fullmatch(session):
-                    return fast_candidates[0].resolved
+                    database_conflict = (
+                        _codex_has_outranking_id(
+                            session,
+                            fast_candidates[0],
+                            codex_home,
+                        )
+                        if agent in (None, "codex")
+                        else False
+                    )
+                    if database_conflict is False:
+                        return fast_candidates[0].resolved
                 conflict = _has_fast_path_conflict(
                     session,
                     fast_candidates[0],
@@ -645,21 +766,22 @@ def resolve_session_query(
             session, agent_name, home, resolver_errors
         )
         if result is not None and result.kind != "not_found":
-            results.append(result)
+            validated_result = _validate_resolver_content_ids(
+                result,
+                claude_home,
+                codex_home,
+                fast_candidates_overflowed=fast_candidates_overflowed,
+            )
+            if validated_result is not None:
+                results.append(validated_result)
 
+    results = _retain_winning_tier(results, session)
     if len(results) == 1 and results[0].kind == "single":
         record = results[0].records[0]
         path = Path(record.session_file)
         discovered_path = _restore_discovered_path(
             session, record.agent, path, claude_home, codex_home
         )
-        content_id = _session_id_from_content(record.agent, path)
-        if (
-            content_id is not None
-            and content_id.casefold()
-            != get_session_uuid(discovered_path.stem).casefold()
-        ):
-            raise SessionQueryError(f"Session not found: {session}")
         _, branch = _metadata_for_path(record.agent, path)
         return ResolvedSessionQuery(
             record.agent, discovered_path, record.directory, branch

--- a/claude_code_tools/session_resolution.py
+++ b/claude_code_tools/session_resolution.py
@@ -1,0 +1,678 @@
+"""Shared session-query resolution for command-line actions.
+
+Direct paths are classified content-first: JSONL records identify what a
+session is, while its location is only a fallback when content is
+inconclusive. A location-derived Claude result must still be a valid session,
+so malformed files and Codex rollouts copied into a Claude home are not
+misclassified.
+
+Symlinked in-home transcripts are only partially handled. One discovered link
+to an external transcript is preserved and several are ambiguous, but exotic
+topologies may resolve to the canonical target. This is a known, accepted
+limitation because agent homes are not expected to contain such links.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, cast
+
+if TYPE_CHECKING:
+    from claude_code_tools.resolve_session import ResolveResult, ResolverError
+
+from claude_code_tools.session_utils import (
+    _iter_named_session_files,
+    detect_agent_from_content,
+    detect_agent_from_path,
+    extract_cwd_from_session,
+    extract_git_branch_claude,
+    extract_session_metadata_codex,
+    get_claude_home,
+    get_codex_home,
+    get_session_uuid,
+    is_malformed_session,
+    is_valid_session,
+)
+
+_ID_FRAGMENT_RE = re.compile(r"^[0-9a-fA-F-]{4,}$")
+_FULL_ID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+    r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+_MAX_FAST_PATH_CANDIDATES = 25
+_MAX_AMBIGUITY_LINES = 25
+_MAX_AMBIGUITY_NAME_CHARS = 60
+
+
+class SessionQueryError(Exception):
+    """A user-facing failure while resolving a session query."""
+
+
+@dataclass(frozen=True)
+class ResolvedSessionQuery:
+    """A resolved session file and metadata needed by CLI actions.
+
+    Attributes:
+        agent: ``"claude"`` or ``"codex"``.
+        session_file: Absolute path to the selected transcript.
+        directory: Project working directory recorded by the session.
+        git_branch: Git branch recorded by the session, when available.
+    """
+
+    agent: str
+    session_file: Path
+    directory: str | None
+    git_branch: str | None
+
+
+@dataclass(frozen=True)
+class _ValidatedFastCandidate:
+    """A fast-path result paired with its content-confirmed identity."""
+
+    resolved: ResolvedSessionQuery
+    session_id: str
+
+
+def _detect_direct_path_agent(
+    session_file: Path,
+    claude_home: Optional[str],
+    codex_home: Optional[str],
+) -> Optional[str]:
+    """Detect the agent of an explicitly supplied session file.
+
+    Content is authoritative, so a rollout copied beneath the other agent's
+    home is classified by what it is rather than where it is stored. Location
+    is used only when content detection is inconclusive, and a
+    location-derived Claude classification must pass
+    :func:`is_valid_session`, just as it must for id-based lookup.
+
+    Args:
+        session_file: Existing session file path.
+        claude_home: Optional custom Claude home directory.
+        codex_home: Optional custom Codex home directory.
+
+    Returns:
+        ``"claude"``, ``"codex"``, or None when undetectable.
+    """
+    # Stream the entire file, while remaining memory-bounded. Recognizable
+    # records may follow leading records that are unknown or oversized.
+    detected = detect_agent_from_content(session_file, max_lines=None)
+    if detected is not None:
+        return detected
+
+    # Content was inconclusive. Prefer configured homes before falling back
+    # to the default path conventions.
+    resolved = session_file.resolve()
+    claude_root = get_claude_home(claude_home).resolve()
+    codex_root = get_codex_home(codex_home).resolve()
+    if resolved.is_relative_to(claude_root):
+        located: Optional[str] = "claude"
+    elif resolved.is_relative_to(codex_root):
+        located = "codex"
+    else:
+        located = detect_agent_from_path(session_file)
+
+    # A location alone cannot make malformed content a portable Claude
+    # session, or a bad file beneath the Claude home could silently succeed.
+    if located == "claude" and not is_valid_session(session_file):
+        return None
+    return located
+
+
+def _resolve_query_for_agent(
+    query: str,
+    agent: str,
+    home: Optional[str],
+    errors: list["ResolverError"] | None = None,
+) -> "Optional[ResolveResult]":
+    """Resolve a query for one agent, tolerating expected resolver errors.
+
+    A missing or unreadable home counts as no match for that agent, allowing
+    the other agent to resolve successfully. Codex database failures also
+    fall back to on-disk rollout enumeration. Callers that need to surface an
+    operational failure when no agent matches can collect it in ``errors``.
+
+    Args:
+        query: Session id, name, or filename fragment.
+        agent: ``"claude"`` or ``"codex"``.
+        home: Optional custom home directory for the agent.
+        errors: Optional destination for tolerated resolver errors.
+
+    Returns:
+        A resolver result, or None when resolution failed for this agent.
+    """
+    from claude_code_tools.resolve_session import (
+        Agent,
+        ResolverError,
+        resolve,
+    )
+
+    try:
+        return resolve(
+            query,
+            cast(Agent, agent),
+            home,
+            fallback_on_database_error=True,
+        )
+    except ResolverError as error:
+        if errors is not None:
+            errors.append(error)
+        return None
+
+
+def build_ambiguity_message(
+    session: str, results: "list[ResolveResult]"
+) -> str:
+    """Build the shared multi-candidate ambiguity message.
+
+    Args:
+        session: Original session query.
+        results: Non-empty resolver results from one or both agents.
+
+    Returns:
+        A user-facing message listing the matching candidates.
+    """
+    records = [record for result in results for record in result.records]
+    records.sort(key=lambda record: record._modified_timestamp, reverse=True)
+    total = sum(
+        1 if result.kind == "single" else result.match_count
+        for result in results
+    )
+    lines = []
+    for record in records[:_MAX_AMBIGUITY_LINES]:
+        # Codex auto-titles can contain entire prompts. Normalize whitespace
+        # and truncate them to keep every candidate on a readable line.
+        name = " ".join((record.name or "").split())
+        if len(name) > _MAX_AMBIGUITY_NAME_CHARS:
+            name = name[: _MAX_AMBIGUITY_NAME_CHARS - 3] + "..."
+        name_part = f" ({name})" if name else ""
+        lines.append(
+            f"  [{record.agent}] {record.session_id}{name_part}"
+            f"  modified {record.modified}"
+        )
+    remaining = total - len(records[:_MAX_AMBIGUITY_LINES])
+    if remaining > 0:
+        lines.append(f"  ... and {remaining} more")
+    listing = "\n".join(lines)
+    return (
+        f"Ambiguous session '{session}' matches {total} sessions:\n"
+        f"{listing}\n"
+        "Use a longer unique id, the exact session name, or the "
+        "full file path."
+    )
+
+
+def _metadata_for_path(
+    agent: str, session_file: Path
+) -> tuple[str | None, str | None]:
+    """Read the cwd and branch metadata for a selected session file."""
+    if agent == "claude":
+        return (
+            extract_cwd_from_session(session_file, agent="claude"),
+            extract_git_branch_claude(session_file),
+        )
+    metadata = extract_session_metadata_codex(session_file)
+    if not metadata:
+        return None, None
+    cwd = metadata.get("cwd")
+    branch = metadata.get("branch")
+    return (
+        cwd if isinstance(cwd, str) and cwd else None,
+        branch if isinstance(branch, str) and branch else None,
+    )
+
+
+def _session_id_from_content(agent: str, session_file: Path) -> str | None:
+    """Extract a session identity from authoritative transcript content."""
+    import json
+
+    try:
+        with session_file.open(
+            "r", encoding="utf-8", errors="replace"
+        ) as transcript:
+            for line in transcript:
+                try:
+                    record = json.loads(line)
+                except (ValueError, RecursionError):
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                if agent == "claude":
+                    session_id = record.get("sessionId")
+                elif record.get("type") == "session_meta":
+                    payload = record.get("payload")
+                    session_id = (
+                        payload.get("id")
+                        if isinstance(payload, dict)
+                        else None
+                    )
+                elif (
+                    "timestamp" in record
+                    and (
+                        isinstance(record.get("git"), dict)
+                        or isinstance(record.get("instructions"), str)
+                    )
+                ):
+                    session_id = record.get("id")
+                else:
+                    session_id = None
+                if isinstance(session_id, str) and session_id.strip():
+                    return session_id.strip()
+    except (OSError, UnicodeError):
+        return None
+    return None
+
+
+def _validated_fast_candidates(
+    session: str,
+    agent: str | None,
+    claude_home: str | None,
+    codex_home: str | None,
+) -> list[_ValidatedFastCandidate] | None:
+    """Return bounded, resolver-eligible filename matches.
+
+    None means the raw candidate count exceeded the validation bound.
+    """
+    raw_candidates: list[tuple[str, Path]] = []
+    try:
+        for candidate in _iter_named_session_files(
+            session, claude_home=claude_home, codex_home=codex_home
+        ):
+            if agent is not None and candidate[0] != agent:
+                continue
+            raw_candidates.append(candidate)
+            if len(raw_candidates) > _MAX_FAST_PATH_CANDIDATES:
+                return None
+    except (OSError, RuntimeError, UnicodeError, ValueError):
+        return []
+
+    from claude_code_tools.find_claude_session import is_sidechain_session
+    from claude_code_tools.resolve_session import _is_legacy_codex_rollout
+
+    validated: dict[Path, _ValidatedFastCandidate] = {}
+    lowered_query = session.casefold()
+    for candidate_agent, candidate_path in raw_candidates:
+        try:
+            discovered_path = candidate_path.absolute()
+            validation_path = candidate_path.resolve()
+            if candidate_agent == "claude":
+                if is_malformed_session(
+                    validation_path
+                ) or is_sidechain_session(validation_path):
+                    continue
+                directory, branch = _metadata_for_path(
+                    candidate_agent, validation_path
+                )
+                if not directory:
+                    continue
+            else:
+                if not is_valid_session(validation_path) and not (
+                    _is_legacy_codex_rollout(validation_path)
+                ):
+                    continue
+                metadata = extract_session_metadata_codex(validation_path)
+                if metadata is None:
+                    continue
+                cwd = metadata.get("cwd")
+                branch_value = metadata.get("branch")
+                directory = cwd if isinstance(cwd, str) and cwd else None
+                branch = (
+                    branch_value
+                    if isinstance(branch_value, str) and branch_value
+                    else None
+                )
+            content_id = _session_id_from_content(
+                candidate_agent, validation_path
+            )
+            if (
+                content_id is None
+                or lowered_query not in content_id.casefold()
+            ):
+                continue
+        except (
+            OSError,
+            RuntimeError,
+            TypeError,
+            UnicodeError,
+            ValueError,
+        ):
+            continue
+        validated[validation_path] = _ValidatedFastCandidate(
+            resolved=ResolvedSessionQuery(
+                candidate_agent, discovered_path, directory, branch
+            ),
+            session_id=content_id,
+        )
+    return list(validated.values())
+
+
+def _claude_has_exact_name(query: str, home: str | None) -> bool:
+    """Return whether a Claude transcript has the exact custom name."""
+    from claude_code_tools.find_claude_session import get_custom_title
+
+    projects = get_claude_home(home) / "projects"
+    if not projects.is_dir():
+        return False
+    lowered = query.casefold()
+    try:
+        paths = projects.glob("*/*.jsonl")
+        for path in paths:
+            title = get_custom_title(
+                path.stem,
+                "",
+                claude_home=home,
+                session_file=path,
+            )
+            if title.casefold() == lowered:
+                return True
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return False
+
+
+def _codex_has_exact_name(query: str, home: str | None) -> bool | None:
+    """Return whether Codex has an exact name, or None if checking failed."""
+    from claude_code_tools.resolve_session import (
+        ResolverError,
+        _codex_state_database,
+    )
+    from claude_code_tools.resolve_session_names import codex_thread_names
+
+    root = get_codex_home(home)
+    lowered = query.casefold()
+    try:
+        explicit_names = codex_thread_names(root)
+        database = _codex_state_database(root)
+    except (
+        OSError,
+        ResolverError,
+        RuntimeError,
+        UnicodeError,
+        ValueError,
+    ):
+        return None
+    if any(name.casefold() == lowered for name in explicit_names.values()):
+        return True
+    if database is None:
+        return False
+    try:
+        connection = sqlite3.connect(
+            f"file:{database}?mode=ro", uri=True
+        )
+        try:
+            rows = connection.execute(
+                "SELECT id, title FROM threads WHERE title IS NOT NULL"
+            )
+            return any(
+                isinstance(session_id, str)
+                and session_id.casefold() not in explicit_names
+                and isinstance(title, str)
+                and title.casefold() == lowered
+                for session_id, title in rows
+            )
+        finally:
+            connection.close()
+    except (OSError, sqlite3.Error, UnicodeError, ValueError):
+        return None
+
+
+def _has_exact_name(
+    query: str,
+    agent: str | None,
+    claude_home: str | None,
+    codex_home: str | None,
+) -> bool | None:
+    """Check the higher-priority exact-name tier without full resolution."""
+    if agent in (None, "claude") and _claude_has_exact_name(
+        query, claude_home
+    ):
+        return True
+    if agent in (None, "codex"):
+        return _codex_has_exact_name(query, codex_home)
+    return False
+
+
+def _codex_has_outranking_id(
+    query: str,
+    candidate: _ValidatedFastCandidate,
+    home: str | None,
+) -> bool | None:
+    """Return whether a database ID prefix outranks the fast candidate."""
+    from claude_code_tools.resolve_session import (
+        ResolverError,
+        _codex_state_database,
+    )
+
+    try:
+        database = _codex_state_database(get_codex_home(home))
+    except (
+        OSError,
+        ResolverError,
+        RuntimeError,
+        UnicodeError,
+        ValueError,
+    ):
+        return None
+    if database is None:
+        return False
+
+    candidate_id = candidate.session_id.casefold()
+    lowered = query.casefold()
+    try:
+        connection = sqlite3.connect(
+            f"file:{database}?mode=ro", uri=True
+        )
+        try:
+            rows = connection.execute("SELECT id FROM threads")
+            for (session_id,) in rows:
+                if not isinstance(session_id, str):
+                    continue
+                normalized_id = session_id.casefold()
+                if not normalized_id.startswith(lowered):
+                    continue
+                if (
+                    candidate.resolved.agent != "codex"
+                    or normalized_id != candidate_id
+                ):
+                    return True
+            return False
+        finally:
+            connection.close()
+    except (OSError, sqlite3.Error, UnicodeError, ValueError):
+        return None
+
+
+def _has_fast_path_conflict(
+    query: str,
+    candidate: _ValidatedFastCandidate,
+    agent: str | None,
+    claude_home: str | None,
+    codex_home: str | None,
+) -> bool | None:
+    """Check cheap higher-priority name and database ID tiers."""
+    exact_name = _has_exact_name(
+        query, agent, claude_home, codex_home
+    )
+    if exact_name is not False:
+        return exact_name
+    if agent in (None, "codex"):
+        return _codex_has_outranking_id(query, candidate, codex_home)
+    return False
+
+
+def _restore_discovered_path(
+    session: str,
+    agent: str,
+    canonical_path: Path,
+    claude_home: str | None,
+    codex_home: str | None,
+) -> Path:
+    """Map a canonical path to one unique discovered in-home path."""
+    root = (
+        get_claude_home(claude_home) / "projects"
+        if agent == "claude"
+        else get_codex_home(codex_home)
+    )
+    pattern = "*/*.jsonl" if agent == "claude" else "**/*.jsonl"
+    try:
+        canonical = canonical_path.resolve()
+        if canonical.is_relative_to(root.absolute()):
+            return canonical_path
+    except (OSError, RuntimeError, UnicodeError, ValueError):
+        return canonical_path
+    matches: list[Path] = []
+    try:
+        for path in root.glob(pattern):
+            try:
+                if path.is_symlink() and path.resolve() == canonical:
+                    matches.append(path.absolute())
+            except (OSError, RuntimeError, UnicodeError, ValueError):
+                continue
+    except (OSError, RuntimeError, UnicodeError, ValueError):
+        if not matches:
+            return canonical_path
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        candidates = [
+            ResolvedSessionQuery(agent, path, None, None)
+            for path in matches
+        ]
+        raise SessionQueryError(
+            _fast_candidate_ambiguity(session, candidates)
+        )
+    return canonical_path
+
+
+def _fast_candidate_ambiguity(
+    session: str, candidates: list[ResolvedSessionQuery]
+) -> str:
+    """Build a fallback ambiguity message for resolver-invisible files."""
+    lines = [
+        f"  [{candidate.agent}] {candidate.session_file}"
+        for candidate in candidates[:_MAX_AMBIGUITY_LINES]
+    ]
+    remaining = len(candidates) - len(lines)
+    if remaining:
+        lines.append(f"  ... and {remaining} more")
+    listing = "\n".join(lines)
+    return (
+        f"Ambiguous session '{session}' matches {len(candidates)} sessions:\n"
+        f"{listing}\n"
+        "Use a longer unique id, the exact session name, or the "
+        "full file path."
+    )
+
+
+def resolve_session_query(
+    session: str,
+    *,
+    agent: str | None = None,
+    claude_home: str | None = None,
+    codex_home: str | None = None,
+) -> ResolvedSessionQuery:
+    """Resolve a path, id fragment, filename fragment, or session name.
+
+    Args:
+        session: User-supplied session query.
+        agent: Optional hard agent constraint.
+        claude_home: Optional Claude home override.
+        codex_home: Optional Codex home override.
+
+    Returns:
+        The uniquely resolved session and its project metadata.
+
+    Raises:
+        SessionQueryError: If no unique eligible session can be selected.
+    """
+    try:
+        input_path: Path | None = Path(session).expanduser()
+        is_direct_file = input_path.is_file()
+    except (OSError, RuntimeError, ValueError):
+        input_path = None
+        is_direct_file = False
+    if is_direct_file and input_path is not None:
+        detected = _detect_direct_path_agent(
+            input_path, claude_home, codex_home
+        )
+        if detected not in ("claude", "codex"):
+            raise SessionQueryError(
+                f"Could not detect agent for session file: {input_path}"
+            )
+        if agent is not None and agent != detected:
+            raise SessionQueryError(
+                f"Session file is a {detected} session, but --agent "
+                f"{agent} was specified: {input_path}"
+            )
+        supplied_path = input_path.absolute()
+        directory, branch = _metadata_for_path(detected, supplied_path)
+        return ResolvedSessionQuery(
+            detected, supplied_path, directory, branch
+        )
+
+    fast_candidates: list[_ValidatedFastCandidate] = []
+    if _ID_FRAGMENT_RE.fullmatch(session):
+        bounded = _validated_fast_candidates(
+            session, agent, claude_home, codex_home
+        )
+        if bounded is not None:
+            fast_candidates = bounded
+            if len(fast_candidates) == 1:
+                if _FULL_ID_RE.fullmatch(session):
+                    return fast_candidates[0].resolved
+                conflict = _has_fast_path_conflict(
+                    session,
+                    fast_candidates[0],
+                    agent,
+                    claude_home,
+                    codex_home,
+                )
+                if conflict is False:
+                    return fast_candidates[0].resolved
+
+    results: list[ResolveResult] = []
+    resolver_errors: list[ResolverError] = []
+    homes = (
+        ((agent, claude_home if agent == "claude" else codex_home),)
+        if agent is not None
+        else (("claude", claude_home), ("codex", codex_home))
+    )
+    for agent_name, home in homes:
+        result = _resolve_query_for_agent(
+            session, agent_name, home, resolver_errors
+        )
+        if result is not None and result.kind != "not_found":
+            results.append(result)
+
+    if len(results) == 1 and results[0].kind == "single":
+        record = results[0].records[0]
+        path = Path(record.session_file)
+        discovered_path = _restore_discovered_path(
+            session, record.agent, path, claude_home, codex_home
+        )
+        content_id = _session_id_from_content(record.agent, path)
+        if (
+            content_id is not None
+            and content_id.casefold()
+            != get_session_uuid(discovered_path.stem).casefold()
+        ):
+            raise SessionQueryError(f"Session not found: {session}")
+        _, branch = _metadata_for_path(record.agent, path)
+        return ResolvedSessionQuery(
+            record.agent, discovered_path, record.directory, branch
+        )
+    if results:
+        raise SessionQueryError(build_ambiguity_message(session, results))
+    if len(fast_candidates) > 1:
+        raise SessionQueryError(
+            _fast_candidate_ambiguity(
+                session,
+                [candidate.resolved for candidate in fast_candidates],
+            )
+        )
+    if resolver_errors:
+        raise SessionQueryError(str(resolver_errors[0]))
+    raise SessionQueryError(f"Session not found: {session}")

--- a/claude_code_tools/session_utils.py
+++ b/claude_code_tools/session_utils.py
@@ -1485,7 +1485,12 @@ def count_user_messages(session_file: Path, agent: str) -> int:
     user_count = 0
 
     try:
-        with open(session_file, "r", encoding="utf-8") as f:
+        with open(
+            session_file,
+            "r",
+            encoding="utf-8",
+            errors="replace",
+        ) as f:
             for line in f:
                 line = line.strip()
                 if not line:

--- a/docs-site/src/content/docs/tools/aichat/actions.mdx
+++ b/docs-site/src/content/docs/tools/aichat/actions.mdx
@@ -119,3 +119,35 @@ exports go to:
 
 You can specify a custom destination path when
 prompted.
+
+## Move action
+
+`aichat move <session> <new-project>` re-homes a
+session on a different project directory. Both
+arguments are required, and the session may be named
+any way the [shared lookup](../resolve/) accepts:
+
+```bash
+aichat move session-finder ~/Git/other-repo
+aichat move 2945d228 ~/Git/other-repo
+```
+
+It rewrites the working directory recorded on every
+line of the transcript, then:
+
+- **Claude:** relocates the transcript into the new
+  project's directory under the Claude home. The
+  destination filename and the resume command it
+  prints both come from the session id recorded
+  *inside* the transcript, so a file you renamed
+  yourself still lands as `<session-id>.jsonl`.
+- **Codex:** rewrites the rollout in place. Codex
+  organizes sessions by date rather than by project,
+  so the file itself does not move.
+
+A name you set with `/rename` survives either way: a
+Claude name is recorded inside the transcript, and a
+Codex name lives in the home-level
+`session_index.jsonl`, keyed by a session id that
+`move` never changes. Afterwards `move` offers to
+switch to the new directory and resume the session.

--- a/docs-site/src/content/docs/tools/aichat/agent-access.mdx
+++ b/docs-site/src/content/docs/tools/aichat/agent-access.mdx
@@ -110,6 +110,27 @@ consume tokens in your main conversation.
 
 The full list of `aichat` subcommands:
 
+Most of them share one lookup. `info`, `export`, `copy`, `move`, `query`,
+`clone`, `rollover`, `lineage`, `smart-trim`, `trim`, and `resume` all accept
+a full session id, a partial id (prefix, middle, or suffix fragment), a
+session name (set with `/rename`), a rollout filename fragment (e.g.
+`2026-03-25T14-50`), or a session file path — across both agents, with the
+agent auto-detected. See [Resolve](../resolve/) for the exact match
+precedence.
+
+An ambiguous query fails with the list of matching sessions rather than
+silently picking one. `--agent` restricts which agent home is searched; a
+session file path searches no home at all, so there `--agent` instead
+requires the file to belong to that agent. `delete` and `menu` keep their
+legacy id-or-path lookup, so the bare `aichat <id>` shortcut (which routes to
+`menu`) does too.
+
+[`port`](../port/) accepts the same query forms, but resolves them slightly
+differently: it has no `--agent`, it searches both homes for every non-path
+query (a file path is classified from its content instead), and it calls a
+query ambiguous whenever each agent yields a match, even when one of them
+matched on a stronger tier.
+
 <Tabs>
   <TabItem label="Session management">
 
@@ -119,10 +140,12 @@ The full list of `aichat` subcommands:
     | `aichat resume [id]` | Resume with strategy options |
     | `aichat rollover [id]` | Rollover to fresh session |
     | `aichat trim [id]` | Trim session content |
+    | `aichat smart-trim [id]` | AI-guided trim of session content |
     | `aichat clone [id]` | Clone a session file |
     | `aichat menu [id]` | Interactive action menu |
     | `aichat lineage [id]` | Show parent lineage chain |
     | `aichat query [id]` | Query a session with AI |
+    | `aichat port <session>` | Port a session to the other agent |
 
   </TabItem>
   <TabItem label="Search & index">
@@ -138,21 +161,12 @@ The full list of `aichat` subcommands:
   </TabItem>
   <TabItem label="Export & info">
 
-    The session argument of `info`, `export`, `copy`, `move`, `query`,
-    `clone`, `rollover`, `lineage`, and `smart-trim` accepts a full session
-    id, a partial id (prefix, middle, or suffix fragment), a session name
-    (set with `/rename`), a rollout filename fragment (e.g.
-    `2026-03-25T14-50`), or a session file path. An ambiguous query fails
-    with the list of matching sessions rather than picking one, and
-    `--agent` restricts which agent home is searched. `delete` retains its
-    legacy id-or-path lookup.
-
     | Command | Description |
     |---------|-------------|
     | `aichat info [id]` | Show session metadata |
     | `aichat export [id]` | Export session to text |
     | `aichat copy [id]` | Copy session file |
-    | `aichat move [id]` | Move session file |
+    | `aichat move <session> <new-project>` | Move session to another project |
     | `aichat delete [id]` | Delete a session |
 
   </TabItem>

--- a/docs-site/src/content/docs/tools/aichat/agent-access.mdx
+++ b/docs-site/src/content/docs/tools/aichat/agent-access.mdx
@@ -138,6 +138,15 @@ The full list of `aichat` subcommands:
   </TabItem>
   <TabItem label="Export & info">
 
+    The session argument of `info`, `export`, `copy`, `move`, `query`,
+    `clone`, `rollover`, `lineage`, and `smart-trim` accepts a full session
+    id, a partial id (prefix, middle, or suffix fragment), a session name
+    (set with `/rename`), a rollout filename fragment (e.g.
+    `2026-03-25T14-50`), or a session file path. An ambiguous query fails
+    with the list of matching sessions rather than picking one, and
+    `--agent` restricts which agent home is searched. `delete` retains its
+    legacy id-or-path lookup.
+
     | Command | Description |
     |---------|-------------|
     | `aichat info [id]` | Show session metadata |

--- a/docs-site/src/content/docs/tools/aichat/resolve.mdx
+++ b/docs-site/src/content/docs/tools/aichat/resolve.mdx
@@ -47,8 +47,12 @@ session:
 
 - **Claude:** the `custom-title` recorded in the
   transcript — not the auto-generated `ai-title`.
-- **Codex:** the `title` column in the Codex
-  `threads` database.
+- **Codex:** the `thread_name` recorded in the
+  home-level `session_index.jsonl`. When a thread has
+  no explicit name, the `title` column of the Codex
+  `threads` database is used instead — that one is
+  auto-captured from your first message, not chosen
+  by you.
 
 ## Match precedence
 
@@ -135,7 +139,9 @@ aichat lineage 88e9-43d7
 
 Those commands search **both** agent homes and detect
 the agent themselves, so `--agent` there narrows the
-search rather than selecting a home. Pass a session
+search rather than selecting a home. It may come
+before or after the session argument, and
+`--agent=codex` works as well as `--agent codex`. Pass a session
 file path and no home is searched at all: the agent
 comes from the file's content, and `--agent` then
 requires the file to be that agent's. An ambiguous

--- a/docs-site/src/content/docs/tools/aichat/resolve.mdx
+++ b/docs-site/src/content/docs/tools/aichat/resolve.mdx
@@ -118,6 +118,39 @@ and exits `0`:
 | `modified` | Session file mtime (ISO-8601) |
 | `archived` | Codex archived flag (`false` for Claude) |
 
+## The same lookup in other commands
+
+You rarely need to call `resolve` by hand first. The
+ordinary session commands — `info`, `export`, `copy`,
+`move`, `query`, `clone`, `rollover`, `lineage`,
+`smart-trim`, `trim`, and `resume` — accept the same
+queries directly:
+
+```bash
+# All of these name one session
+aichat move session-finder ~/Git/other-repo
+aichat info a15f9ced
+aichat lineage 88e9-43d7
+```
+
+Those commands search **both** agent homes and detect
+the agent themselves, so `--agent` there narrows the
+search rather than selecting a home. Pass a session
+file path and no home is searched at all: the agent
+comes from the file's content, and `--agent` then
+requires the file to be that agent's. An ambiguous
+query fails with the candidate list instead of acting
+on an arbitrary match. `delete` and `menu` still use
+the older id-or-path lookup.
+
+[`port`](../port/) takes the same query forms but
+resolves them on its own path: no `--agent` (use
+`--claude-home` / `--codex-home`), and a query that
+matches in **both** agents is ambiguous there even
+when one side matched on a stronger tier — the
+precedence table above is applied per agent, not
+across the two.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/docs-site/src/content/docs/tools/aichat/resume.mdx
+++ b/docs-site/src/content/docs/tools/aichat/resume.mdx
@@ -198,11 +198,21 @@ aichat resume
 
 # Resume a specific session (opens resume menu)
 aichat resume <session_id>
+
+# A session name, or a partial id, works too
+aichat resume session-finder
+aichat resume a15f9ced
 ```
 
 The resume menu presents the strategy options listed
 above. Pick one and the tool handles cloning,
 trimming, or rollover automatically.
+
+The session argument accepts a name (set with
+`/rename`), a full or partial id, a rollout filename
+fragment, or a file path, across both agents — see
+[Resolve](../resolve/). An ambiguous query lists the
+candidates instead of guessing.
 
 ## Rollover options
 

--- a/tests/test_aichat_session_actions.py
+++ b/tests/test_aichat_session_actions.py
@@ -1,0 +1,440 @@
+"""Regressions for session resolution used by direct ``aichat`` actions."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from claude_code_tools.aichat import main
+from tests.resolve_session_helpers import (
+    FakeHome,
+    claude_home,
+    codex_home,
+    runner,
+)
+
+__all__ = ["claude_home", "codex_home", "runner"]
+
+
+def _root_args(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> list[str]:
+    """Return root options that isolate both agent homes."""
+    return [
+        "--claude-home",
+        str(claude_home.path),
+        "--codex-home",
+        str(codex_home.path),
+    ]
+
+
+def _share_claude_title_with_codex(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> str:
+    """Give a Codex thread the third Claude session's exact title."""
+    title = "Unique Deployment Review"
+    with sqlite3.connect(codex_home.path / "state_5.sqlite") as connection:
+        connection.execute(
+            "UPDATE threads SET title = ? WHERE id = ?",
+            (title, codex_home.ids[2]),
+        )
+        connection.commit()
+    assert claude_home.files[2].is_file()
+    return title
+
+
+def _write_session_without_cwd(tmp_path: Path) -> Path:
+    """Create an explicit Claude transcript that has no cwd metadata."""
+    session_id = "eeee4444-4444-4444-8444-444444444444"
+    session_file = tmp_path / "explicit-sessions" / f"{session_id}.jsonl"
+    session_file.parent.mkdir()
+    session_file.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "message": {"content": "hello"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return session_file
+
+
+def test_copy_agent_constrains_cross_agent_name_collision(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """``copy --agent`` selects that home when an exact name is shared."""
+    query = _share_claude_title_with_codex(claude_home, codex_home)
+    destination = tmp_path / "copied-session.jsonl"
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "copy",
+            query,
+            "--agent",
+            "codex",
+            "--dest",
+            str(destination),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert destination.read_bytes() == codex_home.files[2].read_bytes()
+
+
+def test_export_agent_constrains_cross_agent_name_collision(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """``export --agent`` resolves a shared name within the forced home."""
+    query = _share_claude_title_with_codex(claude_home, codex_home)
+    destination = tmp_path / "exported-session.txt"
+    marker = "selected constrained Codex transcript"
+    with codex_home.files[2].open("a", encoding="utf-8") as session_stream:
+        session_stream.write(
+            json.dumps(
+                {
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": marker}
+                        ],
+                    },
+                }
+            )
+            + "\n"
+        )
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "export",
+            "--agent",
+            "codex",
+            query,
+            "--output",
+            str(destination),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert destination.is_file()
+    assert marker in destination.read_text(encoding="utf-8")
+    assert "Detected CODEX session" in result.output
+    assert "Exporting with CODEX" in result.output
+    assert "user specified" not in result.output
+
+
+def test_export_agent_after_session_is_consumed_as_constraint(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A post-SESSION ``--agent=`` is consumed instead of forwarded."""
+    query = _share_claude_title_with_codex(claude_home, codex_home)
+    destination = tmp_path / "post-session-export.txt"
+    marker = "post-session agent selected Codex"
+    with codex_home.files[2].open("a", encoding="utf-8") as session_stream:
+        session_stream.write(
+            json.dumps(
+                {
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": marker}
+                        ],
+                    },
+                }
+            )
+            + "\n"
+        )
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "export",
+            query,
+            "--agent=codex",
+            "--output",
+            str(destination),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert marker in destination.read_text(encoding="utf-8")
+    assert "Detected CODEX session" in result.output
+
+
+def test_smart_trim_dry_run_without_session_has_cli_error(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """The option-only smart-trim path does not raise ``NameError``."""
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "smart-trim",
+            "--dry-run",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "Direct smart-trim options require a session ID" in result.output
+    assert "NameError" not in result.output
+
+
+def test_smart_trim_session_dry_run_reaches_delegate(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The session dry-run path reaches the underlying CLI without NameError."""
+    import sys
+
+    called = False
+
+    def capture_main() -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(sys, "argv", sys.argv.copy())
+    monkeypatch.setattr("claude_code_tools.smart_trim.main", capture_main)
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "smart-trim",
+            claude_home.ids[2],
+            "--dry-run",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert called
+    assert "NameError" not in result.output
+
+
+@pytest.mark.parametrize("command", ["info", "lineage"])
+def test_converted_read_only_command_runs(
+    command: str,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Converted read-only commands retain every runtime import."""
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            command,
+            str(claude_home.files[2]),
+            "--agent",
+            "claude",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "NameError" not in result.output
+
+
+def test_export_agent_help_describes_search_constraint(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """``export --agent`` help describes lookup scope, not an override."""
+    result = runner.invoke(
+        main,
+        [*_root_args(claude_home, codex_home), "export", "--help"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Restrict the search to this agent's home" in result.output
+    assert "force export" not in result.output.lower()
+
+
+def test_rollover_direct_action_falls_back_to_session_parent(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The shared direct-action UI gets a stable cwd without metadata."""
+    session_file = _write_session_without_cwd(tmp_path)
+    captured: dict[str, Any] = {}
+
+    def capture_ui(
+        sessions: list[dict[str, Any]],
+        *_args: object,
+        **_kwargs: object,
+    ) -> None:
+        captured.update(sessions[0])
+
+    monkeypatch.setattr(
+        "claude_code_tools.node_menu_ui.run_node_menu_ui",
+        capture_ui,
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "rollover",
+            str(session_file),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["cwd"] == str(session_file.parent)
+
+
+def test_smart_trim_falls_back_to_session_parent(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Smart trim passes the explicit file's parent when cwd is absent."""
+    session_file = _write_session_without_cwd(tmp_path)
+    captured: dict[str, str] = {}
+
+    def capture_trim(
+        session_id: str,
+        project_path: str,
+        claude_home: str | None = None,
+        custom_instructions: str | None = None,
+    ) -> None:
+        captured["session_id"] = session_id
+        captured["project_path"] = project_path
+
+    monkeypatch.setattr(
+        "claude_code_tools.find_claude_session."
+        "handle_smart_trim_resume_claude",
+        capture_trim,
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "smart-trim",
+            str(session_file),
+            "--instructions",
+            "keep the conclusion",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["project_path"] == str(session_file.parent)
+
+
+def test_query_falls_back_to_session_parent(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive query receives the explicit file's parent as cwd."""
+    session_file = _write_session_without_cwd(tmp_path)
+    captured: dict[str, Any] = {}
+
+    def capture_ui(
+        sessions: list[dict[str, Any]],
+        *_args: object,
+        **_kwargs: object,
+    ) -> None:
+        captured.update(sessions[0])
+
+    monkeypatch.setattr(
+        "claude_code_tools.node_menu_ui.run_node_menu_ui",
+        capture_ui,
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "query",
+            str(session_file),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["cwd"] == str(session_file.parent)
+
+
+def test_clone_falls_back_to_session_parent(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clone receives the explicit file's parent when cwd is absent."""
+    session_file = _write_session_without_cwd(tmp_path)
+    captured: dict[str, str] = {}
+
+    def capture_clone(
+        session_id: str,
+        project_path: str,
+        shell_mode: bool = False,
+        claude_home: str | None = None,
+    ) -> None:
+        captured["session_id"] = session_id
+        captured["project_path"] = project_path
+
+    monkeypatch.setattr(
+        "claude_code_tools.find_claude_session.clone_session",
+        capture_clone,
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "clone",
+            str(session_file),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["project_path"] == str(session_file.parent)

--- a/tests/test_aichat_session_actions.py
+++ b/tests/test_aichat_session_actions.py
@@ -11,8 +11,11 @@ import pytest
 from click.testing import CliRunner
 
 from claude_code_tools.aichat import main
+from claude_code_tools.session_utils import encode_claude_project_path
 from tests.resolve_session_helpers import (
     FakeHome,
+    _write_claude_session,
+    _write_codex_session,
     claude_home,
     codex_home,
     runner,
@@ -245,6 +248,250 @@ def test_smart_trim_session_dry_run_reaches_delegate(
     assert "NameError" not in result.output
 
 
+def test_direct_trim_agent_rejects_other_agent_session(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct trim applies ``--agent`` before invoking its delegate."""
+    called = False
+
+    def capture_main() -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(
+        "claude_code_tools.trim_session.main",
+        capture_main,
+    )
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "trim",
+            claude_home.ids[2],
+            "--simple-ui",
+            "--agent",
+            "codex",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "Session not found" in result.output
+    assert not called
+
+
+def test_direct_trim_passes_resolved_path_to_delegate(
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct trim delegates only after constrained shared resolution."""
+    import sys
+
+    captured: list[str] = []
+
+    def capture_main() -> None:
+        captured.extend(sys.argv)
+
+    monkeypatch.setattr(sys, "argv", sys.argv.copy())
+    monkeypatch.setattr(
+        "claude_code_tools.trim_session.main",
+        capture_main,
+    )
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "trim",
+            claude_home.ids[2],
+            "--simple-ui",
+            "--agent",
+            "claude",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert str(claude_home.files[2].resolve()) in captured
+    assert captured[captured.index("--agent") + 1] == "claude"
+
+
+@pytest.mark.parametrize("claude_home_value", ["", "   "])
+def test_direct_trim_rejects_empty_command_local_claude_home(
+    claude_home_value: str,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit empty home cannot fall back through the filename fast path."""
+    called = False
+
+    def capture_main() -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(
+        "claude_code_tools.trim_session.main",
+        capture_main,
+    )
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "trim",
+            claude_home.ids[2],
+            "--simple-ui",
+            "--agent",
+            "claude",
+            "--claude-home",
+            claude_home_value,
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "Claude home must not be empty" in result.output
+    assert not called
+
+
+@pytest.mark.parametrize("command", ["trim", "smart-trim", "resume"])
+def test_interactive_session_action_resolves_name_before_ui(
+    command: str,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive actions pass a name's resolved absolute path to the UI."""
+    import sys
+
+    captured: dict[str, Any] = {}
+
+    def capture_ui(
+        sessions: list[dict[str, Any]],
+        *_args: object,
+        **_kwargs: object,
+    ) -> None:
+        captured.update(sessions[0])
+
+    monkeypatch.setattr(
+        "claude_code_tools.session_menu_cli.run_node_menu_ui",
+        capture_ui,
+    )
+    monkeypatch.setattr(sys, "argv", sys.argv.copy())
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            command,
+            "Unique Deployment Review",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["file_path"] == str(claude_home.files[2].resolve())
+    assert captured["agent"] == "claude"
+    assert captured["claude_home"] == str(claude_home.path)
+
+
+@pytest.mark.parametrize("command", ["resume", "trim", "smart-trim"])
+def test_interactive_action_uses_command_local_claude_home(
+    command: str,
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A command-local home resolves before a same-named default session."""
+    import sys
+
+    custom_home = tmp_path / "custom-claude"
+    custom_id = "eeee4444-4444-4444-8444-444444444444"
+    custom_file = _write_claude_session(
+        custom_home,
+        custom_id,
+        str(tmp_path / "custom-worktree"),
+        "Unique Deployment Review",
+        1_730_000_000.0,
+    )
+    captured: dict[str, Any] = {}
+
+    def capture_ui(
+        sessions: list[dict[str, Any]],
+        *_args: object,
+        **_kwargs: object,
+    ) -> None:
+        captured.update(sessions[0])
+
+    monkeypatch.setattr(
+        "claude_code_tools.session_menu_cli.run_node_menu_ui",
+        capture_ui,
+    )
+    monkeypatch.setattr(sys, "argv", sys.argv.copy())
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            command,
+            "--agent",
+            "claude",
+            "--claude-home",
+            str(custom_home),
+            "Unique Deployment Review",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["file_path"] == str(custom_file.resolve())
+    assert captured["file_path"] != str(claude_home.files[2].resolve())
+    assert captured["claude_home"] == str(custom_home)
+
+
+@pytest.mark.parametrize("command", ["trim", "smart-trim", "resume"])
+def test_interactive_session_action_rejects_ambiguous_query_before_ui(
+    command: str,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive actions report all candidates without launching the UI."""
+    menu_called = False
+
+    def capture_menu() -> None:
+        nonlocal menu_called
+        menu_called = True
+
+    monkeypatch.setattr(
+        "claude_code_tools.session_menu_cli.main",
+        capture_menu,
+    )
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            command,
+            "aaaa",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    assert "ambiguous" in result.output.lower()
+    assert claude_home.ids[0] in result.output
+    assert claude_home.ids[1] in result.output
+    assert not menu_called
+
+
 @pytest.mark.parametrize("command", ["info", "lineage"])
 def test_converted_read_only_command_runs(
     command: str,
@@ -267,6 +514,102 @@ def test_converted_read_only_command_runs(
 
     assert result.exit_code == 0, result.output
     assert "NameError" not in result.output
+
+
+@pytest.mark.parametrize("agent", ["claude", "codex"])
+def test_info_rejects_malformed_explicit_path_inside_agent_home(
+    agent: str,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """An agent home's location cannot make malformed JSONL resumable."""
+    home = claude_home.path if agent == "claude" else codex_home.path
+    malformed = home / "sessions" / "bogus.jsonl"
+    malformed.parent.mkdir(exist_ok=True)
+    malformed.write_text('{"cwd":"/wrong"}\n', encoding="utf-8")
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "info",
+            str(malformed),
+            "--agent",
+            agent,
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code != 0
+    assert "Could not detect agent for session file" in result.output
+
+
+def test_info_accepts_valid_codex_rollout_as_explicit_path(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A valid Codex rollout remains usable through direct-path lookup."""
+    session_id = "eeee4444-4444-4444-8444-444444444444"
+    rollout = _write_codex_session(
+        codex_home.path,
+        session_id,
+        str(tmp_path / "valid-codex-worktree"),
+        1_720_000_000.0,
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "info",
+            str(rollout),
+            "--agent",
+            "codex",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert f'"session_id": "{session_id}"' in result.output
+
+
+def test_info_counts_lines_in_transcript_with_undecodable_bytes(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Info reports a valid session despite an undecodable earlier line."""
+    session_id = "eeee4444-4444-4444-8444-444444444444"
+    session_file = tmp_path / f"{session_id}.jsonl"
+    record = json.dumps(
+        {
+            "type": "user",
+            "sessionId": session_id,
+            "cwd": str(tmp_path),
+            "message": {"role": "user", "content": "hello"},
+        }
+    ).encode()
+    session_file.write_bytes(b"\xff\n" + record + b"\n")
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "info",
+            str(session_file),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert '"line_count": 2' in result.output
 
 
 def test_export_agent_help_describes_search_constraint(
@@ -417,9 +760,11 @@ def test_clone_falls_back_to_session_parent(
         project_path: str,
         shell_mode: bool = False,
         claude_home: str | None = None,
+        source_path: Path | None = None,
     ) -> None:
         captured["session_id"] = session_id
         captured["project_path"] = project_path
+        captured["source_path"] = str(source_path)
 
     monkeypatch.setattr(
         "claude_code_tools.find_claude_session.clone_session",
@@ -438,3 +783,204 @@ def test_clone_falls_back_to_session_parent(
 
     assert result.exit_code == 0, result.output
     assert captured["project_path"] == str(session_file.parent)
+    assert captured["source_path"] == str(session_file)
+
+
+def test_clone_uses_exact_resolved_claude_transcript(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Claude clone copies the named path when metadata collides."""
+    import uuid
+
+    session_id = "11111111-1111-4111-8111-111111111111"
+    cwd = str(tmp_path / "shared-cwd")
+    encoded_cwd = encode_claude_project_path(cwd)
+    in_home = (
+        claude_home.path
+        / "projects"
+        / encoded_cwd
+        / f"{session_id}.jsonl"
+    )
+    in_home.parent.mkdir()
+    in_home.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "cwd": cwd,
+                "message": {"role": "user", "content": "HOME"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    external = tmp_path / f"{session_id}.jsonl"
+    external.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "cwd": cwd,
+                "message": {"role": "user", "content": "OUTSIDE"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    clone_id = uuid.UUID("22222222-2222-4222-8222-222222222222")
+    monkeypatch.setattr(uuid, "uuid4", lambda: clone_id)
+    monkeypatch.setattr(
+        "claude_code_tools.find_claude_session.resume_session",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "clone",
+            str(external),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    clone = (
+        claude_home.path
+        / "projects"
+        / encoded_cwd
+        / f"{clone_id}.jsonl"
+    )
+    assert clone.is_file()
+    assert "OUTSIDE" in clone.read_text(encoding="utf-8")
+    assert "HOME" not in clone.read_text(encoding="utf-8")
+
+
+def test_clone_reports_destination_creation_failure(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Claude clone reports an unwritable home without a traceback."""
+    from claude_code_tools.find_claude_session import get_session_file_path
+
+    source = _write_session_without_cwd(tmp_path)
+    destination_dir = Path(
+        get_session_file_path(
+            source.stem,
+            str(source.parent),
+            str(claude_home.path),
+        )
+    ).parent
+    original_mkdir = Path.mkdir
+
+    def reject_destination(
+        path: Path,
+        mode: int = 0o777,
+        parents: bool = False,
+        exist_ok: bool = False,
+    ) -> None:
+        if path == destination_dir:
+            raise PermissionError("configured Claude home is unwritable")
+        original_mkdir(
+            path,
+            mode=mode,
+            parents=parents,
+            exist_ok=exist_ok,
+        )
+
+    monkeypatch.setattr(Path, "mkdir", reject_destination)
+
+    result = runner.invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "clone",
+            str(source),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code != 0
+    assert "Error cloning session" in result.output
+    assert "configured Claude home is unwritable" in result.output
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    "command_args",
+    [
+        ["smart-trim", "--agent", "claude", "Shared Plan"],
+        ["smart-trim", "Shared Plan", "--agent", "claude"],
+        ["resume", "--agent", "claude", "Shared Plan"],
+        ["resume", "Shared Plan", "--agent", "claude"],
+    ],
+)
+def test_interactive_agent_option_constrains_requested_session(
+    command_args: list[str],
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interactive lookup retains both the session and agent constraint."""
+    captured: dict[str, object] = {}
+
+    def capture_ui(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "claude_code_tools.aichat._find_and_run_session_ui",
+        capture_ui,
+    )
+    result = runner.invoke(
+        main,
+        [*_root_args(claude_home, codex_home), *command_args],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["session_id"] == "Shared Plan"
+    assert captured["agent_constraint"] == "claude"
+
+
+@pytest.mark.parametrize(
+    "command_args",
+    [
+        ["rollover", "--agent", "claude", "Shared Plan"],
+        ["rollover", "Shared Plan", "--agent", "claude"],
+    ],
+)
+def test_rollover_agent_constraint_keeps_interactive_mode(
+    command_args: list[str],
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adding only an agent constraint does not execute rollover directly."""
+    captured: dict[str, object] = {}
+
+    def capture_ui(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "claude_code_tools.aichat._find_and_run_session_ui",
+        capture_ui,
+    )
+    result = runner.invoke(
+        main,
+        [*_root_args(claude_home, codex_home), *command_args],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["session_id"] == "Shared Plan"
+    assert captured["agent_constraint"] == "claude"
+    assert captured["direct_action"] == "continue"

--- a/tests/test_move_session.py
+++ b/tests/test_move_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import stat
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -98,6 +99,7 @@ def test_move_claude_session_by_name(
         "".join(f"{json.dumps(record)}\n" for record in records),
         encoding="utf-8",
     )
+    source.chmod(0o640)
     new_project = tmp_path / "new.project_name"
     new_project.mkdir()
 
@@ -122,6 +124,7 @@ def test_move_claude_session_by_name(
         / source.name
     )
     assert destination.is_file()
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o640
     assert not source.exists()
     moved_records = _json_lines(destination)
     assert len(moved_records) == len(records)
@@ -228,6 +231,7 @@ def test_move_codex_session_by_name_updates_in_place(
         "".join(f"{json.dumps(record)}\n" for record in records),
         encoding="utf-8",
     )
+    source.chmod(0o640)
     original_rollouts = set(
         (codex_home.path / "sessions").rglob("*.jsonl")
     )
@@ -249,6 +253,7 @@ def test_move_codex_session_by_name_updates_in_place(
 
     assert result.exit_code == 0, result.output
     assert source.is_file()
+    assert stat.S_IMODE(source.stat().st_mode) == 0o640
     assert set((codex_home.path / "sessions").rglob("*.jsonl")) == (
         original_rollouts
     )
@@ -407,7 +412,7 @@ def test_move_claude_symlink_preserves_target(
         claude_home.path
         / "projects"
         / encode_claude_project_path(str(new_project.resolve()))
-        / symlink.name
+        / f"{target.stem}.jsonl"
     )
     assert destination.is_file()
     assert not symlink.exists()
@@ -624,3 +629,256 @@ def test_move_rejects_direct_path_outside_agent_constraint(
     assert source.read_bytes() == source_contents
     encoded = encode_claude_project_path(str(new_project.resolve()))
     assert not (claude_home.path / "projects" / encoded).exists()
+
+
+def test_move_preserves_pathologically_nested_line(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Unparseable nested JSON is preserved while valid metadata is moved."""
+    session_id = "11111111-1111-4111-8111-111111111111"
+    nested = "[" * 1100 + "]" * 1100 + "\n"
+    metadata = json.dumps(
+        {
+            "type": "session_meta",
+            "payload": {"id": session_id, "cwd": "/tmp"},
+        }
+    )
+    source = tmp_path / f"{session_id}.jsonl"
+    source.write_text(nested + metadata + "\n", encoding="utf-8")
+    new_project = tmp_path / "nested-target"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            str(source),
+            new_project,
+        ),
+        catch_exceptions=False,
+        input="n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert source.read_text(encoding="utf-8").startswith(nested)
+    moved_records = source.read_text(encoding="utf-8").splitlines()
+    assert json.loads(moved_records[1])["payload"]["cwd"] == str(
+        new_project.resolve()
+    )
+
+
+def test_move_preserves_undecodable_line_byte_for_byte(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Moving a transcript round-trips an undecodable line unchanged."""
+    session_id = "11111111-1111-4111-8111-111111111111"
+    source = tmp_path / f"{session_id}.jsonl"
+    valid_record = json.dumps(
+        {
+            "type": "user",
+            "sessionId": session_id,
+            "cwd": "/tmp/old",
+            "message": {"role": "user", "content": "x"},
+        }
+    ).encode()
+    source.write_bytes(b"\xff\n" + valid_record + b"\n")
+    new_project = tmp_path / "new-project"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            str(source),
+            new_project,
+        ),
+        catch_exceptions=False,
+        input="n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    encoded = encode_claude_project_path(str(new_project.resolve()))
+    moved = claude_home.path / "projects" / encoded / source.name
+    assert moved.read_bytes().startswith(b"\xff\n")
+    assert str(new_project.resolve()).encode() in moved.read_bytes()
+
+
+def test_move_updates_parseable_line_containing_undecodable_byte(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Moving rewrites cwd without changing an undecodable string byte."""
+    session_id = "11111111-1111-4111-8111-111111111111"
+    source = tmp_path / f"{session_id}.jsonl"
+    source.write_bytes(
+        b'{"type":"user","sessionId":"'
+        + session_id.encode()
+        + b'","cwd":"/tmp/old","message":{"role":"user",'
+        + b'"content":"bad \xff byte"},'
+        + b'"legit":"\\u005f\\u005faichat_raw_byte_dcff_0'
+        + b'\\u005f\\u005f"}\n'
+    )
+    new_project = tmp_path / "new-project"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            str(source),
+            new_project,
+        ),
+        catch_exceptions=False,
+        input="n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    encoded = encode_claude_project_path(str(new_project.resolve()))
+    moved = claude_home.path / "projects" / encoded / source.name
+    contents = moved.read_bytes()
+    assert b"bad \xff byte" in contents
+    assert b'"legit": "__aichat_raw_byte_dcff_0__"' in contents
+    assert str(new_project.resolve()).encode() in contents
+    assert b"/tmp/old" not in contents
+
+
+def test_move_preserves_escaped_lone_surrogate_as_valid_json(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Moving leaves an escaped surrogate encoded as valid UTF-8 JSON."""
+    session_id = "11111111-1111-4111-8111-111111111111"
+    source = tmp_path / f"{session_id}.jsonl"
+    source.write_bytes(
+        b'{"type":"user","sessionId":"'
+        + session_id.encode()
+        + b'","cwd":"/tmp/old","message":{"role":"user",'
+        + b'"content":"escaped \\udcff"}}\n'
+    )
+    new_project = tmp_path / "new-project"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            str(source),
+            new_project,
+        ),
+        catch_exceptions=False,
+        input="n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    encoded = encode_claude_project_path(str(new_project.resolve()))
+    moved = claude_home.path / "projects" / encoded / source.name
+    contents = moved.read_bytes()
+    parsed = json.loads(contents.decode("utf-8"))
+    assert parsed["message"]["content"] == "escaped \udcff"
+    assert b"escaped \\udcff" in contents
+    assert b"\xff" not in contents
+
+
+def test_move_uses_claude_content_id_for_destination_and_resume(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Claude move uses transcript identity when the supplied name differs."""
+    session_id = "11111111-1111-4111-8111-111111111111"
+    source = tmp_path / "backup.jsonl"
+    source.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "cwd": "/tmp/old",
+                "message": {"role": "user", "content": "hello"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    new_project = tmp_path / "content-id-target"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            str(source),
+            new_project,
+        ),
+        catch_exceptions=False,
+        input="n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    destination = (
+        claude_home.path
+        / "projects"
+        / encode_claude_project_path(str(new_project.resolve()))
+        / f"{session_id}.jsonl"
+    )
+    assert destination.is_file()
+    assert not source.exists()
+    assert not destination.with_name("backup.jsonl").exists()
+    assert "claude --resume" in result.output
+    assert session_id in result.output
+
+
+def test_move_rejects_unsafe_claude_content_id(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Claude move rejects a content identity that is unsafe as a filename."""
+    source = tmp_path / "backup.jsonl"
+    source_contents = (
+        json.dumps(
+            {
+                "type": "user",
+                "sessionId": "../../escaped",
+                "cwd": "/tmp/old",
+                "message": {"role": "user", "content": "hello"},
+            }
+        )
+        + "\n"
+    )
+    source.write_text(source_contents, encoding="utf-8")
+    new_project = tmp_path / "unsafe-id-target"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            str(source),
+            new_project,
+        ),
+        catch_exceptions=False,
+        input="n\n",
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid sessionId in Claude transcript" in result.output
+    assert source.read_text(encoding="utf-8") == source_contents
+    assert not (claude_home.path / "escaped.jsonl").exists()

--- a/tests/test_move_session.py
+++ b/tests/test_move_session.py
@@ -1,0 +1,626 @@
+"""End-to-end tests for name-aware ``aichat move`` resolution."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from claude_code_tools.aichat import main
+from claude_code_tools.session_utils import encode_claude_project_path
+from tests.resolve_session_helpers import (
+    FakeHome,
+    _write_claude_session,
+    claude_home,
+    codex_home,
+    runner,
+)
+
+__all__ = ["claude_home", "codex_home", "runner"]
+
+
+def _move_args(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    session: str,
+    new_project: Path,
+    *,
+    agent: str | None = None,
+) -> list[str]:
+    """Build a move invocation constrained to isolated fake homes."""
+    args = [
+        "--claude-home",
+        str(claude_home.path),
+        "--codex-home",
+        str(codex_home.path),
+        "move",
+        session,
+        str(new_project),
+    ]
+    if agent is not None:
+        args.extend(["--agent", agent])
+    return args
+
+
+def _json_lines(session_file: Path) -> list[object]:
+    """Read every JSON object from a fake transcript."""
+    return [
+        json.loads(line)
+        for line in session_file.read_text(encoding="utf-8").splitlines()
+    ]
+
+
+def _without_cwd(records: list[object], agent: str) -> list[object]:
+    """Return a deep copy with only move-managed cwd fields removed."""
+    copied = json.loads(json.dumps(records))
+    for record in copied:
+        if not isinstance(record, dict):
+            continue
+        if agent == "claude":
+            record.pop("cwd", None)
+            continue
+        record_type = record.get("type")
+        payload = record.get("payload")
+        if (
+            isinstance(record_type, str)
+            and record_type
+            in {"session_meta", "turn_context", "response_item"}
+            and isinstance(payload, dict)
+        ):
+            payload.pop("cwd", None)
+    return copied
+
+
+def _tree_snapshot(root: Path) -> dict[str, bytes | None]:
+    """Snapshot every relative path and file payload beneath a home."""
+    return {
+        str(path.relative_to(root)): (
+            path.read_bytes() if path.is_file() else None
+        )
+        for path in sorted(root.rglob("*"))
+    }
+
+
+def test_move_claude_session_by_name(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A named Claude transcript moves and rewrites all cwd fields."""
+    source = claude_home.files[2]
+    records = _json_lines(source)
+    records[1]["cwd"] = claude_home.directories[2]
+    records[2]["cwd"] = claude_home.directories[2]
+    source.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records),
+        encoding="utf-8",
+    )
+    new_project = tmp_path / "new.project_name"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            "Unique Deployment Review",
+            new_project,
+            agent="claude",
+        ),
+        input="n\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    destination = (
+        claude_home.path
+        / "projects"
+        / encode_claude_project_path(str(new_project.resolve()))
+        / source.name
+    )
+    assert destination.is_file()
+    assert not source.exists()
+    moved_records = _json_lines(destination)
+    assert len(moved_records) == len(records)
+    assert all(
+        isinstance(record, dict) and "cwd" in record
+        for record in moved_records
+    )
+    assert all(
+        record["cwd"] == str(new_project.resolve())
+        for record in moved_records
+        if isinstance(record, dict)
+    )
+    assert _without_cwd(moved_records, "claude") == _without_cwd(
+        records, "claude"
+    )
+
+
+def test_move_hex_name_outranks_another_sessions_id_fragment(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Move honors exact-name precedence for an 8+ character hex name."""
+    query = "deadbeef"
+    named = _write_claude_session(
+        claude_home.path,
+        "eeee4444-4444-4444-8444-444444444444",
+        claude_home.directories[0],
+        query,
+        1_720_000_000.0,
+    )
+    fragment = _write_claude_session(
+        claude_home.path,
+        f"ffff{query}-beef-4444-8444-444444444444",
+        claude_home.directories[1],
+        "Different session",
+        1_720_000_001.0,
+    )
+    fragment_contents = fragment.read_bytes()
+    new_project = tmp_path / "hex-name-destination"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            query,
+            new_project,
+            agent="claude",
+        ),
+        input="n\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    destination = (
+        claude_home.path
+        / "projects"
+        / encode_claude_project_path(str(new_project.resolve()))
+        / named.name
+    )
+    assert destination.is_file()
+    assert not named.exists()
+    assert fragment.is_file()
+    assert fragment.read_bytes() == fragment_contents
+
+
+def test_move_codex_session_by_name_updates_in_place(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A named Codex rollout is rewritten without changing its path."""
+    source = codex_home.files[2]
+    records = _json_lines(source)
+    records.extend(
+        [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "cwd": codex_home.directories[2],
+                },
+            },
+            {
+                "type": "turn_context",
+                "payload": {
+                    "cwd": codex_home.directories[2],
+                    "approval_policy": "never",
+                },
+            },
+            {"type": ["turn_context"], "payload": {"cwd": "unchanged"}},
+            {"type": "turn_context", "payload": None},
+            {"type": "turn_context", "payload": ["unchanged"]},
+            {"type": "turn_context", "payload": {"cwd": "rewrite-me"}},
+            None,
+            ["non-dict", "record"],
+        ]
+    )
+    source.write_text(
+        "".join(f"{json.dumps(record)}\n" for record in records),
+        encoding="utf-8",
+    )
+    original_rollouts = set(
+        (codex_home.path / "sessions").rglob("*.jsonl")
+    )
+    new_project = tmp_path / "new-codex-project"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            "Unique Codex Migration",
+            new_project,
+            agent="codex",
+        ),
+        input="n\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert source.is_file()
+    assert set((codex_home.path / "sessions").rglob("*.jsonl")) == (
+        original_rollouts
+    )
+    moved_records = [
+        json.loads(line)
+        for line in source.read_text(encoding="utf-8").splitlines()
+    ]
+    cwd_values = [
+        payload["cwd"]
+        for record in moved_records
+        if isinstance(record, dict)
+        if isinstance((payload := record.get("payload")), dict)
+        and isinstance(record.get("type"), str)
+        and record["type"] in {"session_meta", "turn_context", "response_item"}
+        and "cwd" in payload
+    ]
+    assert cwd_values == [str(new_project.resolve())] * 4
+    assert moved_records[-6:-2] == [
+        {"type": ["turn_context"], "payload": {"cwd": "unchanged"}},
+        {"type": "turn_context", "payload": None},
+        {"type": "turn_context", "payload": ["unchanged"]},
+        {
+            "type": "turn_context",
+            "payload": {"cwd": str(new_project.resolve())},
+        },
+    ]
+    assert moved_records[-2:] == [None, ["non-dict", "record"]]
+    assert _without_cwd(moved_records, "codex") == _without_cwd(
+        records, "codex"
+    )
+
+
+def test_move_codex_id_atomically_replaces_discovered_symlink(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A Codex move replaces its discovered link with a complete file."""
+    discovered = codex_home.files[2]
+    external = tmp_path / "external-codex-session.jsonl"
+    external.write_bytes(discovered.read_bytes())
+    original_target = external.read_bytes()
+    original_records = _json_lines(external)
+    discovered.unlink()
+    discovered.symlink_to(external)
+    new_project = tmp_path / "atomic-codex-destination"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            codex_home.ids[2],
+            new_project,
+            agent="codex",
+        ),
+        input="n\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert discovered.is_file()
+    assert not discovered.is_symlink()
+    assert external.read_bytes() == original_target
+    moved_records = _json_lines(discovered)
+    assert len(moved_records) == len(original_records)
+    assert _without_cwd(moved_records, "codex") == _without_cwd(
+        original_records, "codex"
+    )
+    assert all(
+        record["payload"]["cwd"] == str(new_project.resolve())
+        for record in moved_records
+        if isinstance(record, dict)
+        and record.get("type") in {"session_meta", "turn_context"}
+        and isinstance(record.get("payload"), dict)
+        and "cwd" in record["payload"]
+    )
+    assert not list(discovered.parent.glob(f".{discovered.stem}.*.tmp"))
+
+
+def test_move_full_codex_id_rejects_filename_content_mismatch(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A full filename ID cannot select a different content-ID session."""
+    misleading_id = codex_home.ids[1]
+    misleading_link = codex_home.files[1]
+    content_target = codex_home.files[2]
+    original_target = content_target.read_bytes()
+    misleading_link.unlink()
+    misleading_link.symlink_to(content_target)
+    connection = sqlite3.connect(codex_home.path / "state_5.sqlite")
+    try:
+        connection.execute(
+            "UPDATE threads SET archived = 1 WHERE id = ?",
+            (misleading_id,),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    new_project = tmp_path / "codex-mismatch-destination"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            misleading_id,
+            new_project,
+            agent="codex",
+        ),
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "Error: Session not found" in result.output
+    assert misleading_link.is_symlink()
+    assert content_target.is_file()
+    assert content_target.read_bytes() == original_target
+
+
+def test_move_claude_symlink_preserves_target(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Moving an explicit symlink removes only the link, not its target."""
+    target = claude_home.files[2]
+    original_target = target.read_bytes()
+    symlink = tmp_path / "linked-session.jsonl"
+    symlink.symlink_to(target)
+    new_project = tmp_path / "symlink-destination"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            str(symlink),
+            new_project,
+            agent="claude",
+        ),
+        input="n\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    destination = (
+        claude_home.path
+        / "projects"
+        / encode_claude_project_path(str(new_project.resolve()))
+        / symlink.name
+    )
+    assert destination.is_file()
+    assert not symlink.exists()
+    assert target.is_file()
+    assert target.read_bytes() == original_target
+    moved_records = _json_lines(destination)
+    cwd_values = [
+        record["cwd"] for record in moved_records if "cwd" in record
+    ]
+    assert cwd_values == [str(new_project.resolve())] * len(cwd_values)
+
+
+def test_move_claude_symlink_by_id_preserves_target(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """ID lookup moves the discovered link without unlinking its target."""
+    discovered = claude_home.files[2]
+    external = tmp_path / "external-session.jsonl"
+    external.write_bytes(discovered.read_bytes())
+    original_target = external.read_bytes()
+    discovered.unlink()
+    discovered.symlink_to(external)
+    new_project = tmp_path / "id-symlink-destination"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            claude_home.ids[2],
+            new_project,
+            agent="claude",
+        ),
+        input="n\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    destination = (
+        claude_home.path
+        / "projects"
+        / encode_claude_project_path(str(new_project.resolve()))
+        / discovered.name
+    )
+    assert destination.is_file()
+    assert not discovered.exists()
+    assert external.is_file()
+    assert external.read_bytes() == original_target
+    moved_records = _json_lines(destination)
+    cwd_values = [
+        record["cwd"] for record in moved_records if "cwd" in record
+    ]
+    assert cwd_values == [str(new_project.resolve())] * len(cwd_values)
+
+
+def test_move_claude_symlink_by_name_preserves_target(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Name lookup moves an in-home link without deleting its target."""
+    discovered = claude_home.files[2]
+    external = tmp_path / "named-external-session.jsonl"
+    external.write_bytes(discovered.read_bytes())
+    original_target = external.read_bytes()
+    discovered.unlink()
+    discovered.symlink_to(external)
+    new_project = tmp_path / "name-symlink-destination"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            "Unique Deployment Review",
+            new_project,
+            agent="claude",
+        ),
+        input="n\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    destination = (
+        claude_home.path
+        / "projects"
+        / encode_claude_project_path(str(new_project.resolve()))
+        / discovered.name
+    )
+    assert destination.is_file()
+    assert not discovered.exists()
+    assert external.is_file()
+    assert external.read_bytes() == original_target
+
+
+def test_move_name_rejects_two_links_to_external_transcript(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Two in-home links are ambiguous and preserve the external target."""
+    first_link = claude_home.files[2]
+    external = tmp_path / "shared-named-external.jsonl"
+    external.write_bytes(first_link.read_bytes())
+    original_target = external.read_bytes()
+    first_link.unlink()
+    first_link.symlink_to(external)
+    second_project = claude_home.path / "projects" / "second-link-project"
+    second_project.mkdir()
+    second_link = second_project / first_link.name
+    second_link.symlink_to(external)
+    new_project = tmp_path / "two-links-destination"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            "Unique Deployment Review",
+            new_project,
+            agent="claude",
+        ),
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "Error: Ambiguous session 'Unique Deployment Review'" in (
+        result.output
+    )
+    assert str(first_link.absolute()) in result.output
+    assert str(second_link.absolute()) in result.output
+    assert first_link.is_symlink()
+    assert second_link.is_symlink()
+    assert external.is_file()
+    assert external.read_bytes() == original_target
+    encoded = encode_claude_project_path(str(new_project.resolve()))
+    assert not (claude_home.path / "projects" / encoded).exists()
+
+
+def test_ambiguous_move_exits_without_mutation(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """An ambiguous name exits one and leaves every candidate untouched."""
+    original_homes = {
+        "claude": _tree_snapshot(claude_home.path),
+        "codex": _tree_snapshot(codex_home.path),
+    }
+    new_project = tmp_path / "ambiguous-target"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            "Shared Plan",
+            new_project,
+            agent="claude",
+        ),
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "Error: Ambiguous session 'Shared Plan'" in result.output
+    assert {
+        "claude": _tree_snapshot(claude_home.path),
+        "codex": _tree_snapshot(codex_home.path),
+    } == original_homes
+    encoded = encode_claude_project_path(str(new_project.resolve()))
+    destination = claude_home.path / "projects" / encoded
+    assert not destination.exists()
+
+
+def test_move_rejects_direct_path_outside_agent_constraint(
+    tmp_path: Path,
+    runner: CliRunner,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A direct Codex path cannot be relabeled and moved as Claude."""
+    source = codex_home.files[2]
+    source_contents = source.read_bytes()
+    new_project = tmp_path / "wrong-agent-target"
+    new_project.mkdir()
+
+    result = runner.invoke(
+        main,
+        _move_args(
+            claude_home,
+            codex_home,
+            str(source),
+            new_project,
+            agent="claude",
+        ),
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "is a codex session, but --agent claude was specified" in (
+        result.output
+    )
+    assert source.is_file()
+    assert source.read_bytes() == source_contents
+    encoded = encode_claude_project_path(str(new_project.resolve()))
+    assert not (claude_home.path / "projects" / encoded).exists()

--- a/tests/test_session_resolution.py
+++ b/tests/test_session_resolution.py
@@ -14,7 +14,9 @@ Tests cover all duplicated functions across:
 
 import json
 import os
+import sqlite3
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -31,6 +33,20 @@ from claude_code_tools.session_utils import (
     is_valid_session,
     is_malformed_session,
 )
+from claude_code_tools.resolve_session import resolve as resolve_full_session
+from claude_code_tools.session_resolution import (
+    ResolvedSessionQuery,
+    SessionQueryError,
+    resolve_session_query,
+)
+from tests.resolve_session_helpers import (
+    FakeHome,
+    _write_claude_session,
+    claude_home,
+    codex_home,
+)
+
+__all__ = ["claude_home", "codex_home"]
 
 
 class TestHomeDirectoryResolution:
@@ -511,6 +527,449 @@ class TestCommandIntegration:
         # but actual Claude sessions store it as metadata.git.branch, which is extracted
         # separately by extract_git_branch_claude(). For this test, we just verify the
         # session is found - git_branch extraction is tested separately in TestMetadataExtraction.
+
+
+def _resolve_query_in_fake_homes(
+    query: str,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    *,
+    agent: str | None = None,
+) -> ResolvedSessionQuery:
+    """Resolve against only the two supplied fake homes."""
+    return resolve_session_query(
+        query,
+        agent=agent,
+        claude_home=str(claude_home.path),
+        codex_home=str(codex_home.path),
+    )
+
+
+@pytest.mark.parametrize("agent_name", ["claude", "codex"])
+@pytest.mark.parametrize("query_kind", ["full", "prefix", "middle"])
+def test_shared_resolution_id_forms(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    agent_name: str,
+    query_kind: str,
+) -> None:
+    """Full ids, prefixes, and middle fragments resolve for both agents."""
+    home = claude_home if agent_name == "claude" else codex_home
+    session_id = home.ids[2]
+    queries = {
+        "full": session_id,
+        "prefix": session_id[:12],
+        "middle": session_id[9:21],
+    }
+    result = _resolve_query_in_fake_homes(
+        queries[query_kind],
+        claude_home,
+        codex_home,
+        agent=agent_name,
+    )
+    assert result.agent == agent_name
+    assert result.session_file == home.files[2].resolve()
+    assert result.directory == home.directories[2]
+
+
+@pytest.mark.parametrize(
+    ("agent_name", "name"),
+    [
+        ("claude", "Unique Deployment Review"),
+        ("codex", "Unique Codex Migration"),
+    ],
+)
+def test_shared_resolution_exact_session_names(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    agent_name: str,
+    name: str,
+) -> None:
+    """Claude custom titles and Codex thread names are accepted."""
+    home = claude_home if agent_name == "claude" else codex_home
+    result = _resolve_query_in_fake_homes(
+        name, claude_home, codex_home, agent=agent_name
+    )
+    assert result.session_file == home.files[2].resolve()
+
+
+def test_shared_resolution_rollout_filename_fragment(
+    claude_home: FakeHome, codex_home: FakeHome
+) -> None:
+    """A structural rollout filename fragment resolves one Codex file."""
+    query = f"2026-07-14T10-00-00-{codex_home.ids[2][:8]}"
+    result = _resolve_query_in_fake_homes(
+        query, claude_home, codex_home
+    )
+    assert result.agent == "codex"
+    assert result.session_file == codex_home.files[2].resolve()
+
+
+def test_shared_resolution_direct_path_prefers_content(
+    tmp_path: Path, claude_home: FakeHome, codex_home: FakeHome
+) -> None:
+    """Codex content copied under Claude's home remains Codex."""
+    project = claude_home.path / "projects" / "misplaced"
+    project.mkdir(parents=True)
+    misplaced = project / codex_home.files[2].name
+    misplaced.write_bytes(codex_home.files[2].read_bytes())
+
+    result = _resolve_query_in_fake_homes(
+        str(misplaced), claude_home, codex_home
+    )
+    assert result.agent == "codex"
+    assert result.session_file == misplaced.resolve()
+    assert result.directory == codex_home.directories[2]
+
+
+def test_shared_resolution_ambiguity_lists_candidates(
+    claude_home: FakeHome, codex_home: FakeHome
+) -> None:
+    """Ambiguity errors identify every matching candidate."""
+    with pytest.raises(SessionQueryError) as exc_info:
+        _resolve_query_in_fake_homes(
+            "Shared Plan",
+            claude_home,
+            codex_home,
+            agent="claude",
+        )
+    message = str(exc_info.value)
+    assert "Ambiguous session 'Shared Plan' matches 2 sessions" in message
+    assert claude_home.ids[0] in message
+    assert claude_home.ids[1] in message
+
+
+def test_shared_resolution_agent_constraint(
+    claude_home: FakeHome, codex_home: FakeHome
+) -> None:
+    """An agent constraint excludes an exact match from the other home."""
+    connection = sqlite3.connect(codex_home.path / "state_5.sqlite")
+    try:
+        connection.execute(
+            "UPDATE threads SET title = ? WHERE id = ?",
+            ("Unique Deployment Review", codex_home.ids[2]),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with pytest.raises(SessionQueryError, match="Ambiguous"):
+        _resolve_query_in_fake_homes(
+            "Unique Deployment Review", claude_home, codex_home
+        )
+    result = _resolve_query_in_fake_homes(
+        "Unique Deployment Review",
+        claude_home,
+        codex_home,
+        agent="codex",
+    )
+    assert result.agent == "codex"
+    assert result.session_file == codex_home.files[2].resolve()
+
+
+@pytest.mark.parametrize("query_length", [12, 36])
+def test_shared_resolution_fast_path_matches_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    query_length: int,
+) -> None:
+    """An 8+ character prefix or full ID avoids full enumeration."""
+    from claude_code_tools import session_resolution
+
+    query = claude_home.ids[2][:query_length]
+    full_result = resolve_full_session(
+        query,
+        "claude",
+        claude_home.path,
+        fallback_on_database_error=True,
+    )
+    assert full_result.kind == "single"
+
+    validated: set[Path] = set()
+    original_metadata = session_resolution._metadata_for_path
+
+    def track_metadata(
+        candidate_agent: str, candidate_path: Path
+    ) -> tuple[str | None, str | None]:
+        validated.add(candidate_path)
+        return original_metadata(candidate_agent, candidate_path)
+
+    def fail_full_resolver(*args: object) -> None:
+        raise AssertionError("8+ character prefix reached full resolver")
+
+    monkeypatch.setattr(
+        session_resolution, "_metadata_for_path", track_metadata
+    )
+    monkeypatch.setattr(
+        session_resolution, "_resolve_query_for_agent", fail_full_resolver
+    )
+    fast_result = _resolve_query_in_fake_homes(
+        query, claude_home, codex_home, agent="claude"
+    )
+
+    assert fast_result.session_file == Path(
+        full_result.records[0].session_file
+    )
+    assert fast_result.directory == full_result.records[0].directory
+    assert 0 < len(validated) <= 25
+
+
+def test_shared_resolution_fast_path_can_be_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Falling through from an id-like query preserves the selection."""
+    from claude_code_tools import session_resolution
+
+    query = codex_home.ids[2]
+    expected = _resolve_query_in_fake_homes(
+        query, claude_home, codex_home, agent="codex"
+    )
+
+    def disable_fast_path(*args: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        session_resolution, "_validated_fast_candidates", disable_fast_path
+    )
+    actual = _resolve_query_in_fake_homes(
+        query, claude_home, codex_home, agent="codex"
+    )
+    assert actual == expected
+
+
+def test_shared_resolution_name_bypasses_fast_path(
+    monkeypatch: pytest.MonkeyPatch,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Free-text names bypass filename-glob validation entirely."""
+    from claude_code_tools import session_resolution
+
+    def fail_fast_path(*args: object) -> None:
+        raise AssertionError("name query entered the fast path")
+
+    monkeypatch.setattr(
+        session_resolution, "_validated_fast_candidates", fail_fast_path
+    )
+    result = _resolve_query_in_fake_homes(
+        "Unique Deployment Review",
+        claude_home,
+        codex_home,
+        agent="claude",
+    )
+    assert result.session_file == claude_home.files[2].resolve()
+
+
+@pytest.mark.parametrize("query", ["dead", "deadb", "deadbe", "deadbee"])
+def test_short_hex_query_defers_to_exact_name(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    query: str,
+) -> None:
+    """Exact hex-like names of lengths four through seven outrank IDs."""
+    named = _write_claude_session(
+        claude_home.path,
+        "eeee4444-4444-4444-8444-444444444444",
+        claude_home.directories[0],
+        query,
+        1_720_000_000.0,
+    )
+    _write_claude_session(
+        claude_home.path,
+        f"ffff{query}-beef-4444-8444-444444444444",
+        claude_home.directories[1],
+        "Different session",
+        1_720_000_001.0,
+    )
+
+    result = _resolve_query_in_fake_homes(
+        query, claude_home, codex_home, agent="claude"
+    )
+
+    assert result.session_file == named.resolve()
+
+
+def test_fast_path_filesystem_error_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A failed bounded enumeration does not abort authoritative lookup."""
+    from claude_code_tools import session_resolution
+
+    def fail_enumeration(
+        *args: object, **kwargs: object
+    ) -> Iterator[tuple[str, Path]]:
+        raise OSError("unreadable directory")
+        yield
+
+    monkeypatch.setattr(
+        session_resolution, "_iter_named_session_files", fail_enumeration
+    )
+    result = _resolve_query_in_fake_homes(
+        claude_home.ids[2][:12],
+        claude_home,
+        codex_home,
+        agent="claude",
+    )
+    assert result.session_file == claude_home.files[2].resolve()
+
+
+def test_fast_path_rejects_invalid_codex_filename_match(
+    tmp_path: Path,
+) -> None:
+    """Garbage in a matching rollout filename is not a fast-path session."""
+    claude = tmp_path / "claude"
+    codex = tmp_path / "codex"
+    rollout = codex / "sessions" / "2026" / "07" / "24"
+    rollout.mkdir(parents=True)
+    invalid = rollout / (
+        "rollout-2026-07-24T10-00-00-abc12345-"
+        "1111-4111-8111-111111111111.jsonl"
+    )
+    invalid.write_text("garbage\n", encoding="utf-8")
+
+    with pytest.raises(SessionQueryError, match="Session not found"):
+        resolve_session_query(
+            "abc12345",
+            agent="codex",
+            claude_home=str(claude),
+            codex_home=str(codex),
+        )
+
+
+def test_short_id_uses_bounded_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A unique 4-7 character ID avoids full resolver enumeration."""
+    from claude_code_tools import session_resolution
+
+    def fail_full_resolver(*args: object) -> None:
+        raise AssertionError("unique short ID reached full resolver")
+
+    monkeypatch.setattr(
+        session_resolution, "_resolve_query_for_agent", fail_full_resolver
+    )
+    result = _resolve_query_in_fake_homes(
+        codex_home.ids[2][:6],
+        claude_home,
+        codex_home,
+        agent="codex",
+    )
+
+    assert result.session_file == codex_home.files[2].resolve()
+
+
+def test_fast_path_cap_applies_after_agent_filter(
+    monkeypatch: pytest.MonkeyPatch,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Irrelevant matches neither consume the cap nor get read."""
+    from claude_code_tools import session_resolution
+
+    query = codex_home.ids[2][:12]
+    project = claude_home.path / "projects" / "many-irrelevant-matches"
+    project.mkdir()
+    irrelevant = {
+        project / f"{index:02d}-{query}-garbage.jsonl"
+        for index in range(26)
+    }
+    for path in irrelevant:
+        path.write_text("garbage\n", encoding="utf-8")
+    reads: set[Path] = set()
+    original_valid = session_resolution.is_valid_session
+    original_metadata = session_resolution.extract_session_metadata_codex
+
+    def track_valid(path: Path) -> bool:
+        reads.add(path)
+        return original_valid(path)
+
+    def track_metadata(path: Path) -> dict[object, object] | None:
+        reads.add(path)
+        return original_metadata(path)
+
+    def fail_full_resolver(*args: object) -> None:
+        raise AssertionError("agent-filtered candidate reached full resolver")
+
+    monkeypatch.setattr(session_resolution, "is_valid_session", track_valid)
+    monkeypatch.setattr(
+        session_resolution,
+        "extract_session_metadata_codex",
+        track_metadata,
+    )
+    monkeypatch.setattr(
+        session_resolution, "_resolve_query_for_agent", fail_full_resolver
+    )
+
+    result = _resolve_query_in_fake_homes(
+        query, claude_home, codex_home, agent="codex"
+    )
+
+    assert result.session_file == codex_home.files[2].resolve()
+    assert reads == {codex_home.files[2].resolve()}
+    assert reads.isdisjoint(irrelevant)
+
+
+def test_fast_path_stops_before_reading_candidate_26(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """More than 25 relevant filename matches are not validated."""
+    from claude_code_tools import session_resolution
+
+    query = "deadbeef"
+    claude = tmp_path / "claude"
+    codex = tmp_path / "codex"
+    project = claude / "projects" / "cap-boundary"
+    project.mkdir(parents=True)
+    candidates = [
+        project / f"{index:02d}-{query}-candidate.jsonl"
+        for index in range(26)
+    ]
+    for path in candidates:
+        path.write_text("garbage\n", encoding="utf-8")
+    reads: set[Path] = set()
+
+    def track_malformed(path: Path) -> bool:
+        reads.add(path)
+        return True
+
+    monkeypatch.setattr(
+        session_resolution, "is_malformed_session", track_malformed
+    )
+
+    result = session_resolution._validated_fast_candidates(
+        query,
+        "claude",
+        str(claude),
+        str(codex),
+    )
+
+    assert result is None
+    assert reads == set()
+
+
+def test_direct_symlink_path_is_preserved(
+    tmp_path: Path,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Direct-path resolution retains the supplied symlink for mutation."""
+    link = tmp_path / "session-link.jsonl"
+    link.symlink_to(claude_home.files[2])
+
+    result = _resolve_query_in_fake_homes(
+        str(link), claude_home, codex_home
+    )
+
+    assert result.session_file == link.absolute()
+    assert result.session_file.is_symlink()
 
 
 if __name__ == "__main__":

--- a/tests/test_session_resolution_review.py
+++ b/tests/test_session_resolution_review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
@@ -66,6 +67,181 @@ def test_long_hex_exact_name_outranks_id_fragment(
     )
 
     assert result.session_file == named.resolve()
+
+
+def test_cross_agent_exact_name_outranks_id_substring(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Global tier ordering favors an exact name across agent homes."""
+    query = "deadbeef"
+    named = _write_claude_session(
+        claude_home.path,
+        "eeee4444-4444-4444-8444-444444444444",
+        claude_home.directories[0],
+        query,
+        1_720_000_000.0,
+    )
+    _write_codex_session(
+        codex_home.path,
+        f"eeee{query}-4444-4444-8444-444444444444",
+        codex_home.directories[1],
+        1_720_000_001.0,
+    )
+
+    result = _resolve(query, claude_home, codex_home)
+
+    assert result.agent == "claude"
+    assert result.session_file == named.resolve()
+
+
+def test_direct_path_rejects_superficial_codex_marker(
+    tmp_path: Path,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Content detection alone cannot make malformed Codex JSONL resumable."""
+    malformed = tmp_path / "not-session.jsonl"
+    malformed.write_text(
+        '{"type":"response_item","payload":null}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SessionQueryError, match="Could not detect agent"):
+        _resolve(str(malformed), claude_home, codex_home)
+
+
+def test_direct_path_preserves_content_detected_claude_behavior(
+    tmp_path: Path,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Direct-path validation does not change content-detected Claude files."""
+    session_file = tmp_path / "content-detected-claude.jsonl"
+    session_file.write_text(
+        '{"type":"custom-title","sessionId":"superficial"}\n',
+        encoding="utf-8",
+    )
+
+    result = _resolve(str(session_file), claude_home, codex_home)
+
+    assert result.agent == "claude"
+    assert result.session_file == session_file.absolute()
+
+
+def test_full_id_fast_path_checks_codex_database_collision(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A database-only duplicate full ID remains ambiguous."""
+    session_id = "11111111-1111-4111-8111-111111111111"
+    _write_claude_session(
+        claude_home.path,
+        session_id,
+        claude_home.directories[0],
+        "Claude duplicate",
+        1_720_000_100.0,
+    )
+    rollout = _write_codex_session(
+        codex_home.path,
+        session_id,
+        codex_home.directories[0],
+        1_720_000_101.0,
+    )
+    archived = codex_home.path / "archived_sessions" / rollout.name
+    archived.parent.mkdir()
+    rollout.rename(archived)
+    _insert_codex_thread(
+        codex_home.path / "state_5.sqlite",
+        session_id,
+        archived,
+        codex_home.directories[0],
+        "Codex duplicate",
+        1_720_000_101,
+        archived=True,
+    )
+
+    with pytest.raises(SessionQueryError, match="Ambiguous session") as error:
+        _resolve(session_id, claude_home, codex_home)
+
+    assert "[claude]" in str(error.value)
+    assert "[codex]" in str(error.value)
+
+
+def test_full_id_discards_ambiguous_filename_with_mismatched_content(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Content-ID validation precedes resolver ambiguity classification."""
+    session_id = "11111111-1111-4111-8111-111111111111"
+    expected = _write_claude_session(
+        claude_home.path,
+        session_id,
+        claude_home.directories[0],
+        "Expected session",
+        1_720_000_100.0,
+    )
+    misleading = (
+        claude_home.path
+        / "projects"
+        / "z-bad"
+        / f"{session_id}.jsonl"
+    )
+    misleading.parent.mkdir()
+    misleading.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "sessionId": "22222222-2222-4222-8222-222222222222",
+                "cwd": claude_home.directories[1],
+                "message": {"role": "user", "content": "misleading"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _resolve(
+        session_id, claude_home, codex_home, agent="claude"
+    )
+
+    assert result.session_file == expected.resolve()
+
+
+def test_truncated_mismatched_records_preserve_ambiguity(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Unvalidated records beyond the resolver cap prevent false not-found."""
+    session_id = "11111111-1111-4111-8111-111111111111"
+    for index in range(26):
+        session_file = (
+            claude_home.path
+            / "projects"
+            / f"duplicate-{index:02d}"
+            / f"{session_id}.jsonl"
+        )
+        session_file.parent.mkdir()
+        session_file.write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "sessionId": (
+                        session_id
+                        if index == 0
+                        else "22222222-2222-4222-8222-222222222222"
+                    ),
+                    "cwd": claude_home.directories[0],
+                    "message": {"role": "user", "content": str(index)},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        session_file.touch()
+
+    with pytest.raises(SessionQueryError, match="Ambiguous session"):
+        _resolve(session_id, claude_home, codex_home, agent="claude")
 
 
 def test_id_lookup_preserves_discovered_symlink(

--- a/tests/test_session_resolution_review.py
+++ b/tests/test_session_resolution_review.py
@@ -1,0 +1,194 @@
+"""Regression tests for reviewed shared-session resolution edge cases."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from claude_code_tools.session_resolution import (
+    ResolvedSessionQuery,
+    SessionQueryError,
+    resolve_session_query,
+)
+from tests.resolve_session_helpers import (
+    FakeHome,
+    _insert_codex_thread,
+    _write_claude_session,
+    _write_codex_session,
+    claude_home,
+    codex_home,
+)
+
+__all__ = ["claude_home", "codex_home"]
+
+
+def _resolve(
+    query: str,
+    claude: FakeHome,
+    codex: FakeHome,
+    *,
+    agent: str | None = None,
+) -> ResolvedSessionQuery:
+    """Resolve a query against isolated test homes."""
+    return resolve_session_query(
+        query,
+        agent=agent,
+        claude_home=str(claude.path),
+        codex_home=str(codex.path),
+    )
+
+
+def test_long_hex_exact_name_outranks_id_fragment(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """An 8+ character exact name outranks another session's partial ID."""
+    query = "deadbeef"
+    named = _write_claude_session(
+        claude_home.path,
+        "eeee4444-4444-4444-8444-444444444444",
+        claude_home.directories[0],
+        query,
+        1_720_000_000.0,
+    )
+    _write_claude_session(
+        claude_home.path,
+        f"ffff{query}-beef-4444-8444-444444444444",
+        claude_home.directories[1],
+        "Different session",
+        1_720_000_001.0,
+    )
+
+    result = _resolve(
+        query, claude_home, codex_home, agent="claude"
+    )
+
+    assert result.session_file == named.resolve()
+
+
+def test_id_lookup_preserves_discovered_symlink(
+    tmp_path: Path,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """ID resolution retains an in-home symlink rather than its referent."""
+    external = tmp_path / "external-session.jsonl"
+    external.write_bytes(claude_home.files[2].read_bytes())
+    discovered = claude_home.files[2]
+    discovered.unlink()
+    discovered.symlink_to(external)
+
+    result = _resolve(
+        claude_home.ids[2],
+        claude_home,
+        codex_home,
+        agent="claude",
+    )
+
+    assert result.session_file == discovered.absolute()
+    assert result.session_file.is_symlink()
+    assert result.session_file.resolve() == external.resolve()
+
+
+def test_constrained_invalid_home_surfaces_resolver_error(
+    tmp_path: Path,
+) -> None:
+    """A missing constrained home is not mislabeled as a missing session."""
+    missing = tmp_path / "missing-claude-home"
+
+    with pytest.raises(SessionQueryError, match="Home does not exist"):
+        resolve_session_query(
+            "deadbeef",
+            agent="claude",
+            claude_home=str(missing),
+        )
+
+
+def test_failed_other_agent_is_suppressed_when_match_exists(
+    tmp_path: Path,
+    codex_home: FakeHome,
+) -> None:
+    """A usable result wins over another agent home's operational failure."""
+    missing = tmp_path / "missing-claude-home"
+
+    result = resolve_session_query(
+        codex_home.ids[2],
+        claude_home=str(missing),
+        codex_home=str(codex_home.path),
+    )
+
+    assert result.agent == "codex"
+    assert result.session_file == codex_home.files[2].resolve()
+
+
+def test_stray_codex_state_file_cannot_bypass_exact_name(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A nonnumeric state filename does not defeat exact-name precedence."""
+    query = "deadbeef"
+    database = codex_home.path / "state_5.sqlite"
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "UPDATE threads SET title = ? WHERE id = ?",
+            (query, codex_home.ids[0]),
+        )
+        connection.commit()
+    fragment = _write_codex_session(
+        codex_home.path,
+        f"eeee{query}-4444-4444-8444-444444444444",
+        codex_home.directories[1],
+        1_720_000_000.0,
+    )
+    (codex_home.path / "state_backup.sqlite").touch()
+
+    result = _resolve(
+        query, claude_home, codex_home, agent="codex"
+    )
+
+    assert fragment != codex_home.files[0]
+    assert result.session_file == codex_home.files[0].resolve()
+
+
+def test_database_id_prefix_outranks_active_mid_id_fragment(
+    tmp_path: Path,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A database-only ID prefix forces full tiered resolution."""
+    query = "deadbeef"
+    archived_id = "deadbeef-1111-4111-8111-111111111111"
+    active_id = "ffff1111-beef-4111-8111-1111deadbeef"
+    archived_source = _write_codex_session(
+        codex_home.path,
+        archived_id,
+        str(tmp_path / "archived"),
+        1_720_000_000.0,
+    )
+    archived = codex_home.path / "archived_sessions" / archived_source.name
+    archived.parent.mkdir()
+    archived_source.rename(archived)
+    active = _write_codex_session(
+        codex_home.path,
+        active_id,
+        str(tmp_path / "active"),
+        1_720_000_001.0,
+    )
+    _insert_codex_thread(
+        codex_home.path / "state_5.sqlite",
+        archived_id,
+        archived,
+        str(tmp_path / "archived"),
+        "Archived exact prefix",
+        1_720_000_000,
+        archived=True,
+    )
+
+    result = _resolve(
+        query, claude_home, codex_home, agent="codex"
+    )
+
+    assert query in active.name
+    assert result.session_file == archived.resolve()


### PR DESCRIPTION
## Problem

`aichat move` only accepted something that looked like a session id. Under the hood it — and eight sibling commands — used `session_utils.find_session_file()`, which globs `*<query>*.jsonl` across both agent homes and returns the **first** hit. So:

- session **names** (Claude `/rename` custom titles, Codex thread names) never worked;
- an ambiguous fragment **silently** resolved to an arbitrary file (sorted order, Claude home first) — for a mutating command like `move`, that means editing the wrong transcript;
- `--agent` didn't constrain the search, it only relabelled the result afterwards.

`aichat resolve` already did this properly (exact id → exact name → id prefix → id substring → name substring → rollout filename fragment), and `port_service.resolve_port_session()` already wrapped it across both homes with content-first path classification and a real ambiguity error.

## Why not just call the resolver everywhere

It enumerates and content-sniffs every session file before matching, so the cost is constant regardless of which tier wins. Measured warm on a real home with 4,774 Claude transcripts:

| | |
|---|---|
| `aichat resolve --agent claude <miss>` | 12.5s |
| `aichat resolve --agent codex <miss>` | 4.1s |

The tantivy index doesn't help — `resolve` deliberately skips auto-indexing and reads the JSONL files directly. Making every command pay ~16s was not acceptable. Speeding up the resolver itself is a separate project and explicitly out of scope here.

## Solution

New `claude_code_tools/session_resolution.py` resolving in three layers:

1. **Direct file path**, classified content-first.
2. **Bounded filename fast path** for id-like queries — capped at 25 candidates, identity taken from the candidate's *content* rather than its filename, and applying the resolver's malformed/sidechain exclusions so it can never return a session the resolver would consider ineligible.
3. **Full resolver** for everything else.

An exact full id short-circuits immediately: it's the resolver's top tier, so nothing can outrank it. Shorter fragments first rule out an exact-name match, which preserves the resolver's tier ordering rather than quietly diverging from it.

| query | before | after |
|---|---|---|
| full UUID | instant | 0.19s |
| partial id | instant | ~2.0s |
| session name | **didn't work** | resolver speed |

The ~2s on partials is the exact-name conflict check. Against the ~4.5s the CLI already spends auto-indexing, it's noise.

## Scope

Converted: `move`, `info`, `copy`, `query`, `clone`, `rollover`, `lineage`, `smart-trim`, `export`, and the direct-action UI helper. Every `find_session_file` call in `aichat.py` is gone; the function itself is untouched for its other callers.

Behavior changes worth flagging:

- an ambiguous query now **fails with the candidate list** instead of picking one;
- `--agent` is a real search constraint on every command, including when it follows the positional argument (Click was leaving it in `ctx.args` because of `allow_interspersed_args=False`);
- `export` passes the **resolved path** downstream instead of the raw query, so names survive the hand-off to `export-claude-session` / `export-codex-session`.

`port_service.py` keeps its exact prior behavior — same exception type, same semantics, byte-identical ambiguity messages — and drops 384 → 247 lines by importing the extracted helpers. `aichat port` is deliberately unchanged.

Also in `move`: transcripts are now written atomically (temp file + `os.replace`), so an interrupted move can't leave a truncated session and a discovered symlink is replaced rather than written through; and the hand-rolled project-path encoding is replaced with the shared `encode_claude_project_path()`.

## Known accepted limitation

Exotic symlink topologies inside an agent home — a link whose canonical target also lives in the home, or two links that deduplicate to one fast-path candidate — may still resolve to the canonical target rather than the discovered link. Common cases are handled (a single discovered link maps back to itself; several links to one external transcript are rejected as ambiguous). This is documented in the module docstring so it reads as a decision rather than an oversight.

## Testing

**354 targeted tests pass**, covering name lookup for both agents end to end through the CLI, id prefixes and mid-id fragments, rollout filename fragments, ambiguity rejection asserting nothing was mutated, the `--agent` constraint before and after the positional argument, symlink handling, and `move` for both agents (Claude relocates the file and rewrites `cwd` on every line; Codex rewrites in place).

Full repo suite: **906 passed, 1 failed**. The failure is `test_tmux_cli_controller.py::TestCreatePane::test_invalid_pane_id_returns_none` — an `IndexError` parsing `tmux list-panes` output, in a file this PR doesn't touch. Environmental and pre-existing.

Two real bugs were caught and fixed during review, both with regression tests: `aichat smart-trim --dry-run` crashed with `NameError: name 'sys' is not defined` (the refactor dropped the import along with the old import block), and `export --agent` was silently ignored when it followed the session argument.

## Out of scope

`delete` (delegates straight to `delete_session.main`), `resume` / `menu` / `find-*` (Node UI with its own search), resolver performance, and `port`'s resolution semantics.

Note for a follow-up: `aichat.py` grew 93 lines net (2959 → 3052). It was already well over the repo's 1000-line guidance before this change; extracting `_resolve_cli_session`, `_resolve_export_session`, and `_extract_agent_option` would claw back ~90 lines.

---

## Update (99f4baf) — after the GitHub Codex review + a codex cold-diff loop

The reviewer caught that `aichat smart-trim SESSION` without `--instructions` bypassed the new resolution. The root cause was broader: `_find_and_run_session_ui()` resolved only on its `direct_action` branch, and its normal-mode branch passed the raw query into `session-menu`'s argv, where the legacy lookup took over. **`trim`, `smart-trim`, and `resume`** all reached it that way. Normal mode now resolves and passes the resolved absolute path downstream, which `session_menu_cli.py:284` already accepts and which cannot be re-ambiguated.

That widens this PR: **`trim` and `resume` were not in the original scope** (neither ever called `find_session_file`), and their session arguments now get name and ambiguity handling too.

Four more issues came out of the follow-up cold-diff loop:

- **Home overrides ignored on interactive paths** — `resume`, `trim`, and `smart-trim` each computed their effective `--claude-home` / `--codex-home` and then called the UI helper without them, so resolution used the *default* homes. A session living only in a custom home was reported missing, or a same-named default-home session was silently chosen. Now threaded through resolution, the menu arguments, and the action handlers.
- **Unvalidated Codex direct paths** — a location-derived Codex classification accepted *any* file under a Codex home, while the Claude side required `is_valid_session`. Fixed in `resolve_session_query` rather than inside `_detect_direct_path_agent`, which `port_service` imports, so `aichat port` is untouched.
- **`move` used the filename, not the session id** — moving an explicitly named path (say `backup.jsonl` whose content carries a different sessionId) produced a session neither Claude nor an id lookup could find. Destination name and resume id now come from the content session id.
- **`clone_session` crash** — its destination `mkdir` ran outside the error handling, so an unwritable Claude home produced a traceback; it now fails cleanly with a nonzero exit. It also accepts an optional `source_path` so a resolved transcript is cloned directly instead of reconstructed from cwd (defaults to the previous behavior).

Two transcript reads also gained explicit `encoding="utf-8", errors="replace"` so an undecodable byte cannot crash lineage or message counting.

### Files beyond the original scope

`find_claude_session.py` (the `source_path` parameter), `session_menu_cli.py` (passes it through), and `session_lineage.py` / `session_utils.py` (the encoding fixes). All small and backward compatible, but worth calling out rather than letting them slide in.

### Verification

**391 tests passing.** The change went through a codex cold-diff review loop — a contract-free reviewer that sees only the diff, plus a lens that actually executes every touched command through `CliRunner` — iterating until both returned zero blocking findings.

Two behaviors were investigated and consciously **not** changed, because they reproduce identically on `main` and are therefore not regressions from this PR: transcript validation reads physical lines unbounded (one enormous unterminated line could exhaust memory before the bounded resolver is reached), and exotic symlink topologies inside an agent home. Both are documented in `session_resolution.py`.
