### PR TITLE
Add writing plugin: agent-style + remove-ai-patterns skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -27,6 +27,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "writing",
+      "source": {
+        "source": "local",
+        "path": "./plugins/writing"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,6 +49,11 @@
       "name": "agent-tunnel",
       "source": "./plugins/agent-tunnel",
       "description": "Publish the current Claude session via >share so teammates can ask it questions through the agent-tunnel Discord bot (read-only forks)"
+    },
+    {
+      "name": "writing",
+      "source": "./plugins/writing",
+      "description": "Prose-quality skills: agent-style (21 literature-backed rules for formal technical prose) and remove-ai-patterns (de-AI text using the avoid-ai-writing catalog plus a deterministic detector)"
     }
   ]
 }

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -151,6 +151,10 @@ export default defineConfig({
               label: "Langroid",
               slug: "plugins-detail/langroid",
             },
+            {
+              label: "Writing",
+              slug: "plugins-detail/writing",
+            },
           ],
         },
         {

--- a/docs-site/src/content/docs/getting-started/plugins.mdx
+++ b/docs-site/src/content/docs/getting-started/plugins.mdx
@@ -28,6 +28,7 @@ This repo provides plugins for Codex and for the
 | `voice` | Spoken audio summaries |
 | `agent-tunnel` | `>share` a live session so teammates can ask it questions over Discord |
 | `dynamic-workflow` | Durable JavaScript orchestration for headless Codex agents |
+| `writing` | Prose-quality skills: agent-style rules and remove-ai-patterns de-AI-ing |
 
 ## Codex Plugin Installation
 
@@ -87,6 +88,7 @@ for its JavaScript API, state model, and safety boundaries.
    claude plugin install "langroid@cctools-plugins"
    claude plugin install "voice@cctools-plugins"
    claude plugin install "agent-tunnel@cctools-plugins"
+   claude plugin install "writing@cctools-plugins"
    ```
 
    Or use `/plugin` without arguments inside a
@@ -222,3 +224,24 @@ questions — `agent-tunnel serve` and the rest of the CLI — ships with the
 `claude-code-tools` package (`uv tool install claude-code-tools`). See the
 [agent-tunnel tool page](/claude-code-tools/tools/agent-tunnel/) for the full
 setup: creating the Discord bot, configuration, and running the daemon.
+
+---
+
+## writing Plugin
+
+Two explicit-trigger skills for prose quality; neither fires on ordinary
+writing tasks — you invoke them by name for a dedicated editing pass.
+
+| Skill | What it does |
+|-------|--------------|
+| `/agent-style` | 21 literature-backed rules for formal technical prose (papers, design docs, READMEs) |
+| `/remove-ai-patterns` | Remove AI-writing patterns at any register, with voice profiles and a deterministic Node.js detector |
+
+Both skills vendor a pinned snapshot of their upstream source
+([agent-style](https://github.com/yzhao062/agent-style), CC BY 4.0, and
+[avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing),
+MIT), so they work offline with no extra installs.
+
+See the
+[Writing detail page](/claude-code-tools/plugins-detail/writing/)
+for the two skills' lanes and the detector workflow.

--- a/docs-site/src/content/docs/getting-started/plugins.mdx
+++ b/docs-site/src/content/docs/getting-started/plugins.mdx
@@ -32,12 +32,19 @@ This repo provides plugins for Codex and for the
 
 ## Codex Plugin Installation
 
-Install the dynamic workflow plugin from the Codex marketplace in this repo:
+This repo also hosts a Codex marketplace (`cctools-codex-plugins`, read
+from `.agents/plugins/marketplace.json`), currently offering the
+`dynamic-workflow`, `voxtype`, and `writing` plugins. Add it once, then
+install with `codex plugin add`:
 
 ```bash
 codex plugin marketplace add pchalasani/claude-code-tools
+codex plugin marketplace upgrade cctools-codex-plugins  # refresh if already added
 codex plugin add dynamic-workflow@cctools-codex-plugins
+codex plugin add writing@cctools-codex-plugins
 ```
+
+### dynamic-workflow
 
 The plugin itself does not require `uv tool install claude-code-tools` or an
 `npm install`. It includes the skill and compiled runner; Node.js 20 or newer
@@ -231,6 +238,8 @@ setup: creating the Discord bot, configuration, and running the daemon.
 
 Two explicit-trigger skills for prose quality; neither fires on ordinary
 writing tasks — you invoke them by name for a dedicated editing pass.
+Works in both Claude Code (`writing@cctools-plugins`) and Codex
+(`writing@cctools-codex-plugins`).
 
 | Skill | What it does |
 |-------|--------------|
@@ -244,4 +253,5 @@ MIT), so they work offline with no extra installs.
 
 See the
 [Writing detail page](/claude-code-tools/plugins-detail/writing/)
-for the two skills' lanes and the detector workflow.
+for installation in both agents, the two skills' lanes, the detector
+workflow, and how the vendored upstream snapshots are updated.

--- a/docs-site/src/content/docs/plugins-detail/writing.mdx
+++ b/docs-site/src/content/docs/plugins-detail/writing.mdx
@@ -1,0 +1,90 @@
+---
+title: "Writing Plugin"
+description: >
+  Prose-quality skills: agent-style rules for formal
+  technical prose, and remove-ai-patterns for de-AI-ing
+  text with a deterministic detector.
+---
+
+import { Steps } from "@astrojs/starlight/components";
+
+<style>{`
+  table td:first-child,
+  table th:first-child {
+    white-space: nowrap;
+  }
+`}</style>
+
+The `writing` plugin bundles two skills for improving prose quality. Both
+are **explicit-trigger only**: they never fire on ordinary writing or
+documentation tasks, so they add no noise to normal sessions. You invoke
+them by name when you want a dedicated editing pass.
+
+Install via the Claude Code marketplace:
+
+```bash
+claude plugin install writing@cctools-plugins
+```
+
+## Skills
+
+| Skill | What It Does |
+|-------|--------------|
+| `writing:agent-style` | 21 literature-backed rules for formal technical prose (papers, design docs, proposals, READMEs, commit messages) |
+| `writing:remove-ai-patterns` | Remove AI-writing patterns ("AI-isms") from text at any register, with voice profiles and a deterministic detector |
+
+## Two lanes, not one
+
+The skills are complementary and deliberately kept apart:
+
+- **agent-style** is a clarity and composition ruleset for *formal*
+  technical prose: passive voice, needless words, claim calibration,
+  parallel structure, stress position, and a set of field-observed rules
+  about LLM habits (bullet overuse, dash overuse, summary closers, and so
+  on). It is based on
+  [The Elements of Agent Style](https://github.com/yzhao062/agent-style)
+  (CC BY 4.0).
+- **remove-ai-patterns** de-AIs text of *any* voice: it applies the
+  [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing)
+  catalog (MIT, by Conor Bronsdon) of AI-writing tells, supports voice
+  profiles (casual / professional / technical / warm / blunt), and ships
+  a self-contained Node.js detector for machine-checkable audits.
+
+Pick one as the final gate on a given document; interleaving passes of
+both tends to churn the same sentences back and forth.
+
+## How to Use
+
+Ask for a pass by name:
+
+> "Apply agent-style to this design doc."
+
+> "De-AI this blog post with remove-ai-patterns, technical voice, and
+> iterate until the detector is clean."
+
+> "Run a detect-only audit of README.md."
+
+### The deterministic detector
+
+remove-ai-patterns includes a JSON-emitting detector that needs only a
+`node` binary (no npm install):
+
+```bash
+node <skill-dir>/scripts/detect.js FILE
+```
+
+It reports an overall score, a label, a document classification, and
+per-issue findings with severities and suggestions. For "iterate until
+clean" requests the agent loops revise → detect until findings stop
+improving; the detector is the objective stopping criterion, so the loop
+cannot argue with itself about whether the text is done.
+
+## Vendored, pinned upstream content
+
+Each skill vendors a pinned snapshot of its upstream source (rule bodies,
+pattern catalog, detector), so the skills work offline and behave the
+same on every machine. The pinned commit of each upstream is recorded in
+an `UPSTREAM-PIN` file next to the vendored content, and upstream
+licenses are included alongside. Maintainers refresh the snapshots with
+`plugins/writing/scripts/update-upstream.sh` and review the diff before
+committing; users pick up refreshed catalogs by updating the plugin.

--- a/docs-site/src/content/docs/plugins-detail/writing.mdx
+++ b/docs-site/src/content/docs/plugins-detail/writing.mdx
@@ -1,12 +1,13 @@
 ---
 title: "Writing Plugin"
 description: >
-  Prose-quality skills: agent-style rules for formal
-  technical prose, and remove-ai-patterns for de-AI-ing
-  text with a deterministic detector.
+  Prose-quality skills for Claude Code and Codex:
+  agent-style rules for formal technical prose, and
+  remove-ai-patterns for de-AI-ing text with a
+  deterministic detector.
 ---
 
-import { Steps } from "@astrojs/starlight/components";
+import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <style>{`
   table td:first-child,
@@ -15,23 +16,57 @@ import { Steps } from "@astrojs/starlight/components";
   }
 `}</style>
 
-The `writing` plugin bundles two skills for improving prose quality. Both
-are **explicit-trigger only**: they never fire on ordinary writing or
-documentation tasks, so they add no noise to normal sessions. You invoke
-them by name when you want a dedicated editing pass.
-
-Install via the Claude Code marketplace:
-
-```bash
-claude plugin install writing@cctools-plugins
-```
+The `writing` plugin bundles two skills for improving prose quality, and
+works in **both Claude Code and Codex** (this repo hosts a marketplace
+for each). Both skills are **explicit-trigger only**: they never fire on
+ordinary writing or documentation tasks, so they add no noise to normal
+sessions. You invoke them by name when you want a dedicated editing
+pass.
 
 ## Skills
 
 | Skill | What It Does |
 |-------|--------------|
-| `writing:agent-style` | 21 literature-backed rules for formal technical prose (papers, design docs, proposals, READMEs, commit messages) |
-| `writing:remove-ai-patterns` | Remove AI-writing patterns ("AI-isms") from text at any register, with voice profiles and a deterministic detector |
+| `agent-style` | 21 literature-backed rules for formal technical prose (papers, design docs, proposals, READMEs, commit messages) |
+| `remove-ai-patterns` | Remove AI-writing patterns ("AI-isms") from text at any register, with voice profiles and a deterministic detector |
+
+## Installation
+
+The plugin is published in two marketplaces in the same repo: Claude
+Code reads `.claude-plugin/marketplace.json` (marketplace name
+`cctools-plugins`), Codex reads `.agents/plugins/marketplace.json`
+(marketplace name `cctools-codex-plugins`). Add the marketplace once,
+then install:
+
+<Tabs>
+<TabItem label="Claude Code">
+
+```bash
+claude plugin marketplace add pchalasani/claude-code-tools
+claude plugin marketplace update cctools-plugins   # refresh if already added
+claude plugin install writing@cctools-plugins
+```
+
+Or run `/plugin` inside a session for the interactive browser.
+
+</TabItem>
+<TabItem label="Codex">
+
+```bash
+codex plugin marketplace add pchalasani/claude-code-tools
+codex plugin marketplace upgrade cctools-codex-plugins  # refresh if already added
+codex plugin add writing@cctools-codex-plugins
+```
+
+If you added the marketplace before this plugin was published, the
+`upgrade` step is what refreshes the cached snapshot so the plugin
+shows up.
+
+</TabItem>
+</Tabs>
+
+No further setup: the skills are self-contained. The detector only
+needs a `node` binary on PATH (no `npm install`).
 
 ## Two lanes, not one
 
@@ -55,7 +90,8 @@ both tends to churn the same sentences back and forth.
 
 ## How to Use
 
-Ask for a pass by name:
+Usage is the same in Claude Code and Codex: ask for a pass by name, in
+natural language.
 
 > "Apply agent-style to this design doc."
 
@@ -64,10 +100,18 @@ Ask for a pass by name:
 
 > "Run a detect-only audit of README.md."
 
+remove-ai-patterns supports three modes (defined in its vendored
+catalog): **detect-only** (report findings, change nothing),
+**edit-in-place** (minimal rewrites at flagged spans, meaning
+preserved), and **iterate-to-convergence** (revise, re-detect, repeat
+until clean). agent-style keeps its 21 compact rules in the SKILL.md
+itself and the full rule bodies (BAD/GOOD pairs, rationale) in a
+vendored `references/RULES.md`.
+
 ### The deterministic detector
 
 remove-ai-patterns includes a JSON-emitting detector that needs only a
-`node` binary (no npm install):
+`node` binary:
 
 ```bash
 node <skill-dir>/scripts/detect.js FILE
@@ -79,12 +123,41 @@ clean" requests the agent loops revise → detect until findings stop
 improving; the detector is the objective stopping criterion, so the loop
 cannot argue with itself about whether the text is done.
 
-## Vendored, pinned upstream content
+## Updating the vendored catalogs
 
-Each skill vendors a pinned snapshot of its upstream source (rule bodies,
-pattern catalog, detector), so the skills work offline and behave the
-same on every machine. The pinned commit of each upstream is recorded in
-an `UPSTREAM-PIN` file next to the vendored content, and upstream
-licenses are included alongside. Maintainers refresh the snapshots with
-`plugins/writing/scripts/update-upstream.sh` and review the diff before
-committing; users pick up refreshed catalogs by updating the plugin.
+Both skills derive from third-party GitHub repos, and the plugin vendors
+a **pinned snapshot** of each (rule bodies, pattern catalog, detector)
+rather than fetching at install or run time. That makes the skills work
+offline and behave identically on every machine. The exact upstream
+commit is recorded next to the vendored content:
+
+- `plugins/writing/skills/agent-style/references/UPSTREAM-PIN`
+- `plugins/writing/skills/remove-ai-patterns/upstream/UPSTREAM-PIN`
+
+**As a user**, you never touch upstream directly; you pick up refreshed
+catalogs by updating the marketplace and reinstalling the plugin:
+
+```bash
+# Claude Code
+claude plugin marketplace update cctools-plugins
+claude plugin install writing@cctools-plugins
+
+# Codex
+codex plugin marketplace upgrade cctools-codex-plugins
+codex plugin add writing@cctools-codex-plugins
+```
+
+**As a maintainer** (or in your own fork), refresh the snapshots from
+the upstream repos with:
+
+```bash
+plugins/writing/scripts/update-upstream.sh
+```
+
+The script shallow-clones both upstreams, copies the vendored files,
+and rewrites the `UPSTREAM-PIN` files. It commits nothing: review the
+diff before committing, because freshly fetched rule text is
+third-party input (check that the changes are writing-rule content, not
+new tool invocations or scope changes). Upstream licenses (CC BY 4.0
+and MIT) ship alongside the vendored files, with attribution in
+`references/NOTICE.md`.

--- a/plugins/writing/.claude-plugin/plugin.json
+++ b/plugins/writing/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "writing",
+  "version": "1.0.0",
+  "description": "Prose-quality skills: agent-style (21 literature-backed rules for formal technical prose) and remove-ai-patterns (de-AI text using the avoid-ai-writing catalog plus a deterministic detector)",
+  "author": {
+    "name": "Prasad Chalasani"
+  }
+}

--- a/plugins/writing/.codex-plugin/plugin.json
+++ b/plugins/writing/.codex-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "writing",
+  "version": "1.0.0",
+  "description": "Prose-quality skills: agent-style (21 literature-backed rules for formal technical prose) and remove-ai-patterns (de-AI text using the avoid-ai-writing catalog plus a deterministic detector)",
+  "author": {
+    "name": "Prasad Chalasani"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "writing",
+    "shortDescription": "Prose-quality skills: agent-style and remove-ai-patterns",
+    "longDescription": "Two explicit-trigger skills for improving prose quality: agent-style applies 21 literature-backed rules for formal technical prose (papers, design docs, READMEs), and remove-ai-patterns removes AI-writing patterns at any register using the avoid-ai-writing catalog, voice profiles, and a deterministic Node.js detector.",
+    "developerName": "Prasad Chalasani",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Apply agent-style rules to formal technical prose",
+      "Remove AI-writing patterns with voice profiles",
+      "Deterministic AI-pattern detection (JSON audit)"
+    ],
+    "defaultPrompt": "Use $writing to de-AI this text with remove-ai-patterns, or apply agent-style rules to formal prose."
+  }
+}

--- a/plugins/writing/README.md
+++ b/plugins/writing/README.md
@@ -1,0 +1,46 @@
+# writing plugin
+
+Two skills for improving prose quality, both explicit-trigger only (they
+never fire on ordinary writing tasks):
+
+- **agent-style** — 21 literature-backed rules for FORMAL technical prose
+  (papers, design docs, proposals, READMEs, commit messages). Based on
+  [The Elements of Agent Style](https://github.com/yzhao062/agent-style),
+  CC BY 4.0.
+- **remove-ai-patterns** — remove AI-writing patterns ("AI-isms") from text
+  at any register, with voice profiles and a deterministic Node.js
+  detector. Wraps
+  [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing)
+  (MIT) by Conor Bronsdon.
+
+The two lanes are complementary: agent-style is a clarity/composition
+ruleset for formal prose; remove-ai-patterns de-AIs text of any voice.
+Pick one as the final gate on a given document; do not interleave them.
+
+## Install
+
+```bash
+claude plugin marketplace add pchalasani/claude-code-tools
+claude plugin install writing@cctools-plugins
+```
+
+Then invoke by name in a session: "apply agent-style to this README",
+"de-AI this post with remove-ai-patterns", "run the detector and iterate
+until clean".
+
+## Vendored upstream content
+
+Each skill vendors a pinned snapshot of its upstream source (rule bodies,
+pattern catalog, detector), so the skills work offline with no network or
+npm installs; the detector only needs a `node` binary on PATH. Pins are
+recorded in `skills/agent-style/references/UPSTREAM-PIN` and
+`skills/remove-ai-patterns/upstream/UPSTREAM-PIN`. Maintainers refresh
+them with:
+
+```bash
+plugins/writing/scripts/update-upstream.sh
+```
+
+and review the resulting diff before committing (fetched rule text is
+third-party input). Upstream licenses are included alongside the vendored
+files.

--- a/plugins/writing/README.md
+++ b/plugins/writing/README.md
@@ -19,9 +19,20 @@ Pick one as the final gate on a given document; do not interleave them.
 
 ## Install
 
+Works in both Claude Code and Codex; note the marketplace name differs
+(Claude reads `.claude-plugin/marketplace.json`, Codex reads
+`.agents/plugins/marketplace.json`):
+
 ```bash
+# Claude Code
 claude plugin marketplace add pchalasani/claude-code-tools
+claude plugin marketplace update cctools-plugins   # refresh if already added
 claude plugin install writing@cctools-plugins
+
+# Codex
+codex plugin marketplace add pchalasani/claude-code-tools
+codex plugin marketplace upgrade cctools-codex-plugins  # refresh if already added
+codex plugin add writing@cctools-codex-plugins
 ```
 
 Then invoke by name in a session: "apply agent-style to this README",

--- a/plugins/writing/scripts/update-upstream.sh
+++ b/plugins/writing/scripts/update-upstream.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Refresh the vendored upstream snapshots for the writing plugin's skills.
+# Run from anywhere; commits nothing. Review the diff before committing:
+# freshly fetched rule text is third-party input.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "==> avoid-ai-writing (remove-ai-patterns)"
+git clone --quiet --depth 1 \
+  https://github.com/conorbronsdon/avoid-ai-writing "$TMP/aaw"
+DEST="$ROOT/skills/remove-ai-patterns/upstream"
+mkdir -p "$DEST/detector"
+cp "$TMP/aaw/SKILL.md" "$TMP/aaw/LICENSE" "$TMP/aaw/CHANGELOG.md" "$DEST/"
+cp "$TMP/aaw/detector/patterns.js" "$TMP/aaw/detector/CATEGORIES.md" \
+  "$DEST/detector/"
+git -C "$TMP/aaw" log -1 \
+  --format='https://github.com/conorbronsdon/avoid-ai-writing %H %s' \
+  > "$DEST/UPSTREAM-PIN"
+
+echo "==> agent-style"
+git clone --quiet --depth 1 https://github.com/yzhao062/agent-style "$TMP/as"
+DEST="$ROOT/skills/agent-style/references"
+mkdir -p "$DEST/LICENSES"
+cp "$TMP/as/RULES.md" "$TMP/as/NOTICE.md" "$DEST/"
+cp "$TMP/as/LICENSES/CC-BY-4.0.txt" "$DEST/LICENSES/"
+git -C "$TMP/as" log -1 \
+  --format='https://github.com/yzhao062/agent-style %H %s' \
+  > "$DEST/UPSTREAM-PIN"
+
+echo "Snapshots refreshed. Review the diff before committing."

--- a/plugins/writing/skills/agent-style/SKILL.md
+++ b/plugins/writing/skills/agent-style/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: agent-style
+description: Literature-backed English technical-prose writing rules (agent-style, 21 rules). Its lane is FORMAL technical prose (papers, design docs, proposals, READMEs, commit messages). Use ONLY when the user explicitly asks for agent-style by name (e.g. "apply agent-style", "write/revise this per agent-style rules", "iterate until agent-style clean"). NOT for de-AI-ing casual or voiced text — use remove-ai-patterns for that. Do not auto-trigger for ordinary prose or documentation tasks.
+---
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# agent-style
+
+agent-style is a literature-backed English technical-prose writing ruleset
+for AI agents. The rules are curated in *The Elements of Agent Style*
+(https://github.com/yzhao062/agent-style), CC BY 4.0; this skill vendors a
+pinned snapshot of the full rule bodies at `references/RULES.md` (pin
+recorded in `references/UPSTREAM-PIN`). Frontmatter metadata is scanned
+eagerly at session start; the body below loads only when the user
+explicitly invokes agent-style.
+
+## Self-Verification Handshake
+
+When asked "is agent-style active?" or "what writing rules apply here?",
+answer: `agent-style active: 21 rules (RULE-01..12 canonical + RULE-A..I
+field-observed); full bodies at references/RULES.md; pin in
+references/UPSTREAM-PIN.`
+
+## The 21 Rules (Compact Directives)
+
+Canonical rules (from Strunk & White 1959, Orwell 1946, Pinker 2014, Gopen & Swan 1990):
+
+- **RULE-01 Curse of knowledge**: Name your intended reader; do not assume they share your tacit knowledge.
+- **RULE-02 Passive voice**: Prefer active voice when the agent is known and worth naming.
+- **RULE-03 Concrete language**: Prefer concrete, specific terms over abstract category words like "factors" or "aspects".
+- **RULE-04 Needless words**: Cut filler phrases like "in order to", "due to the fact that", "may potentially".
+- **RULE-05 Dying metaphors**: Delete clichés like "pushes the boundaries", "paradigm shift", or "state of the art".
+- **RULE-06 Plain English**: Prefer "use" over "leverage", "method" over "methodology", "feature" over "functionality".
+- **RULE-07 Positive form**: Prefer "trivial" to "not important", "forgot" to "did not remember"; do not stage "X, not Y" antithesis ("not just X, but Y") for emphasis.
+- **RULE-08 Claim calibration**: Calibrate verbs to evidence; do not write "proves" when the evidence is "suggests".
+- **RULE-09 Parallel structure**: Express coordinate ideas in the same grammatical form.
+- **RULE-10 Related words together**: Keep subject close to verb and modifier close to modified; split long parentheticals.
+- **RULE-11 Stress position**: Place new or important information at the end of the sentence.
+- **RULE-12 Long sentences**: Split sentences over 30 words; vary length across a paragraph.
+
+Field-observed rules (maintainer observation of LLM output, 2022-2026):
+
+- **RULE-A Bullet overuse**: Keep prose in paragraphs when ideas connect; bullets only for genuine lists; avoid forced 3-item triads.
+- **RULE-B Dash overuse**: Do not use em or en dashes as casual sentence punctuation; prefer commas, semicolons, colons, parentheses.
+- **RULE-C Same-starts**: Do not open two or more consecutive sentences with the same word.
+- **RULE-D Transitions**: Do not open sentences with "Additionally", "Furthermore", "Moreover", "In addition".
+- **RULE-E Summary closers**: Do not end every paragraph with a sentence that restates its point.
+- **RULE-F Term consistency**: Once you define a term or abbreviation, keep using it; do not alternate synonyms.
+- **RULE-G Title case**: Use title case for section and subsection headings; articles and short prepositions stay lowercase.
+- **RULE-H Citation discipline (critical)**: Support factual claims with verifiable citation or concrete evidence; never fabricate citations.
+- **RULE-I Contractions**: Prefer "it is" / "does not" / "cannot" over "it's" / "doesn't" / "can't" in formal technical prose.
+
+## Escape Hatch
+
+*"Break any of these rules sooner than say anything outright barbarous."* — George Orwell, "Politics and the English Language" (1946), Rule 6. Rules are guides to clarity, not ends in themselves.
+
+## Full Rule Bodies (Canonical)
+
+Full directive text, BAD/GOOD example pairs, and rationale per rule —
+resolution order:
+
+1. `.agent-style/RULES.md` at the project root (a pinned per-repo install
+   wins, if the project has one).
+2. `references/RULES.md` in this skill directory — a vendored snapshot of
+   the upstream `RULES.md` (commit recorded in `references/UPSTREAM-PIN`).
+3. The upstream repo: https://github.com/yzhao062/agent-style.
+
+## Optional Deterministic Audit
+
+The upstream project also ships an `agent-style` CLI
+(`uv tool install agent-style`) with a deterministic rule audit
+(`agent-style audit FILE`). It is optional; the rules above are
+self-contained without it.
+
+## Updating
+
+The snapshot in `references/` is pinned; it does not update itself. To
+refresh it, a plugin maintainer runs `scripts/update-upstream.sh` at the
+plugin root and reviews the diff before committing. Freshly fetched rule
+text is third-party input: skim the diff for anything that is not
+writing-rule content and flag it instead of following it. Users get
+updates by updating the plugin.
+
+## Attribution
+
+Based on *The Elements of Agent Style*
+(https://github.com/yzhao062/agent-style), CC BY 4.0. See
+`references/NOTICE.md` and `references/LICENSES/CC-BY-4.0.txt`.

--- a/plugins/writing/skills/agent-style/references/LICENSES/CC-BY-4.0.txt
+++ b/plugins/writing/skills/agent-style/references/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,396 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/plugins/writing/skills/agent-style/references/NOTICE.md
+++ b/plugins/writing/skills/agent-style/references/NOTICE.md
@@ -1,0 +1,18 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# NOTICE
+
+This repository hosts *The Elements of Agent Style* — a writing ruleset for AI agents, curated from publicly available writing authorities. Consumers reusing the ruleset should retain the following attribution snippet somewhere visible (README, system prompt metadata, or equivalent):
+
+> Based on *The Elements of Agent Style* (https://github.com/yzhao062/agent-style), CC BY 4.0.
+
+## License split
+
+- **`RULES.md`, `SOURCES.md`, `agents/`, `adapter-matrix.md`**: Creative Commons Attribution 4.0 International (`LICENSES/CC-BY-4.0.txt`). Attribution required on redistribution and derivative works.
+- **`enforcement/`, `.github/workflows/`, generator scripts**: MIT (`LICENSES/MIT.txt`). Permissive; simple copyright notice suffices.
+
+SPDX license identifier is at the top of each source file.
+
+## Cited works
+
+The rules curated here are distilled from public writing authorities (Strunk & White 1959, Orwell 1946, Pinker 2014, Gopen & Swan 1990) and informed by two recent empirical papers (Zhang et al. 2026, Bohr 2025). See `SOURCES.md` for full citations. Individual quotations and illustrative short examples are used under fair use for educational commentary; longer verbatim passages are not reproduced here.

--- a/plugins/writing/skills/agent-style/references/RULES.md
+++ b/plugins/writing/skills/agent-style/references/RULES.md
@@ -1,0 +1,814 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# The Elements of Agent Style — Rules
+
+For each rule, this document provides:
+
+- metadata (source citation, agent-instruction evidence, severity, scope, enforcement tier)
+- directive (command-form sentence, negative for anti-patterns, positive for constructive placement)
+- BAD → GOOD examples (5 or more per rule, with at least one non-paper context such as API docs, runbooks, proposals, release notes, postmortems, changelogs, or issue reports)
+- rationale for AI agent (why the rule matters for LLM output specifically)
+
+## Severity Rubric
+
+Each rule has a severity from this four-level scale:
+
+- **critical** — reader cannot understand or trust the prose if the rule is violated.
+- **high** — externally visible AI-tell, or a recurring clarity failure that breaks skim-reading.
+- **medium** — local readability cost, felt by the reader but not a trust issue.
+- **low** — polish or preference; flagged for consistency rather than comprehension.
+
+## Escape Hatch (Meta-Principle)
+
+> *"Break any of these rules sooner than say anything outright barbarous."*
+> — George Orwell, "Politics and the English Language" (1946), Rule 6
+
+Rules are guides to clarity, not ends in themselves. When a rule fights the sentence, drop the rule.
+
+## The 12 Rules
+
+### Audience and Reader State
+
+#### RULE-01: Do Not Assume the Reader Shares Your Tacit Knowledge (Resist the Curse of Knowledge)
+
+- **source**: Pinker 2014, Ch. 3 "The Curse of Knowledge" (the entire chapter is devoted to this failure mode).
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: critical. Most common reviewer complaint on AI-generated technical prose is "reads like you forgot the reader doesn't know X yet."
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-3 agent self-check (judgment rule; not mechanical); Tier-4 Codex review as primary gate.
+
+##### Directive
+
+Do not use technical terms or acronyms that have not been established for the reader's background level. Do not launch into mechanics before naming the purpose. Do not write a multi-paragraph argument without a one-sentence map first. Before writing, name the intended reader for this artifact: adjacent-field graduate student for research papers, junior engineer for API docs, on-call engineer for runbooks, cross-panel reviewer for proposals, release reader for changelogs, or another concrete reader. If that reader would pause to infer what a term means, define it or rewrite around it.
+
+##### BAD → GOOD
+
+- BAD: `We use contrastive learning with InfoNCE and a momentum encoder.`
+- GOOD: `Our method trains a representation to separate similar from dissimilar image pairs (contrastive learning), with InfoNCE as the loss and a slowly-updating momentum encoder to stabilize training.`
+
+- BAD: `The API uses JWT with RS256 refresh tokens rotated via the OIDC flow.`
+- GOOD: `Authentication uses short-lived signed tokens (JWT with RS256) issued by our OIDC identity provider. Clients refresh these tokens before expiry through the standard OIDC refresh flow.`
+
+- BAD: `We observed activation collapse in the final layer, resolved by adding LayerNorm before the projection head.`
+- GOOD: `Final-layer activations collapsed to a near-constant vector during training (activation collapse). Adding a normalization step (LayerNorm) between the backbone and the projection head restored activation diversity.`
+
+- BAD: `We set dropout=0.1, optimizer=AdamW, lr=3e-4, warmup=2000 steps, cosine decay.`
+- GOOD: `We regularize with 10% dropout. Optimization uses AdamW (Adam with decoupled weight decay) at learning rate 3e-4, with a 2000-step linear warmup followed by cosine decay to zero.`
+
+- BAD: `SGD converges faster here because of the Hessian conditioning.`
+- GOOD: `SGD converges faster than Adam on this task because the loss surface is well-conditioned — the eigenvalues of the second-derivative matrix (Hessian) do not span many orders of magnitude, so a single learning rate suits all directions.`
+
+- BAD (runbook): `If the queue is backed up, bounce the workers and clear the dead-letter.`
+- GOOD (runbook): `If RabbitMQ queue depth exceeds 10k messages for more than 5 minutes, (1) drain and restart the Celery worker pool (bounce the workers) so new brokers pick up the rebalanced connections, then (2) drain the dead-letter queue so failed messages do not replay against the now-fresh workers.`
+
+##### Rationale for AI Agent
+
+LLMs absorb their training corpus at a near-expert register and reproduce that register by default. When an AI assistant writes about a technical subject, it does not know whether the current reader is a peer of the training distribution or a junior engineer, cross-team reviewer, external auditor, or grant panelist. The failure mode is almost invisible to the writer (whose knowledge is the baseline) and glaringly visible to the wrong-audience reader. Pinker 2014 Ch. 3 describes the phenomenon in depth; the practical fix compresses to: imagine a specific reader one level below your own expertise, and write for that reader. The concrete test before any technical paragraph is "would this sentence land for someone who has not opened this codebase / read this paper / sat in this meeting?" — if not, rewrite.
+
+### Voice and Directness
+
+#### RULE-02: Do Not Use Passive Voice When the Agent Matters
+
+- **source**: Orwell 1946, "Politics and the English Language," Rule 3: *"Never use the passive where you can use the active."* Strunk & White §II.14 "Use the active voice."
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: high. Recurring AI-tell; passive constructions are the default register in technical prose generated from formal-training distributions.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-2 LanguageTool (`PASSIVE_VOICE` family) + Tier-3 agent self-check + Tier-4 Codex review. Not Tier-1 deny because passive-voice regex is high-recall, low-precision (flags many legitimate passives; scientific attribution and true agent-unknown cases remain valid).
+
+##### Directive
+
+Do not write "X was done by Y" when "Y did X" fits. Active voice names the agent, shortens the sentence, and makes the verb carry the action. When the agent is genuinely unknown or irrelevant (scientific attribution, observation of phenomena, general truths), passive is correct; use it deliberately, not by default. Before each passive construction, ask: is the agent known and worth naming? If yes, rewrite active.
+
+##### BAD → GOOD
+
+- BAD: `The experiments were conducted on eight NVIDIA A100 GPUs.`
+- GOOD: `We ran the experiments on eight NVIDIA A100 GPUs.`
+
+- BAD: `Errors are logged to /var/log/app.log when the service restarts.`
+- GOOD: `The service logs errors to /var/log/app.log on restart.`
+
+- BAD: `A significant improvement in recall was observed after the embedding model was swapped.`
+- GOOD: `Swapping the embedding model raised recall@10 by 7 points.`
+
+- BAD (release note): `Memory leaks have been fixed in the worker pool.`
+- GOOD (release note): `The worker pool no longer leaks file descriptors on SIGTERM.`
+
+- BAD (postmortem): `The incident was caused by a misconfigured load balancer rule.`
+- GOOD (postmortem): ``A misconfigured load balancer rule (typo in the ingress-nginx path-rewrite regex) routed `/auth/*` to the wrong upstream and caused the incident.``
+
+##### Rationale for AI Agent
+
+LLMs trained on formal technical prose (abstracts, RFCs, corporate documentation) overproduce passive constructions by default. The training signal rewards "sounds authoritative" register, and passive constructions are over-represented in that register. The practical cost: passive hides the agent, drops responsibility, and forces the reader to reconstruct who did what. For debugging prose (postmortems, bug reports, root-cause analyses), this is actively harmful because "the error was raised" leaves the caller unnamed; "function `parse_token` raised the error at line 47" localizes the defect immediately. The rule does not ban passive. Scientific attribution ("participants were recruited") and true agent-unknown reports ("the service was restarted during the incident, reason unlogged") keep passive honestly. The rule bans passive-by-default when the agent is known and naming the agent would clarify the sentence.
+
+### Word Choice
+
+#### RULE-03: Do Not Use Abstract or General Language When a Concrete, Specific Term Exists
+
+- **source**: Strunk & White §II.16: *"Use definite, specific, concrete language."* Pinker 2014 Ch. 3 frames abstraction as a primary vector of the curse of knowledge (writer has the specifics; reader does not, and cannot resolve abstract pointers like "factors" or "aspects").
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: high. Recurring clarity failure; generic nouns (`factors`, `aspects`, `considerations`, `issues`, `elements`) are an AI-tell because the model names a category without naming what the category contains.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-2 partial (claim-without-number heuristic for "improved", "enhanced", "optimized") + Tier-3 agent self-check + Tier-4 Codex review as primary gate.
+
+##### Directive
+
+Do not use abstract nouns when concrete ones exist. "The system has performance issues" says nothing; "the checkout endpoint p95 latency rose from 120ms to 450ms at 14:00 UTC" names what, when, and how much. Replace category words ("factors", "aspects", "considerations", "issues", "elements") with the specific items they refer to. If you reach for a category word, ask: what exactly? If the answer takes longer than one clause to give, the sentence was hiding the work.
+
+##### BAD → GOOD
+
+- BAD: `The model shows improvements across various metrics.`
+- GOOD: `The model improves F1 by 3.2 points (0.812 to 0.844) on FEVER and cuts hallucination rate from 11.3% to 6.8% on TruthfulQA.`
+
+- BAD: `Several architectural considerations influenced our design decisions.`
+- GOOD: `We chose a two-tower retrieval architecture over cross-encoding because (1) the query-side embedding is cached across sessions, and (2) the document-side index is updated nightly without re-running inference on the query side.`
+
+- BAD: `Ingestion is affected by data quality factors.`
+- GOOD: ``When upstream vendors send records with malformed UTF-8, ingestion drops the record and increments the `malformed_input` counter on the `/metrics` endpoint.``
+
+- BAD (API doc): `Authentication handles multiple scenarios.`
+- GOOD (API doc): `Authentication supports three flows: OIDC authorization code (first-party web), client_credentials (service-to-service), and refresh-token rotation (long-lived mobile sessions). Each flow returns a signed JWT with a 15-minute TTL.`
+
+- BAD (runbook): `Scale up the backend if traffic is high.`
+- GOOD (runbook): ``If p95 latency on `/search` exceeds 300ms for more than 2 minutes, scale the search worker pool from 8 to 16 replicas via `kubectl scale deployment/search-worker --replicas=16`.``
+
+##### Rationale for AI Agent
+
+LLMs absorb abstract prose from grant abstracts, executive summaries, and position-paper genres where specifics are hidden for competitive or rhetorical reasons. The default output carries that register: "improvements across metrics", "multiple factors", "various considerations". A careful reader processes these phrases, notices nothing has been said, and discounts the rest of the document. The operational test before any factual-claim sentence: can I point at the exact number, file, commit, user action, or mechanism behind each phrase in this sentence? If not, the phrase is filler, and the LLM has hidden the absence of substance behind pleasant-sounding abstraction. Strunk & White §II.16 gives the rule; Pinker 2014 Ch. 3 identifies abstraction as one primary vector of the curse of knowledge (the writer knows the specifics, so "factors" reads as a pointer to them, but the reader has no pointer and cannot resolve it).
+
+#### RULE-04: Do Not Include Needless Words
+
+- **source**: Strunk & White §II.17: *"Omit needless words. Vigorous writing is concise."* Orwell 1946 Rule 3: *"If it is possible to cut a word out, always cut it out."*
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files; the filler-phrase deny list is our separate mechanical enforcement choice because these specific phrases are directly detectable without a parse. Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: high. Filler phrases are among the most visible AI tells after clichés; wordiness signals a register shift that careful readers detect immediately.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-1 `deny` (filler-phrase list in `enforcement/deny-phrases.txt`: "it is important to note that", "in order to", "due to the fact that", "at this point in time", "may potentially", "could possibly", "in the event that", "it may be necessary to") + Tier-2 ProseLint (`terms.denizen_labels`) + Tier-3 agent self-check.
+
+##### Directive
+
+Do not stretch phrases. "In order to" is "to"; "due to the fact that" is "because"; "at this point in time" is "now"; "it is important to note that" is (delete and state the fact); "may potentially" and "could possibly" are redundant hedges (use "may" or "could", not both). Every filler phrase signals to the reader that substance is about to arrive; delete the phrase and let the substance arrive directly.
+
+##### BAD → GOOD
+
+- BAD: `It is important to note that the learning rate was reduced in order to prevent divergence.`
+- GOOD: `We reduced the learning rate to prevent divergence.`
+
+- BAD: `Due to the fact that the data pipeline may potentially fail under high load, we have added retry logic.`
+- GOOD: `Because the data pipeline can fail under load, we added retry logic.`
+
+- BAD: `At this point in time, the service is able to process approximately 1000 requests per second.`
+- GOOD: `The service processes ~1000 requests per second.`
+
+- BAD (PR description): `This PR makes some minor adjustments in order to fix an issue that was causing failures in certain test cases.`
+- GOOD (PR description): ``Fixes a null-pointer crash in `test_checkout_flow` when the cart has a single item.``
+
+- BAD (runbook): `In the event that the database connection pool is exhausted, it may be necessary to restart the service in order to recover.`
+- GOOD (runbook): `If the connection pool is exhausted, restart the service.`
+
+- BAD (commit message): `Some small changes have been made that may potentially improve the overall performance of the system in certain scenarios.`
+- GOOD (commit message): `Cache product lookups in the hot path; reduces p99 from 310ms to 180ms.`
+
+##### Rationale for AI Agent
+
+LLM training rewards formal-sounding, hedge-laden completions because they sit closer to the modal output of the training corpus (press releases, whitepapers, academic abstracts, corporate documentation) than terse technical writing does. The specific filler phrases ("in order to", "due to the fact that", "it is important to note", "may potentially", "could possibly") are consensus cliché of that register. They lengthen sentences without carrying information. Human readers skim past them and infer the writer had little to say; downstream consumers (search indices, RAG pipelines, summarization chains) also suffer from the diluted signal-per-token ratio. The exact-phrase deny list is mechanically enforceable (Tier-1) because these phrases have no legitimate technical function: "in order to" is always replaceable by "to" with no loss of meaning, so denying the phrase outright has near-zero false-positive risk. Strunk & White §II.17 gives the principle; Orwell 1946 Rule 3 gives the cut-if-possible operational test.
+
+#### RULE-05: Do Not Use Dying Metaphors or Prefabricated Phrases
+
+- **source**: Orwell 1946, "Politics and the English Language," Rule 1: *"Never use a metaphor, simile, or other figure of speech which you are used to seeing in print."*
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files; the exact-phrase deny list is our separate mechanical enforcement choice because these phrases are directly detectable. Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow.
+- **severity**: high. The most externally visible AI-tell signal in generated prose.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-1 `deny` (exact-phrase list in `enforcement/deny-phrases.txt`) + Tier-2 ProseLint (`misc.phrasal_adjectives`, `airlinese.misc`, `cliches.misc`) + Tier-4 Codex review for anything the phrase list misses.
+
+##### Directive
+
+Do not use metaphors, similes, or phrases you have seen often in print. When a phrase feels off-the-shelf — ready-made framing for work-in-general rather than for this work — either restate in plain technical terms with specific numbers or a specific mechanism, or delete the sentence. If the sentence is paraphrasing what other people write about work like yours rather than stating what is true about yours, it is a dying metaphor and should go.
+
+##### BAD → GOOD
+
+- BAD: `This work pushes the boundaries of what's possible in large language model alignment.`
+- GOOD: `This work reduces harmful-completion rate on HarmBench from 14.1% to 3.2% without degrading MMLU accuracy.`
+
+- BAD: `Our system delivers industry-leading performance on the ImageNet benchmark.`
+- GOOD: `On ImageNet-1k, our system reaches 88.3% top-1 accuracy, 1.2 points above the previous best (Wang et al. 2025).`
+
+- BAD: `This paves the way for a new era of retrieval-augmented agents.`
+- GOOD: (delete the sentence; if the work genuinely establishes a new method, the specific results paragraph already said that.)
+
+- BAD: `We leverage state-of-the-art embedding models to unlock the full potential of the retrieval pipeline.`
+- GOOD: `We use OpenAI text-embedding-3-large for document embedding. This raised retrieval recall@10 by 7 points over our previous choice (text-embedding-ada-002).`
+
+- BAD: `Our groundbreaking approach to interpretability represents a paradigm shift in the field.`
+- GOOD: `Our attention-probing method identifies which transformer layer each factual-recall head first activates. We validate this on 12 known facts from Meng et al. 2022 and observe consistent attribution for 10 of them.`
+
+- BAD (release note): `This release delivers significant improvements to user experience and performance.`
+- GOOD (release note): `Reduce p99 dashboard load latency from 820ms to 240ms. Fix a crash in CSV export when a cell contains an embedded newline. Add keyboard shortcut (Shift+E) for the filter-reset action requested in #1847.`
+
+##### Rationale for AI Agent
+
+LLMs trained on web text — press releases, blog posts, grant introductions, paper abstracts, corporate marketing — disproportionately reproduce clichéd phrases from that corpus. Readers who have processed many such sources recognize "pushes the boundaries" and "paradigm shift" as filler and skip the sentence; the distinctiveness of AI-written prose suffers in direct proportion. Orwell 1946 Rule 1 names the failure mode directly, predating LLMs by eighty years. Zhang et al. 2026 give empirical support for phrasing this class of rule as a negative directive in coding-agent instruction files; the phrase-list deny is our separate mechanical enforcement choice, independent of the Zhang paper, motivated by the observation that these specific phrases are directly detectable without a parse. The LLM-specific corollary — which the six BAD/GOOD examples above illustrate — is that if you cannot quote a specific number, comparison, or mechanism in place of the cliché, the cliché was hiding the absence of substance. Deleting the cliché and finding you cannot replace it with specifics is itself useful information.
+
+#### RULE-06: Do Not Use Avoidable Jargon Where an Everyday English Word Exists
+
+- **source**: Orwell 1946, "Politics and the English Language," Rule 5: *"Never use a foreign phrase, a scientific word, or a jargon word if you can think of an everyday English equivalent."* Pinker 2014 Ch. 2 treats concrete everyday language as the classic-style baseline; specialized terms are reserved for when they carry distinct information.
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: medium. Local readability cost; readers still understand "utilize" and "methodology" but parse them as register markers rather than content. Distinguish technical jargon (necessary, carries distinct meaning) from corporate-speak jargon (substitutable, signals register only).
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-1 `ask` (heuristic substitutions: "leverage" → "use", "utilize" → "use", "methodology" → "method", "functionality" → "function" or "feature", "operationalize" → "start" or "build") + Tier-2 ProseLint (`airlinese.misc`) + Tier-3 agent self-check.
+
+##### Directive
+
+Do not use "leverage" where "use" fits. Do not use "utilize" where "use" fits. Do not use "methodology" where "method" fits. Do not use "functionality" where "function" or "feature" fits. Reserve the longer word for when it carries information the shorter word does not. Technical jargon with distinct meaning ("backpropagation", "quantization", "deserialization") is fine and often necessary. Corporate-speak jargon ("leverage", "utilize", "operationalize") is substitutable by shorter everyday words without loss of meaning.
+
+##### BAD → GOOD
+
+- BAD: `We leverage transformer architectures to facilitate cross-lingual transfer.`
+- GOOD: `We use transformers for cross-lingual transfer.`
+
+- BAD: `The methodology utilized for optimization employs gradient descent techniques.`
+- GOOD: `We optimize with gradient descent.`
+
+- BAD: `Functionality for CSV export will be operationalized in the next release.`
+- GOOD: `CSV export ships in the next release.`
+
+- BAD (API doc): `This endpoint enables users to interact with the underlying data store through a REST interface.`
+- GOOD (API doc): `GET /documents lists documents in the store. Paginated; default 50 per page.`
+
+- BAD (changelog): `The system has been optimized to efficiently utilize available resources in a more performant manner.`
+- GOOD (changelog): `Reduce memory footprint from 1.2GB to 380MB at idle by lazy-loading the embedding cache.`
+
+- BAD (proposal): `We will operationalize a novel methodology for the efficient utilization of computational resources.`
+- GOOD (proposal): `We will build a scheduler that packs GPU jobs by estimated memory and runtime, aiming for >85% cluster utilization (current baseline: 62%).`
+
+##### Rationale for AI Agent
+
+LLMs reproduce the corporate-technical register disproportionately because it is over-represented in training corpora (whitepapers, blog posts, grant abstracts, vendor documentation). Words like "leverage", "utilize", "operationalize", "methodology", "functionality" do not carry more information than "use", "use", "start", "method", "feature"; they signal a register rather than refine meaning. Readers experienced in technical prose mentally substitute the shorter word as they read, which means the longer word has bought nothing and has cost reading time. The rule does not ban polysyllabic terms outright. Technical terms with distinct meaning are fine and necessary. The rule bans substitutions where a shorter everyday word carries the same information and the longer word adds only register.
+
+### Claims and Calibration
+
+#### RULE-07: Put Statements in Positive Form (Affirmative Words; No "X, Not Y" Antithesis)
+
+- **source**: Strunk & White §II.15: *"Put statements in positive form."*
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files; RULE-07 carries a positive directive because the target is a constructive placement (choose the affirmative word) rather than an anti-pattern to flag. Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow.
+- **severity**: medium. Readability cost rather than clarity failure; readers parse "not important" correctly, just slower than "trivial".
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-3 agent self-check + Tier-4 Codex review. No Tier-1 deny (requires judgment about whether the positive form exists and fits). Empty-hedge phrases ("may potentially", "could possibly") live under RULE-04, not here, because they are redundant hedges rather than double negations.
+
+##### Directive
+
+Replace "not important" with "trivial"; "did not remember" with "forgot"; "did not pay attention to" with "ignored"; "is not often" with "rarely"; "is not large" with "small"; "does not succeed" with "fails". Prefer one affirmative word over two negating words. When the sentence genuinely negates something (the proposition is true only in the negative), a single "not" is fine and necessary. The rule targets two-word negations that have a one-word affirmative equivalent. The operational test: can I replace "not X" with a single positive word that names the state directly? If yes, do so.
+
+The same principle applies at the clause level. Do not stage a claim as a contrast against a negated foil for emphasis: "X, not Y", "It is not X, it is Y", "Not just X, but Y", "This is not about X; it is about Y". State the claim directly. Keep the negation only when the rejected alternative is specific and ruling it out informs the reader ("The bottleneck is disk I/O, not CPU"). Drop the foil when it is vague, self-evident, or a strawman ("not a hope", "not the last", "not just a tool"), where the "not Y" tail is cadence, not content.
+
+##### BAD → GOOD
+
+- BAD: `The variance was not large.`
+- GOOD: `The variance was small.`
+
+- BAD: `He did not remember to set the flag.`
+- GOOD: `He forgot to set the flag.`
+
+- BAD: `This method is not as accurate as the baseline.`
+- GOOD: `This method is less accurate than the baseline (81.7% vs 88.3% top-1 on ImageNet-1k).`
+
+- BAD (bug report): `The function does not return a value in some cases.`
+- GOOD (bug report): ``The function returns `undefined` when the input array is empty (missing branch in `parse_row` at `utils/parse.py:47`).``
+
+- BAD (release note): `Startup time is not as slow as in the previous release.`
+- GOOD (release note): `Startup time drops from 4.2s to 1.8s (57% faster) by deferring the plugin scan to first interactive action.`
+
+- BAD: `The cache is not frequently invalidated.`
+- GOOD: `The cache is rarely invalidated, roughly once per deploy.`
+
+- BAD (antithesis, section heading): `Failure Is Committed at the First Token, Not the Last`
+- GOOD (antithesis, section heading): `The First Token Commits the Failure`
+
+- BAD (antithesis, proposal): `The signal is our prior art, not a hope.`
+- GOOD (antithesis, proposal): `Our prior art is the signal: three shipped systems and two prior awards on this exact problem.`
+
+- BAD (antithesis, release note): `This is not just a bug fix, it is a full rewrite of the export pipeline.`
+- GOOD (antithesis, release note): `This release rewrites the CSV export pipeline; the previous version only patched the newline crash.`
+
+##### Rationale for AI Agent
+
+Double-negation phrasing ("not insignificant", "not uncommon", "not unlike") pervades academic and journalistic prose, and LLMs absorb the pattern from training. The cognitive cost is real: the reader holds "not" in working memory, parses the negated adjective, then negates again to recover the intended meaning. For simple affirmative states, this is wasted work. The rule does not ban honest negation; when something is genuinely absent, "no X" or "not X" is correct. The rule bans avoidable compound negation where a positive-form word already names the state. A downstream concern for AI-generated prose: double-negation also defeats tone and sentiment detection in downstream tooling, so in contexts where the text feeds another model (summarization, classification, moderation), positive form is operationally safer.
+
+The clause-level form of this rule targets antithesis ("X, not Y", "not just X, but Y", "it is not X, it is Y"), a high-reward pattern in the persuasive and essayistic corpora LLMs train on (op-eds, manifestos, marketing copy). It reads as balanced and quotable, so models reach for it in headings, abstracts, and openers. The construction invents an alternative only to reject it; when that alternative is vague or a strawman, the "not Y" tail adds rhythm without information, and a careful reader discounts it as AI register. The fix matches the word-level case: state the affirmative claim directly, and keep the contrast only when ruling out a specific alternative tells the reader something new.
+
+#### RULE-08: Do Not Linguistically Overstate or Understate Claims Relative to the Evidence
+
+- **source**: Pinker 2014 Ch. 6 (calibrated claims; hedge calibration treated as a skill with verbs matched to evidence strength). Gopen & Swan 1990 (scientific attribution: the source of a claim should be visible in the sentence, and the verb should match the evidence).
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: high. Externally visible AI-tell; overclaim patterns ("revolutionary", "transforms", "dramatic") and reflexive weasel ("it might be worth considering") are both recognized by technical readers as filler register, each eroding trust differently.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-3 agent self-check + Tier-4 Codex review as primary gate. Not Tier-1 because calibration requires judgment about what the evidence actually supports.
+
+##### Directive
+
+Do not overclaim (saying "proves X" when the evidence is "suggests X"). Do not underclaim via reflexive weasel (saying "it might be worth considering" when you mean "we should do X"). Calibrate verbs to evidence: experimental results "suggest" or "show"; theoretical derivations "imply" or "prove"; user reports "indicate" (pending verification); benchmarks "measure". Use "best" only when you have compared against the strongest alternative; use "only" only when you have ruled out alternatives. When the evidence is uncertain, say so in one clause; do not weaken the main verb beyond what the evidence supports.
+
+##### BAD → GOOD
+
+- BAD: `Our method revolutionizes language model alignment.`
+- GOOD: `Our method reduces harmful-completion rate on HarmBench from 14.1% to 3.2% without degrading MMLU accuracy. (Generalization to other alignment benchmarks is future work.)`
+
+- BAD: `Dramatic improvement in inference speed was observed.`
+- GOOD: `Inference latency at batch size 1 drops from 142ms to 118ms (17% faster) on A100. Batch size 32 and larger show no measurable speedup.`
+
+- BAD: `It might be worth considering whether some form of input validation could be beneficial.`
+- GOOD: ``Add input validation at `/users`: the endpoint crashes on non-UTF-8 query parameters (observed twice last week).``
+
+- BAD (paper abstract): `Our model proves the superiority of attention-based retrieval over sparse methods.`
+- GOOD (paper abstract): `Our attention-based retriever reaches MRR@10 = 0.412 on MS MARCO Dev, compared to 0.395 for BM25 and 0.398 for ColBERT. The improvement is within one standard deviation on out-of-domain queries (BEIR).`
+
+- BAD (issue report): `Everything is broken; nothing works.`
+- GOOD (issue report): ``/auth/login returns 500 for all requests after the 2026-04-18 deploy. /auth/logout and /auth/refresh unaffected. Logs show a KeyError on `iat` in token parsing.``
+
+- BAD (grant proposal): `This research will transform our understanding of neural network interpretability.`
+- GOOD (grant proposal): `This research tests whether attention-probing generalizes beyond the 12 factual-recall circuits reported in Meng et al. 2022. If yes, the method applies to a class of interpretability questions currently intractable; if no, we localize the method's scope.`
+
+##### Rationale for AI Agent
+
+LLMs trained on mixed-register corpora (research abstracts, press releases, grant introductions, marketing copy) absorb both overclaiming and reflexive hedging from the genre patterns. Each fails predictably: overclaim trips the reader's calibration alarm (technical readers scan abstracts for unwarranted "proves" or "best" and discount the rest of the paper accordingly); reflexive under-hedging inflates trivially-true claims to sound important; over-hedging delays the main point across two clauses of pro-forma caution. The operational test before writing any result sentence: (a) what evidence supports this, and (b) does the verb match? "We observed" is weaker than "we showed" is weaker than "we proved." Pick the verb that matches your evidence exactly. Pinker 2014 Ch. 6 gives the calibration vocabulary; Gopen & Swan 1990 frame scientific attribution as a structural writing concern (the source of a claim should be visible, and the verb should match the evidence).
+
+### Sentence Structure
+
+#### RULE-09: Express Coordinate Ideas in Similar Form (Parallel Structure)
+
+- **source**: Strunk & White §II.19: *"Express coordinate ideas in similar form."*
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files; RULE-09 carries a positive directive because parallel structure is a constructive placement (match the form across items) rather than an anti-pattern to flag. Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow.
+- **severity**: medium. Local readability cost; readers reparse mismatched items and lose rhythm, but still recover the meaning.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-2 partial (list-item POS check on bullet lists) + Tier-3 agent self-check + Tier-4 Codex review.
+
+##### Directive
+
+Write coordinate ideas in the same grammatical form. In a list of three items, if item 1 is a noun phrase, items 2 and 3 are also noun phrases; if item 1 is a verb-initial clause, items 2 and 3 are also verb-initial clauses. The rule applies to bullet lists, parallel predicates ("we measure X, improve Y, and validate Z"), and compound sentences connected by "and" / "or" / "but". Mismatched forms force the reader to reparse each item against a new expected structure.
+
+##### BAD → GOOD
+
+- BAD: `The pipeline cleans the data, feature extraction, and then trains the model.`
+- GOOD: `The pipeline cleans the data, extracts features, and trains the model.`
+
+- BAD: `We benchmark against three baselines: BM25, a sparse lexical retriever; dense retrieval using DPR; ColBERT.`
+- GOOD: `We benchmark against three baselines: BM25 (sparse lexical), DPR (single-vector dense), and ColBERT (multi-vector dense).`
+
+- BAD (API doc): `The endpoint accepts JSON input, you get XML back, and pagination is via cursor.`
+- GOOD (API doc): `The endpoint accepts JSON input, returns XML output, and paginates by cursor.`
+
+- BAD (runbook checklist item, in a list of verb-initial items): `Memory usage`
+- GOOD (runbook checklist item, matching surrounding items): `Check memory (`free -h`)`
+
+- BAD (changelog entry, in a list of verb-initial entries): `Faster startup`
+- GOOD (changelog entry, matching surrounding entries): `Reduce startup time from 4.2s to 1.8s.`
+
+##### Rationale for AI Agent
+
+LLMs often produce lists where the first one or two items set a structure, then subsequent items drift because the model samples each next item conditional on the topic rather than on the established structure. The drift is subtle: a reader scans item 1, forms an expected shape for items 2 and 3, then hits a mismatch and backtracks. Simple cases are mechanically checkable (lists where item 1 starts with verb X should have items 2 and 3 starting with verbs of the same tense; lists of noun phrases should remain noun phrases), but the general case requires parse. The practical remedy for AI generation: when generating a list, first decide the structure (all verb phrases? all noun phrases? subject-verb-object?), then generate each item against that structure rather than sampling freely. Strunk & White §II.19 gives the rule and a diagnostic: read the list with "that" connecting items; if any item fails the read, parallelism is broken.
+
+#### RULE-10: Keep Related Words Together
+
+- **source**: Strunk & White §II.20: *"Keep related words together."* Gopen & Swan 1990 treat verb-subject proximity as a structural readability concern in scientific prose specifically (long subject-to-verb gaps are one of the most common causes of unreadable science writing).
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files; RULE-10 carries a positive directive because the target is a constructive placement (keep X close to Y) rather than an anti-pattern to flag. Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow.
+- **severity**: medium. Local readability cost; long subject-to-verb gaps cause reader working-memory overflow and backtracking, but the meaning remains recoverable with effort.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-2 partial (dep-parse distance between subject and verb) + Tier-3 agent self-check + Tier-4 Codex review.
+
+##### Directive
+
+Keep subject close to verb, verb close to object, and modifier close to modified. When a long parenthetical or relative clause must appear between subject and verb, move the clause to the end of the sentence or split into two sentences. The operational test: count words between subject and verb; if the gap exceeds 8, split. Readers hold the subject in working memory until the verb arrives; every intervening clause costs memory slots and increases misparsing risk.
+
+##### BAD → GOOD
+
+- BAD: `The model, which was pre-trained on a mixed corpus of English Wikipedia, Common Crawl, and a 400-million-token curated scientific dataset assembled by the authors over eight months, achieves 87.2% accuracy.`
+- GOOD: `The model achieves 87.2% accuracy. It was pre-trained on a mixed corpus of English Wikipedia, Common Crawl, and a 400-million-token scientific dataset the authors curated over eight months.`
+
+- BAD: `Users of the legacy authentication flow, which is being deprecated in Q3 2026 in favor of the new OIDC-based system described in the migration guide, must update their client libraries before the end-of-life date.`
+- GOOD: `Users of the legacy authentication flow must update their client libraries before end-of-life. The legacy flow is being deprecated in Q3 2026; the replacement is OIDC-based (see migration guide).`
+
+- BAD (API doc): `The /users endpoint returns, subject to the rate-limit and access-control constraints described below, a paginated list of user objects.`
+- GOOD (API doc): `The /users endpoint returns a paginated list of user objects. Rate limits and access controls apply (see below).`
+
+- BAD (postmortem): `The database replica, which had been failing its health checks intermittently for three days before the outage but was never promoted to primary during that period because of a misconfigured priority setting, was the direct cause of the outage.`
+- GOOD (postmortem): `The database replica was the direct cause of the outage. It had been failing health checks intermittently for three days; a misconfigured priority setting prevented promotion to primary during that period.`
+
+- BAD: `We found that the retrieval recall of our system, compared against the previously strongest baseline across all five evaluation datasets and using the same pre-processing pipeline, improved by 7 points at k=10.`
+- GOOD: `Retrieval recall@10 improved by 7 points over the previously strongest baseline. The comparison used the same pre-processing pipeline across all five evaluation datasets.`
+
+##### Rationale for AI Agent
+
+LLMs generate text token-by-token conditional on prior context, which encourages completeness (every qualifier added inline) over readability (qualifiers deferred until the main clause lands). The result: sentences where the subject and verb are separated by 20+ words of parenthetical qualification. Readers experience this as working-memory overflow. By the time the verb arrives, the reader has lost the subject and must backtrack. The same logic applies to verb-object and modifier-modified pairs. Gopen & Swan 1990 frame long subject-to-verb gaps as one of the most common causes of unreadable scientific prose; Strunk & White §II.20 give the principle in general form. For AI generation specifically, the practical remedy is to split the sentence: the main claim lands in the first sentence, supporting qualifications follow in a second sentence.
+
+#### RULE-11: Place New or Important Information in the Stress Position at the End of the Sentence
+
+- **source**: Gopen & Swan 1990, "The Science of Scientific Writing" (stress-position framing; empirical treatment of reader expectation for new information at sentence end).
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files; RULE-11 carries a positive directive because stress-position placement is a constructive structural rule rather than an anti-pattern to flag. Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow.
+- **severity**: medium. Local readability cost; readers recover the claim from a front-loaded sentence but at the cost of re-reading, and skim-readers pick up the words before the final punctuation as the takeaway, so stress-position misuse dilutes the sentence's impact.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-3 agent self-check + Tier-4 Codex review. Not Tier-1 because identifying the "key fact" in a sentence requires judgment.
+
+##### Directive
+
+End sentences with the information you want the reader to remember. The beginning of a sentence (topic position) connects to what came before; the end (stress position) is where new or important information lands with maximum emphasis. If the key fact is in the middle, move it to the end or rebalance. The rule applies especially to result sentences in papers, conclusions in design docs, and root-cause lines in postmortems.
+
+##### BAD → GOOD
+
+- BAD: `A 3.2-point improvement in F1 over the previous best model was demonstrated by the new architecture on the SQuAD 2.0 test set.`
+- GOOD: `On the SQuAD 2.0 test set, the new architecture improves F1 by 3.2 points over the previous best model.`
+
+- BAD: `The outage was caused by a cron job that ran at the wrong time.`
+- GOOD: ``The outage was caused by a cron job firing every minute instead of every hour (typo in the crontab: `* * * * *` instead of `0 * * * *`).``
+
+- BAD (commit message): `Fix for issue where users occasionally see a blank page in the dashboard when their session has expired and they try to navigate to a protected route.`
+- GOOD (commit message): `On expired-session navigation to protected routes, redirect to /login instead of rendering the blank dashboard frame.`
+
+- BAD (release note): `Performance improvements in the search pipeline are included in this release, with p95 query latency improving from 340ms to 95ms and p99 from 870ms to 180ms.`
+- GOOD (release note): `p95 search latency drops from 340ms to 95ms; p99 drops from 870ms to 180ms.`
+
+- BAD (paper sentence): `The approach is to first train a contrastive embedder, and then the retrieval performance can be measured across the five benchmarks.`
+- GOOD (paper sentence): `We first train a contrastive embedder, then measure retrieval performance across five benchmarks: MS MARCO, FEVER, HotpotQA, NQ, and TriviaQA.`
+
+##### Rationale for AI Agent
+
+Gopen & Swan 1990 show empirically (American Scientist study of sentence clarity) that readers unconsciously expect the stress position for new information. When a sentence front-loads the new information and tails off into background, readers experience the sentence as flat and re-read to recover the claim. LLMs often produce the BAD pattern because token-by-token generation rewards completing the sentence with whatever is most fluent, frequently a prepositional phrase that restates topic material already established rather than introducing new information. The operational rewrite: identify the sentence's key claim, then rebuild the sentence so that the claim lands at the end. For multi-sentence units (paragraphs), the same logic applies at the paragraph level: the opening sentence frames; the final sentence lands the main point; middle sentences support.
+
+#### RULE-12: Break Long Sentences; Vary Length (Split Sentences over 30 Words)
+
+- **source**: Strunk & White §II.18 (arrangement of sentences; varied length across a paragraph). Pinker 2014 Ch. 4 (syntax and working-memory limits; long sentences with nested clauses tax the reader's parsing budget).
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files; RULE-12 carries a positive directive because sentence-splitting and length-variation are constructive structural choices rather than anti-patterns to flag. Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow.
+- **severity**: high. Long sentences are a recurring AI tell and a recurring clarity failure; time-constrained technical readers (on-call engineers, reviewers, release-note skimmers) cannot parse 40+ word sentences reliably.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-1 `ask` (sentence > 30 words; suggest split) + Tier-2 variance-of-sentence-length metric + Tier-3 agent self-check.
+
+##### Directive
+
+Split any sentence over 30 words into two or more sentences. Vary sentence length across a paragraph: a paragraph of five 25-word sentences reads less well than the same content in sentences of 8, 18, 22, 14, 30 words. Short sentences land points; long sentences carry qualification and detail. A paragraph that does only one of these reads as monotone. When a long sentence is unavoidable (single logical unit that resists splitting), make the previous and following sentences short to balance.
+
+##### BAD → GOOD
+
+- BAD (43 words, single sentence): `We evaluate our model on five standard benchmarks covering natural-language inference, reading comprehension, and factual-recall tasks, reporting both in-distribution accuracy on held-out splits of the training corpora and out-of-distribution accuracy on benchmarks not seen during training or fine-tuning.`
+- GOOD (three sentences, 15 + 12 + 11 words): `We evaluate our model on five standard benchmarks: NLI, reading comprehension, and factual-recall. In-distribution accuracy uses held-out splits of the training corpora. Out-of-distribution accuracy uses benchmarks not seen during training.`
+
+- BAD (monotone paragraph, four 22-word sentences): `The ingestion pipeline processes incoming records in batches of one thousand items and stores them in the primary document store. Each batch is processed by the ingest worker which runs on a schedule of every five minutes. The document store maintains an index on the timestamp field which enables range queries. Query performance is acceptable for batch sizes up to fifty thousand records per minute.`
+- GOOD (varied, 8 + 22 + 14 + 11 words): `The ingest worker handles incoming records in batches. Every five minutes, it pulls up to a thousand records and writes them to the primary document store. The store keeps a timestamp index that supports range queries. At fifty thousand records per minute, performance holds.`
+
+- BAD (runbook, 34 words): `If the primary database instance becomes unavailable for more than two minutes due to either a network partition or a full restart cycle, initiate failover to the replica using the promote_replica.sh script in the ops directory.`
+- GOOD (split): ``Fail over to the replica if the primary is unavailable for more than two minutes. Unavailability includes both network partition and full restart cycle. Run `ops/promote_replica.sh` to promote.``
+
+- BAD (paper abstract, 54 words): `In this work we investigate whether large language models pre-trained on code exhibit emergent understanding of algorithmic concepts, testing this hypothesis by measuring zero-shot performance on a suite of algorithm-design tasks and comparing the pattern of successes and failures to human performance on the same tasks collected from online programming forums over a period of six months.`
+- GOOD (four sentences): `Do code-pretrained LLMs exhibit emergent understanding of algorithmic concepts? We test this by measuring zero-shot performance on a suite of algorithm-design tasks. We compare performance to human baselines collected from online programming forums over six months. We report the pattern of shared successes and failures across model size and task difficulty.`
+
+- BAD (changelog, monotone): `This release adds support for OAuth 2.0 device flow authentication. This release also adds a new audit log for all API requests. This release introduces rate limiting on the free tier at 100 requests per minute. This release fixes a crash in CSV export when a cell contains an embedded newline.`
+- GOOD (varied): `OAuth 2.0 device flow authentication ships in this release. A new audit log now captures all API requests. Free-tier clients see rate limiting at 100 req/min. CSV export no longer crashes on cells containing embedded newlines.`
+
+##### Rationale for AI Agent
+
+LLM decoding rewards well-formed completions; the next-token objective encourages sentences to continue with qualifications rather than stop and restart. The result is a tendency toward 30+ word sentences with multiple subordinate clauses. Readers, especially time-constrained readers of technical prose, read in chunks; chunks larger than working-memory capacity cause comprehension failure and re-reading. Short sentences also carry emphasis that long sentences dilute; a paragraph that never shifts sentence length reads as a flat surface, and the reader skims over the points that were meant to land. The operational guide for AI generation: after drafting, count words per sentence in each paragraph of technical prose; split anything over 30 words; vary lengths across the paragraph (no five similarly-sized sentences in a row). Pinker 2014 Ch. 4 frames the syntax/working-memory tradeoff; Strunk & White §II.18 give the variation principle.
+
+## The 9 Field-Observed Rules
+
+The following nine rules (RULE-A through RULE-I) come from my observation of LLM output across dozens of writing projects and code releases, 2022 to 2026. They are not drawn from cited writing authorities; each rule names a recurring pattern I saw frequently enough across distinct projects to warrant a named rule. They are treated as peer input to the 12 canonical rules in all adapter files; when an agent consumes the ruleset, both groups are binding.
+
+### Observed LLM Patterns
+
+#### RULE-A: Do Not Convert Prose into Bullet Points Unless the Content Is a Genuine List
+
+- **source**: My observation of LLM output across dozens of writing projects and code releases, 2022–2026. Adjacent to `agent-config` / `anywhere-agents` AGENTS.md Formatting Defaults: "Do not convert paragraphs into bullet points unless the user asks for that format."
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: medium. Recurring structural AI-tell; bullet-ification fragments reasoning and signals "AI summary" register in proposals, design docs, and research-paper introductions.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-2 heuristic (flag consecutive bullet lists longer than 4 items with identical opener pattern, or bullets where subject-verb flow would connect the items into prose) + Tier-3 agent self-check + Tier-4 Codex review.
+
+##### Directive
+
+Keep prose in paragraphs when ideas connect by cause-and-effect, argument, or narrative. Use bullets only when items are genuinely parallel enumerations (API endpoints, config options, checklist steps). The test: if a reader reads only the first few words of each bullet, does the shape recover meaning? For a genuine list, yes (each bullet names a thing); for fragmented prose, no (bullets are sentence shards with connective tissue stripped). Do not force 3-item lists when 2 items or a sentence fit; LLMs over-produce "first, second, third" triads where 2 items would be natural. Resist the pattern.
+
+##### BAD → GOOD
+
+- BAD (proposal, bullet-ified argument):
+
+    ```text
+    Our approach consists of:
+    - Training a contrastive embedder
+    - Because this improves retrieval recall
+    - Which is important for RAG pipelines
+    - And enables downstream applications
+    ```
+
+- GOOD (proposal): `Our approach trains a contrastive embedder, which improves retrieval recall for downstream RAG pipelines.`
+
+- BAD (design doc, bullet-ified causal chain):
+
+    ```text
+    The architecture decision:
+    - We chose two-tower retrieval
+    - Rather than cross-encoding
+    - Because query embeddings cache across sessions
+    - And document index updates nightly without re-inference
+    ```
+
+- GOOD (design doc): `We chose two-tower retrieval over cross-encoding because the query embedding caches across sessions, and the document index updates nightly without re-running inference on the query side.`
+
+- BAD (API doc, fragmented single sentence):
+
+    ```text
+    Rate limits:
+    - Free tier
+    - 100 requests
+    - Per minute
+    - Per user
+    ```
+
+- GOOD (API doc): `Rate limits: the free tier allows 100 requests per minute per user.`
+
+- BAD (postmortem, forced 3-item triad):
+
+    ```text
+    The outage had three causes:
+    - A misconfigured load balancer rule
+    - An outdated auth-v1 service
+    - And insufficient alerting on auth-v1
+    ```
+
+- GOOD (postmortem): `A misconfigured load balancer rule routed /auth/* traffic to the outdated auth-v1 service. Insufficient alerting on auth-v1 delayed detection by 37 minutes.`
+
+- BAD (README, forced "three strengths" triad):
+
+    ```text
+    Our framework has three key strengths:
+    - It is fast
+    - It is accurate
+    - It is easy to use
+    ```
+
+- GOOD (README): `Our framework is fast (~2ms per query), accurate (94.3% top-1 on the benchmark suite), and ships as a drop-in Python library.`
+
+##### Rationale for AI Agent
+
+LLMs default to bullets whenever they present multiple ideas because bullets read as structured and signal "I am being organized." But bullets fragment reasoning: each bullet becomes an isolated shard, the connective tissue (because, therefore, however) disappears, and the reader reconstructs the argument from the shards. The specific 3-item triad is especially common; LLMs have learned that "first, second, third" structures feel balanced and complete, so they produce them even when the underlying content is two items or a flowing sentence. The fix: use bullets only when items are genuinely independent enumerations; use prose when ideas connect. The test sentence after drafting any list: can this become prose without loss? If yes, it probably should.
+
+#### RULE-B: Do Not Use Em or En Dashes as Casual Sentence Punctuation
+
+- **source**: My observation of LLM output across dozens of writing projects and code releases, 2022–2026. Adjacent to `agent-config` / `anywhere-agents` AGENTS.md Formatting Defaults: "Avoid heavy dash use. Do not use em dashes or en dashes as casual sentence punctuation. Prefer commas, semicolons, colons, or parentheses instead."
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files; the dash-as-punctuation regex flag is our separate mechanical enforcement choice (Zhang does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: medium. Recurring and externally visible AI-tell; LLMs produce em dashes at substantially higher rates than skilled human technical writers, producing a cadence that human readers recognize as AI-paced.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-1 `ask` (em-dash and en-dash regex, excluding ranges and paired names) + Tier-3 agent self-check + Tier-4 Codex review.
+
+##### Directive
+
+Do not use em dashes or en dashes as casual sentence punctuation. Prefer commas for appositives, semicolons for linked independent clauses, colons for expansions, and parentheses for asides. En dashes remain correct in numeric ranges (`1-3`, `2020-2026`), paired names ("the Stein-Strömberg theorem"), and bibliographic page ranges. Normal hyphens in compound words and technical terms (`command-line`, `co-PI`, `zero-shot`) are not dashes and should not be flagged.
+
+##### BAD → GOOD
+
+- BAD: `The model converges quickly — typically within 5000 training steps — on most datasets.`
+- GOOD: `The model converges quickly, typically within 5000 training steps, on most datasets.`
+
+- BAD: `We use three optimizers — AdamW, Lion, and SGD — in the ablation.`
+- GOOD: `We use three optimizers in the ablation: AdamW, Lion, and SGD.`
+
+- BAD (release note): `This release fixes the CSV export crash — the one reported last week — and adds a filter-reset shortcut.`
+- GOOD (release note): `This release fixes the CSV export crash reported in issue #1847 and adds a filter-reset shortcut.`
+
+- BAD (paper): `The method works well on in-distribution data — our primary evaluation target — and degrades gracefully on out-of-distribution inputs.`
+- GOOD (paper): `The method works well on in-distribution data (our primary evaluation target) and degrades gracefully on out-of-distribution inputs.`
+
+- BAD (blog post): `This is important — and somewhat surprising — because earlier work suggested the opposite.`
+- GOOD (blog post): `This is important, and somewhat surprising, because earlier work suggested the opposite.`
+
+##### Rationale for AI Agent
+
+LLMs absorb the em dash as a favored connector from long-form journalism and essay prose (the register of magazine essays and essay-heavy blogs), where it carries rhythm and emphasis. In dense technical prose, every em dash is a pause the reader must hold in working memory while the parenthetical completes; two em dashes per sentence approach the working-memory ceiling for most readers. The recent public awareness of em dash overuse as an AI-tell is partly because LLMs produce them at several times the rate of skilled human technical writers, producing a cadence human readers recognize as AI-paced. Commas, semicolons, colons, and parentheses each carry a clearer semantic signal (list-separator, independent-clause break, expansion, aside); replacing em dashes with the punctuation that actually matches the relationship makes the sentence's logical structure explicit rather than rhythm-dependent. Normal hyphenation in compound words and technical terms remains correct; the rule targets dashes acting as punctuation, not hyphens joining words.
+
+#### RULE-C: Do Not Start Consecutive Sentences with the Same Word or Phrase
+
+- **source**: My observation of LLM output across dozens of writing projects and code releases, 2022–2026. Adjacent to `agent-config` / `anywhere-agents` AGENTS.md Formatting Defaults: "Prefer not to start several consecutive sentences with the same word or phrase."
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: medium. Local rhythm issue; paragraphs read as monotone and template-filled when same-starts accumulate.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-2 (first-word check across consecutive sentences in a paragraph; flag two or more consecutive identical openers) + Tier-3 agent self-check + Tier-4 Codex review.
+
+##### Directive
+
+Do not open two or more consecutive sentences with the same word. The pattern signals a drafting template that the generation process locked into (often `This ... This ... This ...`, `The ... The ... The ...`, or `We ... We ... We ...`). Vary the opener: topic-fronted versus subject-fronted versus connective. Pronoun subjects (`It`, `We`, `They`) are the most common offenders in LLM output because the model samples the next sentence conditional on the topic and re-picks the most fluent subject.
+
+##### BAD → GOOD
+
+- BAD (paper): `The method uses a contrastive loss. The method also applies dropout. The method converges in 5000 steps.`
+- GOOD (paper): `The method uses a contrastive loss with 10% dropout, converging in 5000 steps.`
+
+- BAD (release note): `This release adds OAuth support. This release fixes a CSV export bug. This release improves startup time.`
+- GOOD (release note): `OAuth support lands in this release. A CSV export bug is fixed. Startup time drops from 4.2s to 1.8s.`
+
+- BAD (paper, we-starts): `We trained the model. We evaluated on five benchmarks. We found improvements across all metrics.`
+- GOOD (paper): `We trained the model and evaluated it on five benchmarks, finding improvements across all metrics.`
+
+- BAD (API doc): `The API returns JSON. The API supports pagination. The API rate-limits at 100 req/min.`
+- GOOD (API doc): `The API returns paginated JSON and rate-limits at 100 req/min.`
+
+- BAD (postmortem, it-starts): `It started at 14:00 UTC. It lasted 37 minutes. It affected 12% of users.`
+- GOOD (postmortem): `The incident started at 14:00 UTC, lasted 37 minutes, and affected 12% of users.`
+
+##### Rationale for AI Agent
+
+LLMs producing text token-by-token often lock into a successful opener and repeat it. Once `The method ...` works, the next-token distribution for the following sentence frequently starts with `The method ...` again because the prefix has become conditionally likely given the topic. The result: paragraphs with three or four identically-opened sentences. Human readers read these as template-filled rather than argued; even when the content is correct, the form signals a machine pattern. The fix at generation time: after a sentence is drafted, the next sentence's opener should vary, either by moving the new information to the subject position, combining the two sentences, or using a connective. This rule interacts with RULE-12 (sentence length variation); both aim at paragraph-level rhythm.
+
+#### RULE-D: Do Not Overuse Transition Words ("Additionally", "Furthermore", "Moreover")
+
+- **source**: My observation of LLM output across dozens of writing projects and code releases, 2022–2026. Adjacent to `agent-config` / `anywhere-agents` AGENTS.md Formatting Defaults: "Avoid overusing transition words like 'Additionally' or 'Furthermore.'"
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: medium. Recurring externally visible AI-tell; opening two or three consecutive sentences with "Additionally" / "Furthermore" / "Moreover" is one of the most distinctive cadences AI-generated text is recognized by.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-1 `ask` (sentence-initial transition word list: "Additionally", "Furthermore", "Moreover", "In addition", "What's more", "Notably"; flag when combined with paragraph-level frequency) + Tier-2 ProseLint + Tier-3 agent self-check.
+
+##### Directive
+
+Do not open sentences with "Additionally", "Furthermore", "Moreover", "In addition", "What's more", or "Notably" unless the sentence genuinely builds on the preceding clause in a way that a period or `And` would not convey. In most cases, a period ends the prior sentence and the next sentence makes the connection by content alone. Reserve explicit transitions for the rare case where the logical move (addition, contrast, concession) needs to be flagged for the reader.
+
+##### BAD → GOOD
+
+- BAD (paper): `The model outperforms BM25 on MS MARCO. Additionally, it outperforms DPR on Natural Questions. Furthermore, it reaches state-of-the-art on BEIR.`
+- GOOD (paper): `The model outperforms BM25 on MS MARCO and DPR on Natural Questions, and reaches state-of-the-art on BEIR.`
+
+- BAD (proposal): `The project addresses retrieval accuracy. Moreover, it addresses latency. In addition, it addresses interpretability.`
+- GOOD (proposal): `The project addresses three targets: retrieval accuracy, latency, and interpretability.`
+
+- BAD (design doc): `We cache embeddings for 24 hours. Additionally, we invalidate on source-document update. Furthermore, we rebuild the cache nightly.`
+- GOOD (design doc): `We cache embeddings for 24 hours, invalidate on source-document update, and rebuild the cache nightly.`
+
+- BAD (release note): `This release adds OAuth support. Additionally, it fixes the CSV export crash. Furthermore, it improves startup time.`
+- GOOD (release note): `OAuth support lands in this release. The CSV export crash is fixed. Startup time drops from 4.2s to 1.8s.`
+
+- BAD (blog): `The method is simple. Additionally, it is fast. Furthermore, it generalizes.`
+- GOOD (blog): `The method is simple, fast, and generalizes to new domains.`
+
+##### Rationale for AI Agent
+
+LLM training on formal essay corpora (academic prose, Wikipedia, editorial writing) over-represents explicit transitions. "Additionally", "Furthermore", "Moreover" appear at higher frequency in LLM output than in skilled technical prose, producing the distinctive sentence-initial cadence AI-generated text is recognized by. The fix: connective tissue should usually be implicit (the next sentence is obviously an addition because of its content) rather than marked. Explicit transitions remain legitimate where the logical move is non-obvious, or where a paragraph-level contrast needs flagging for the reader. Related: RULE-04 catches word-level filler phrases ("in order to", "due to the fact that"); RULE-D catches the specific sentence-initial transition pattern that RULE-04's phrase list does not target. Both rules cut needless words; they target different positions in the sentence.
+
+#### RULE-E: Do Not Close Every Paragraph with a Summary Sentence
+
+- **source**: My observation of LLM output across dozens of writing projects and code releases, 2022–2026. Adjacent to `agent-config` / `anywhere-agents` AGENTS.md Formatting Defaults: "Not every paragraph needs a tidy summary sentence at the end."
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: medium. Structural throat-clearing; adds length without adding information. Pattern is externally visible because well-read technical readers skim past it, marking the prose as machine-generated or unedited.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-3 agent self-check (paragraph-level judgment) + Tier-4 Codex review.
+
+##### Directive
+
+Do not end every paragraph with a sentence that restates the paragraph's point ("In summary, ...", "Thus, the contribution is ...", "Overall, this means ...", "In conclusion, ..."). Summary closers are correct for the final paragraph of a piece, or for a long section that the reader will skim rather than read sequentially. For body paragraphs, trust the content to land its own point; a closer that restates the same claim in different words is noise. The test: if the closer sentence is deleted, does the paragraph still make its point? If yes, delete the closer.
+
+##### BAD → GOOD
+
+- BAD: `We trained the model on 50k query-passage pairs and evaluated on five benchmarks. The model reaches 0.79 recall@10 on our held-out set. Overall, these results demonstrate that our method is effective.`
+- GOOD: `We trained the model on 50k query-passage pairs and evaluated on five benchmarks. The model reaches 0.79 recall@10 on our held-out set.`
+
+- BAD (design doc): `We chose two-tower retrieval because query embeddings cache across sessions. Thus, the architecture is well-suited to our caching strategy.`
+- GOOD (design doc): `We chose two-tower retrieval because query embeddings cache across sessions.`
+
+- BAD (proposal): `The proposed work advances retrieval-augmented generation for medical question answering. In summary, the project combines several research directions into a unified framework.`
+- GOOD (proposal): `The proposed work advances retrieval-augmented generation for medical question answering.`
+
+- BAD (blog): `The bug was a single-character typo in the crontab (five asterisks instead of "0 hour"). In conclusion, this small typo caused a large outage.`
+- GOOD (blog): `The bug was a single-character typo in the crontab: five asterisks instead of the intended hourly schedule.`
+
+- BAD (paper): `Our method reaches 88.3% top-1 on ImageNet-1k, 1.2 points above Wang et al. 2025. Overall, our approach sets a new benchmark on ImageNet.`
+- GOOD (paper): `Our method reaches 88.3% top-1 on ImageNet-1k, 1.2 points above Wang et al. 2025.`
+
+##### Rationale for AI Agent
+
+LLMs often add paragraph-closing summaries because academic and expository corpora include "topic sentence + body + summary sentence" structures prominently. The closer signals "I am finishing this thought" but adds no new information. Technical readers who skim skip the closer anyway (they read the topic sentence and the first specific claim); careful readers feel the redundancy as padding. Related: RULE-04 catches word-level filler phrases; RULE-E catches the paragraph-level padding pattern that RULE-04's word-level deny list does not reach. Both rules cut needless content; they operate at different structural levels (word versus paragraph).
+
+#### RULE-F: Use Consistent Terms; Do Not Redefine Abbreviations Mid-Document
+
+- **source**: My observation of LLM output across dozens of writing projects and code releases, 2022–2026. Adjacent to `agent-config` / `anywhere-agents` AGENTS.md Writing Defaults: "Use consistent terms. If an abbreviation is defined once, do not define it again later."
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: medium. Recurring clarity failure in long documents; varied terms force the reader to check whether each new term refers to the same concept or a new one.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-2 (first-use abbreviation tracking across document; flag later re-expansions and flag synonym drift when a defined abbreviation is replaced with a paraphrase without reason) + Tier-3 agent self-check + Tier-4 Codex review.
+
+##### Directive
+
+Once you introduce a term or abbreviation, keep using it. Do not alternate "large language model", "LLM", "language model", "LM", "neural language model", "foundation model" as synonyms for the same thing. Do not redefine an abbreviation: if `LLM` was defined as `large language model` in the introduction, do not expand it again in section 3. For the reader, a consistent term signals "this is the same concept I saw earlier"; varied terms signal "I should check whether this is something new."
+
+##### BAD → GOOD
+
+- BAD (paper, term drift): introduces "large language models (LLMs)" in §1, then writes in §3: "Neural language models achieve..."
+- GOOD (paper): introduces "large language models (LLMs)" in §1, then writes in §3: "LLMs achieve..."
+
+- BAD (doc, expansion re-emerges): "We use retrieval-augmented generation (RAG). ... / later / Retrieval-augmented-generation architectures..."
+- GOOD (doc): "We use retrieval-augmented generation (RAG). ... / later / RAG architectures..."
+
+- BAD (API doc, drift across synonyms): "The `/users` endpoint returns user objects. ... / later / The user endpoint supports filtering. ... / later / Our user resource accepts query parameters ..."
+- GOOD (API doc): "The `/users` endpoint returns user objects. ... / later / `/users` supports filtering. ... / later / `/users` accepts query parameters ..."
+
+- BAD (proposal, specific-aim drift): "Aim 1 focuses on retrieval. ... Aim 1 addresses document selection. ... The first aim investigates retrieval-augmented generation."
+- GOOD (proposal): "Aim 1 focuses on retrieval. ... Aim 1 addresses document selection. ... Aim 1 investigates retrieval-augmented generation."
+
+- BAD (runbook, system synonyms): "If the service is down, restart the service. If `app-v2` is offline, bounce the worker pool. If the backend stops responding, failover."
+- GOOD (runbook): "If `app-v2` is offline, restart via `systemctl restart app-v2.service`. If `app-v2` still fails, failover to the replica."
+
+##### Rationale for AI Agent
+
+LLMs often vary terminology within a document because variety is mildly rewarded in the training distribution (reviewers and editors mark repetitive vocabulary as prose to be varied, and LLMs learn to alternate). But in technical writing, variety across terminology for the same entity masks the entity's identity and forces the reader to check whether each new term refers to the same concept. RULE-01 covers the first-use introduction of terms; RULE-F covers keeping them consistent thereafter. Gopen & Swan 1990 discuss this under "topic continuity", where subjects and entities should reappear as the same linguistic form across sentences. For documents produced in multi-turn generation, the risk is especially high because the model samples each new paragraph without guaranteed visibility into earlier-introduced terms, leading to drift. The fix at generation time: after defining a term, the agent should maintain a running glossary for the document and re-use the defined form consistently.
+
+#### RULE-G: Use Title Case for Section and Subsection Headings
+
+- **source**: My observation of LLM output across dozens of writing projects and code releases, 2022–2026. LLMs default to sentence case for Markdown and LaTeX headings; in academic and engineering contexts that call for title case, the sentence-case drift is a visible AI-tell.
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files; RULE-G uses a positive directive because applying title case is a constructive placement rather than an anti-pattern to flag. Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: low. Polish rather than comprehension; readers recover meaning from either case. Pattern is high-visibility however because headings are the first thing a skimmer sees.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and similar structural heading surfaces.
+- **enforcement**: Tier-1 `ask` (heading-style check; H2/H3/H4 starting with sentence-case pattern flagged for title-case conversion, excluding question-style or full-sentence headings where sentence case is intended) + Tier-3 agent self-check.
+
+##### Directive
+
+Capitalize the first word, the last word, and all major words (nouns, verbs, adjectives, adverbs, pronouns) in section and subsection headings. Lowercase articles (`a`, `an`, `the`), coordinating conjunctions (`and`, `but`, `or`, `nor`), and short prepositions (`of`, `in`, `on`, `to`, `for`, `by`, `at`, `with`). This applies in Markdown (H1 through H6), LaTeX (`\section`, `\subsection`, `\subsubsection`), reStructuredText, and similar structural-heading surfaces. Does not apply to sentence-style titles (question-form headings or full-sentence article titles where sentence case is intended).
+
+##### BAD → GOOD
+
+- BAD (Markdown): `## Experimental results and analysis`
+- GOOD (Markdown): `## Experimental Results and Analysis`
+
+- BAD (LaTeX): `\subsection{Limitations and future work}`
+- GOOD (LaTeX): `\subsection{Limitations and Future Work}`
+
+- BAD (README): `## Getting started with the API`
+- GOOD (README): `## Getting Started with the API`
+
+- BAD: `### Related work in medical image retrieval`
+- GOOD: `### Related Work in Medical Image Retrieval`
+
+- BAD: `## Evaluating on out-of-distribution data`
+- GOOD: `## Evaluating on Out-of-Distribution Data`
+
+##### Rationale for AI Agent
+
+LLMs default to sentence case for Markdown and LaTeX headings because their training data includes a substantial amount of modern blog and docs-site Markdown where sentence case is the convention (large platform developer documentation and docs-site prose). But academic and engineering venues (most conferences, most IEEE and ACM journals, most research groups' README conventions) use title case. A document with sentence-case headings inside a title-case context reads as machine-generated or unedited. The fix is mechanical: apply title case at heading write time. This rule is low-severity in terms of comprehension (readers recover meaning regardless) but high-visibility in terms of AI-tell detection, because headings are the first thing a skimmer sees, and miscased headings signal inattention.
+
+#### RULE-H: Support Factual Claims with Citation or Concrete Evidence; Do Not Be Handwavy
+
+- **source**: My observation of LLM output across dozens of writing projects and code releases, 2022–2026. Adjacent to `agent-config` / `anywhere-agents` AGENTS.md Writing Defaults: "If citing papers, verify that they exist." This rule is the flagship of the three-rule cluster against handwavy prose (RULE-03 on vague nouns, RULE-08 on uncalibrated verbs, RULE-H on unsupported claims).
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files (does not validate mechanical enforcement). Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: critical. Uncited claims are a trust failure; fabricated citations are worse (permanent damage to reader trust once the fabrication is discovered). LLMs both default to citation-free hedges ("prior work shows", "recent studies suggest") and actively hallucinate plausible-looking citations that do not exist (Ji et al. 2023 survey of hallucination in NLG; Agrawal et al. 2024 empirical measurement).
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-3 agent self-check (judgment about what needs attribution) + Tier-4 Codex review as primary gate. Supporting practice for agents: before writing any `Author Year` citation, verify via search (DBLP, arXiv, Google Scholar, or the cited paper's own bibliography) that the reference exists and supports the cited claim; otherwise mark `[UNVERIFIED]` placeholder or rewrite the sentence. Never generate a citation without verification.
+
+##### Directive
+
+When a sentence asserts a factual claim that warrants attribution (empirical result, published method, community consensus, comparative benchmark, historical fact), provide a verifiable citation, or name the specific source (a paper by author and year, a benchmark, a dataset, an observed experiment). Do not write handwavy attributions ("prior work shows", "it is well known that", "recent studies suggest", "many researchers believe") without naming the specific work. When the claim is the author's own observation, state the concrete evidence (number, dataset, experiment, condition). Never invent a citation; if the cited paper cannot be verified, remove the claim, soften it to the author's own observation, or mark `[UNVERIFIED]` and flag for review.
+
+##### BAD → GOOD
+
+- BAD (paper): `Prior work has shown that late-interaction retrieval improves over lexical retrieval.`
+- GOOD (paper): `Khattab and Zaharia 2020 (ColBERT) report MS MARCO passage-ranking MRR@10 of 0.360 for ColBERT versus 0.187 for BM25-Anserini, using contextualized late interaction over BERT token embeddings.`
+
+- BAD: `It is widely accepted that longer context improves RAG performance.`
+- GOOD: `Liu et al. 2023/2024 (TACL, "Lost in the Middle") show that models answer less accurately when the relevant evidence is in the middle of a long context than near the beginning or end; Dsouza et al. 2024 report the same lost-in-the-middle pattern for GPT-4 and Claude 3 Opus.`
+
+- BAD (paper): `Several studies have demonstrated the effectiveness of this approach.`
+- GOOD (paper): `In our reproduced evaluation, the model improves GSM8K exact-match accuracy from 92.1% to 95.2% and MATH exact-match accuracy from 48.0% to 51.4% under the same decoding settings.`
+
+- BAD (grant proposal): `Our pilot results look promising.`
+- GOOD (grant proposal): `Our pilot (N=30 cohort, 3-month follow-up) shows AUROC 0.84 for the primary endpoint versus 0.72 for the standard-of-care baseline (p=0.012).`
+
+- BAD (blog post): `Many researchers believe that contrastive learning produces better embeddings.`
+- GOOD (blog post): `Chen et al. 2020 (SimCLR) report 76.5% ImageNet top-1 linear-evaluation accuracy for a self-supervised ResNet-50, a 7% relative gain over prior self-supervised methods and comparable to a supervised ResNet-50 baseline in their setup.`
+
+- BAD (commit message): `Fix based on user feedback.`
+- GOOD (commit message): `Fix null-pointer crash reported in issue #1847 (reproducible with empty cart).`
+
+##### Rationale for AI Agent
+
+LLMs produce handwavy, citation-free claims as a default register absorbed from formulaic abstract and review prose in the training corpus. Phrases like "prior work shows", "recent studies suggest", "it is well known that", "many researchers believe" appear at high frequency in academic introductions and review articles, where they serve as transition filler between specific claims. LLMs sample them at comparable rates without carrying the specific attributions that human authors have in mind when writing them. Additionally, LLMs hallucinate citations that look plausible (matching author conventions, year ranges, venue patterns) but point to non-existent papers; the hallucination rate is well-documented across domains. Both failures compound: an uncited claim is unverifiable, and a fabricated citation is worse than no citation because it damages reader trust permanently once discovered. The operational test before writing any factual-claim sentence: is there a specific, verifiable source, observation, or number behind this? If yes, state it by author and year, or by dataset and measurement. If no, either find the source before writing, or rewrite the sentence as a claim about the author's own experience (which must still be concrete: numbers, dataset, conditions). For LLMs specifically: never generate a citation without first verifying via DBLP, arXiv, Google Scholar, or the cited paper's own bibliography. If verification is not possible in the current session, mark `[UNVERIFIED]` and flag for review. Related: RULE-03 fights vague nouns; RULE-08 fights uncalibrated verbs; RULE-H fights unsupported claims. All three aim at specific, verifiable, honest prose; a single sloppy sentence often fires all three rules simultaneously.
+
+#### RULE-I: Prefer Full Forms over Contractions in Technical Prose
+
+- **source**: My observation of LLM output across dozens of writing projects and code releases, 2022–2026. Adjacent to `agent-config` / `anywhere-agents` AGENTS.md Formatting Defaults: "Prefer full forms such as 'it is' and 'he would' rather than contractions."
+- **agent-instruction evidence**: Zhang et al. 2026 supports negative phrasing for anti-pattern directives in coding-agent instruction files; RULE-I uses a positive directive because preferring full forms is a constructive placement rather than an anti-pattern to flag. Bohr 2025 supports pairing directives with examples for stronger initial style control over a paired two-turn code-generation workflow (not open-ended prose).
+- **severity**: low. Register rather than comprehension; readers parse contractions correctly. Flagged for consistency because register drift (a contraction in otherwise formal prose) reads as careless.
+- **scope**: `.md`, `.tex`, `.rst`, `.txt`, and prose sections of source files.
+- **enforcement**: Tier-1 `ask` (contraction list: "it's", "doesn't", "don't", "won't", "can't", "I'm", "you're", "we're", "they're", "that's"; flagged with expansion suggestion) + Tier-3 agent self-check.
+
+##### Directive
+
+In formal technical prose (research papers, grant proposals, API specifications, technical documentation), prefer "it is" over "it's", "does not" over "doesn't", "cannot" over "can't", "will not" over "won't", "I am" over "I'm", "you are" over "you're". Contractions are acceptable in informal registers (blog posts, release notes, commit messages, casual documentation), but even there, be deliberate: a contraction sets a register, and if the surrounding prose is formal, the contraction reads as a tonal break. The operational test: if the surrounding sentences use full forms, the contraction stands out; if the surrounding sentences use contractions, the full form stands out. Pick the register and hold it within the document.
+
+##### BAD → GOOD
+
+- BAD (paper): `It's worth noting that the model doesn't converge when the learning rate is too high.`
+- GOOD (paper): `The model does not converge when the learning rate is too high.` (The "it is worth noting that" phrase is itself filler and should also be cut per RULE-04.)
+
+- BAD (proposal): `We've shown in prior work that this approach isn't sensitive to initialization.`
+- GOOD (proposal): `We have shown in prior work that this approach is not sensitive to initialization.`
+
+- BAD (API spec): `If the request body can't be parsed, the endpoint won't return a 200 response.`
+- GOOD (API spec): `If the request body cannot be parsed, the endpoint does not return a 200 response.`
+
+- BAD (technical spec): `The client shouldn't retry on 4xx errors.`
+- GOOD (technical spec): `The client must not retry on 4xx errors.`
+
+- BAD (register drift in paper abstract): opens with full forms, then: `Our results show it's possible to achieve this with less compute.`
+- GOOD (paper abstract): `Our results show that it is possible to achieve this with less compute.`
+
+##### Rationale for AI Agent
+
+LLMs produce contractions in technical prose at higher rates than skilled human writers do, because the training corpus mixes formal registers (papers, specifications, government documents) and informal registers (blog posts, forum answers, release notes), and LLMs sample across them without register-matching the surrounding prose. The effect: within a single formal paragraph, one or two contractions appear where a careful writer would have used full forms. Contractions are not wrong; they are register markers. In formal technical prose (the target scope of this ruleset), full forms are the expected register. In informal surfaces (release notes, blog posts, commit messages), contractions are acceptable and sometimes preferred for voice. The rule is about consistency with the surrounding register: pick one and hold it within a document, rather than drifting mid-paragraph.

--- a/plugins/writing/skills/agent-style/references/UPSTREAM-PIN
+++ b/plugins/writing/skills/agent-style/references/UPSTREAM-PIN
@@ -1,0 +1,1 @@
+https://github.com/yzhao062/agent-style e3f14369e66095e518f7b5b328a6cfdc9eb97163 ci: add publish.yml for OIDC Trusted Publishing (PyPI + npm)

--- a/plugins/writing/skills/remove-ai-patterns/SKILL.md
+++ b/plugins/writing/skills/remove-ai-patterns/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: remove-ai-patterns
+description: Remove AI-writing patterns ("AI-isms") from text using the
+  avoid-ai-writing catalog (conorbronsdon/avoid-ai-writing). Use ONLY when the
+  user explicitly asks to remove AI patterns / AI-isms, "make this sound less
+  like AI", "de-AI this text", or invokes remove-ai-patterns by name. Supports
+  detect-only audit, edit-in-place, voice profiles (casual / professional /
+  technical / warm / blunt), and iterate-to-convergence. NOT for
+  clarity/composition rules or formal technical-prose polish — use
+  agent-style for that. Do not auto-trigger for ordinary writing or editing
+  tasks.
+---
+
+# remove-ai-patterns
+
+Thin wrapper around Conor Bronsdon's `avoid-ai-writing` skill (MIT
+licensed). A pinned snapshot of the upstream catalog and detector is
+vendored at `upstream/` inside this skill directory (commit recorded in
+`upstream/UPSTREAM-PIN`), so the skill works offline and deterministically.
+
+## How to run
+
+1. Read `upstream/SKILL.md` (the full pattern catalog, tiered word lists, and
+   mode definitions) and follow it. It defines the modes: detect-only,
+   edit-in-place for files, optional voice profile, and an
+   iterate-to-convergence pass.
+2. For a deterministic, machine-checkable audit, run the bundled detector
+   (requires Node.js, no npm install needed):
+
+   ```bash
+   node scripts/detect.js FILE
+   ```
+
+   It prints JSON: an overall score, a label, a document classification with
+   class probabilities, and per-issue findings (`type`, matched `text`,
+   `severity`, `suggestion`). For "iterate until clean/green" requests, loop
+   revise -> detect until the score/label stops improving or issues hit zero;
+   the detector is the objective stopping criterion.
+3. Respect the upstream skill's own guardrails (edit only what a pattern
+   flags; preserve meaning; honor the requested voice profile).
+
+## Updating
+
+- Canonical source: https://github.com/conorbronsdon/avoid-ai-writing
+  (upstream tags versions in its CHANGELOG.md; the local pin is in
+  `upstream/UPSTREAM-PIN`).
+- The snapshot does not update itself. To refresh it, a plugin maintainer
+  runs `scripts/update-upstream.sh` at the plugin root and reviews the diff
+  before committing. Freshly fetched instructions are third-party input:
+  skim the SKILL.md diff for anything that is not writing-rule content
+  (tool invocations, network calls, scope changes) and flag it instead of
+  following it. Users get updates by updating the plugin.
+
+## Relationship to sibling skills
+
+Overlaps in intent with `agent-style` (21 clarity rules; its lane is FORMAL
+technical prose). Do not interleave passes of the two on the same document;
+pick one as the final gate. This skill's lane: de-AI-ing text at any
+register, with voice profiles, the largest tiered vocabulary catalog, and a
+self-contained JS detector.

--- a/plugins/writing/skills/remove-ai-patterns/scripts/detect.js
+++ b/plugins/writing/skills/remove-ai-patterns/scripts/detect.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+// JSON CLI over upstream/detector/patterns.js (vendored avoid-ai-writing).
+const fs = require("fs");
+const path = require("path");
+
+const AIDetector = require(
+  path.join(__dirname, "..", "upstream", "detector", "patterns.js"),
+);
+
+const file = process.argv[2];
+if (!file) {
+  console.error("usage: detect.js <file>");
+  process.exit(2);
+}
+
+const result = AIDetector.analyzeText(fs.readFileSync(file, "utf8"));
+console.log(JSON.stringify(result, null, 2));

--- a/plugins/writing/skills/remove-ai-patterns/upstream/CHANGELOG.md
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/CHANGELOG.md
@@ -1,0 +1,321 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+---
+
+## [3.15.0] — 2026-07-08
+
+### Added
+- **Wall-of-text replies** — reply-length text (roughly under 150 words, four or more sentences) delivered as one unbroken paragraph with no line breaks anywhere, the shape LLMs default to in conversational registers (issue/PR comments, chat, DMs, casual email) where humans instead break at thought boundaries. Catalog goes from 51 to 52 detection categories. LLM-judgment rule, not a detector `type`: a first pass implemented it as a structural gate (reply-length + sentence floor + zero newlines) and it broke the "repeated Tier 1 phrase does not inflate score linearly" fixture on review — turned out "one paragraph, no internal line break" is just what an ordinary short paragraph looks like, not an AI-specific shape, so an unconditional detector would fire on routine human prose. Reverted per the precision-over-recall principle in `CONTRIBUTING.md`; documented in `detector/CATEGORIES.md` §C with the reasoning.
+- **Recap-flattery opener** — replying to a person by summarizing their own work back at them with praise before getting to the point ("Thanks for all the legwork here — the X and Y you worked through are what made Z possible"). The reader already knows what they did; the recap performs appreciation instead of conveying information. Catalog goes from 52 to 53 detection categories. LLM-judgment rule (no detector `type` — the tell is redundancy with information the reader already holds, which requires reading both sides of an exchange, not a fixed phrase).
+
+### Changed
+- **Formatting** — extended the curly-quotes weak-signal tier with **immaculate typography in casual registers**: perfect spacing, punctuation, and capitalization in a context humans type fast (comments, chat) is corroborating evidence, never conclusive alone. Also flags the inverse: when editing a human's casual text, preserve their typos — smoothing them away erases the fingerprint that marks the text as theirs. LLM-judgment rule; folded into the existing Formatting section (same tier as curly quotes), no new category.
+- Cursor port (`cursor-rules/avoid-ai-writing.mdc`) caught up from v3.12.0 to v3.15.0: ported the 3.13.0 (speculative scenario openers, "deeply" conditional Tier 2, multi-negation countdown, invented concept labels, historical analogy stacking) and 3.14.0 (vague third-party validation) rule changes it had missed, plus this release's three additions.
+
+### Source
+- Observed in the wild: a maintainer on a GitHub issue flagged an assisted-sounding reply with "I prefer to talk human to human." The block-paragraph shape and the recap of the maintainer's own prior work were the tells, not any single word. Name and repo withheld.
+
+---
+
+## [3.14.0] — 2026-07-07
+
+### Added
+- **Vague third-party validation** — manufacturing credibility by pointing at an *unnamed* external authority, usually with a generic superlative ("an outside party measuring the same models everyone runs and putting us on top," "independent testing confirms," "analysts agree"). The authority is faceless and the claim unfalsifiable, so the reader can't tell who measured what or go check. The inverse of **Notability name-dropping** (which over-names *specific* prestigious sources); a passage can run both moves at once. Carve-out: specifically attributed, checkable validation — a named benchmark, a linked report, a dated audit — stays unflagged, since the tell is the vagueness, not the citation. Catalog goes from 50 to 51 detection categories. LLM-judgment rule (no detector `type`); listed in `detector/CATEGORIES.md` §C. Addresses #39 (the follow-up half raised by @hiSandog).
+
+---
+
+## [3.13.0] — 2026-07-07
+
+### Added
+- **Speculative scenario openers** — the LLM habit of opening an argument with a hypothetical that lists desirable outcomes instead of making a claim: "Imagine a world where…", "Picture a future in which…", "Envision a world where…", including the comma-interrupted "Imagine, for a moment, a world where…" cadence. The scenario does the persuading; no evidence is offered. New detection category (49 → 50) and a `speculative-opener` detector `type` (44 → 45). Gated to the world/future/reality object plus where/in-which, so instructional "imagine you have a sorted array" and analytical "consider a scenario where…" stay clean. Known accepted false positive: fiction openings and staged thought experiments also match; the skill's carve-out handles that judgment, and a lone hit cannot flip a document's classification. Source: tropes.fyi ("Imagine a World Where…").
+- **"deeply" as a conditional Tier 2 word** — one of the "magic adverbs" AI uses to inflate mundane descriptions. Stricter than standard Tier 2: "deeply" only counts toward a cluster in its significance collocations ("deeply integrated," "deeply committed," "deeply rooted"), because bare "deeply" is everyday English — adversarial testing showed an unconditional entry flags clean human prose ("deeply nested JSON… crucial") and can tip an otherwise-borderline human document across a classification boundary. Literal uses never count, in any company. Source: tropes.fyi ("Quietly" and Other Magic Adverbs).
+
+### Changed
+- **"It's not X — it's Y" contrastive rule** — extended to name the **multi-negation countdown** ("It's not the price. It's not the features. It's the trust."), the same reveal move inflated across several negated options. LLM-judgment rule; no new category. Source: tropes.fyi ("Not X. Not Y. Just Z.").
+- **Novelty inflation** — extended to flag **invented concept labels**: pseudo-analytical compound terms coined mid-sentence and never defined ("the supervision paradox," "a coordination tax"). Naming a concept is not explaining it. LLM-judgment rule; no new category. Source: tropes.fyi ("Invented Concept Labels").
+- **Notability name-dropping** — extended with a related-pattern note on **historical analogy stacking**: rapid-fire lists of past technologies or companies to borrow their weight ("like the printing press, the telegraph, and the internet before it"). LLM-judgment rule; no new category. Source: tropes.fyi ("Historical Analogy Stacking").
+
+Trope review sourced from [tropes.fyi/directory](https://tropes.fyi/directory) and its [tropes-md digest](https://tropes.fyi/tropes-md), with thanks to the [tropes.fyi markdown gist](https://gist.github.com/ossa-ma/f3baa9d25154c33095e22272c631f5a1) by ossa-ma. Most of the 33 catalogued tropes were already covered; this release adds the gaps that survived a false-positive review.
+
+---
+
+## [3.12.0] — 2026-07-06
+
+### Added
+- **"quietly" to Tier 2 word table** — AI uses "quietly" as a significance adverb to imply underdog credibility without evidence: "quietly building," "quietly reshaping," "quietly becoming." On its own in a sentence it's fine; in a paragraph already leaning on other Tier 2 words it's a cluster tell. Added to both the SKILL.md Tier 2 table and the detector engine. The detector fires when "quietly" appears alongside one other Tier 2 word in the same paragraph. Replacement: cut the adverb, or name the concrete contrast. Source: tropes.fyi/tropes ("Quietly" and Other Magic Adverbs).
+
+---
+
+## [3.11.0] — 2026-07-05
+
+### Changed
+- **"It's not X — it's Y" contrastive rule** — broadened to name the **split-sentence variant**, where the negation and the correction land in two separate sentences ("The headline isn't the speed. The real story is Y.") rather than pivoting on a single dash or comma. The joined form was the rule's implicit template, so the two-sentence split — which reads as two innocent declaratives — was slipping through. Same move, now flagged. LLM-judgment rule; catalog stays at 49 categories. Addresses #39.
+
+---
+
+## [3.10.0] — 2026-06-10
+
+### Added
+- **List-label periods** — in bulleted lists where each item leads with a short label, LLMs end the label with a period and run the gloss as a separate sentence, where a person almost always uses a colon. Strongest with bold labels (`**Intros.**` vs `**Intros:**`); the unbolded shape (`- Intros. Years of...`) is the same tell, slightly weaker. The colon reads as "here's what this label means"; the period reads as a sentence the next clause then contradicts by continuing. Fix is to swap the period for a colon and lowercase the gloss, or drop the bold label entirely. Distinct from inline-header lists (bold headers that repeat the point): this rule is about the punctuation on the label, not the redundancy. Carve-out: a bold span that is a full standalone sentence keeps its period. Catalog goes from 48 to 49 detection categories. LLM-judgment rule (no detector `type`). Closes #31.
+
+---
+
+## [3.9.0] — 2026-06-05
+
+### Added
+- **Social endorsement closers** — the curatorial sign-off LLMs append to LinkedIn/X share posts, usually a colon teeing up a link: "This one is worth your time:", "This one's a must-read:", "Do yourself a favor and read this," "You won't want to miss this one," "Thank me later," "Bookmark this," "Don't sleep on this one." Performs a recommendation without giving the reader a reason to click. Distinct from the bare "worth [verb]ing" word-table entry (a single weak word inside a sentence) and from infomercial engagement hooks (mid-flow teasers) — this is the whole closing line of a social post. Demonstrative-anchored ("THIS one is worth your time") so it stays off plain human endorsements ("the book is worth reading, but the middle drags"). Catalog goes from 47 to 48 detection categories; the detector engine gains a `social-cta-closer` `type` (43 → 44). Closes #29.
+
+---
+
+## [3.8.0] — 2026-05-29
+
+### Added
+- **Self-labeling significance** — back-pointing labels that flag which item in a list is supposed to matter ("That last move is the contrarian one," "This is the interesting part," "That third bullet is the real story") instead of writing the list so the right item carries the weight on its own. Distinct from confidence calibration (which front-loads the cue) and emotional flatline (which prefaces a single claim) — this one back-points after the fact. Catalog goes from 46 to 47 detection categories. LLM-judgment rule (no detector `type`); documented in `detector/CATEGORIES.md` §C.
+
+---
+
+## [3.7.2] — 2026-05-28
+
+### Changed
+- **Curly quotation marks** — recalibrated per review of #15. Reframed from a "strong" tell to a **weak, corroborating** signal meaningful mainly in plain-text contexts (code comments, commit messages, plaintext drafts), since Word/Google Docs/macOS/iOS auto-curl quotes by default. Curly apostrophes (U+2019) are no longer flagged on their own (they appear in every contraction). Fixes the German low-9 example. Keeps it consistent with the deterministic detector's co-occurrence logic (#16).
+
+---
+
+## [3.7.1] — 2026-05-28
+
+### Changed
+- **Curly quotation marks** — refined the 3.7.0 "mixed straight/curly punctuation" rule into a single Formatting rule: flag the unexplained presence of Unicode curly quotes (U+201C / U+201D / U+2018 / U+2019) in otherwise plain-ASCII text as a copy-paste-from-chat fingerprint, with carve-outs for deliberate publication typography and locale-correct punctuation (French guillemets, German low-9 quotes).
+- Version bump to 3.7.1.
+
+### Credit
+- Contributed by [@augustasas](https://github.com/augustasas) (#15).
+
+---
+## [3.7.0] — 2026-05-28
+
+### Added
+- **Hyphenated-pair overuse** — stacked compound modifiers ("a high-quality, well-architected, future-proof solution") and the attributive/predicate error (hyphenate "a high-quality report" but not "the report is high quality").
+- **Speculative gap-filling** — hedged speculation dressed as background ("maintains a low profile," "is believed to have," "likely began his career") that hides a knowledge gap rather than admitting it. Distinct from cutoff disclaimers.
+
+### Changed
+- **Formatting** — added **mixed straight/curly punctuation** (quote/apostrophe style mixed in one document — a paste-from-chat-UI tell).
+- **Confidence calibration phrases** — extended with **persuasive-authority tropes** ("the real question is," "at its core," "fundamentally," "make no mistake").
+- Version bump to 3.7.0.
+
+### Credit
+- Patterns adapted from `blader/humanizer` (P21, P26, P27) and Wikipedia's "Signs of AI writing," identified in the competitive research tracked in #22.
+
+---
+
+## [3.6.0] — 2026-05-28
+
+### Added
+- **Voice profiles** — an optional persona axis, independent of the audience context profiles. Five profiles (`casual`, `professional`, `technical`, `warm`, `blunt`), each a set of concrete targets (sentence length, contraction policy, hedging tolerance, jargon level, rhythm) drawn from writing-craft sources (Strunk, Provost, Ogilvy, Handley). Plus optional calibration to a user-supplied writing sample. Includes a composition rule: voice sets the target, context sets enforcement strictness, conflicts resolve toward the stricter.
+- **Edit mode** — a third mode alongside `rewrite` and `detect`. Edits a named file in place via the Edit tool with minimal, targeted changes, preserving already-human passages, then re-reads to verify. Returns an edits-made + verification report, not the full file.
+- **Iterate to convergence** — rewrite mode can repeat the audit→rewrite cycle until no patterns remain or N passes (capped at 2). Generalizes the existing built-in second pass.
+- **Invocation surface** — documented optional flags (`--mode`, `--voice`, `--context`, `--file`, `--iterate N`) alongside the existing natural-language triggers.
+
+### Changed
+- Frontmatter `description` updated to advertise the new modes and voice profiles.
+- Version bump to 3.6.0.
+
+### Notes
+- Designed from a competitive feature audit (Aboudjem/humanizer-skill, brandonwise/humanizer, blader/humanizer) plus detection-science and writing-craft research. The `--score` feature and four additional catalog patterns from that research are tracked separately (#21, #22).
+
+---
+
+## [3.5.0] — 2026-05-27
+
+### Added
+- **Infomercial engagement hooks** — punchy fragment-hooks that fake momentum around ordinary information: "The catch?", "The kicker?", "Here's the thing.", "Plot twist:", "The best part?". Distinct from rhetorical-question openers (which stall before a point) and chatbot artifacts (which perform helpfulness).
+- **Paragraph-reshuffle immunity** — a writer-side structure test: if you can swap two body paragraphs without breaking the piece, you've written a list of points, not an argument that builds.
+- **Treadmill effect / low information density** — a writer-side content test: each paragraph should contribute one new fact, claim, or turn rather than restate the premise in fresh words. The tell is that you could cut 40-60% and lose no information.
+
+### Changed
+- **Superficial -ing analyses** — extended to cover the declarative "meaning-telling" variant ("this represents a broader shift," "speaks to a larger trend") that glosses a mundane subject as profound without the -ing construction.
+- Version bump to 3.5.0.
+
+### Credit
+- Patterns adapted from [`Aboudjem/humanizer-skill`](https://github.com/Aboudjem/humanizer-skill) (P38, P40, P41, P43), identified during a competitive catalog audit.
+
+---
+
+## [3.4.0] — 2026-05-16
+
+### Added
+- **Tier 3 phrases** — multi-word boilerplate that's individually unobjectionable but stacks heavily in AI-generated crypto/web3/DePIN/AI-infra content: `emerging sector`, `the integration of`, `the intersection of`, `community-driven`, `long-term sustainability`, `user engagement`, `decentralized compute`, `sustainable reward emissions`, `tokenized incentive structures`, `designed for long-term`. Flagged by per-phrase density (≥2 repetitions) *or* cluster (≥3 distinct phrases in one piece — the LLM-varies-its-own-boilerplate shape).
+- **Generic future-narrative closers** — "May become one of the most important narratives of the next market cycle" template family. Modal + "become" + (one of) the most + (narrative / story / trend / theme / chapter / movement).
+- **Hedge-stacked predictions** — `could potentially`, `may eventually`, `might ultimately`. Modal + hedge adverb stack where each word cancels the next.
+- **"Real/actual" adjective inflation** — `real on-chain tokenomics`, `actual reward sustainability`, `genuine utility`, `true product-market fit`. The noun-modifier form distinct from the existing sentence-level hollow-intensifier rule.
+- **Hashtag stuffing** — trailing blocks of 6+ hashtags on short posts, especially when mixing one project tag with broad category tags (#AI #Crypto #Web3 #Innovation #FutureTech).
+- **Bullet lists of bare noun phrases** — 5+ consecutive bullets where each is a short adj+noun pair with no verb. Detector heuristic excludes genuine list content (verbs in items, ingredient lists, changelog entries).
+
+### Changed
+- **Emotional flatline** — extended to cover the bare section-header variant: "Interesting part of the project:" / "Interesting thing here:" — same role as "the most interesting part" but as a header opener.
+- **Severity tiers** — all six new categories wired into P0/P1/P2 ladder (hashtag stuffing varies by profile; the rest are P1, with phrase repetition at P2).
+- **Context profiles tolerance matrix** — added rows for all six new categories so the `linkedin` and `docs` profiles don't false-positive on legitimate use (e.g., bullet-NP lists relaxed on `technical-blog` and `docs` since technical option lists are correctly bare-NP).
+- **"6+" hashtag threshold** — added rationale paragraph explaining the empirical floor.
+- **"Real/actual" inflation** — added named-contrast carve-out so honest contrastive writing ("real on-chain settlement, not bridged IOUs") isn't flagged.
+- Version bump to 3.4.0.
+
+### Reported by
+- A user of the avoid-ai-writing extension flagged two crypto-shill social posts (MineBench reviews) that the v3.3.x wordlist+regex detector scored as "Minimal AI signals" despite being obvious LLM output. Both posts avoided every Tier 1 vocabulary entry by substituting synonyms ("emerging sector," "scalable network contribution," "viability") and used structural shapes (hashtag block, bare-NP bullet lists, hedge stacks, future-narrative templates) the detector had no rule for. v3.4 adds rules for the structures, not just the words.
+
+---
+
+## [3.3.0] — 2026-04-01
+
+### Added
+- **"Worth [verb]ing" vague endorsement pattern**: `worth reading`, `worth paying attention to`, `worth a look`, `worth exploring`, `worth checking out`, `worth your time` — broadens existing "it's worth noting that" to the full family
+- **Reader-steering frames**: `Here's what's interesting`, `Here's what caught my eye`, `Here's what stood out` — added to both transition phrases and confidence calibration sections with context on when the pattern is a genuine problem vs. when data-backed usage is acceptable
+
+### Changed
+- Version bump to 3.3.0
+
+---
+
+## [3.2.0] — 2026-03-31
+
+### Added
+- **Detect mode**: flag-only mode that identifies AI patterns without rewriting. Trigger with "detect," "flag only," "audit only," "just flag," "scan," or similar. Returns issues grouped by severity (P0/P1/P2) plus an assessment of which flags are clear problems vs. judgment calls. Useful when flagged patterns are intentional, when auditing published or third-party content, or when you want a quick scan without a full rewrite.
+
+### Changed
+- Output format section now documents both rewrite (default) and detect mode outputs
+- Version bump to 3.2.0
+
+---
+
+## [3.1.0] — 2026-03-25
+
+### Added
+- 3 new Tier 1 words from Pangram AI detection research: `keen` (as intensifier), `symphony` (metaphor), `embrace` (metaphor)
+- 2 new template phrases: "Whether you're X or Y" (false-breadth), "I recently had the pleasure of" (review/social AI pattern)
+- "In summary" added to transition phrases (alongside existing "In conclusion" / "To summarize")
+- Structure-priority note in Rhythm section: structural regularity is the #1 signal AI detectors weight, above vocabulary
+- Over-polishing warning: aggressive editing can push writing toward AI statistical profiles by removing natural disfluency
+
+### Changed
+- Total vocabulary: 106 → 109 entries (60 Tier 1 + 38 Tier 2 + 11 Tier 3)
+- Template phrases: 2 → 4 entries
+
+### Source
+- Pangram Labs AI detection research (pangram.com) — decoder-only classifier trained on 28M human documents. Key insight: structural uniformity and pacing consistency are weighted higher than individual word choices.
+
+---
+
+## [3.0.0] — 2026-03-20
+
+### Added
+- Novelty inflation pattern (AI treats established concepts as speaker inventions)
+- False concession structure pattern
+- Rhetorical question openers pattern
+- Parenthetical hedging pattern
+- Numbered list inflation pattern
+- Severity tiers (P0/P1/P2) for prioritized auditing
+- Self-reference escape hatch (exempts quoted examples from flagging)
+- Context profiles with tolerance matrix (linkedin, blog, technical-blog, investor-email, docs, casual)
+- Auto-detection cues for context inference
+- Extended frontmatter: license, compatibility, author, tags, agentskills_spec
+
+### Changed
+- Pattern count: 30 → 35 categories
+
+---
+
+## [2.2.0] — 2026-03-18
+
+### Added
+- OpenClaw compatibility — added `version` and `metadata.openclaw` to SKILL.md frontmatter
+- OpenClaw installation instructions in README (ClawHub and manual)
+- Skill now works with both Claude Code and OpenClaw from a single `SKILL.md`
+
+### Changed
+- `README.md` — broadened description to reference both platforms, reorganized installation into Claude Code and OpenClaw sections
+
+---
+
+## [2.1.0] — 2026-03-18
+
+### Added
+- 5 new pattern categories: reasoning chain artifacts, sycophantic tone, acknowledgment loops, confidence calibration phrases, excessive structure
+- New "Rhythm and uniformity" section — checks for sentence length uniformity, paragraph length uniformity, missing first-person perspective, and read-aloud test guidance
+- New "When to rewrite from scratch vs. patch" threshold — advises full rewrites when AI density is too high for patching
+- 5 rewrite principles in tone calibration section (vary length, be concrete, have a voice, cut neutrality, earn emphasis)
+- New "Meta Patterns" group in README pattern table
+- Expanded credits: OpenClaw humanizer ecosystem (community patterns)
+
+### Changed
+- Pattern count: 23 → 30 categories
+- `README.md` — updated pattern count, added Meta Patterns table, expanded credits with source descriptions
+- Communication Patterns table in README now includes all communication patterns
+
+---
+
+## [2.0.0] — 2026-03-18
+
+### Added
+- **Tiered vocabulary system** — words are now organized into three tiers based on AI-signal strength:
+  - Tier 1 (always flag): 53 entries — dead giveaways that appear 5–20x more often in AI text
+  - Tier 2 (flag in clusters): 38 entries — legitimate words that signal AI when 2+ appear in the same paragraph
+  - Tier 3 (flag by density): 11 entries — common words that only flag when the text is saturated with them
+- 39 new vocabulary entries across all tiers, including: bustling, intricate, complexities, ever-evolving, daunting, holistic, actionable, impactful, learnings, thought leadership, best practices, synergy, interplay, encompass, catalyze, reimagine, galvanize, augment, cultivate, illuminate, elucidate, juxtapose, paradigm-shifting, transformative, cornerstone, paramount, poised, burgeoning, nascent, quintessential, overarching, underpinning, significant, innovative, dynamic, scalable, compelling, unprecedented, sophisticated, instrumental, world-class
+- Credit to [brandonwise/humanizer](https://github.com/brandonwise/humanizer) for tiered vocabulary research
+
+### Changed
+- Word/phrase table reorganized from flat list to tiered structure with usage guidance
+- Total vocabulary: 58 → 102 entries (53 Tier 1 + 38 Tier 2 + 11 Tier 3)
+- `README.md` — updated replacement table description, pattern table, and credits
+
+---
+
+## [1.4.0] — 2026-03-17
+
+### Added
+- 15 new word/phrase replacements: nuanced, crucial, multifaceted, ecosystem, myriad, plethora, deep dive/dive into, unpack, bolster, spearhead, resonate, revolutionize, facilitate, underpin
+- New pattern category: "let's" constructions (false-collaborative openers like "let's explore," "let's break this down")
+- Skill now covers 23 pattern categories with 58 word/phrase replacements
+
+### Changed
+- Deduplicated filler phrases that appeared in both the word table and the filler section
+- `README.md` — updated pattern count (22 → 23), replacement table count (43 → 58), added "let's" constructions row to pattern table
+
+---
+
+## [1.3.0] — 2026-03-17
+
+### Changed
+- Em dash detection now catches double-hyphen (`--`) in addition to Unicode em dash (`—`)
+- `README.md` — updated formatting pattern description to mention `--`
+
+---
+
+## [1.2.0] — 2026-03-06
+
+### Added
+- New pattern category: emotional flatline (AI claims emotions as structural crutch without conveying them; also flags lazy human writing)
+- Skill now covers 22 pattern categories with 43 word/phrase replacements
+
+---
+
+## [1.1.0] — 2026-03-06
+
+### Added
+- 8 new pattern categories: notability name-dropping, superficial -ing analyses, promotional language, formulaic challenges, false ranges, inline-header lists, title case headings, cutoff disclaimers
+- 5 new word table entries (nestled, vibrant, thriving, despite challenges, showcasing)
+- Skill now covers 21 pattern categories with 43 word/phrase replacements
+
+### Changed
+- `README.md` — expanded full example (6 paragraphs → 4 clean sentences, 40+ tells flagged); added per-pattern before/after table organized into Content, Language, Structure, Communication groups; updated pattern count and replacement table count throughout
+
+---
+
+## [1.0.0] — 2026-03-05
+
+### Added
+- `SKILL.md` — Claude Code skill with 13 pattern categories: formatting, sentence structure, word/phrase replacements (38 entries), template phrases, transition phrases, structural issues, significance inflation, copula avoidance, synonym cycling, vague attributions, filler phrases, generic conclusions, chatbot artifacts
+- Four-section output format: issues found, rewritten version, what changed, second-pass audit
+- `README.md` — installation guide (3 methods), full pattern reference, usage examples
+- `LICENSE` — MIT
+- `.gitignore` — OS/editor exclusions

--- a/plugins/writing/skills/remove-ai-patterns/upstream/LICENSE
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Conor Bronsdon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/writing/skills/remove-ai-patterns/upstream/SKILL.md
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/SKILL.md
@@ -1,0 +1,683 @@
+---
+name: avoid-ai-writing
+description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
+version: 3.15.0
+license: MIT
+compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
+metadata:
+  author: Conor Bronsdon
+  tags: writing editing voice quality
+  agentskills_spec: "1.0"
+  openclaw:
+    emoji: "\u270D\uFE0F"
+---
+
+# Avoid AI Writing — Audit & Rewrite
+
+You are editing content to remove AI writing patterns ("AI-isms") that make text sound machine-generated.
+
+## What this skill is and isn't
+
+This is a **writing-quality tool**, not a verdict. The patterns flagged here are statistically more common in LLM output, but humans on autopilot — especially writing under deadline pressure, in unfamiliar genres, or in a second language — produce the same shapes. Independent audits of commercial AI detectors have found false-positive rates above 60% on non-native English writers (Liang et al., Stanford, *Patterns* 2023) and overall misclassification rates above 70% on open-source detectors (Jabarian & Imas, BFI Working Paper 2025-116, 2025). Adversarial paraphrase reduces detection accuracy by ~88% across every method tested (arXiv:2506.07001, 2025).
+
+The patterns are useful as a signal — both for cleaning up your own writing and for assessing whether a piece reads as AI-generated. Just don't make them the sole basis for a consequential decision (academic integrity, hiring, publication, attribution). Several rules here also fire on second-language writing, deadline-pressed humans, and technical genres that compress vocabulary by design. Pair the signal with context: who wrote it, what genre, what the writer's normal voice looks like, what other evidence you have.
+
+In short: signals, not proof. Worth acting on; not worth ruining someone's day over.
+
+## Modes
+
+This skill operates in one of three modes:
+
+**`rewrite`** (default) — Flag AI-isms and rewrite the text to fix them.
+
+**`detect`** — Flag AI-isms only. No rewriting. Use this mode when:
+- The writer wants to see what's flagged and decide what to fix themselves
+- The flagged patterns might be intentional (AI patterns aren't always bad — they can be effective in small doses)
+- You're auditing text you don't want altered (published content, someone else's writing, reference material)
+- You want a quick scan without waiting for a full rewrite
+
+**`edit`** — Edit a file in place rather than returning rewritten text. Use this when the writer points you at a file ("clean up `draft.md`", "fix the AI-isms in this file directly") and wants the file changed, not a copy to paste back. Make **minimal, targeted edits** with the Edit tool — change the flagged spans, not the whole document. **Preserve passages that are already human**: if a paragraph has no tells, leave it untouched. **Don't edit quoted material, code blocks, or text attributed to someone else** — flag those instead of rewriting them. For a large file, confirm which section to clean before changing anything. After editing, re-read the file and confirm the flagged patterns are resolved.
+
+Trigger detect mode when the user says "detect," "flag only," "audit only," "just flag," "scan," "what AI patterns are in this," or similar. Trigger edit mode when the user names a file and asks you to fix or clean it in place. Default to rewrite mode if not specified.
+
+**Invocation.** Natural language is enough ("rewrite this in a blunt voice for LinkedIn," "edit `post.md` in place," "scan this, don't rewrite"). Power users can also pass explicit options, which map to the sections below: `[--mode rewrite|detect|edit]`, `[--voice casual|professional|technical|warm|blunt]`, `[--context linkedin|blog|technical-blog|investor-email|docs|casual]`, `[--file PATH]`, `[--iterate N]` (max 2).
+
+**Iterate to convergence (optional).** Rewrite mode already runs one corrective second pass (see Output format) — that built-in pass *is* pass 2, so `--iterate` does not stack on top of it. When the writer asks to "iterate," "keep going until it's clean," or passes `--iterate N`, repeat the audit→rewrite cycle until no patterns remain or **N passes** are reached. Cap **N at 2**: a rewrite plus one corrective pass clears the flagged patterns, and a third pass costs a full regeneration while rarely finding more. Report how many passes it took ("converged in 2 passes").
+
+---
+
+In **rewrite** mode, your job is to:
+
+1. **Audit it**: identify every AI-ism present, citing the specific text
+2. **Rewrite it**: return a clean version with all AI-isms removed
+3. **Show a diff summary**: briefly list what you changed and why
+
+In **detect** mode, your job is to:
+
+1. **Audit it**: identify every AI-ism present, citing the specific text
+2. **Assess it**: note which flags are clear problems vs. patterns that may be intentional or effective in context
+
+In **edit** mode, your job is to:
+
+1. **Read** the file the writer named
+2. **Edit in place**: apply minimal, targeted fixes to the flagged spans with the Edit tool, leaving already-human passages untouched
+3. **Verify**: re-read the file and confirm the flagged patterns are resolved; report what you changed
+
+---
+
+## What to remove or fix
+
+### Formatting
+- **Em dashes (— and --)**: Replace with commas, periods, parentheses, or rewrite as two sentences. Target: zero. Hard max: one per 1,000 words. This applies to headings and section titles too, not just body prose. Catch both the Unicode em dash (—) and the double-hyphen substitute (--).
+- **Bold overuse**: Strip bold from most phrases. One bolded phrase per major section at most, or none. If something's important enough to bold, restructure the sentence to lead with it instead.
+- **Emoji in headers**: Remove entirely. No `## 🚀 What This Means`. Exception: social posts may use one or two emoji sparingly — at the end of a line, never mid-sentence.
+- **Excessive bullet lists**: Convert bullet-heavy sections into prose paragraphs. Bullets only for genuinely list-like content (feature comparisons, step-by-step instructions, API parameters).
+- **Curly quotation marks (“ ” ‘ ’) and apostrophes**: Curly quotes and apostrophes (U+201C/U+201D, U+2018/U+2019) are a *weak* paste-from-chat signal — meaningful mainly in plain-text contexts like code comments, commit messages, or plaintext drafts, where nothing auto-curls. Treat as corroborating, never conclusive: Word, Google Docs, macOS, and iOS curl quotes by default, so most human prose contains them too. Don't flag curly apostrophes (U+2019) on their own. Replace with straight quotes in plain-text/code; leave them in finished publications and locale-correct punctuation (French « », German „ “).
+- **Immaculate typography in casual registers**: Same tier as curly quotes — a *weak*, register-scoped signal, never conclusive alone. Perfect spacing, punctuation, and capitalization in a context where humans type fast (issue/PR comments, chat, DMs) is corroborating evidence, not proof: a careful human can type a flawless comment, and a rushed one can type a sloppy one. Judge it alongside other signals. Inverse case worth flagging the other direction: when editing a human's casual text (a Slack message, a quick reply), preserve their typos, contractions, and idiosyncratic capitalization rather than correcting them — smoothing away the rough edges erases the fingerprint that marks the text as theirs.
+
+### Sentence structure
+- **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument. This includes the **split-sentence form**, where the negation and the correction fall in two separate sentences rather than pivoting on a single dash or comma: "The headline isn't the speed. The real story is Y." Read on its own, each sentence looks like an innocent declarative, which is exactly why the split version slips past a check tuned to the joined phrasing — flag it the same way. AI also stacks the negation across several options before the reveal ("It's not the price. It's not the features. It's the trust."). The multi-negation countdown is the same move inflated; flag it and cut straight to the positive claim.
+- **Hollow intensifiers**: Cut `genuine` / `genuinely`, `real` (as in "a real improvement"), `truly`, `quite frankly`, `to be honest`, `let's be clear`, `it's worth noting that`. Just state the fact.
+- **Vague endorsement ("worth [verb]ing")**: Cut or replace `worth reading`, `worth paying attention to`, `worth a look`, `worth exploring`, `worth checking out`, `worth your time`. These substitute a generic thumbs-up for a specific reason. Say *why* something matters instead.
+- **Hedging**: Cut `perhaps`, `could potentially`, `it's important to note that`, `to be clear`. Make the point directly.
+- **Missing bridge sentences**: Each paragraph should connect to the last. If paragraphs could be rearranged without the reader noticing, add connective tissue.
+- **Compulsive rule of three**: Vary groupings. Use two items, four items, or a full sentence instead of triads. Max one "adjective, adjective, and adjective" pattern per piece.
+
+### Words and phrases to replace
+
+Words are organized into three tiers based on how reliably they signal AI-generated text. This tiered approach — adapted from [brandonwise/humanizer](https://github.com/brandonwise/humanizer)'s vocabulary research — reduces false positives on words that are fine in isolation but suspicious in clusters.
+
+- **Tier 1 — Always flag.** These words appear 5–20x more often in AI text than human text. Replace on sight.
+- **Tier 2 — Flag in clusters.** Individually fine, but two or more in the same paragraph is a strong AI signal. Flag when they appear together.
+- **Tier 3 — Flag by density.** Common words that AI simply overuses. Only flag when they make up a noticeable fraction of the text (roughly 3%+ of total words).
+
+**Match inflected forms.** Each entry below covers the listed word *and its morphological variants* — adverb (`-ly`), gerund/participle (`-ing`), plural, comparative/superlative, and verb conjugations — unless a variant carries a distinct, legitimate meaning. So `genuine` also flags `genuinely`, `leverage` also flags `leveraging` / `leveraged`, `delve` covers `delving`, and `meticulous` covers `meticulously`. When a variant has a separate honest sense (e.g. `real` meaning factual, not the intensifier in "a real improvement"), judge by context rather than matching blindly.
+
+#### Tier 1 — Always replace
+
+| Replace | With |
+|---|---|
+| delve / delve into | explore, dig into, look at |
+| landscape (metaphor) | field, space, industry, world |
+| tapestry | (describe the actual complexity) |
+| realm | area, field, domain |
+| paradigm | model, approach, framework |
+| embark | start, begin |
+| beacon | (rewrite entirely) |
+| testament to | shows, proves, demonstrates |
+| robust | strong, reliable, solid |
+| comprehensive | thorough, complete, full |
+| cutting-edge | latest, newest, advanced |
+| leverage (verb) | use |
+| pivotal | important, key, critical |
+| underscores | highlights, shows |
+| meticulous / meticulously | careful, detailed, precise |
+| seamless / seamlessly | smooth, easy, without friction |
+| game-changer / game-changing | describe what specifically changed and why it matters |
+| hit differently / hits different | (say what specifically changed, or cut) |
+| utilize | use |
+| watershed moment | turning point, shift (or describe what changed) |
+| marking a pivotal moment | (state what happened) |
+| the future looks bright | (cut — say something specific or nothing) |
+| only time will tell | (cut — say something specific or nothing) |
+| nestled | is located, sits, is in |
+| vibrant | (describe what makes it active, or cut) |
+| thriving | growing, active (or cite a number) |
+| despite challenges… continues to thrive | (name the challenge and the response, or cut) |
+| showcasing | showing, demonstrating (or cut the clause) |
+| deep dive / dive into | look at, examine, explore |
+| unpack / unpacking | explain, break down, walk through |
+| bustling | busy, active (or cite what makes it busy) |
+| intricate / intricacies | complex, detailed (or name the specific complexity) |
+| complexities | (name the actual complexities, or use "problems" / "details") |
+| ever-evolving | changing, growing (or describe how) |
+| enduring | lasting, long-running (or cite how long) |
+| daunting | hard, difficult, challenging |
+| holistic / holistically | complete, full, whole (or describe what's included) |
+| actionable | practical, useful, concrete |
+| impactful | effective, significant (or describe the impact) |
+| learnings | lessons, findings, takeaways |
+| thought leader / thought leadership | expert, authority (or describe their actual contribution) |
+| best practices | what works, proven methods, standard approach |
+| at its core | (cut — just state the thing) |
+| synergy / synergies | (describe the actual combined effect) |
+| interplay | relationship, connection, interaction |
+| in order to | to |
+| due to the fact that | because |
+| serves as | is |
+| features (verb) | has, includes |
+| boasts | has |
+| presents (inflated) | is, shows, gives |
+| commence | start, begin |
+| ascertain | find out, determine, learn |
+| endeavor | effort, attempt, try |
+| keen (as intensifier) | interested, eager, enthusiastic (or cut — just state the interest) |
+| genuinely / genuine (as intensifier) | (cut — just state the fact) |
+| symphony (metaphor) | (describe the actual coordination or combination) |
+| embrace (metaphor) | adopt, accept, use, switch to |
+
+#### Tier 2 — Flag when 2+ appear in the same paragraph
+
+These words are legitimate on their own. When two or more show up together, the paragraph likely needs a rewrite.
+
+| Replace | With |
+|---|---|
+| harness | use, take advantage of |
+| navigate / navigating | work through, handle, deal with |
+| foster | encourage, support, build |
+| elevate | improve, raise, strengthen |
+| unleash | release, enable, unlock |
+| streamline | simplify, speed up |
+| empower | enable, let, allow |
+| bolster | support, strengthen, back up |
+| spearhead | lead, drive, run |
+| resonate / resonates with | connect with, appeal to, matter to |
+| revolutionize | change, transform, reshape (or describe what changed) |
+| facilitate / facilitates | enable, help, allow, run |
+| underpin | support, form the basis of |
+| nuanced | specific, subtle, detailed (or name the actual nuance) |
+| crucial | important, key, necessary |
+| multifaceted | (describe the actual facets, or cut) |
+| ecosystem (metaphor) | system, community, network, market |
+| myriad | many, numerous (or give a number) |
+| plethora | many, a lot of (or give a number) |
+| encompass | include, cover, span |
+| catalyze | start, trigger, accelerate |
+| reimagine | rethink, redesign, rebuild |
+| galvanize | motivate, rally, push |
+| augment | add to, expand, supplement |
+| cultivate | build, develop, grow |
+| illuminate | clarify, explain, show |
+| elucidate | explain, clarify, spell out |
+| juxtapose | compare, contrast, set side by side |
+| paradigm-shifting | (describe what actually shifted) |
+| transformative / transformation | (describe what changed and how) |
+| cornerstone | foundation, basis, key part |
+| paramount | most important, top priority |
+| poised (to) | ready, set, about to |
+| burgeoning | growing, emerging (or cite a number) |
+| nascent | new, early-stage, emerging |
+| quintessential | typical, classic, defining |
+| overarching | main, central, broad |
+| quietly | cut, or name the concrete contrast |
+| deeply *(significance collocations only — "deeply integrated," "deeply committed," "deeply rooted"; literal uses like "deeply nested" or "cares deeply" never count toward a cluster)* | cut, or name what specifically runs deep |
+| underpinning / underpinnings | basis, foundation, what supports |
+
+#### Tier 3 — Flag only at high density
+
+These are normal words. Only flag them when the text is saturated with them — a sign that AI filled space with vague praise instead of specifics.
+
+| Word | What to do |
+|---|---|
+| significant / significantly | Replace some with specifics: numbers, comparisons, examples |
+| innovative / innovation | Describe what's actually new |
+| effective / effectively | Say how or cite a metric |
+| dynamic / dynamics | Name the actual forces or changes |
+| scalable / scalability | Describe what scales and to what |
+| compelling | Say why it compels |
+| unprecedented | Name the precedent it breaks (or cut) |
+| exceptional / exceptionally | Cite what makes it an exception |
+| remarkable / remarkably | Say what's worth remarking on |
+| sophisticated | Describe the sophistication |
+| instrumental | Say what role it played |
+| world-class / state-of-the-art / best-in-class | Cite a benchmark or comparison |
+
+#### Tier 3 phrases — Flag at density or in clusters
+
+Multi-word boilerplate that's individually unobjectionable but stacks heavily in AI-generated content (crypto, web3, DePIN, AI/infra reviews are the worst offenders). Flag at **2+ uses of the same phrase** (the per-phrase rule — lower threshold than single-word Tier 3 because a two-word match repeated twice is already stronger evidence than re-using "significant"), *plus* a **cluster rule**: three or more *distinct* phrases from this table in one piece is a strong signal even when each phrase only appears once — that's the shape LLMs take when they vary their own boilerplate to seem less repetitive.
+
+| Phrase | What to do |
+|---|---|
+| emerging sector / emerging space / emerging category | Name the actual sector or what's emerging about it |
+| the integration of (X with Y) | Describe what's being integrated and what changes for the user |
+| the intersection of (X and Y) | Pick the specific overlap that matters or cut the framing |
+| community-driven | Name what the community does. "Community-driven" alone is filler |
+| long-term sustainability | Cite the time horizon and the constraint. "Long-term" is hand-waving |
+| user engagement | Name the action. "Engagement" is a wrapper around clicks/comments/retention |
+| decentralized compute | Specify the architecture or cut. The phrase has become a category label, not a claim |
+| (sustainable) reward emissions | Cite the emission schedule and the sink |
+| tokenized incentive structures | Describe the actual mechanism (vesting, gauge, bonded LP, etc.) |
+| designed for long-term [X] | Cut "designed for" — either it is or it isn't. Then state the property |
+
+### Template phrases (avoid)
+
+These slot-fill constructions signal that a sentence was generated, not written. If a phrase has a blank where a noun or adjective could go and still sound the same, it's too generic.
+
+- "a [adjective] step towards [adjective] AI infrastructure" → describe the specific capability, benchmark, or outcome
+- "a [adjective] step forward for [noun]" → same rule: say what actually changed
+- "Whether you're [X] or [Y]" → false-breadth construction. Pick the audience you're actually addressing, or cut. "Whether you're a startup founder or an enterprise architect" means nothing — it's just "everyone."
+- "I recently had the pleasure of [verb]-ing" → review/social AI pattern. Just say what happened: "I talked to," "I read," "I attended."
+
+### Transition phrases to remove or rewrite
+- "Moreover" / "Furthermore" / "Additionally" → restructure so the connection is obvious, or use "and," "also," "on top of that"
+- "In today's [X]" / "In an era where" → cut or state specific context
+- "It's worth noting that" / "Notably" → just state the fact
+- "Here's what's interesting" / "Here's what caught my eye" / "Here's what stood out" → reader-steering frames. Let the content signal its own importance. If you need a lead-in, make it specific: "The revenue number matters because..." not "Here's the interesting part."
+- "In conclusion" / "In summary" / "To summarize" → your conclusion should be obvious
+- "When it comes to" → just talk about the thing directly
+- "At the end of the day" → cut
+- "That said" / "That being said" → cut or use "but," "yet," or "however." Don't overuse any one of them.
+
+### Structural issues
+- **Uniform paragraph length**: Vary deliberately. Include some 1-2 sentence paragraphs and some longer ones. If every paragraph is roughly the same size, fix it.
+- **Formulaic openings**: If the piece opens with broad context before getting to the point ("In the rapidly evolving world of..."), rewrite to lead with the news or the insight. Context can come second.
+- **Suspiciously clean grammar**: Don't sand away all personality. Deliberate fragments, sentences starting with "And" or "But," comma splices for effect: if the natural voice uses them, keep them.
+
+### Significance inflation
+- Phrases like "marking a pivotal moment in the evolution of..." or "a watershed moment for the industry" inflate routine events into history-making ones. State what happened and let the reader judge significance.
+- If the sentence still works after you delete the inflation clause, delete it.
+
+### Generic future-narrative closers
+- "May become one of the most important narratives of the next market cycle," "could become the defining trend of the coming decade," "is poised to become the next major chapter in [X]." AI defaults to this shape when it needs to land a closing thought without committing to a falsifiable claim. The closer is grammatically a prediction but contains no testable content.
+- Pattern: modal (may / could / will / is poised to) + "become" + (one of) the most [adjective] + (narrative / story / trend / theme / chapter / movement / force).
+- Fix: pick the falsifiable version. "DePIN compute may exceed AWS spot pricing for embarrassingly parallel workloads by 2027" is a prediction. "The intersection of AI and DePIN may become one of the most important narratives of the next market cycle" is not.
+
+### Hedge-stacked predictions
+- Stacking a modal with a hedge adverb: "could potentially create," "may eventually unlock," "might ultimately transform." Either word alone is acceptable; the stack is the tell. Each hedge cancels the next, leaving a sentence that asserts nothing while sounding cautious and thoughtful.
+- Fix: pick one. If you mean "could create," say that. If you mean "potentially creates," say that. Both together is filler.
+
+### "Real/actual" adjective inflation
+- "Real on-chain tokenomics," "actual reward sustainability," "genuine utility," "true product-market fit." Using `real` / `actual` / `genuine` / `true` as an empty intensifier on an abstract noun implies the rest of the field is fake or superficial — without naming what makes this instance the real one. Common in crypto/AI/web3 content where the writer wants to signal sophistication.
+- Distinct from the existing "hollow intensifiers" rule (genuine / truly / quite frankly as sentence-level hedges). This is the noun-modifier form, where the intensifier latches onto an abstract noun to manufacture a contrast that goes unsaid.
+- **Carve-out — named contrast:** if the sentence explicitly names what the fake/superficial version is, leave it. "Real on-chain settlement, not bridged IOUs" or "actual revenue from paying customers, not grants" is honest contrastive writing. The AI tell is the unsaid contrast.
+- Fix when no contrast is named: drop the adjective and add the specific claim. "Reward sustainability" → "rewards funded from $X/mo in fees rather than emissions."
+
+### Hashtag stuffing
+- Long trailing hashtag blocks (6+ hashtags on a single short post) are near-universal in LLM-generated social content and rare in thoughtful human posts. The block usually mixes a project-specific tag with broad category tags (#AI #Crypto #Web3 #Innovation #FutureTech #Technology) — the categorical ones do nothing for discoverability and read as bot output.
+- **Why 6?** Empirical floor. LinkedIn and X organic engagement plateaus or declines past 3-5 tags; human posts that exceed 5 are usually launch posts trading reach for engagement, while LLM-generated posts default to 10-15. Six is the threshold where false positives on legitimate human use start dropping below false negatives on AI output. The detector treats 6+ as a hard flag; the spec treats 5+ as a soft tell worth a second look on `linkedin` and `investor-email` profiles.
+- Fix: 2-3 specific tags max, or none. If a hashtag wouldn't help a reader find related work, it's filler.
+
+### Bullet lists of bare noun phrases
+- A list of 5+ consecutive bullet items where each item is a short (≤6 word) adjective-plus-noun phrase with no verb. "Stable mining efficiency / Reliable pool connectivity / Optimized RandomX performance / Low failed share rates / Effective hardware utilization / Consistent thermal stability." Reads as a marketing one-pager because that's the shape LLMs default to when asked to summarize features.
+- The tell is the *symmetry*: every item is the same grammatical shape, every item is parallel in length, none of them assert anything checkable. A genuine list of observations would have varying length, occasional verbs, and at least one item that doesn't fit the pattern.
+- Fix: convert to prose paragraph, or rewrite items as full claims ("Failed shares stayed under 1% across a 12-hour run" beats "Low failed share rates"). If the list is genuinely the right form, vary the items so each carries a different shape of information.
+- This rule does *not* apply to genuine list content (changelog entries, todo lists, parameter docs, ingredient lists) where bare noun phrases are the correct form. The detector keys on absence of finite verbs to separate the two — but in prose audits, ask whether the bullets are summarizing claims (rewrite) or enumerating items (leave).
+
+### Copula avoidance
+- AI text avoids "is" and "has" by substituting fancier verbs: "serves as," "features," "boasts," "presents," "represents." These sound like a press release.
+- Default to "is" or "has" unless a more specific verb genuinely adds meaning.
+
+### Synonym cycling
+- AI rotates synonyms to avoid repeating a word: "developers… engineers… practitioners… builders" in the same paragraph. Human writers repeat the clearest word.
+- If the same noun or verb appears three times in a paragraph and that's the right word, keep all three. Forced variation reads as thesaurus abuse.
+
+### Vague attributions
+- "Experts believe," "Studies show," "Research suggests," "Industry leaders agree" — without naming the expert, study, or leader. Either cite a specific source or drop the attribution and state the claim directly.
+
+### Filler phrases
+- Strip mechanical padding that adds words without meaning:
+  - "It is important to note that" → (just state it)
+  - "In terms of" → (rewrite)
+  - "The reality is that" → (cut or just state the claim)
+- Note: "In order to," "Due to the fact that," and "At the end of the day" are covered in the word/phrase table and transition sections above — don't duplicate rules.
+
+### Generic conclusions
+- "The future looks bright," "Only time will tell," "One thing is certain," "As we move forward" — these are filler disguised as conclusions. Cut them. If the piece needs a closing thought, make it specific to the argument.
+
+### Chatbot artifacts
+- "I hope this helps!", "Certainly!", "Absolutely!", "Great question!", "Feel free to reach out," "Let me know if you need anything else" — these are conversational tics from chat interfaces, not writing. Remove entirely.
+- Also watch for: "In this article, we will explore…" or "Let's dive in!" — these are AI-generated meta-narration. Cut or rewrite with a direct opening.
+
+### "Let's" constructions
+- "Let's explore," "Let's take a look," "Let's break this down," "Let's examine" — AI uses "let's" as a false-collaborative opener to ease into a topic. It's filler that delays the actual point. Just start with the point. "Let's dive in" is covered above under chatbot artifacts, but the pattern is broader than that — flag any "let's + verb" that's functioning as a transition rather than a genuine invitation to act.
+
+### Notability name-dropping
+- AI text piles on prestigious citations to manufacture credibility: "cited in The New York Times, BBC, Financial Times, and The Hindu." If a source matters, use it with context: "In a 2024 NYT interview, she argued..." One specific reference beats four name-drops.
+- Related — **historical analogy stacking**: rapid-fire lists of past technologies or companies to borrow their weight ("like the printing press, the telegraph, and the internet before it"). The montage substitutes for the argument. Name the one parallel that does analytical work and say what it explains, or cut. Source: tropes.fyi (Historical Analogy Stacking).
+
+### Vague third-party validation
+- AI manufactures credibility by pointing at an **unnamed** external authority, usually paired with a generic superlative: "an outside party measuring the same models everyone runs and putting us on top," "independent testing confirms," "third-party benchmarks show we lead," "analysts agree," "studies consistently show." The authority is faceless and the claim unfalsifiable — the reader can't tell who measured what, against whom, or go check.
+- Fix: name the source, the test, and the result so a reader can verify it. "An outside party put us on top" becomes "On Stanford's HELM leaderboard (April 2026 run), we ranked first on reasoning latency." If you can't name it, cut the claim rather than dress it up as validation.
+- Carve-out: specifically attributed, checkable validation is legitimate and stays unflagged — a named benchmark, a linked report, a dated audit ("SOC 2 Type II, audited by Prescient Assurance"). The tell is the *vagueness*, not the act of citing outside proof.
+- Distinct from **Notability name-dropping**: that flags piling on *specific* prestigious names to borrow their weight; this is the inverse move — the authority is deliberately *unnamed*, which is both harder to check and easier to invent. A passage can run both at once (a vague authority plus a superlative); judge each on its own terms. Raised in #39.
+
+### Superficial -ing analyses
+- Strings of present participles used as pseudo-analysis: "symbolizing the region's commitment to progress, reflecting decades of investment, and showcasing a new era of collaboration." These say nothing. Replace with specific facts or cut entirely.
+- The same move shows up without the -ing: declarative "meaning-telling" that glosses a mundane subject as if it were profound — "this represents a broader shift," "the decision symbolizes a commitment to excellence," "it speaks to a larger trend in the industry." If the significance is real, show it with a specific consequence; otherwise cut. Adapted from `Aboudjem/humanizer-skill` P40.
+
+### Promotional language
+- AI defaults to tourism-brochure prose: "nestled within the breathtaking foothills," "a vibrant hub of innovation," "a thriving ecosystem." Replace with plain description: "is a town in the Gonder region," "has 12 startups." If you wouldn't say it in conversation, cut it.
+
+### Formulaic challenges
+- "Despite challenges, [subject] continues to thrive" or "While facing headwinds, the organization remains resilient." This is a non-statement. Name the actual challenge and the actual response, or cut the sentence.
+
+### Speculative scenario openers
+- "Imagine a world where…", "Picture a future in which…", "Envision a world where…" AI opens an argument with a hypothetical that lists desirable outcomes instead of making a claim. The scenario does the persuading; no evidence is offered.
+- Fix: cut the hypothetical and state the real claim. "Imagine a world where every deploy is instant" becomes "Instant deploys would cut our release cycle from a day to minutes."
+- Carve-out: fiction, a thought experiment with a stated payoff, and instructional "imagine you have a sorted array" (a teaching device pointing at a concrete example, not a speculative world) are fine. Flag only the world/future-scenario opener that stands in for an argument. Source: tropes.fyi (Imagine a World Where).
+
+### False ranges
+- AI creates false breadth by pairing unrelated extremes: "from the Big Bang to dark matter," "from ancient civilizations to modern startups." These sound sweeping but say nothing. List the actual topics or pick the one that matters.
+
+### Inline-header lists
+- Bullet lists where each item starts with a bold header that repeats itself: "**Performance:** Performance improved by..." Strip the bold header and write the point directly. If the list items need headers, they should probably be paragraphs.
+
+### List-label periods
+- In bulleted lists where each item leads with a short label, LLMs end the label with a period and then run the explanation as a separate sentence. A person writing the same list almost always uses a colon instead. Strongest form: bold labels (`**Intros.**`, `**Content distribution.**`, `**Developer GTM.**` where a human writes `**Intros:**`). Weaker but still a tell: the same shape without bold (`- Intros. Years of conferences and operator network.`) — a short noun-phrase label terminated with a period at the start of a bullet, followed by a gloss. The colon reads as "here's what this label means"; the period reads as a sentence that the following clause then contradicts by continuing. Example tell: `- **Intros.** Years of conferences and operator network.` becomes `- **Intros:** years of conferences and operator network.` Fix the period to a colon and lowercase the start of the gloss, or drop the label and write the point as a plain sentence. Carve-outs: when the label span is a full sentence on its own (not a label introducing a gloss), the period is correct; and for the unbolded form, only flag when the leading fragment is clearly a label (a 1-4 word noun phrase, no verb) — a short complete sentence opening a bullet is fine.
+
+### Title case headings
+- AI over-capitalizes headings: "Strategic Negotiations And Key Partnerships" instead of "Strategic negotiations and key partnerships." Use sentence case for subheadings. Title case only for the piece's main title, if at all.
+
+### Hyphenated-pair overuse
+- AI stacks compound modifiers: "a high-quality, well-architected, future-proof solution." Two distinct problems. First, density — strings of hyphenated adjectives piled on one noun; cut to the modifier that actually matters. Second, the attributive/predicate error: a compound is hyphenated *before* the noun ("a high-quality report") but not *after* a linking verb ("the report is high quality," no hyphen). AI frequently hyphenates the predicate form; fix it to two words. Adapted from `blader/humanizer` P26.
+
+### Cutoff disclaimers
+- "While specific details are limited based on available information," "As of my last update," "I don't have access to real-time data." These are model limitations leaking into prose. Either find the information or remove the hedge. Never publish a sentence that admits the writer didn't look something up.
+
+### Speculative gap-filling
+- When the model lacks a fact, it fills the gap with hedged speculation dressed up as background: "maintains a relatively low public profile," "is believed to have," "likely began his career in," "appears to have studied." These are guesses formatted as statements. Distinct from cutoff disclaimers, which *admit* the gap — this one hides it behind plausible-sounding filler, which is worse because the reader can't tell what's known from what's invented. Cut the speculation, or replace it with a sourced fact. Adapted from `blader/humanizer` P21.
+
+### Unfilled placeholders
+- Bracketed slot-fillers that were meant to be replaced before publishing: `[Your Name]`, `[INSERT SOURCE URL]`, `[Describe the specific section]`, `2025-XX-XX`, `<!-- Add citation if available -->`. These are near-definitive evidence that AI-generated boilerplate was pasted without editing. Humans use placeholders in templates too, but rarely ship them. Treat any visible placeholder as a publishing bug: fill it in with real content or delete the sentence entirely.
+- Catch the obvious shapes: `\[(?:Your|Insert|Add|Enter|Describe|Specify|Choose)[^\]]+\]`, `\b\d{4}-XX-XX\b`, HTML/Markdown comments with placeholder verbs (`add`, `fill in`, `todo`, `insert`).
+
+### Chatbot citation markup leaks
+- Internal citation tokens that leak through when text is copy-pasted from chat UIs: `citeturn0search0`, `contentReference[oaicite:0]{index=0}`, `oai_citation`, `[attached_file:1]`, `grok_card`. These are not patterns — they are fingerprints. Their presence is essentially proof the text was generated by a specific chat tool and pasted without cleanup.
+- The fix is mechanical: strip every markup token. If a citation was meaningful, replace it with a real reference. Don't try to humanize the markup — delete it.
+- Adapted from `Aboudjem/humanizer-skill` P34. Worth catching even when nothing else in the text reads as AI — the token itself is enough.
+
+### AI-tool URL parameters
+- Tracking parameters that AI tools auto-append to URLs they generate, surviving copy-paste into published content: `utm_source=chatgpt.com`, `utm_source=copilot.com`, `utm_source=openai`, `utm_source=claude.ai`, `utm_source=perplexity.ai`, `referrer=grok.com`. Same logic as citation markup leaks — the presence of the parameter is the signature, regardless of what the surrounding text reads like.
+- The fix: strip the parameter from every URL. Keep the URL itself if the link is meaningful; lose the parameter entirely. Adapted from `Aboudjem/humanizer-skill` P35.
+
+### Novelty inflation
+- AI text treats established concepts as if the speaker invented or discovered them: "He introduced a term," "She coined the phrase," "a concept nobody's naming," "a failure mode nobody talks about." In reality, most ideas in a conversation are applications of existing concepts, not inventions.
+- Two problems. First, it's factually risky: if the concept already has a Wikipedia page or conference talks from last year, claiming novelty makes the writer look uninformed. Second, it flatters the subject in a way that reads as promotional rather than analytical.
+- The fix: describe what the person *did with* the concept, not that they discovered it. "Michel walked through how context poisoning works in practice" instead of "Michel introduced a term I hadn't heard before: context poisoning." If you're unsure whether something is novel, assume it isn't and frame accordingly.
+- Related patterns to flag: "the failure mode nobody's naming," "a problem nobody talks about," "the insight everyone's missing," "what nobody tells you about." These are engagement-bait framings that claim scarcity of knowledge where none exists.
+- Also flag invented labels: pseudo-analytical compound terms coined mid-sentence and never defined ("the supervision paradox," "the context-collapse problem," "a coordination tax"). Naming a concept is not explaining it. Define the term on first use or describe the mechanism instead of branding it. Source: tropes.fyi (Invented Labels).
+
+### Infomercial engagement hooks
+- Punchy fragment-hooks that tee up a reveal: "The catch?", "The kicker?", "Here's the thing.", "But here's the kicker:", "The best part?", "Plot twist:", "The result?". AI uses these to fake momentum and manufacture suspense around ordinary information — the prose equivalent of a late-night infomercial.
+- Distinct from rhetorical-question openers (which stall before a point) and chatbot artifacts (which perform helpfulness): these are mid-flow teasers that pad the rhythm. The fix is to delete the hook and state the thing. "The catch? It only works on weekends." becomes "It only works on weekends." Adapted from `Aboudjem/humanizer-skill` P41.
+
+### Social endorsement closers
+- The curatorial sign-off LLMs append to LinkedIn and X posts that share or recommend something — usually a colon teeing up a link: "This one is worth your time:", "This one's a must-read:", "I highly recommend giving this a read.", "Do yourself a favor and read this.", "You won't want to miss this one.", "Save this for later.", "Bookmark this.", "Don't sleep on this one.", "Trust me, you'll want to read this.", "Thank me later."
+- Why it's a tell: it performs a recommendation without giving the reader a reason to click. The endorsement is generic and demonstrative-anchored ("THIS one is worth your time") — it could sit under any link, which is exactly why an LLM reaches for it to close a share post.
+- Distinct from the bare "worth [verb]ing" word-table entry (a single weak word inside a sentence) and from infomercial engagement hooks (mid-flow teasers like "The catch?"): this is the whole closing line of a social post.
+- The fix: say *what* the thing is and *who* it's for, then drop the CTA. "This one is worth your time:" becomes "Sarah's breakdown of why context windows leak — the clearest explanation I've found for anyone debugging RAG pipelines." If you can't name a specific reason, the share doesn't need a sign-off at all; let the link stand on its own.
+
+### Emotional flatline
+- AI claims emotions as a structural crutch without conveying them through the writing: "What surprised me most," "I was fascinated to discover," "What struck me was," "I was excited to learn," "The most interesting part," and the bare section-header variant: "Interesting part of the project:" / "Interesting thing here:" / "Interesting aspect:". The header form drops "the most" but does the same job — pre-announcing significance the writing hasn't earned.
+- Two problems. First, it's tell-don't-show: if the thing is genuinely surprising, the reader should feel that from the content, not from the writer announcing it. Second, these phrases are massively overused as list introductions and transitions. They're filler wearing an emotion costume.
+- This pattern isn't always AI. It's also a sign of lazy human writing on autopilot. Flag it either way.
+- The fix isn't "never say surprised." It's: if you claim an emotion, the writing around it should earn it. Otherwise cut the claim and present the thing directly.
+- Related pattern: "hit differently" / "hits different." AI uses trendy colloquialisms as a shortcut to sound relatable without earning the emotional beat. If something genuinely affected you, describe how. Otherwise cut.
+
+### False concession structure
+- "While X is impressive, Y remains a challenge" or "Although X has made strides, Y is still an open question." AI uses this to sound balanced without actually weighing anything. Both halves are vague. Either make the concession specific (name what's impressive, name the actual challenge) or pick a side and argue it.
+
+### Rhetorical question openers
+- "But what does this mean for developers?" / "So why should you care?" / "What's next?" — AI uses rhetorical questions to stall before the actual point. If you know the answer, just say it. Rhetorical questions are earned by strong setup, not dropped as section transitions.
+
+### Parenthetical hedging
+- "(and, increasingly, Z)" / "(or, more precisely, Y)" / "(and perhaps more importantly, W)" — AI inserts parenthetical asides to sound nuanced without committing. If the aside matters, give it its own sentence. If it doesn't, cut it.
+
+### Numbered list inflation
+- "Three key takeaways" / "Five things to know" / "Here are the top seven" — AI defaults to numbered lists because they're structurally safe. Only use numbered lists when the content genuinely has that many discrete, parallel items. If you're padding to hit a number, the list shouldn't exist.
+
+### Reasoning chain artifacts
+- "Let me think step by step," "Breaking this down," "To approach this systematically," "Step 1:," "Here's my thought process," "First, let's consider," "Working through this logically" — these are artifacts of chain-of-thought reasoning leaking into published prose. The reader doesn't need to see the scaffolding. State the conclusion, then the evidence.
+- Also watch for numbered reasoning steps that read like an internal monologue rather than an argument meant for an audience.
+
+### Sycophantic tone
+- "Great question!", "Excellent point!", "You're absolutely right!", "That's a really insightful observation" — these are conversational rewards from chat interfaces, not writing. Remove entirely.
+- Distinct from chatbot artifacts: sycophancy specifically validates the reader/questioner rather than just performing helpfulness.
+
+### Acknowledgment loops
+- "You're asking about," "The question of whether," "To answer your question," "That's a great question. The..." — AI restates the prompt before answering. In writing, this is pure filler. The reader knows what they asked. Just answer.
+- Related pattern: opening a section by summarizing what the previous section said. If the structure is clear, the reader doesn't need a recap.
+
+### Confidence calibration phrases
+- "It's worth noting that," "Interestingly," "Surprisingly," "Importantly," "Significantly," "Notably," "Certainly," "Undoubtedly," "Without a doubt" — AI uses these to signal how the reader should feel about a fact instead of letting the fact speak for itself.
+- "Here's what's interesting," "Here's the interesting part," "Here are the parts I found interesting" — reader-steering cue that pre-interprets importance. Works when followed by genuinely surprising data; fails when it introduces a restatement of something obvious (which is the AI default).
+- One "notably" in a 2,000-word piece is fine. Three in 500 words is AI-style emphasis stacking. Flag by density.
+- Related — **persuasive-authority tropes**: "the real question is," "at its core," "fundamentally," "make no mistake," "the truth is." Same move as the calibration phrases above, but they assert depth or stakes instead of feeling: they announce that what follows is important rather than showing it. Cut the trope and lead with the substance. Adapted from `blader/humanizer` P27.
+
+### Self-labeling significance
+- After listing or describing several items, the writer points back at one and labels it as contrarian / clever / surprising / counterintuitive / key: "That last move is the contrarian one," "This is the interesting part," "That third bullet is the real story," "Here's where it gets clever," "The last bit is the counterintuitive one."
+- The label does the work the content was supposed to do. If a move is genuinely contrarian, the reader recognizes it from the description; if it isn't recognizable without the label, the label is unearned. The pattern reads as the writer auditing their own list to flag which item should matter, instead of writing the list so the right item carries the weight on its own.
+- Distinct from confidence calibration ("Notably," "Interestingly") which front-loads the cue, and from emotional flatline ("What surprised me most," "The most interesting part") which prefaces a single claim. This pattern back-points after the fact, usually as "[that / this / the Xth / the last] [noun] is the [adjective] one."
+- Significance-adjectives that signal the pattern: contrarian, clever, surprising, counterintuitive, interesting, key, important, unusual, smart, brilliant, real, actual.
+- Fix: cut the labeling sentence and let the explanation that follows do the work directly. Or restructure so the item you wanted to highlight is positioned first or expanded with specifics, making the label redundant.
+- Example. Before: "→ Two separate indexes for tiered storage. That last move is the contrarian one. Co-locating related data usually helps cache locality." After: "→ Two separate indexes for tiered storage. Co-locating related data usually helps cache locality, but splitting the indexes is what makes the hot path cheap." The contrast carries itself; the label is gone.
+
+### Wall-of-text replies (missing line breaks)
+- In conversational registers — issue and PR comments, chat, DMs, casual email — humans break a reply at thought boundaries: one idea, then a break, then the next. LLMs default to a single dense block regardless of length. The tell: a reply-length text (roughly under 150 words) with four or more sentences delivered as one unbroken paragraph, no line break anywhere in it.
+- Fix: break at thought boundaries. One idea per line-group, the way a person actually types a reply.
+- Observed in the wild: a maintainer on a GitHub issue called out an assisted-sounding reply with "I prefer to talk human to human" — the dense block-paragraph shape was the tell, not any single word in it.
+- Distinct from paragraph-length uniformity (which is about long-form prose where every paragraph is the same size): this rule is about short, reply-length text having *zero* breaks at all, not uneven ones.
+- Carve-out: a single dense paragraph is the *correct* shape in formal, long-form registers — a blog intro, a docs paragraph, a deliberately tight one-paragraph email. This rule fires only in conversational reply registers; never flag continuous long-form prose just because it lacks internal breaks. That false-positive class is exactly why the structural detector was reverted (see `detector/CATEGORIES.md` §C), and why the tolerance matrix below is the wrong home for it: a plain issue comment auto-detects to the `blog` profile, so the scoping has to live in this rule's judgment, not in a per-profile strictness cell.
+
+### Recap-flattery opener
+- Replying to a person by summarizing their own work back at them with praise before getting to the point: "Thanks for all the legwork here — the migration script and the rollback plan you worked through are what made this possible." The reader already knows what they did; the recap performs appreciation instead of conveying information.
+- Distinct from a genuine thank-you, which is short and moves on. The tell is the *recap* — restating specifics the other person already knows, dressed as gratitude, ahead of the actual point.
+- Distinct also from two nearby conversational tells: **Sycophantic tone** (generic validation of the reader — "Great question!") and **Acknowledgment loops** (restating the prompt or the prior section). Those echo the *question or context*; recap-flattery echoes the other person's *own work* back at them, dressed as praise.
+- Fix: substance first. If thanks is warranted, one plain clause without the recap: "Thanks for the legwork — this looks right to me, one comment below."
+- Observed in the wild: the same exchange that surfaced the wall-of-text tell above — an assisted-sounding reply opened by recapping the maintainer's own prior work back at them before answering the actual question.
+
+### Excessive structure
+- Too many headers in short text: more than 3 headings in under 300 words is almost always AI trying to look organized. Merge sections or use prose transitions instead.
+- Too many list items: 8+ bullet points in under 200 words means the content should be a paragraph, not a list.
+- Formulaic section headers: "Overview," "Key Points," "Summary," "Conclusion," "Introduction" — these are default AI scaffolding. Use headers that tell the reader something specific about what follows.
+
+### Rhythm and uniformity
+
+These aren't individual word or phrase problems — they're patterns in how the text flows as a whole. AI text is metronomic; human text has varied rhythm.
+
+**Structure is the #1 detection signal.** AI detection tools (including Pangram, which trains a classifier on 28M human documents) weight structural regularity higher than vocabulary. Consistent sentence construction, uniform pacing, and symmetrical phrasing patterns are harder to mask than swapping out a few flagged words. If you fix every word on the Tier 1 list but leave the rhythm untouched, the text still reads as AI-generated.
+
+- **Sentence length uniformity**: If most sentences are 15–25 words, the text sounds robotic. Mix short punchy sentences (3–8 words) with longer flowing ones (20+). Fragments work. Questions break the monotony.
+- **Paragraph length uniformity**: If every paragraph is 3–5 sentences and roughly the same size, vary deliberately. Some paragraphs should be one sentence. Some should be longer.
+- **Vocabulary repetition vs. synonym cycling**: AI either repeats the same word mechanically or cycles through synonyms conspicuously. Human writers repeat when the word is right and vary when it's natural — there's no formula.
+- **Read-aloud test**: If the text sounds like it could be read by a text-to-speech engine without sounding weird, it's probably too uniform. Human writing has rhythm that resists robotic delivery.
+- **Missing first-person perspective**: Where appropriate, the writer should have opinions, preferences, and reactions. AI is relentlessly neutral. If the piece is supposed to have a voice, the absence of "I think," "in my experience," or a stated preference is itself an AI tell.
+- **Over-polishing**: Aggressively editing out every irregularity can push human writing *toward* AI statistical profiles. Natural disfluency, idiosyncratic word choices, and uneven pacing are what keep text out of the "AI-generated" classification. Don't sand away all personality in pursuit of clean prose. This skill should make writing sound more human, not less — if you apply every rule at maximum strictness, you risk creating the very uniformity you're trying to avoid.
+
+### Vocabulary diversity (stylometric)
+
+In longer pieces (200+ words), look at how much vocabulary the text actually uses. The type-token ratio (TTR) — distinct word types divided by total tokens — is a classical stylometric signal that's easy to read by eye. Human prose at this length usually lands somewhere around 0.50–0.65 in English. AI text trends flatter, sometimes drifting under 0.40 when the model gets locked on a small vocabulary loop.
+
+A very low TTR is not by itself proof of AI authorship — narrow topics, technical reference material, and second-language writing all legitimately compress vocabulary. But on general prose where you'd expect range (essays, articles, social content over ~200 words), a TTR below 0.40 is worth a second look. The fix is rarely to thesaurus the text; it's to broaden the *what* — name specific things, cite specific cases, replace a re-used abstract noun with the concrete instance behind it.
+
+This is the first of four stylometric signals on the roadmap. The others (sentence-length burstiness as a continuous measure, function-word z-scores against a human-prose reference, POS-bigram log-odds) require either a POS tagger or a reference distribution and aren't implemented as detector categories yet.
+
+### Paragraph-reshuffle immunity (structure test)
+- A writer-side diagnostic, not a regex: can you swap two body paragraphs without breaking the piece? If the order doesn't matter, you've written a list of points, not an argument that builds. AI prose often fails this — each paragraph is a self-contained module with no load-bearing connection to its neighbors.
+- The fix is structural, not lexical: establish a through-line where each paragraph depends on the one before it. If the paragraphs are genuinely independent, decide whether the piece should be an explicit list, or whether it's missing a thesis. Adapted from `Aboudjem/humanizer-skill` P38.
+
+### Treadmill effect / low information density (content test)
+- Another writer-side test: read each paragraph and ask "what's actually new here?" AI prose frequently restates the premise in fresh words instead of advancing it — lots of motion, no distance covered. The tell is that you could cut 40-60% and lose no information.
+- The fix: for each paragraph, name the one fact, claim, or turn it contributes. If there isn't one, cut it. If there is, lead with it and drop the throat-clearing. Adapted from `Aboudjem/humanizer-skill` P43.
+
+### When to rewrite from scratch vs. patch
+
+If the text has 5+ flagged vocabulary hits across multiple categories, 3+ distinct pattern categories triggered, and uniform sentence/paragraph length, patching individual phrases won't fix it — the structure itself is AI-generated. Advise a full rewrite: state the core point in one sentence, then rebuild from there.
+
+---
+
+## Severity tiers
+
+Not all AI-isms are equal. When doing a quick pass or triaging a large document, prioritize by tier:
+
+### P0 — Credibility killers (fix immediately)
+- Cutoff disclaimers ("As of my last update")
+- Chatbot artifacts ("I hope this helps!", "Great question!")
+- Vague attributions without sources ("Experts believe")
+- Significance inflation on routine events
+- Hashtag stuffing on `linkedin` and `investor-email` posts (severity varies by profile — same rule, lower priority on `blog`/`technical-blog` where a launch post may legitimately stack tags; see the context-profile table below)
+
+### P1 — Obvious AI smell (fix before publishing)
+- Word-list violations (delve, leverage, harness, robust, etc.)
+- Template phrases and slot-fill constructions
+- "Let's" transition openers
+- Synonym cycling within a paragraph
+- Formulaic openings ("In the rapidly evolving world of...")
+- Bold overuse
+- Em dash frequency (above 1 per 1,000 words)
+- Generic future-narrative closers ("may become one of the most important narratives…")
+- Social endorsement closers ("This one is worth your time:", "thank me later")
+- Hedge-stacked predictions ("could potentially," "may eventually")
+- Real/actual adjective inflation ("real on-chain tokenomics")
+- Bullet lists of bare noun phrases (5+ short adj+noun items, no verbs)
+- Tier 3 phrase clustering (≥3 distinct boilerplate phrases in one piece)
+
+### P2 — Stylistic polish (fix when time allows)
+- Generic conclusions ("The future looks bright")
+- Compulsive rule of three
+- Uniform paragraph length
+- Copula avoidance (serves as, features, boasts)
+- Transition phrases (Moreover, Furthermore, Additionally)
+- Hashtag stuffing (`blog`/`technical-blog` profiles)
+- Tier 3 phrase repetition (single phrase ≥2× — fine in isolation, suspect in stacks)
+
+Use P0+P1 for quick passes. Full audit covers all three tiers.
+
+---
+
+## Self-reference escape hatch
+
+When writing *about* AI writing patterns (blog posts, tutorials, skill documentation like this file), quoted examples are exempt from flagging. Text inside quotation marks, code blocks, or explicitly marked as illustrative ("for example, AI might write...") should not be rewritten. Only flag patterns that appear in the author's own prose, not in cited examples of bad writing.
+
+---
+
+## Context profiles
+
+Pass an optional context hint to adjust rule strictness. If no context is specified, auto-detect from content cues (short + hashtags = social, code blocks = technical, salutation = email, default = blog).
+
+### Profile definitions
+
+**`linkedin`** — Short-form social. Punchy fragments, visual formatting matter.
+**`blog`** — Default. Standard long-form prose. All rules apply at full strength.
+**`technical-blog`** — Long-form with code, architecture, APIs. Technical terms get a pass.
+**`investor-email`** — High-trust audience. Tighten everything; promotional language is the biggest risk.
+**`docs`** — Documentation, READMEs, guides. Clarity over voice.
+**`casual`** — Slack messages, internal notes, quick replies. Only catch the worst offenders.
+
+### Tolerance matrix
+
+Rules not listed in the table apply at full strength across all profiles.
+
+| Rule | linkedin | blog | technical-blog | investor-email | docs | casual |
+|------|----------|------|----------------|----------------|------|--------|
+| Em dashes | relaxed (2/post OK) | strict | strict | strict | relaxed | skip |
+| Bold overuse | relaxed (bold hooks OK) | strict | strict | strict | relaxed | skip |
+| Emoji in headers | relaxed (1-2 end-of-line OK) | strict | strict | strict | skip | skip |
+| Excessive bullets | skip (lists work on LinkedIn) | strict | relaxed (technical lists OK) | strict | skip (lists are docs) | skip |
+| Hedging | strict | strict | relaxed ("may" is accurate in technical) | strict | relaxed | skip |
+| Word table (full list) | strict | strict | **partial** (see below) | strict | relaxed | P0 only |
+| Promotional language | relaxed (some sell is expected) | strict | strict | **extra strict** | strict | skip |
+| Significance inflation | strict | strict | strict | **extra strict** | relaxed | skip |
+| Copula avoidance | skip | strict | relaxed | strict | skip | skip |
+| Uniform paragraph length | skip (short-form) | strict | strict | strict | relaxed | skip |
+| Numbered list inflation | relaxed | strict | relaxed | strict | skip | skip |
+| Rhetorical questions | relaxed (1 as hook OK) | strict | strict | strict | strict | skip |
+| Transition phrases | skip (short-form) | strict | strict | strict | relaxed | skip |
+| Generic conclusions | skip | strict | strict | **extra strict** | skip | skip |
+| Hashtag stuffing | strict | strict | strict | **extra strict** | skip (no hashtags in docs) | skip |
+| Bullet-NP lists | strict | strict | relaxed (technical option lists OK) | strict | relaxed (parameter lists OK) | skip |
+| Tier 3 phrase clustering | strict | strict | strict | **extra strict** | relaxed | skip |
+| Future-narrative closers | strict | strict | strict | **extra strict** | skip | skip |
+| Social endorsement closers | strict (the LinkedIn share-post tell) | strict | strict | strict | skip | relaxed (1 OK in a DM) |
+| Hedge-stacked predictions | strict | strict | relaxed ("could" is hedged accuracy) | **extra strict** | relaxed | skip |
+| Real/actual inflation | strict | strict | strict | **extra strict** | relaxed | skip |
+
+**Technical-blog word table exceptions:** These terms have legitimate technical meaning and should not be flagged in technical context: `robust`, `comprehensive`, `seamless`, `ecosystem`, `leverage` (when discussing actual platform leverage/APIs), `facilitate`, `underpin`, `streamline`. Still flag: `delve`, `tapestry`, `beacon`, `embark`, `testament to`, `game-changer`, `harness`.
+
+**"Extra strict"** means: flag even borderline instances. In investor emails, a single "thriving ecosystem" can undermine the whole message.
+
+**"Skip"** means: don't audit this category for this profile. The rule doesn't apply or isn't worth the edit.
+
+### Auto-detection cues
+
+When no context is specified, infer from these signals:
+
+| Signal | Inferred context |
+|--------|-----------------|
+| Under 300 words + hashtags or mentions | `linkedin` |
+| Code blocks, API references, or technical architecture | `technical-blog` |
+| Salutation ("Hi [name]", "Dear") + investor/fundraising language | `investor-email` |
+| Step-by-step instructions, parameter docs, README structure | `docs` |
+| No strong signals | `blog` (safest default — all rules apply) |
+
+If auto-detection feels wrong, say which profile you're using and why. The user can override.
+
+---
+
+
+## Voice profiles
+
+Context profiles (above) set *how strict* to be for an audience. Voice profiles set *how the prose should sound* — the persona. They're independent axes: you can write blunt for a blog or warm for docs. Voice is **optional** — if the writer doesn't name one, infer it from the input's existing register and don't impose a persona on text that already has one.
+
+Each profile is a set of concrete targets, not a vibe:
+
+**`casual`** — Contractions throughout; their absence reads stiff. Short sentences (aim for ≤14 words on average); fragments allowed. At least one first-person or concrete-anecdote touch. Near-zero jargon. Keep warm hedges ("honestly," "I think") but cut corporate ones ("it's worth noting"). *Blog posts, social, community.*
+
+**`professional`** — Active voice for most sentences. Vary sentence length; avoid three in a row within a few words of each other. One concrete claim per paragraph (a number, a name, a date), never "experts say." Make the ask explicit. Low tolerance for hedging. *LinkedIn, investor email, sponsor pitches.*
+
+**`technical`** — Prefer plain copulatives ("X is Y") over inflated substitutes ("serves as," "stands as a testament to"). One idea per sentence; imperative mood for instructions. Jargon is fine, but define it on first use. Tables and lists only where the content is genuinely list-shaped, not for decoration. *Docs, technical blog.*
+
+**`warm`** — Address the reader directly ("you") and acknowledge them at least once. Cut intensifiers ("very," "truly," "incredibly") in favor of stronger verbs. No performative-empathy openers ("I completely understand how you feel"). Medium sentences (15–20 words) for an unhurried cadence. *Mentorship, onboarding, thank-yous.*
+
+**`blunt`** — Lead with the claim; cut "It's important to note that" windups. Em-dashes are rare here; use periods for emphasis. No padding to hit a rule of three. Near-zero hedging; flag "may / could / potentially" stacks. Short declaratives, with the occasional long sentence for contrast. *Decision memos, thought leadership, hard feedback.*
+
+**Calibrate to a sample (optional).** If the writer gives you a sample of their own writing ("match my voice — here's a post"), analyze its sentence-length pattern, contraction rate, paragraph openings, and recurring word choices, then match those instead of a named profile. Don't "upgrade" their vocabulary: if they write "stuff" and "things," keep that register.
+
+**How voice composes with context.** Voice sets the target; context sets how hard to enforce it. A voice *target* always applies, even where a context profile would skip that category — `technical` voice still prefers plain copulatives in a `casual` context that otherwise ignores copula avoidance. Where both axes govern the same rule and agree, they reinforce: `blunt` voice wants near-zero em-dashes and a `blog` context is already strict on them, so it stays a hard edit. Where they disagree, resolve toward the **stricter** of the two — a `warm` voice on `docs` still doesn't get decorative tables. Sensible default pairings: casual↔casual, professional↔linkedin/investor-email, technical↔docs/technical-blog.
+
+---
+
+## Output format
+
+### Rewrite mode (default)
+
+Return your response in four sections:
+
+**1. Issues found**
+A bulleted list of every AI-ism identified, with the offending text quoted.
+
+**2. Rewritten version**
+The full rewritten content. Preserve the original structure, intent, and all specific technical details. Only change what the guidelines require.
+
+**3. What changed**
+A brief summary of the major edits made. Not every word, just the meaningful changes.
+
+**4. Second-pass audit**
+Re-read the rewritten version from section 2. Identify any remaining AI tells that survived the first pass — recycled transitions, lingering inflation, copula avoidance, filler phrases, or anything else from the categories above. Fix them, return the corrected text inline, and note what changed in this pass. If the rewrite is clean, say so.
+
+### Detect mode
+
+Return your response in two sections:
+
+**1. Issues found**
+A bulleted list of every AI-ism identified, with the offending text quoted. Group by severity (P0, P1, P2).
+
+**2. Assessment**
+For each flag, note whether it's a clear problem or a judgment call. Some AI-associated patterns are effective writing techniques — uniform paragraph length is a problem, but a well-placed "however" isn't. Call out which flags the writer should definitely fix vs. which ones are worth a second look but might be fine in context. If the text is clean, say so.
+
+### Edit mode
+
+After editing the file in place, return a short report — not the full file:
+
+**1. Edits made**
+A bulleted list of the changes, each with the file location and the before → after. Only the spans you touched.
+
+**2. Verification**
+Confirm you re-read the file and the flagged patterns are resolved. Note anything you deliberately left alone because it was already human or intentional.
+
+---
+
+## Tone calibration
+
+The goal is writing that sounds like a person wrote it. Direct. Specific. The writing should demonstrate confidence, not assert it.
+
+Five principles for human-sounding rewrites:
+1. **Vary sentence length** — mix short with long. Fragments are fine.
+2. **Be concrete** — replace vague claims with numbers, names, dates, or examples.
+3. **Have a voice** — where appropriate, use first person, state preferences, show reactions.
+4. **Cut the neutrality** — humans have opinions. If the piece is supposed to take a position, take it.
+5. **Earn your emphasis** — don't tell the reader something is interesting. Make it interesting.
+
+If the original writing is already strong, say so and make only the necessary cuts. Don't over-edit for the sake of it.
+
+The replacement table provides defaults, not mandates. If a flagged word is clearly the right choice in context, preserve it.

--- a/plugins/writing/skills/remove-ai-patterns/upstream/UPSTREAM-PIN
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/UPSTREAM-PIN
@@ -1,0 +1,1 @@
+https://github.com/conorbronsdon/avoid-ai-writing 500ff59006f19c27120c5ddbd9b56fc3d937b6bf v3.15.0: conversational-register patterns (wall-of-text, recap-flattery) (#53)

--- a/plugins/writing/skills/remove-ai-patterns/upstream/detector/CATEGORIES.md
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/detector/CATEGORIES.md
@@ -1,0 +1,108 @@
+# Category map: SKILL.md ↔ detector
+
+This table is the anti-drift contract between the human-readable rules in
+`../SKILL.md` and the executable engine in `patterns.js`. When you add a rule to
+the skill, decide here whether it's regex-detectable (give it a detector `type`)
+or LLM-only judgment (mark it so). When you add a detector `type`, point it back
+at the skill section it enforces.
+
+The engine exposes 45 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
+skill has more `###` sections than that — the gap is **not** missing coverage,
+it's rules that are judgment calls a regex can't make. The three groups below
+account for every entry on both sides.
+
+Three counts coexist on purpose and should not be forced to match: the README's
+**pattern-category count** (the human-facing prose catalog, derived from SKILL.md
+and guarded in CI), the engine's **45 `type`s** (which split the vocabulary tiers
+and add stylometric signals), and SKILL.md's `###` sections (which also include
+writer-side tests with no detectable form). The
+`categories.test.js` check enforces only the engine ↔ this-file mapping.
+
+## A. Direct mapping (skill rule → detector `type`)
+
+| Detector `type` | Label | SKILL.md section |
+|---|---|---|
+| `tier1` / `tier2` / `tier3` | AI vocabulary / Word cluster / Overused word | Words and phrases to replace |
+| `transition` | AI transition | Transition phrases to remove or rewrite |
+| `template-phrase` | Template phrase | Template phrases (avoid) |
+| `tier3-phrase` / `tier3-phrase-cluster` | Boilerplate phrase / cluster | Template phrases (avoid) |
+| `chatbot` | Chatbot artifact | Chatbot artifacts |
+| `sycophantic` | Sycophantic tone | Sycophantic tone |
+| `acknowledgment-loop` | Acknowledgment loop | Acknowledgment loops |
+| `filler` | Filler phrase | Filler phrases |
+| `hollow-intensifier` | Hollow intensifier | Filler phrases (intensifiers) |
+| `generic-conclusion` | Generic conclusion | Generic conclusions |
+| `social-cta-closer` | Engagement-bait closer | Social endorsement closers |
+| `future-narrative` | Generic future narrative | Generic future-narrative closers |
+| `lets-construction` | "Let's" opener | "Let's" constructions |
+| `reasoning-artifact` | Reasoning artifact | Reasoning chain artifacts |
+| `significance-inflation` | Significance inflation | Significance inflation |
+| `novelty-inflation` | Novelty inflation | Novelty inflation *(the invented-concept-labels sub-rule is LLM-judgment only — open-ended coinages aren't regex-matchable)* |
+| `real-actual-inflation` | "Real/actual" inflation | "Real/actual" adjective inflation |
+| `vague-attribution` | Vague attribution | Vague attributions |
+| `emotional-flatline` | Emotional flatline | Emotional flatline / Superficial -ing analyses |
+| `cutoff-disclaimer` | Cutoff disclaimer | Cutoff disclaimers |
+| `false-concession` | False concession | False concession structure |
+| `rhetorical-question` | Rhetorical question | Rhetorical question openers |
+| `formulaic-opener` | Formulaic opener | Formulaic challenges |
+| `speculative-opener` | Speculative scenario opener | Speculative scenario openers |
+| `confidence-calibration` | Confidence stacking | Confidence calibration phrases |
+| `hedge-stack` | Hedge-stacked prediction | Hedge-stacked predictions |
+| `parenthetical-hedge` | Parenthetical hedge | Parenthetical hedging |
+| `hashtag-stuff` | Hashtag stuffing | Hashtag stuffing |
+| `bullet-np-list` | Bullet-NP list | Bullet lists of bare noun phrases |
+| `title-case-header` | Title Case header | Title case headings |
+| `em-dash` / `formatting` | Em dash overuse / Formatting | Formatting |
+| `uniformity` | Rhythm uniformity | Rhythm and uniformity |
+| `low-ttr` | Low vocabulary diversity | Vocabulary diversity (stylometric) |
+| `ai-placeholder` | Unfilled placeholder | Unfilled placeholders |
+| `ai-citation-markup` | Chatbot citation markup leak | Chatbot citation markup leaks |
+| `ai-utm-source` | AI-tool URL parameter | AI-tool URL parameters |
+| `smart-punct-signature` | Smart-punct signature | Formatting (curly quotation marks) — *partial* |
+
+> **Partial map:** `smart-punct-signature` fires only when curly quotes co-occur
+> with an em-dash, an Oxford comma, and clean typing (≥80 words) — never on curly
+> punctuation alone. The SKILL.md Formatting rule treats curly quotes as a weak,
+> corroborating signal in plain-text contexts and excludes apostrophes. The two
+> agree in spirit (curly punctuation is never conclusive on its own) but differ in
+> mechanism — so this is a partial map, not 1:1.
+
+## B. Detector-only (stylometric / fingerprint — no skill prose)
+
+These extend the skill with signals that work as math over the whole document,
+not as a phrase a human editor would look up:
+
+| Detector `type` | Label | Why it's engine-only |
+|---|---|---|
+| `punct-distribution` | Punctuation distribution | Per-paragraph punctuation uniformity |
+| `fnword-trigram-entropy` | Grammar repetition | Function-word trigram entropy |
+| `cross-para-burstiness` | Cross-paragraph rhythm | Sentence-length variance across paragraphs |
+| `normalization-flag` | Bypass-trick chars | Zero-width / homoglyph humanizer-bypass detection |
+
+## C. Skill-only (LLM judgment — no detector `type`)
+
+Rules that require reading for meaning, so they live in the skill prose and are
+applied by the model, not the regex engine. Listed so future contributors don't
+mistake their absence for a coverage gap:
+
+- Synonym cycling
+- Copula avoidance
+- Promotional language
+- Sentence structure: "It's not X — it's Y" / split-sentence form / multi-negation countdown
+- Structural issues / Excessive structure / Inline-header lists / Numbered list inflation
+- False ranges
+- Notability name-dropping
+- Vague third-party validation
+- Self-labeling significance
+- Wall-of-text replies (missing line breaks) *(tried as a detector — "reply-length, >=4 sentences, zero newlines" — and reverted; it fires on any ordinary short paragraph, not just conversational-reply register, so it stayed judgment-only. See the NOTE in `patterns.js` near the bullet-NP-list block)*
+- Recap-flattery opener
+- Immaculate typography in casual registers *(folded into the Formatting section — same weak-signal tier as curly quotes, not a standalone category)*
+- When to rewrite from scratch vs. patch
+- Severity tiers (P0 / P1 / P2)
+- Self-reference escape hatch
+- Output format
+
+> **Partial:** the skill's **Context profiles / Tolerance matrix / Auto-detection
+> cues** are partly realized by the engine's `options.contextMode`
+> (`general` / `technical`), which suppresses context-inappropriate flags. Full
+> profile-based tolerance remains an LLM-side judgment.

--- a/plugins/writing/skills/remove-ai-patterns/upstream/detector/patterns.js
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/detector/patterns.js
@@ -1,0 +1,1722 @@
+/**
+ * Avoid AI Writing — detection engine (canonical source of truth)
+ * Implements 45-category pattern detection. This repo's SKILL.md
+ * catalogs the human-editable pattern rules; this engine is the executable
+ * expression of the regex-detectable subset and extends it with stylometric and
+ * AI-tool-fingerprint detectors that don't make sense as skill prose
+ * (cross-paragraph burstiness, smart-punct signatures, function-word
+ * trigram entropy, low type-token ratio, AI-tool URL parameters,
+ * chatbot citation markup leaks, unfilled placeholders).
+ *
+ * Scoring model:
+ *   Each category has a weight in the ISSUE_WEIGHTS table. Detection runs
+ *   produce raw (possibly duplicate) issues which are then deduplicated by
+ *   (type, text) pair. rawScore is the sum of category weights across the
+ *   deduped list — so the number reflects the same distinct signals the
+ *   user sees in the issue list.
+ *
+ *   Weights are deliberately non-flat across severity tags. Cutoff
+ *   disclaimers (10) and chatbot artifacts (8) weigh more than vague
+ *   attributions (5), even though all three are tagged `critical`, because
+ *   the skill treats them as stronger or weaker AI-origin signals.
+ *
+ *   rawScore is then normalized to 0-100 via `log2(wordCount/50)` so longer
+ *   texts don't accumulate unboundedly on the same density of patterns.
+ */
+
+const AIDetector = (() => {
+  // ═══ Tier 1 pre-pass: normalize bypass tricks ══════════════════════
+  //
+  // Humanizer tools and prompt-injection bypass techniques insert
+  // invisible / lookalike chars to defeat exact-string detectors. Strip
+  // them BEFORE pattern matching so "delve" with a Cyrillic 'е' still
+  // hits the Tier 1 list. Unicode ranges sourced from
+  // It-s-AI/llm-detection/detection/attacks/.
+  //
+  // Tracks what was stripped so the trinary classifier can use
+  // "normalization triggered" as a corroborating AI signal — humans don't
+  // paste ZWSPs into their own writing.
+  const CYRILLIC_LOOKALIKES = {
+    'а': 'a', 'е': 'e', 'о': 'o', 'р': 'p', 'с': 'c', 'х': 'x',
+    'у': 'y', 'к': 'k', 'м': 'm', 'н': 'h', 'в': 'b', 'т': 't',
+    'А': 'A', 'Е': 'E', 'О': 'O', 'Р': 'P', 'С': 'C', 'Х': 'X',
+    'У': 'Y', 'К': 'K', 'М': 'M', 'Н': 'H', 'В': 'B', 'Т': 'T',
+  };
+  const GREEK_LOOKALIKES = { 'ο': 'o', 'Ο': 'O', 'α': 'a', 'Α': 'A', 'ρ': 'p', 'Ρ': 'P' };
+
+  function normalizeText(text) {
+    const flags = { zeroWidth: 0, homoglyph: 0, roleplay: 0 };
+    let out = text;
+
+    // 1. Strip zero-width chars (ZWSP U+200B, ZWNJ U+200C, ZWJ U+200D,
+    //    BOM U+FEFF, word joiner U+2060).
+    out = out.replace(/[​-‍﻿⁠]/g, () => { flags.zeroWidth++; return ''; });
+
+    // 2. Swap Cyrillic / Greek Latin-lookalike chars back to Latin so
+    //    pattern matching catches obfuscated tokens.
+    out = out.replace(/[Ѐ-ӿͰ-Ͽ]/g, (m) => {
+      const swap = CYRILLIC_LOOKALIKES[m] ?? GREEK_LOOKALIKES[m];
+      if (swap) { flags.homoglyph++; return swap; }
+      return m;
+    });
+
+    // 3. Strip *roleplay-action* markers — paired *...* containing an
+    //    action verb (nods, sighs, laughs, smiles, etc.) anchored to
+    //    the start of the inner phrase. This is the actual chat-model
+    //    artifact shape. Markdown `**bold**` is rejected by the
+    //    lookbehind/lookahead; legitimate multi-word `*italic*` is
+    //    preserved because the verb whitelist is narrow.
+    const ROLEPLAY_VERBS = /^(?:nods|sighs|laughs|smiles|frowns|shrugs|grins|winks|chuckles|gasps|pauses|thinks|wonders|whispers|shouts|gestures|raises|leans|turns|looks|glances|smirks|blinks|nodding|sighing|laughing|smiling|thinking|gesturing)\b/i;
+    out = out.replace(/(?<!\*)\*([^*\n]{1,80}?)\*(?!\*)/gu, (m, inner) => {
+      if (ROLEPLAY_VERBS.test(inner)) { flags.roleplay++; return ''; }
+      return m;
+    });
+
+    return { text: out, flags };
+  }
+
+  // ─── Tier 1: Always flag ───────────────────────────────────────────
+  const TIER1 = {
+    'delve': 'explore, dig into, look at',
+    'tapestry': 'describe the actual complexity',
+    'paradigm': 'model, approach, framework',
+    'beacon': 'rewrite entirely',
+    'robust': 'strong, reliable, solid',
+    'comprehensive': 'thorough, complete, full',
+    'cutting-edge': 'latest, newest, advanced',
+    'pivotal': 'important, key, critical',
+    'meticulous': 'careful, detailed, precise',
+    'meticulously': 'carefully, precisely',
+    'seamless': 'smooth, easy, without friction',
+    'seamlessly': 'smoothly, easily',
+    'game-changer': 'describe what changed',
+    'game-changing': 'describe what changed',
+    'nestled': 'is located, sits',
+    'vibrant': 'describe what makes it active',
+    'thriving': 'growing, active',
+    'bustling': 'busy, active',
+    'intricate': 'complex, detailed',
+    'intricacies': 'complexities, details',
+    'ever-evolving': 'changing, growing',
+    'enduring': 'lasting, long-running',
+    'daunting': 'hard, difficult',
+    'holistic': 'complete, full, whole',
+    'holistically': 'completely, fully',
+    'actionable': 'practical, useful, concrete',
+    'impactful': 'effective, significant',
+    'learnings': 'lessons, findings, takeaways',
+    'synergy': 'describe the combined effect',
+    'synergies': 'describe the combined effect',
+    'interplay': 'relationship, connection',
+    'symphony': 'describe the coordination',
+    'embrace': 'adopt, accept, use',
+  };
+
+  // Multi-word tier 1 phrases
+  const TIER1_PHRASES = [
+    { pattern: /\bdelve\s+into\b/gi, replace: 'explore, dig into' },
+    { pattern: /\blandscape\b/gi, replace: 'field, space, industry', filter: true },
+    { pattern: /\brealm\b/gi, replace: 'area, field, domain' },
+    { pattern: /\btestament\s+to\b/gi, replace: 'shows, proves' },
+    { pattern: /\bleverag(?:e|es|ing|ed)\b/gi, replace: 'use' },
+    { pattern: /\bwatershed\s+moment\b/gi, replace: 'turning point, shift' },
+    { pattern: /\bmarking\s+a\s+pivotal\s+moment\b/gi, replace: 'state what happened' },
+    { pattern: /\bthe\s+future\s+looks\s+bright\b/gi, replace: 'cut or say something specific' },
+    { pattern: /\bonly\s+time\s+will\s+tell\b/gi, replace: 'cut or say something specific' },
+    { pattern: /\bdespite\s+challenges[^.]*continues?\s+to\s+thrive\b/gi, replace: 'name the challenge and response' },
+    { pattern: /\bdeep\s+dive\b/gi, replace: 'look at, examine' },
+    { pattern: /\bdive\s+into\b/gi, replace: 'look at, examine' },
+    { pattern: /\bunpack(?:ing)?\b/gi, replace: 'explain, break down' },
+    { pattern: /\bcomplexities\b/gi, replace: 'name the actual problems' },
+    { pattern: /\bthought\s+leader(?:ship)?\b/gi, replace: 'expert, authority' },
+    { pattern: /\bbest\s+practices\b/gi, replace: 'what works, proven methods' },
+    { pattern: /\bat\s+its\s+core\b/gi, replace: 'cut, just state it' },
+    { pattern: /\bin\s+order\s+to\b/gi, replace: 'to' },
+    { pattern: /\bdue\s+to\s+the\s+fact\s+that\b/gi, replace: 'because' },
+    { pattern: /\bserves\s+as\b/gi, replace: 'is' },
+    { pattern: /\bfeatures\b/gi, replace: 'has, includes', filter: true },
+    { pattern: /\bboasts\b/gi, replace: 'has' },
+    { pattern: /\butiliz(?:e|es|ing|ed)\b/gi, replace: 'use' },
+    { pattern: /\bshowcas(?:e|es|ing|ed)\b/gi, replace: 'show, demonstrate' },
+    { pattern: /\bembark(?:s|ing|ed)?\b/gi, replace: 'start, begin' },
+    { pattern: /\bcommenc(?:e|es|ing|ed)\b/gi, replace: 'start, begin' },
+    { pattern: /\bascertain(?:s|ing|ed)?\b/gi, replace: 'find out, determine' },
+    { pattern: /\bendeavou?r(?:s|ing|ed)?\b/gi, replace: 'effort, attempt, try' },
+    { pattern: /\bunderscor(?:es|ing|ed)\b/gi, replace: 'highlights, shows' },
+  ];
+
+  // ─── Tier 2: Flag in clusters (2+ per paragraph) ──────────────────
+  const TIER2 = {
+    'harness': 'use, take advantage of',
+    'navigate': 'work through, handle',
+    'navigating': 'working through, handling',
+    'foster': 'encourage, support, build',
+    'elevate': 'improve, raise, strengthen',
+    'unleash': 'release, enable, unlock',
+    'streamline': 'simplify, speed up',
+    'empower': 'enable, let, allow',
+    'bolster': 'support, strengthen',
+    'spearhead': 'lead, drive, run',
+    'resonate': 'connect with, appeal to',
+    'resonates': 'connects with, appeals to',
+    'revolutionize': 'change, transform',
+    'facilitate': 'enable, help, allow',
+    'facilitates': 'enables, helps, allows',
+    'underpin': 'support, form the basis of',
+    'nuanced': 'specific, subtle, detailed',
+    'crucial': 'important, key, necessary',
+    'multifaceted': 'describe the actual facets',
+    'ecosystem': 'system, community, network',
+    'myriad': 'many, numerous',
+    'plethora': 'many, a lot of',
+    'encompass': 'include, cover, span',
+    'catalyze': 'start, trigger, accelerate',
+    'reimagine': 'rethink, redesign, rebuild',
+    'galvanize': 'motivate, rally, push',
+    'augment': 'add to, expand, supplement',
+    'cultivate': 'build, develop, grow',
+    'illuminate': 'clarify, explain, show',
+    'elucidate': 'explain, clarify',
+    'juxtapose': 'compare, contrast',
+    'transformative': 'describe what changed',
+    'transformation': 'describe what changed',
+    'cornerstone': 'foundation, basis, key part',
+    'paramount': 'most important, top priority',
+    'poised': 'ready, set, about to',
+    'burgeoning': 'growing, emerging',
+    'nascent': 'new, early-stage',
+    'quintessential': 'typical, classic, defining',
+    'overarching': 'main, central, broad',
+    'quietly': 'cut, or name the concrete contrast',
+    'underpinning': 'basis, foundation',
+    'underpinnings': 'basis, foundations',
+    'paradigm-shifting': 'describe what shifted',
+  };
+
+  // Conditional Tier 2 entries: everyday words whose AI tell is a specific
+  // significance collocation, not the word itself. They join a paragraph's
+  // Tier 2 cluster only when the collocation matches — bare uses ("deeply
+  // nested JSON", "cares deeply") never count, because the base rate of
+  // these words in innocent prose is far higher than the rest of the table
+  // and an unconditional entry measurably flags clean human writing.
+  const TIER2_CONDITIONAL = [
+    {
+      word: 'deeply',
+      pattern: /\bdeeply\s+(?:integrated|committed|rooted|personal|human|flawed|resonant|transformative|interconnected|ingrained|embedded|meaningful)\b/i,
+      suggestion: 'cut, or name what specifically runs deep',
+    },
+  ];
+
+  // ─── Tier 3: Flag by density ───────────────────────────────────────
+  const TIER3 = [
+    'significant', 'significantly', 'innovative', 'innovation',
+    'effective', 'effectively', 'dynamic', 'dynamics',
+    'scalable', 'scalability', 'compelling', 'unprecedented',
+    'exceptional', 'exceptionally', 'remarkable', 'remarkably',
+    'sophisticated', 'instrumental',
+    'world-class', 'state-of-the-art', 'best-in-class',
+  ];
+
+  // Multi-word Tier 3 phrases. Density-gated like single Tier 3 words because
+  // these legitimately show up in human crypto/web3/dev writing. Threshold is
+  // intentionally lower than single-word Tier 3 (≥2 occurrences of the same
+  // phrase) — repeating the same multi-word boilerplate is a stronger AI tell
+  // than re-using "significant."
+  const TIER3_PHRASES = [
+    /\bemerging\s+(?:sector|space|category|industry)\b/gi,
+    /\bthe\s+integration\s+of\b/gi,
+    /\bthe\s+intersection\s+of\b/gi,
+    /\bcommunity-?driven\b/gi,
+    /\blong-?term\s+sustainability\b/gi,
+    /\buser\s+engagement\b/gi,
+    /\bdecentralized\s+compute\b/gi,
+    /\b(?:sustainable\s+)?reward\s+emissions?\b/gi,
+    /\btokenized\s+incentive\s+structures?\b/gi,
+    /\bdesigned\s+for\s+long-?term\b/gi,
+  ];
+
+  // O(1) lookup from any token form (hyphenated or dashless) to its canonical
+  // Tier 3 word. Counting originally did nested-loop word matching which was
+  // O(tokens × TIER3) — slow on long pastes.
+  const TIER3_LOOKUP = new Map();
+  for (const word of TIER3) {
+    TIER3_LOOKUP.set(word, word);
+    const dashless = word.replace(/-/g, '');
+    if (dashless !== word) TIER3_LOOKUP.set(dashless, word);
+  }
+
+  // Per-category score weights. Applied to distinct (deduplicated) issues so
+  // the score reflects the same signals the user sees in the issue list.
+  // Non-uniform on purpose: critical rules like cutoff disclaimers (×10) and
+  // chatbot artifacts (×8) weigh more than vague attributions (×5), even
+  // though all three are tagged `critical`.
+  const ISSUE_WEIGHTS = {
+    tier1: 5,
+    tier2: 3,
+    tier3: 2,
+    transition: 2,
+    chatbot: 8,
+    sycophantic: 8,
+    filler: 2,
+    'generic-conclusion': 3,
+    'lets-construction': 2,
+    'reasoning-artifact': 6,
+    'acknowledgment-loop': 3,
+    'significance-inflation': 4,
+    'vague-attribution': 5,
+    'hollow-intensifier': 2,
+    'emotional-flatline': 2,
+    'novelty-inflation': 3,
+    'cutoff-disclaimer': 10,
+    'template-phrase': 3,
+    'false-concession': 2,
+    'rhetorical-question': 2,
+    'confidence-calibration': 2,
+    'em-dash': 4,
+    uniformity: 5,
+    formatting: 3,
+    'tier3-phrase': 3,
+    // Structural / cluster signals are deliberately weighted high. Unlike
+    // single-vocabulary hits they're near-dispositive on social-length
+    // posts (a 15-hashtag block, a 6-item bullet-NP list, three distinct
+    // crypto-shill phrases stacked) and would otherwise be suppressed by
+    // the log2(words/50) length divisor on short pastes.
+    'tier3-phrase-cluster': 12,
+    'hashtag-stuff': 12,
+    'bullet-np-list': 10,
+    'hedge-stack': 6,
+    'future-narrative': 12,
+    'real-actual-inflation': 5,
+    // Social endorsement / CTA closer. Weighted like formulaic-opener: a
+    // strong single-hit social tell that the length divisor would
+    // otherwise wash out on a short LinkedIn-length post.
+    'social-cta-closer': 8,
+    'formulaic-opener': 8,
+    // Speculative scenario opener ("Imagine a world where…"). Weighted like
+    // formulaic-opener: a single strong opener tell the length divisor would
+    // otherwise wash out on a short post.
+    'speculative-opener': 8,
+    'title-case-header': 4,
+    'parenthetical-hedge': 3,
+    'smart-punct-signature': 6,
+    'punct-distribution': 6,
+    'fnword-trigram-entropy': 5,
+    'cross-para-burstiness': 5,
+    'normalization-flag': 9,
+    // Vocabulary-diversity signal (type-token ratio). Weighted modestly
+    // because the threshold (>=200 tokens AND TTR<0.4) is conservative;
+    // it stacks with structural signals to push borderline scores up.
+    'low-ttr': 3,
+    // AI-tool fingerprints. Weighted higher than statistical patterns
+    // because each is a near-definitive single-hit signal — the AI tool
+    // literally left its mark in the text. citation-markup ranks highest
+    // (smoking gun: the literal internal markup of ChatGPT/Grok/etc.),
+    // UTM tracking second (auto-appended by the tool to URLs it writes),
+    // placeholders third (strong but humans use bracketed slots in
+    // templates legitimately and forget them — still a publishing bug
+    // but slightly less definitive AI evidence).
+    'ai-placeholder': 10,
+    'ai-citation-markup': 15,
+    'ai-utm-source': 12,
+  };
+
+  // ─── Transition phrases ────────────────────────────────────────────
+  const TRANSITIONS = [
+    /\bmoreover\b/gi,
+    /\bfurthermore\b/gi,
+    /\badditionally\b/gi,
+    /\bin\s+today'?s\b/gi,
+    /\bin\s+an\s+era\s+where\b/gi,
+    /\bit'?s\s+worth\s+noting\s+that\b/gi,
+    /\bnotably\b/gi,
+    /\bin\s+conclusion\b/gi,
+    /\bin\s+summary\b/gi,
+    /\bto\s+summarize\b/gi,
+    /\bwhen\s+it\s+comes\s+to\b/gi,
+    /\bat\s+the\s+end\s+of\s+the\s+day\b/gi,
+    /\bthat\s+(?:being\s+)?said\b/gi,
+  ];
+
+  // ─── Chatbot artifacts ─────────────────────────────────────────────
+  const CHATBOT_ARTIFACTS = [
+    /\bi\s+hope\s+this\s+helps\b/gi,
+    /\bcertainly!\b/gi,
+    /\babsolutely!\b/gi,
+    /\bgreat\s+question!\b/gi,
+    /\bexcellent\s+point!\b/gi,
+    /\bfeel\s+free\s+to\s+reach\s+out\b/gi,
+    /\blet\s+me\s+know\s+if\s+you\s+need\s+anything\b/gi,
+    /\bin\s+this\s+article,?\s+we\s+will\s+explore\b/gi,
+    /\blet'?s\s+dive\s+in!?\b/gi,
+  ];
+
+  // ─── Sycophantic tone ──────────────────────────────────────────────
+  const SYCOPHANTIC = [
+    /\byou'?re\s+absolutely\s+right\b/gi,
+    /\bthat'?s\s+a\s+really\s+insightful\b/gi,
+    /\bthat'?s\s+a\s+great\s+question\b/gi,
+    /\bexcellent\s+question\b/gi,
+  ];
+
+  // ─── Filler phrases ────────────────────────────────────────────────
+  const FILLERS = [
+    /\bit\s+is\s+important\s+to\s+note\s+that\b/gi,
+    /\bin\s+terms\s+of\b/gi,
+    /\bthe\s+reality\s+is\s+that\b/gi,
+    /\bit'?s\s+important\s+to\s+note\s+that\b/gi,
+  ];
+
+  // ─── Generic conclusions ───────────────────────────────────────────
+  const GENERIC_CONCLUSIONS = [
+    /\bthe\s+future\s+looks\s+bright\b/gi,
+    /\bonly\s+time\s+will\s+tell\b/gi,
+    /\bone\s+thing\s+is\s+certain\b/gi,
+    /\bas\s+we\s+move\s+forward\b/gi,
+  ];
+
+  // ─── "Let's" constructions ─────────────────────────────────────────
+  const LETS_PATTERNS = [
+    /\blet'?s\s+explore\b/gi,
+    /\blet'?s\s+take\s+a\s+look\b/gi,
+    /\blet'?s\s+break\s+this\s+down\b/gi,
+    /\blet'?s\s+examine\b/gi,
+    /\blet'?s\s+(?:consider|discuss|delve|unpack|walk\s+through)\b/gi,
+  ];
+
+  // ─── Reasoning chain artifacts ─────────────────────────────────────
+  const REASONING_ARTIFACTS = [
+    /\blet\s+me\s+think\s+step\s+by\s+step\b/gi,
+    /\bbreaking\s+this\s+down\b/gi,
+    /\bto\s+approach\s+this\s+systematically\b/gi,
+    /\bhere'?s\s+my\s+thought\s+process\b/gi,
+    /\bfirst,?\s+let'?s\s+consider\b/gi,
+    /\bworking\s+through\s+this\s+logically\b/gi,
+  ];
+
+  // ─── Acknowledgment loops ──────────────────────────────────────────
+  const ACKNOWLEDGMENT_LOOPS = [
+    /\byou'?re\s+asking\s+about\b/gi,
+    /\bthe\s+question\s+of\s+whether\b/gi,
+    /\bto\s+answer\s+your\s+question\b/gi,
+  ];
+
+  // ─── Significance inflation ────────────────────────────────────────
+  const SIGNIFICANCE_INFLATION = [
+    /\bmarking\s+a\s+(?:pivotal|significant|important)\s+moment\b/gi,
+    /\ba\s+watershed\s+moment\s+for\b/gi,
+    /\bin\s+the\s+evolution\s+of\b/gi,
+    /\ba\s+(?:pivotal|defining)\s+moment\s+in\b/gi,
+  ];
+
+  // ─── Vague attributions ────────────────────────────────────────────
+  const VAGUE_ATTRIBUTIONS = [
+    /\bexperts\s+(?:believe|say|suggest|agree)\b/gi,
+    /\bstudies\s+(?:show|suggest|indicate)\b/gi,
+    /\bresearch\s+(?:shows|suggests|indicates)\b/gi,
+    /\bindustry\s+leaders\s+(?:agree|believe|say)\b/gi,
+  ];
+
+  // ─── Hollow intensifiers ──────────────────────────────────────────
+  const HOLLOW_INTENSIFIERS = [
+    /\bgenuine(?:ly)?\b/gi,
+    /\btruly\b/gi,
+    /\bquite\s+frankly\b/gi,
+    /\bto\s+be\s+honest\b/gi,
+    /\blet'?s\s+be\s+clear\b/gi,
+  ];
+
+  // ─── Emotional flatline ────────────────────────────────────────────
+  // The "interesting (part|thing|aspect|piece)" family is matched in two
+  // shapes: (1) "the most interesting X" inline (the canonical AI list
+  // intro), and (2) bare "Interesting X:" used as a section-header opener,
+  // which is the section-break variant that slipped past v3.3.x.
+  const EMOTIONAL_FLATLINE = [
+    /\bwhat\s+surprised\s+me\s+most\b/gi,
+    /\bi\s+was\s+fascinated\s+to\b/gi,
+    /\bwhat\s+struck\s+me\s+was\b/gi,
+    /\bi\s+was\s+excited\s+to\s+learn\b/gi,
+    /\bthe\s+most\s+interesting\s+(?:part|thing|aspect|piece)\b/gi,
+    // Multiline flag (/m) so `^` matches at every line start, including
+    // position 0 of a pasted text that has no leading newline. The earlier
+    // `(?:^|\n)` form silently missed bare openers at the very start of
+    // input — caught by silent-failure audit 2026-05-16.
+    /^\s*interesting\s+(?:part|thing|aspect|piece)(?:\s+of\s+(?:the\s+)?\w+)?\s*:/gim,
+  ];
+
+  // ─── Novelty inflation ─────────────────────────────────────────────
+  const NOVELTY_INFLATION = [
+    /\bthe\s+failure\s+mode\s+nobody'?s?\s+naming\b/gi,
+    /\ba\s+problem\s+nobody\s+talks\s+about\b/gi,
+    /\bthe\s+insight\s+everyone'?s?\s+missing\b/gi,
+    /\bwhat\s+nobody\s+tells\s+you\b/gi,
+  ];
+
+  // ─── Cutoff disclaimers ────────────────────────────────────────────
+  // Includes the canonical LLM self-identification phrases — these are
+  // near-dispositive on their own (real humans don't write "as an AI
+  // language model" in first person). Patterns cover the major model
+  // families' default disclaimer language.
+  const CUTOFF_DISCLAIMERS = [
+    /\bas\s+of\s+my\s+last\s+update\b/gi,
+    /\bas\s+of\s+my\s+(?:knowledge\s+)?(?:cut-?off|last\s+training)\b/gi,
+    /\bi\s+don'?t\s+have\s+access\s+to\s+real-?time\s+(?:data|information)\b/gi,
+    /\bbased\s+on\s+available\s+information\b/gi,
+    /\bas\s+an?\s+(?:ai|artificial\s+intelligence|large\s+language|ai\s+language)\s+(?:language\s+)?model\b/gi,
+    /\bi\s+(?:am|'m)\s+an?\s+(?:ai|artificial\s+intelligence|large\s+language)\s+(?:assistant|model)?\b/gi,
+    /\bi\s+cannot\s+(?:provide|give|offer)\s+(?:legal|medical|financial|professional)\s+advice\b/gi,
+    /\bmy\s+training\s+data\s+(?:only\s+)?(?:goes\s+up\s+to|extends\s+to|ends\s+(?:in|at))\b/gi,
+  ];
+
+  // ─── AI-tool fingerprints ──────────────────────────────────────────
+  // Three near-definitive AI-origin signals adapted from
+  // Aboudjem/humanizer-skill P33-P35 (see docs/competitive/audits/
+  // 2026-05-17-aboudjem-humanizer-skill.md). Unlike the statistical
+  // patterns above, single hit on any of these is strong evidence —
+  // the AI tool literally left its fingerprint in the text.
+
+  // Unfilled slot-fill placeholders. Catches the canonical "[Your Name]"
+  // family plus dated stubs and HTML/MD comments with placeholder verbs.
+  const AI_PLACEHOLDERS = [
+    // Directive stubs ("[Your Name]", "[INSERT SOURCE URL]",
+    // "[Describe the specific section]") — verb-led, the user was
+    // told to fill in.
+    /\[(?:Your|Insert|Add|Enter|Describe|Specify|Choose|Pick)[^\]\n]{1,80}\]/gi,
+    // Noun-only template variables common in AI-generated email or
+    // letter boilerplate. Match the bare noun OR noun + qualifier.
+    // Conservative list: only nouns that almost never appear as
+    // bracketed real content (citation refs, code identifiers, etc.
+    // are excluded because they typically contain dots, slashes,
+    // hyphens, or version numbers).
+    /\[(?:Recipient|Sender|Topic|Subject|Salutation|Closing|Position|Department|Project Name|Company Name|Date)(?:\s+[^\]\n]{0,60})?\]/gi,
+    // All-caps directive forms ("[INSERT X]", "[FILL IN]") — the
+    // uppercase tells you it's a slot, not real content.
+    /\[(?:INSERT|FILL\s+IN|ADD|TODO|TBD|PLACEHOLDER)[^\]\n]{0,80}\]/g,
+    // Date stubs.
+    /\b(?:19|20)\d{2}-XX-XX\b/g,
+    /\bXX\/XX\/(?:19|20)\d{2}\b/g,
+    // HTML/Markdown comment placeholders with placeholder verbs.
+    /<!--\s*(?:add|fill\s+in|insert|todo|placeholder)[^>]{0,120}-->/gi,
+  ];
+
+  // Chatbot citation/markup tokens that leak through copy-paste.
+  // `citeturn0search0` / `citeturn0news5` from ChatGPT, contentReference
+  // tokens, oai_citation, attached_file references, grok_card markers.
+  // Each is a near-definitive signature of a specific tool.
+  const AI_CITATION_MARKUP = [
+    /\bcite(?:turn|news|search|navigation)\d+(?:search|turn|news|navigation)\d+/gi,
+    /contentReference\s*\[oaicite:[^\]]+\]\s*\{[^}]*\}/gi,
+    /\boai_citation\b/gi,
+    /\[attached_file:\d+\]/gi,
+    /\bgrok_card\b/gi,
+  ];
+
+  // UTM/tracking parameters auto-appended by AI tools to URLs they
+  // generate. Survives copy-paste even when nothing else does.
+  const AI_UTM_SOURCE = [
+    /[?&]utm_source=(?:chatgpt|openai|copilot|claude|grok|gemini|perplexity)(?:\.com|\.ai)?\b/gi,
+    /[?&]referrer=(?:chatgpt|copilot|grok|claude|gemini|perplexity)\.(?:com|ai)\b/gi,
+  ];
+
+  // ─── Template phrases ──────────────────────────────────────────────
+  const TEMPLATE_PHRASES = [
+    /\ba\s+\w+\s+step\s+(?:towards?|forward\s+for)\b/gi,
+    /\bwhether\s+you'?re\s+\w+\s+or\s+\w+/gi,
+    /\bi\s+recently\s+had\s+the\s+pleasure\s+of\b/gi,
+  ];
+
+  // ─── False concession ──────────────────────────────────────────────
+  const FALSE_CONCESSION = [
+    /\bwhile\s+\w+\s+is\s+impressive\b/gi,
+    /\balthough\s+\w+\s+has\s+made\s+strides\b/gi,
+    /\bdespite\s+\w+\s+challenges?\b/gi,
+  ];
+
+  // ─── Rhetorical question openers ───────────────────────────────────
+  const RHETORICAL_QUESTIONS = [
+    /\bbut\s+what\s+does\s+this\s+mean\s+for\b/gi,
+    /\bso\s+why\s+should\s+you\s+care\b/gi,
+    /\bwhat'?s\s+next\?\s*/gi,
+  ];
+
+  // ─── Hedge-stacked predictions ─────────────────────────────────────
+  // Stacks a modal with a hedge adverb: "could potentially create new
+  // opportunities", "may eventually unlock value." Either word alone is
+  // fine; the stack is the tell.
+  const HEDGE_STACK = [
+    /\b(?:could|may|might)\s+(?:\w+\s+){0,2}(?:potentially|eventually|ultimately|possibly|conceivably)\b/gi,
+    /\b(?:potentially|eventually|ultimately)\s+(?:could|may|might)\b/gi,
+  ];
+
+  // ─── Generic future-narrative closers ──────────────────────────────
+  // The "may become one of the most important narratives" template — vague
+  // future significance with no falsifiable claim. Covers narratives /
+  // stories / trends / themes / chapters / movements.
+  const FUTURE_NARRATIVE = [
+    /\b(?:may|could|will|is\s+(?:poised|set)\s+to)\s+become\s+(?:one\s+of\s+)?(?:the\s+)?(?:most\s+)?\w+\s+(?:narratives?|stories|developments?|trends?|movements?|chapters?|themes?|forces?)\b/gi,
+    /\bone\s+of\s+the\s+most\s+important\s+(?:narratives?|stories|trends?|themes?)\s+of\s+the\s+(?:next|coming)\s+\w+\b/gi,
+  ];
+
+  // ─── "Real/actual" adjective inflation ─────────────────────────────
+  // "Real on-chain tokenomics", "actual reward sustainability" — using
+  // real/actual/genuine/true as an empty intensifier on an abstract noun
+  // to imply the rest of the field is fake/superficial.
+  const REAL_ACTUAL_INFLATION = [
+    /\b(?:real|actual|genuine|true)\s+(?:on-?chain\s+)?(?:tokenomics|economics|utility|adoption|sustainability|impact|revenue|fundamentals|demand|value|innovation|traction)\b/gi,
+  ];
+
+  // ─── Formulaic openers ─────────────────────────────────────────────
+  // The "In the rapidly evolving world of X, Y has emerged as..." family
+  // — LLM-default essay openers.
+  const FORMULAIC_OPENERS = [
+    /\bin\s+the\s+(?:rapidly\s+|ever-?\s*)?(?:evolving|changing|expanding|growing|shifting)\s+(?:world|landscape|realm|space|field|domain|era)\s+of\b/gi,
+    /\bin\s+(?:an?|the)\s+(?:digital\s+)?age\s+(?:where|of)\b/gi,
+    /\bas\s+(?:we|the\s+world|society|industries?)\s+(?:continue|move|navigate|enter)\s+(?:to\s+)?(?:evolve|forward|into|through)\b/gi,
+    // "has emerged as a leader/force/category" — gated to the inflated
+    // nouns that signal pseudo-significance, since bare "has emerged as
+    // a" matches normal English ("Rust has emerged as a serious systems
+    // language"). Same gating for "has become increasingly".
+    /\bhas\s+emerged\s+as\s+(?:a|the|one\s+of)\s+(?:leading|key|major|critical|essential|fundamental|pivotal|prominent|dominant|important)\s+\w+/gi,
+    /\bhas\s+become\s+increasingly\s+(?:important|critical|popular|relevant|prominent|essential)\b/gi,
+  ];
+
+  // ─── Speculative scenario openers ──────────────────────────────────
+  // "Imagine a world where...", "Picture a future in which...", "Envision
+  // a world where..." — the LLM habit of opening an argument with a
+  // hypothetical that lists desirable outcomes instead of making a claim.
+  // Gated to the world/future/reality object plus where/in-which so it
+  // stays off instructional "imagine you have an array" (a teaching device
+  // pointing at a concrete example, not a speculative world) and bare
+  // "imagine that" asides. "consider a scenario where…" is deliberately
+  // excluded: that is analytical framing common in technical reasoning,
+  // not the marketing-opener tell. An optional short comma interrupter
+  // catches the equally common "Imagine, for a moment, a world where…"
+  // cadence. Known accepted false positive: fiction openings and staged
+  // thought experiments match too — the engine has no fiction context
+  // mode, so that call is left to the skill's carve-out (highlight-only;
+  // a lone hit cannot flip a document's classification).
+  const SPECULATIVE_OPENERS = [
+    /\b(?:imagine|picture|envision)(?:\s*,[^,\n]{1,30},)?\s+a\s+(?:world|future|reality)\s+(?:where|in\s+which)\b/gi,
+  ];
+
+  // ─── Title Case Section Headers in non-technical prose ─────────────
+  // "Strategic Negotiations And Key Partnerships" — every content word
+  // capitalized. Acceptable in API docs, ML papers, news headlines. Tell
+  // in marketing/personal/blog prose. Gated to "personal" / "marketing"
+  // context modes (technical mode skips this check).
+  const TITLE_CASE_HEADER = /^([A-Z][a-z]+(?:\s+(?:[A-Z][a-z]+|and|or|of|the|in|for|to|a|an))+\s+[A-Z][a-z]+)\s*$/gm;
+
+  // ─── Parenthetical hedging asides ──────────────────────────────────
+  // "(and increasingly, X)", "(or more precisely, Y)", "(though to be
+  // fair, Z)" — pseudo-aside that adds no information but performs
+  // thoughtfulness. Different from genuine human parentheticals which
+  // tend to be tangents or clarifications, not hedges.
+  const PARENTHETICAL_HEDGE = [
+    /\(\s*(?:and\s+)?(?:increasingly|notably|importantly|crucially|interestingly|perhaps)[,]?\s+[^)]{3,60}\)/gi,
+    /\(\s*or\s+more\s+(?:precisely|accurately|specifically)[,]?\s+[^)]{3,60}\)/gi,
+    /\(\s*though\s+to\s+be\s+fair[,]?\s+[^)]{3,60}\)/gi,
+    /\(\s*at\s+least\s+(?:in\s+)?(?:theory|principle|part)[,]?\s+[^)]{0,60}\)/gi,
+  ];
+
+  // ─── Confidence calibration ────────────────────────────────────────
+  const CONFIDENCE_CALIBRATION = [
+    /\binterestingly\b/gi,
+    /\bsurprisingly\b/gi,
+    /\bimportantly\b/gi,
+    /\bsignificantly\b/gi,
+    /\bcertainly\b/gi,
+    /\bundoubtedly\b/gi,
+    /\bwithout\s+a\s+doubt\b/gi,
+  ];
+
+  // ─── Social endorsement / CTA closers ──────────────────────────────
+  // The curatorial sign-off LLMs append to LinkedIn / X posts that share
+  // or recommend something — usually a colon teeing up a link. Distinct
+  // from the bare "worth reading" word-table entry (a single weak word)
+  // and from infomercial hooks (mid-flow teasers): this is the
+  // demonstrative-anchored endorsement — "THIS one is worth your time:",
+  // "do yourself a favor and read this", "thank me later" — that performs
+  // a recommendation without giving the reader a reason to click.
+  //
+  // Precision-first: each pattern carries an anchor so it stays off the
+  // literal-verb prose a human writes. The demonstrative object ("read
+  // THIS", not "read the runbook"), the trailing-terminal lookahead on
+  // "miss this" / "bookmark this" (the closing-line shape, not "miss this
+  // meeting" / "bookmark this page"), and the sentence-initial lookbehind
+  // on "thank me later" / "save this for later" (the imperative CTA, not
+  // "she will thank me later") all exist to suppress false positives on
+  // ordinary instructional/conversational text. Apostrophe classes admit
+  // the curly ' (U+2019) because LinkedIn / Word / macOS auto-curl it —
+  // the straight-only form would miss the canonical "you won't" closer.
+  const SOCIAL_CTA_CLOSER = [
+    /\bthis\s+one['’]?s?\s+(?:is\s+)?(?:well\s+|totally\s+|absolutely\s+|definitely\s+|really\s+|truly\s+|easily\s+|more\s+than\s+)?worth\s+(?:your\s+time|the\s+read|a\s+read|every\s+(?:minute|second)|reading|watching|a\s+listen|a\s+watch|a\s+look|it)\b/gi,
+    /\bthis\s+one['’]?s?\s+(?:is\s+)?a\s+must[-\s]?(?:read|watch|listen|see)\b/gi,
+    /\b(?:highly|strongly|can['’]?t|cannot)\s+recommend\w*\s+(?:giving\s+)?(?:this|it)\s+(?:one\s+)?a\s+(?:read|listen|watch|look|go)\b/gi,
+    /\bdo\s+yourself\s+a\s+favou?r\s+and\s+(?:read|watch|check\s+out)\s+(?:this|it)\b/gi,
+    /\byou\s+(?:really\s+)?(?:won['’]?t|do\s*n['’]?t|will\s+not|do\s+not)\s+want\s+to\s+miss\s+this(?:\s+one)?(?=\s*(?:[:.!\n]|$))/gi,
+    /(?<=^|[,.!?:\n]\s{0,4})(?:you\s+can\s+)?thank\s+me\s+later\b/gim,
+    /(?<=^|[.!?:\n]\s{0,4})save\s+this\s+(?:one\s+)?for\s+later\b/gim,
+    /\bbookmark\s+this(?:\s+(?:one|post|thread))?(?=\s*(?:[:.!\n]|$))/gi,
+    /\bdo\s*n['’]?t\s+sleep\s+on\s+this\b/gi,
+    /\btrust\s+me,?\s+(?:on\s+this|you['’]?ll)\b/gi,
+  ];
+
+  // ═══ Helpers ═══════════════════════════════════════════════════════
+
+  function tokenize(text) {
+    return text.toLowerCase().match(/[\w'-]+/g) || [];
+  }
+
+  function countWords(text) {
+    return (text.match(/\S+/g) || []).length;
+  }
+
+  function getParagraphs(text) {
+    return text.split(/\n\s*\n/).filter(p => p.trim().length > 0);
+  }
+
+  function getSentences(text) {
+    return text.split(/[.!?]+/).filter(s => s.trim().length > 5);
+  }
+
+  function matchPatterns(text, patterns, category, severity) {
+    const issues = [];
+    for (const pat of patterns) {
+      const regex = new RegExp(pat.source, pat.flags);
+      let match;
+      while ((match = regex.exec(text)) !== null) {
+        issues.push({
+          type: category,
+          text: match[0],
+          index: match.index,
+          severity,
+          suggestion: null,
+        });
+      }
+    }
+    return issues;
+  }
+
+  // ═══ Main analysis ═════════════════════════════════════════════════
+
+  // Upper bound for one scan. Above this we bail rather than running all
+  // regex passes over a huge buffer — protects page perf on pasted novels.
+  const MAX_WORDS = 10000;
+
+  // V2 contract defaults so early-exit paths (Empty/tooShort/tooLong)
+  // still return the same field shape a v2 consumer expects. Without
+  // this, `result.document_classification === 'AI_ONLY'` is `undefined`
+  // on edge inputs and fails open.
+  // UNSCORED is returned on empty / too-short / too-long inputs where
+  // we declined to score. Distinct from HUMAN_ONLY (which is a positive
+  // classification) so a caller can't mistake a refused scan for a
+  // confident human verdict — a 50k-word LLM-generated document is
+  // not "human", it's just outside our scoring window.
+  function buildV2Defaults(classification, confidence) {
+    const probs = classification === 'HUMAN_ONLY'
+      ? { human: 1, mixed: 0, ai: 0 }
+      : classification === 'AI_ONLY'
+        ? { human: 0, mixed: 0, ai: 1 }
+        : { human: 0.333, mixed: 0.334, ai: 0.333 };
+    return {
+      document_classification: classification,
+      class_probabilities: probs,
+      confidence_category: confidence,
+      highlight_sentence_for_ai: [],
+    };
+  }
+
+  function analyzeText(text, options = {}) {
+    if (!text || text.trim().length === 0) {
+      return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Empty', issues: [], stats: {}, tooShort: true };
+    }
+
+    // Context mode gates rules that are noisy in technical writing. Modes:
+    //   'general' (default) — full ruleset
+    //   'technical' — skip title-case headers, formulaic openers gated to
+    //                 prose-only structures; lower em-dash + formatting weights
+    //   'marketing' — full ruleset + boost on formulaic-opener / future-narrative
+    //   'personal'  — full ruleset, normal weights
+    // Mode is purely a soft gate; nothing is silently suppressed without
+    // being reflected in stats.contextMode for transparency.
+    // Mode validation: an unknown string (e.g. typo "tecnical") would
+    // otherwise silently downgrade to general-mode behavior. Coerce to
+    // 'general' and surface the original value in stats for traceability.
+    const VALID_CONTEXT_MODES = new Set(['general', 'technical', 'marketing', 'personal']);
+    const requestedMode = options.contextMode || 'general';
+    const contextMode = VALID_CONTEXT_MODES.has(requestedMode) ? requestedMode : 'general';
+    const contextModeFallback = requestedMode !== contextMode ? requestedMode : null;
+
+    // Pre-pass: strip Markdown blockquotes before scoring. A human
+    // reacting to AI text by quoting it shouldn't have the quoted block
+    // counted against their own writing. Requires ≥2 consecutive `> `
+    // lines to count as a blockquote — single-line `> ls -la` shell
+    // prompts in technical docs stay in the text.
+    let quotedLines = 0;
+    const rawLines = text.split(/\r?\n/);
+    const isQuote = rawLines.map((l) => /^\s*>\s/.test(l));
+    const stripIdx = new Set();
+    for (let i = 0; i < rawLines.length; i++) {
+      if (isQuote[i] && ((isQuote[i - 1] && i > 0) || isQuote[i + 1])) {
+        stripIdx.add(i);
+        quotedLines++;
+      }
+    }
+    text = rawLines.filter((_, i) => !stripIdx.has(i)).join('\n');
+
+    // Pre-pass: strip bypass-trick chars before pattern matching so
+    // "delve" with a Cyrillic 'е' still hits Tier 1. Original text is
+    // preserved so reported `match.index` values remain visually accurate.
+    const norm = normalizeText(text);
+    text = norm.text;
+
+    const wordCount = countWords(text);
+    if (wordCount < 10) {
+      return { ...buildV2Defaults('UNSCORED', 'low'), score: 0, label: 'Too short', issues: [], stats: { wordCount, contextMode, contextModeFallback }, tooShort: true };
+    }
+    if (wordCount > MAX_WORDS) {
+      return {
+        ...buildV2Defaults('UNSCORED', 'low'),
+        score: 0,
+        label: 'Text too long',
+        issues: [],
+        stats: { wordCount, contextMode, contextModeFallback },
+        tooLong: true,
+      };
+    }
+
+    const tokens = tokenize(text);
+    const paragraphs = getParagraphs(text);
+    const sentences = getSentences(text);
+    const issues = [];
+    let rawScore = 0;
+
+    // ── 1. Tier 1 words ──────────────────────────────────────────
+    const tier1Found = new Set();
+    for (const token of tokens) {
+      if (TIER1[token] && !tier1Found.has(token)) {
+        tier1Found.add(token);
+        issues.push({
+          type: 'tier1',
+          text: token,
+          severity: 'high',
+          suggestion: TIER1[token],
+        });
+      }
+    }
+
+    // Tier 1 multi-word phrases. Adds each distinct phrase (lowercased) to
+    // `tier1Found` so the same phrase hit multiple times only produces one
+    // issue — matches the downstream dedup behavior.
+    for (const phrase of TIER1_PHRASES) {
+      const regex = new RegExp(phrase.pattern.source, phrase.pattern.flags);
+      let match;
+      while ((match = regex.exec(text)) !== null) {
+        const lower = match[0].toLowerCase();
+        if (tier1Found.has(lower)) continue;
+        tier1Found.add(lower);
+        issues.push({
+          type: 'tier1',
+          text: match[0],
+          severity: 'high',
+          suggestion: phrase.replace,
+        });
+      }
+    }
+
+    // ── 2. Tier 2 clusters ───────────────────────────────────────
+    let tier2Clusters = 0;
+    for (const para of paragraphs) {
+      const paraTokens = tokenize(para);
+      const found = [];
+      const suggestions = {};
+      for (const token of paraTokens) {
+        if (TIER2[token] && !found.includes(token)) {
+          found.push(token);
+          suggestions[token] = TIER2[token];
+        }
+      }
+      for (const cond of TIER2_CONDITIONAL) {
+        if (!found.includes(cond.word) && cond.pattern.test(para)) {
+          found.push(cond.word);
+          suggestions[cond.word] = cond.suggestion;
+        }
+      }
+      if (found.length >= 2) {
+        tier2Clusters++;
+        for (const word of found) {
+          issues.push({
+            type: 'tier2',
+            text: word,
+            severity: 'medium',
+            suggestion: suggestions[word],
+          });
+        }
+      }
+    }
+
+    // ── 3. Tier 3 density ────────────────────────────────────────
+    const tier3Counts = {};
+    for (const token of tokens) {
+      const canonical = TIER3_LOOKUP.get(token);
+      if (canonical) tier3Counts[canonical] = (tier3Counts[canonical] || 0) + 1;
+    }
+    // Flag at 3% of word count, but never below 3 occurrences. Previous
+    // floor of 1 meant a 50-word text with one "significant" got flagged
+    // as Tier 3 overuse, which was noise.
+    const densityThreshold = Math.max(3, Math.floor(wordCount * 0.03));
+    let tier3Flags = 0;
+    for (const [word, count] of Object.entries(tier3Counts)) {
+      if (count >= densityThreshold) {
+        tier3Flags++;
+        issues.push({
+          type: 'tier3',
+          text: `"${word}" x${count}`,
+          severity: 'low',
+          suggestion: `Overused (${count} times in ${wordCount} words)`,
+        });
+      }
+    }
+
+    // ── 4–21. Pattern categories ─────────────────────────────────
+    issues.push(...matchPatterns(text, TRANSITIONS, 'transition', 'medium'));
+    issues.push(...matchPatterns(text, CHATBOT_ARTIFACTS, 'chatbot', 'critical'));
+    issues.push(...matchPatterns(text, SYCOPHANTIC, 'sycophantic', 'critical'));
+    issues.push(...matchPatterns(text, FILLERS, 'filler', 'medium'));
+    issues.push(...matchPatterns(text, GENERIC_CONCLUSIONS, 'generic-conclusion', 'medium'));
+    issues.push(...matchPatterns(text, LETS_PATTERNS, 'lets-construction', 'medium'));
+    issues.push(...matchPatterns(text, REASONING_ARTIFACTS, 'reasoning-artifact', 'critical'));
+    issues.push(...matchPatterns(text, ACKNOWLEDGMENT_LOOPS, 'acknowledgment-loop', 'medium'));
+    issues.push(...matchPatterns(text, SIGNIFICANCE_INFLATION, 'significance-inflation', 'high'));
+    issues.push(...matchPatterns(text, VAGUE_ATTRIBUTIONS, 'vague-attribution', 'critical'));
+    issues.push(...matchPatterns(text, HOLLOW_INTENSIFIERS, 'hollow-intensifier', 'medium'));
+    issues.push(...matchPatterns(text, EMOTIONAL_FLATLINE, 'emotional-flatline', 'low'));
+    issues.push(...matchPatterns(text, NOVELTY_INFLATION, 'novelty-inflation', 'medium'));
+    issues.push(...matchPatterns(text, CUTOFF_DISCLAIMERS, 'cutoff-disclaimer', 'critical'));
+    issues.push(...matchPatterns(text, AI_PLACEHOLDERS, 'ai-placeholder', 'critical'));
+    issues.push(...matchPatterns(text, AI_CITATION_MARKUP, 'ai-citation-markup', 'critical'));
+    issues.push(...matchPatterns(text, AI_UTM_SOURCE, 'ai-utm-source', 'critical'));
+    issues.push(...matchPatterns(text, TEMPLATE_PHRASES, 'template-phrase', 'high'));
+    issues.push(...matchPatterns(text, FALSE_CONCESSION, 'false-concession', 'medium'));
+    issues.push(...matchPatterns(text, RHETORICAL_QUESTIONS, 'rhetorical-question', 'medium'));
+    issues.push(...matchPatterns(text, HEDGE_STACK, 'hedge-stack', 'high'));
+    issues.push(...matchPatterns(text, FUTURE_NARRATIVE, 'future-narrative', 'high'));
+    issues.push(...matchPatterns(text, REAL_ACTUAL_INFLATION, 'real-actual-inflation', 'medium'));
+    issues.push(...matchPatterns(text, SOCIAL_CTA_CLOSER, 'social-cta-closer', 'high'));
+
+    // ── Tier 1 v2: formulaic openers + parenthetical hedges ──────────
+    issues.push(...matchPatterns(text, FORMULAIC_OPENERS, 'formulaic-opener', 'high'));
+    issues.push(...matchPatterns(text, SPECULATIVE_OPENERS, 'speculative-opener', 'high'));
+    issues.push(...matchPatterns(text, PARENTHETICAL_HEDGE, 'parenthetical-hedge', 'medium'));
+
+    // Title-case headers — gated to marketing/personal/general modes
+    // (technical mode legitimately uses Title Case section headers).
+    if (contextMode !== 'technical') {
+      const titleHits = matchPatterns(text, [TITLE_CASE_HEADER], 'title-case-header', 'medium');
+      // Drop matches that look like proper-noun titles (single line, all
+      // tokens capitalized incl. function words) — that's headline style,
+      // not the AI-section-header tell which has mid-sentence "And".
+      const filtered = titleHits.filter((h) => {
+        const tokens = h.text.split(/\s+/);
+        return tokens.length >= 4 && /\b(?:And|Or|Of|The|In|For|To|A|An)\b/.test(h.text);
+      });
+      issues.push(...filtered);
+    }
+
+    // ── Normalization-trigger flag ───────────────────────────────────
+    // ZWSPs or homoglyphs in pasted prose are near-dispositive: humans
+    // don't insert these into their own writing. Single roleplay marker
+    // can be a false positive on Markdown emphasis (filtered to multi-
+    // word inner already), so requires ≥2.
+    if (norm.flags.zeroWidth > 0 || norm.flags.homoglyph >= 2) {
+      issues.push({
+        type: 'normalization-flag',
+        text: `${norm.flags.zeroWidth} zero-width + ${norm.flags.homoglyph} homoglyph swap${norm.flags.homoglyph === 1 ? '' : 's'}`,
+        severity: 'critical',
+        suggestion: 'Text contains invisible/lookalike chars typical of AI-humanizer bypass tools. Re-type from your own keyboard.',
+      });
+    }
+    if (norm.flags.roleplay >= 2) {
+      issues.push({
+        type: 'normalization-flag',
+        text: `${norm.flags.roleplay} *roleplay-action* markers stripped`,
+        severity: 'high',
+        suggestion: 'Paired *action* markers are a chat-model artifact.',
+      });
+    }
+
+    // ── Smart-punctuation co-occurrence signature ────────────────────
+    // Curly quotes + em-dash + Oxford comma all present + zero typos
+    // (no double-spaces, no missing apostrophes in common contractions)
+    // is a near-dispositive paste-from-LLM signature: humans typing
+    // directly into a textarea don't produce all four. Standalone any of
+    // these is meaningless — co-occurrence is the signal.
+    {
+      const hasCurly = /[“”‘’]/.test(text);
+      const hasEmDash = /—/.test(text);
+      const oxfordHit = text.match(/\b\w+,\s+\w+,\s+and\s+\w+/g);
+      const hasOxford = (oxfordHit?.length || 0) >= 1;
+      const doubleSpaces = (text.match(/[^.!?]  +/g) || []).length;
+      const missingApos = /\b(?:dont|wont|cant|isnt|wasnt|shouldnt|wouldnt|couldnt|youre|theyre|its\s+a\s+\w+ing)\b/i.test(text);
+      const clean = doubleSpaces === 0 && !missingApos;
+      const signals = [hasCurly, hasEmDash, hasOxford, clean].filter(Boolean).length;
+      if (signals >= 4 && wordCount >= 80) {
+        issues.push({
+          type: 'smart-punct-signature',
+          text: 'curly-quotes + em-dash + Oxford comma + zero typos',
+          severity: 'high',
+          suggestion: 'Smart-punctuation signature consistent with LLM output. Humans typing into textareas rarely produce all four.',
+        });
+      }
+    }
+
+    // ── Punctuation distribution mode ────────────────────────────────
+    // Humans cluster trimodal across paragraphs (some paras heavy, some
+    // light, some none). AI converges on a normal distribution. We can't
+    // run a real modality test client-side, but we can flag the AI
+    // signature: low variance of per-paragraph punctuation density.
+    // Requires ≥4 paragraphs to be meaningful.
+    if (paragraphs.length >= 4) {
+      const densities = paragraphs.map((p) => {
+        const words = (p.match(/\S+/g) || []).length;
+        if (words < 5) return null;
+        const puncts = (p.match(/[,;:—()]/g) || []).length;
+        return puncts / words;
+      }).filter((d) => d !== null);
+      if (densities.length >= 4) {
+        const mean = densities.reduce((a, b) => a + b, 0) / densities.length;
+        const variance = densities.reduce((s, d) => s + (d - mean) ** 2, 0) / densities.length;
+        const cv = mean > 0 ? Math.sqrt(variance) / mean : 0;
+        // CV < 0.25 across paragraphs means each paragraph has the same
+        // punctuation density — the AI signature. Humans usually swing
+        // wider. Threshold derived from stylometry papers (arxiv 2507.00838).
+        if (cv < 0.25 && mean >= 0.04) {
+          issues.push({
+            type: 'punct-distribution',
+            text: `Punctuation density uniform across paragraphs (CV=${cv.toFixed(2)})`,
+            severity: 'medium',
+            suggestion: 'AI text holds punctuation density steady; human writers swing between dense and sparse paragraphs.',
+          });
+        }
+      }
+    }
+
+    // ── Function-word trigram entropy ────────────────────────────────
+    // POS-trigram entropy is the academic signal; function-word trigram
+    // entropy approximates it without a tagger (function words ARE the
+    // closed-class POS classes). AI text has lower entropy because LLM
+    // sampling collapses onto a narrower set of grammatical templates.
+    //
+    // Method: extract function-word indicators per sentence, build
+    // trigrams over the sequence, compute Shannon entropy. Bins below
+    // threshold flag.
+    if (wordCount >= 150) {
+      const FUNC_WORDS = new Set([
+        'the','a','an','and','or','but','of','to','in','on','at','by','for','with',
+        'from','as','is','was','are','were','be','been','being','have','has','had',
+        'do','does','did','will','would','should','could','may','might','must','can',
+        'this','that','these','those','it','its','they','them','their','there','here',
+        'we','our','us','i','you','your','he','she','his','her','him','not','no','so',
+        'if','then','than','when','where','which','who','what','how','why','because',
+      ]);
+      const seq = tokens.map((t) => FUNC_WORDS.has(t) ? t : '_').filter((_, i, arr) => arr[i] !== '_' || (i > 0 && arr[i - 1] !== '_'));
+      if (seq.length >= 50) {
+        const trigrams = {};
+        for (let i = 0; i < seq.length - 2; i++) {
+          const tg = `${seq[i]}|${seq[i + 1]}|${seq[i + 2]}`;
+          trigrams[tg] = (trigrams[tg] || 0) + 1;
+        }
+        const total = seq.length - 2;
+        let entropy = 0;
+        for (const c of Object.values(trigrams)) {
+          const p = c / total;
+          entropy -= p * Math.log2(p);
+        }
+        // Normalize by log2(distinct trigrams) so entropy ranges roughly
+        // 0..1 and threshold is interpretable. Empirical threshold: human
+        // prose ~0.85-0.95 normalized, AI prose ~0.70-0.82.
+        const distinctCount = Object.keys(trigrams).length;
+        const normalized = distinctCount > 1 ? entropy / Math.log2(distinctCount) : 1;
+        if (normalized < 0.82 && total >= 50) {
+          issues.push({
+            type: 'fnword-trigram-entropy',
+            text: `Function-word trigram entropy ${normalized.toFixed(2)} (low)`,
+            severity: 'medium',
+            suggestion: 'Grammatical structure is unusually repetitive. AI sampling collapses onto narrower templates than human writing.',
+          });
+        }
+        // Degenerate case: single distinct trigram repeated across the
+        // whole document is the strongest possible AI signal but the
+        // normalized fallback returns 1.0 (= "fully human"), inverting
+        // the signal. Catch it explicitly.
+        if (distinctCount === 1 && total >= 50) {
+          issues.push({
+            type: 'fnword-trigram-entropy',
+            text: 'Single function-word trigram repeated across document',
+            severity: 'high',
+            suggestion: 'Grammatical structure is fully degenerate — every clause uses the same function-word skeleton.',
+          });
+        }
+      }
+    }
+
+    // ── Cross-paragraph burstiness ───────────────────────────────────
+    // We already check within-paragraph sentence-length uniformity. AI
+    // is also flat ACROSS paragraphs — every paragraph has roughly the
+    // same sentence-length variance. Humans vary: terse paras next to
+    // discursive paras. Measure variance of CV across paragraphs.
+    if (paragraphs.length >= 4) {
+      const cvs = paragraphs.map((p) => {
+        const sents = getSentences(p);
+        if (sents.length < 3) return null;
+        const lens = sents.map(countWords);
+        const m = lens.reduce((a, b) => a + b, 0) / lens.length;
+        if (m === 0) return null;
+        const v = lens.reduce((s, l) => s + (l - m) ** 2, 0) / lens.length;
+        return Math.sqrt(v) / m;
+      }).filter((c) => c !== null);
+      if (cvs.length >= 4) {
+        const cvMean = cvs.reduce((a, b) => a + b, 0) / cvs.length;
+        const cvVar = cvs.reduce((s, c) => s + (c - cvMean) ** 2, 0) / cvs.length;
+        const cvStd = Math.sqrt(cvVar);
+        // Std-of-CV below 0.08 means every paragraph has roughly the same
+        // internal rhythm — AI signature. Human prose typically swings
+        // 0.15-0.40 across paragraphs of mixed purpose.
+        if (cvStd < 0.08 && cvMean < 0.45) {
+          issues.push({
+            type: 'cross-para-burstiness',
+            text: `Sentence-rhythm uniform across paragraphs (σCV=${cvStd.toFixed(2)})`,
+            severity: 'medium',
+            suggestion: 'Every paragraph has the same internal rhythm. Humans vary cadence between terse and discursive paragraphs.',
+          });
+        }
+      }
+    }
+
+    // ── Tier 3 multi-word phrase density ─────────────────────────
+    // Two complementary rules:
+    //   (a) Per-phrase density — same gating as single-word Tier 3: each
+    //       phrase fine alone, repetition is the tell. Threshold = 2.
+    //   (b) Cross-phrase clustering — ≥3 *distinct* boilerplate phrases
+    //       in one piece. LLMs varying their own boilerplate often use
+    //       each phrase only once but stack 5-10 across the text. The
+    //       per-phrase rule misses this; the cluster rule catches it.
+    // Track non-overlapping match spans so a longer phrase swallowing a
+    // shorter one (e.g., "designed for long-term sustainability" matches
+    // both "designed for long-term" AND "long-term sustainability") only
+    // contributes one distinct hit. Without dedup the cluster threshold
+    // can be reached by a single sentence stacking overlapping regexes.
+    const claimedSpans = [];
+    function spanOverlaps(start, end) {
+      for (const [s, e] of claimedSpans) {
+        if (start < e && end > s) return true;
+      }
+      return false;
+    }
+    let distinctPhrasesHit = 0;
+    for (const phrase of TIER3_PHRASES) {
+      const regex = new RegExp(phrase.source, phrase.flags);
+      const phraseSpans = [];
+      let phraseMatch;
+      while ((phraseMatch = regex.exec(text)) !== null) {
+        const start = phraseMatch.index;
+        const end = start + phraseMatch[0].length;
+        if (!spanOverlaps(start, end)) {
+          phraseSpans.push([start, end, phraseMatch[0]]);
+        }
+      }
+      if (phraseSpans.length === 0) continue;
+      for (const [s, e] of phraseSpans) claimedSpans.push([s, e]);
+      distinctPhrasesHit++;
+      if (phraseSpans.length >= 2) {
+        issues.push({
+          type: 'tier3-phrase',
+          text: `"${phraseSpans[0][2].toLowerCase()}" x${phraseSpans.length}`,
+          severity: 'medium',
+          suggestion: `Boilerplate phrase repeated ${phraseSpans.length}× — replace at least one with specifics`,
+        });
+      }
+    }
+    if (distinctPhrasesHit >= 3) {
+      issues.push({
+        type: 'tier3-phrase-cluster',
+        text: `${distinctPhrasesHit} distinct boilerplate phrases`,
+        severity: 'high',
+        suggestion: 'Several stock crypto/web3 phrases stacked in one piece. Rewrite around one specific claim or observation.',
+      });
+    }
+
+    // ── Hashtag stuffing ─────────────────────────────────────────
+    // 6+ hashtags in a single post is rare for thoughtful humans and
+    // near-universal for LLM-generated social posts. Counted globally,
+    // not per-paragraph, since the trailing hashtag block is the shape
+    // we care about.
+    // Match #tag at start of text or after any non-word char (whitespace,
+    // punctuation, line breaks). URL fragments are already excluded
+    // because the char immediately before `#` in a URL path is always
+    // a word char (e.g. `example.com/page#section` — `e` before `#`).
+    // Earlier char class `[\s\\]` had a literal backslash and silently
+    // missed hashtags after sentence punctuation; an interim `[\s]` fix
+    // on origin only caught whitespace-preceded tags.
+    const hashtagMatches = text.match(/(?:^|\W)#\w[\w-]*/g) || [];
+    if (hashtagMatches.length >= 6) {
+      issues.push({
+        type: 'hashtag-stuff',
+        text: `${hashtagMatches.length} hashtags`,
+        severity: 'medium',
+        suggestion: 'Cut to 2-3 specific tags or none. Long hashtag blocks read as bot output.',
+      });
+    }
+
+    // ── Bullet list of bare noun phrases ─────────────────────────
+    // ≥5 consecutive bullet items that are short (≤6 words) and contain
+    // no finite-verb / modal token. Catches the "Stable mining efficiency
+    // / Reliable pool connectivity / Optimized RandomX performance ..."
+    // shape LLMs default to. Markdown bullets, escaped Markdown bullets,
+    // unicode bullets, and dashes are all matched. Numbered lists are
+    // excluded — those have a separate "numbered list inflation" rule.
+    //
+    // Note: verbRe covers auxiliaries and modals ("was", "will", "can",
+    // etc.). Regular past-tense verbs ("fixed", "removed") are not
+    // matched here; instead, the ≤6-word length gate excludes most
+    // real-world changelog lines, which tend to read "fixed the X that
+    // was doing Y" (>6 words). Short two-word action items ("* fixed
+    // bug") would pass both gates — an acceptable trade-off to avoid
+    // false-negative risk from adjectives ending in -ed ("skilled",
+    // "advanced") that share the same surface form.
+    const lines = text.split(/\r?\n/);
+    const bulletRe = /^\s*(?:\*|-|•|\+)\s+(.+)$/;
+    const verbRe = /\b(?:is|are|was|were|has|have|had|will|would|should|must|do|does|did|can|could|may|might|am|been|being)\b/i;
+    const fenceRe = /^\s*(?:```|~~~)/;
+    let run = [];
+    let blankStreak = 0;
+    let inFence = false;
+    function flushRun() {
+      if (run.length >= 5) {
+        const bareNP = run.filter((it) => {
+          const wc = (it.match(/\S+/g) || []).length;
+          return wc > 0 && wc <= 6 && !verbRe.test(it);
+        });
+        if (bareNP.length >= 5 && bareNP.length / run.length >= 0.75) {
+          issues.push({
+            type: 'bullet-np-list',
+            text: `${run.length}-item bullet list of bare noun phrases`,
+            severity: 'high',
+            suggestion: 'Convert to a prose paragraph or merge items. Long lists of bare adj+noun pairs read as AI scaffolding.',
+          });
+        }
+      }
+      run = [];
+      blankStreak = 0;
+    }
+    for (const line of lines) {
+      if (fenceRe.test(line)) {
+        // Code-fence toggle. Bullets inside fences are CLI flag docs or
+        // option dumps, not prose AI scaffolding — flush any prose run
+        // we were tracking and skip until the fence closes.
+        flushRun();
+        inFence = !inFence;
+        continue;
+      }
+      if (inFence) continue;
+      const m = line.match(bulletRe);
+      if (m) {
+        run.push(m[1].trim());
+        blankStreak = 0;
+      } else if (line.trim() === '') {
+        // A single blank line inside a list is normal Markdown spacing;
+        // two or more blank lines break the run, since visually-disjoint
+        // bullet sections shouldn't merge into one logical list.
+        blankStreak++;
+        if (blankStreak >= 2) flushRun();
+      } else {
+        flushRun();
+      }
+    }
+    flushRun();
+
+    // NOTE: "Wall-of-text replies" (SKILL.md) is deliberately NOT a
+    // detector rule here. A first pass tried "reply-length text, >=4
+    // sentences, zero newlines" as a structural gate — it broke the
+    // "repeated Tier 1 phrase does not inflate score linearly" fixture
+    // and, on reflection, would fire on any ordinary short paragraph
+    // (a blog intro, a single-paragraph email) since "one paragraph with
+    // no internal line break" is simply what continuous prose looks
+    // like, not an AI-specific shape. The tell in SKILL.md depends on
+    // knowing the text is conversational-reply register in the first
+    // place, which the engine can't reliably infer from the bytes alone
+    // (CONTRIBUTING.md: "a signal that fires on most normal prose is not
+    // worth adding"). Left as an LLM-judgment rule; see CATEGORIES.md §C.
+
+    // Confidence calibration is only flagged when it stacks (3+ instances).
+    // Gating happens pre-dedup on raw match count, since that signals actual
+    // stacking, not just vocabulary use.
+    const confIssues = matchPatterns(text, CONFIDENCE_CALIBRATION, 'confidence-calibration', 'low');
+    if (confIssues.length >= 3) issues.push(...confIssues);
+
+    // ── 22. Em dash frequency ────────────────────────────────────
+    // Match real em dashes, plus `--` only when surrounded by whitespace on at
+    // least one side (skips CLI flags like --save-dev and YAML `---` blocks).
+    const emDashCount = (text.match(/—|(?<=\s)--(?=\s|$)|(?<=^|\s)--(?=\s)/gm) || []).length;
+    const emDashRate = emDashCount / (wordCount / 1000);
+    if (emDashRate > 1) {
+      issues.push({
+        type: 'em-dash',
+        text: `${emDashCount} em dashes in ${wordCount} words`,
+        severity: 'medium',
+        suggestion: 'Replace with commas, periods, or rewrite',
+      });
+    }
+
+    // ── 23. Sentence length uniformity ───────────────────────────
+    if (sentences.length >= 5) {
+      const lengths = sentences.map(s => countWords(s));
+      const avg = lengths.reduce((a, b) => a + b, 0) / lengths.length;
+      const variance = lengths.reduce((sum, l) => sum + Math.pow(l - avg, 2), 0) / lengths.length;
+      const stdDev = Math.sqrt(variance);
+      const cv = avg > 0 ? stdDev / avg : 0;
+
+      if (cv < 0.25 && avg > 10) {
+        issues.push({
+          type: 'uniformity',
+          text: `Sentence lengths cluster around ${Math.round(avg)} words (low variation)`,
+          severity: 'medium',
+          suggestion: 'Mix short punchy sentences with longer flowing ones',
+        });
+      }
+    }
+
+    // ── Type-token ratio (stylometric — vocabulary diversity) ────
+    // TTR = distinct word types / total tokens. Human prose at 200+
+    // words typically sits around 0.50–0.65 for English; AI prose
+    // tends flatter (0.55–0.75 looks normal, but the lower end of the
+    // *too-flat* tail at >=200 words is where the signal lives — too
+    // FEW unique words for the length). This is the simplest of the
+    // four stylometric signals identified in the May 2026 detection-
+    // research review (docs/competitive/detection-research.md): no
+    // POS tagger required, no model, pure JS.
+    //
+    // Threshold tuning: flag only when the sample is large enough
+    // that low TTR is meaningfully suspicious (>=200 tokens) AND TTR
+    // is below 0.40 (very vocabulary-poor). Conservative on purpose;
+    // false positives on short or topic-narrow human prose are easy
+    // to trigger and would drown out other signals. The detector-
+    // research lens flagged TTR as one of four stylometric add-ons;
+    // POS-bigram log-odds, function-word z-scores, and sentence-
+    // length burstiness are still TODO.
+    if (tokens.length >= 200) {
+      const unique = new Set(tokens).size;
+      const ttr = unique / tokens.length;
+      if (ttr < 0.4) {
+        issues.push({
+          type: 'low-ttr',
+          text: `Vocabulary diversity ${(ttr * 100).toFixed(1)}% (${unique} unique / ${tokens.length} tokens)`,
+          severity: 'low',
+          suggestion: 'Text reuses a narrow word set. Vary nouns and verbs deliberately, or check if the topic genuinely warrants the repetition.',
+        });
+      }
+    }
+
+    // ── 24. Paragraph length uniformity ──────────────────────────
+    if (paragraphs.length >= 4) {
+      const paraLengths = paragraphs.map(p => getSentences(p).length);
+      const avg = paraLengths.reduce((a, b) => a + b, 0) / paraLengths.length;
+      const allSimilar = paraLengths.every(l => Math.abs(l - avg) <= 1);
+      if (allSimilar && avg >= 3) {
+        issues.push({
+          type: 'uniformity',
+          text: `All paragraphs are ~${Math.round(avg)} sentences`,
+          severity: 'low',
+          suggestion: 'Vary paragraph length deliberately',
+        });
+      }
+    }
+
+    // ── 25. Bold overuse ─────────────────────────────────────────
+    const boldMatches = text.match(/\*\*[^*]+\*\*/g) || [];
+    if (boldMatches.length > 3) {
+      issues.push({
+        type: 'formatting',
+        text: `${boldMatches.length} bold phrases`,
+        severity: 'medium',
+        suggestion: 'Strip bold from most; restructure to lead with key info',
+      });
+    }
+
+    // ── Score from the deduped issue list ───────────────────────
+    // Previously rawScore was accumulated inline per pattern hit, so
+    // repeated hits of the same phrase (or overlapping matches) inflated
+    // the score while the displayed issue list was deduplicated. That
+    // produced the UX regression where a "heavy AI patterns" label sat
+    // above a list of two items. Now the dedup runs first, then each
+    // distinct issue contributes its category weight — so the number
+    // reflects the same signals the user actually sees.
+    const deduped = deduplicateIssues(issues);
+    for (const issue of deduped) {
+      rawScore += ISSUE_WEIGHTS[issue.type] ?? 2;
+    }
+
+    // Scale by text length: longer text gets more chances to trigger.
+    const lengthFactor = Math.max(1, Math.log2(wordCount / 50));
+    const normalizedScore = Math.min(100, Math.round(rawScore / lengthFactor));
+
+    const label = getLabel(normalizedScore);
+
+    // ── Sentence-region smoothing (HMM-style without an HMM) ─────────
+    // Map each text-bearing issue back to its sentence indexes, then
+    // merge adjacent flagged sentences into contiguous regions for UI
+    // highlighting. Borrowed from GPTZero's sentence-highlighting model
+    // — gives users "this paragraph is AI" rather than scattered hits.
+    const regions = buildSentenceRegions(text, deduped);
+
+    // Stats derived from the same deduped list so tier counts + patternCount
+    // sum to `deduped.length`. Previously patternCount subtracted
+    // `tier2Clusters` (a paragraph count) which produced inconsistent totals.
+    const tier1Count = deduped.filter((i) => i.type === 'tier1').length;
+    const tier2Count = deduped.filter((i) => i.type === 'tier2').length;
+    const tier3Count = deduped.filter((i) => i.type === 'tier3').length;
+
+    // ── Trinary classification (GPTZero-shaped) ──────────────────────
+    // Decouples confidence from AI-proportion. Maps the 0-100 score plus
+    // structural signals into HUMAN_ONLY / MIXED / AI_ONLY with a
+    // confidence band. Thresholds are FN-biased: ambiguity routes to
+    // MIXED, never AI_ONLY. Quote from GPTZero's design principle:
+    // "biases the detector to prefer making less-harmful false-negative
+    // errors over false-positive errors."
+    // Dense-AI-vocab trifecta: ≥5 distinct tier1 hits + ≥2 tier2 cluster
+    // paragraphs + ≥1 transition phrase, AND ≥150 words. Catches
+    // saturated ChatGPT prose without firing on dense-jargon human
+    // technical writing where the tier1 vocabulary (robust,
+    // comprehensive, leverage, ecosystem) legitimately overlaps with
+    // systems-programming idiom. Word-count gate prevents short ESL or
+    // contrived adversarial sentences from tripping the corroborator.
+    const tier1Distinct = new Set(deduped.filter((i) => i.type === 'tier1').map((i) => (i.text || '').toLowerCase())).size;
+    const hasTier2Cluster = tier2Clusters >= 2;
+    const hasTransition = deduped.some((i) => i.type === 'transition');
+    const denseAIVocab = wordCount >= 150 && tier1Distinct >= 5 && hasTier2Cluster && hasTransition;
+
+    const trinary = classifyTrinary({
+      score: normalizedScore,
+      issues: deduped,
+      regions,
+      normFlags: norm.flags,
+      wordCount,
+      denseAIVocab,
+    });
+
+    return {
+      // Legacy fields preserved for existing callers.
+      score: normalizedScore,
+      label,
+      issues: deduped,
+      stats: {
+        wordCount,
+        tier1Count,
+        tier2Count,
+        tier2Clusters,
+        tier3Count,
+        tier3Flags,
+        patternCount: deduped.length - tier1Count - tier2Count - tier3Count,
+        contextMode,
+        contextModeFallback,
+        normalization: norm.flags,
+        quotedLines,
+        unmappedHighlights: regions._unmapped ?? 0,
+        denseAIVocab,
+        tier1Distinct,
+      },
+      // Trinary API — shape mirrors GPTZero so integrators can swap.
+      document_classification: trinary.classification,
+      class_probabilities: trinary.probabilities,
+      confidence_category: trinary.confidence,
+      highlight_sentence_for_ai: regions,
+    };
+  }
+
+  // ═══ Sentence regions + trinary classifier ═════════════════════════
+
+  function buildSentenceRegions(text, issues) {
+    // Split text into sentences with byte offsets preserved so the UI
+    // can highlight spans accurately. Sentence boundaries are coarse
+    // (.!?) — fine for highlighting, not for linguistic correctness.
+    const sentences = [];
+    const sentenceRe = /[^.!?]+[.!?]+|\S[^.!?]*$/g;
+    let m;
+    while ((m = sentenceRe.exec(text)) !== null) {
+      const trimmed = m[0].trim();
+      if (trimmed.length < 4) continue;
+      sentences.push({ start: m.index, end: m.index + m[0].length, text: trimmed });
+    }
+    if (sentences.length === 0) return [];
+
+    // Map issue.text back to sentence indexes via substring search. Issues
+    // without a meaningful text (e.g. summary signals like "Punctuation
+    // density uniform across paragraphs") have no sentence anchor — they
+    // contribute to the document-level signal but not to highlights.
+    // Filter by issue TYPE not text-regex: text-based filtering used to
+    // drop legitimate phrase issues containing "across" / "density".
+    const SUMMARY_ONLY_TYPES = new Set([
+      'punct-distribution',
+      'cross-para-burstiness',
+      'fnword-trigram-entropy',
+      'smart-punct-signature',
+      'normalization-flag',
+      'uniformity',
+      'em-dash',
+      'formatting',
+      'tier3',
+      'tier3-phrase',
+      'tier3-phrase-cluster',
+      'hashtag-stuff',
+      'bullet-np-list',
+    ]);
+    const hits = sentences.map(() => ({ count: 0, weight: 0 }));
+    const lowerText = text.toLowerCase();
+    let unmappedHighlights = 0;
+    for (const issue of issues) {
+      if (!issue.text || issue.text.length > 200) continue;
+      if (SUMMARY_ONLY_TYPES.has(issue.type)) continue;
+      const needle = issue.text.toLowerCase();
+      let idx = 0;
+      let matched = false;
+      while ((idx = lowerText.indexOf(needle, idx)) !== -1) {
+        matched = true;
+        for (let i = 0; i < sentences.length; i++) {
+          if (idx >= sentences[i].start && idx < sentences[i].end) {
+            hits[i].count++;
+            hits[i].weight += ISSUE_WEIGHTS[issue.type] ?? 2;
+            break;
+          }
+        }
+        idx += needle.length;
+      }
+      if (!matched) unmappedHighlights++;
+    }
+
+    // Window-merge contiguous flagged sentences. Allow 1 unflagged
+    // sentence gap between two flagged ones (the "smoothing" — keeps
+    // a single boring sentence from breaking what's clearly an AI
+    // passage). A sentence is "flagged" if it has ≥1 hit.
+    const regions = [];
+    let cur = null;
+    for (let i = 0; i < sentences.length; i++) {
+      if (hits[i].count > 0) {
+        if (cur === null) {
+          cur = { startSentence: i, endSentence: i, start: sentences[i].start, end: sentences[i].end, hitCount: hits[i].count, weight: hits[i].weight };
+        } else {
+          cur.endSentence = i;
+          cur.end = sentences[i].end;
+          cur.hitCount += hits[i].count;
+          cur.weight += hits[i].weight;
+        }
+      } else if (cur !== null) {
+        // Allow one-sentence gap.
+        const next = hits[i + 1];
+        if (next && next.count > 0) {
+          cur.endSentence = i;
+          cur.end = sentences[i].end;
+          continue;
+        }
+        regions.push(finalizeRegion(cur));
+        cur = null;
+      }
+    }
+    if (cur !== null) regions.push(finalizeRegion(cur));
+    // Expose the unmapped-highlight count via a non-enumerable property
+    // so the array length still reads naturally for consumers; the
+    // analyzer pulls it into stats.unmappedHighlights for diagnostics.
+    Object.defineProperty(regions, '_unmapped', { value: unmappedHighlights, enumerable: false });
+    return regions;
+  }
+
+  function finalizeRegion(r) {
+    // Map cumulative weight inside the region to a 0-1 score. Cap at 20
+    // weight = 1.0 (matches Heavy threshold density).
+    const score = Math.min(1, r.weight / 20);
+    return {
+      startSentence: r.startSentence,
+      endSentence: r.endSentence,
+      start: r.start,
+      end: r.end,
+      hitCount: r.hitCount,
+      score: Math.round(score * 100) / 100,
+    };
+  }
+
+  // FN-biased: false positives damage trust more than false negatives,
+  // so MIXED is wide and AI_ONLY requires multiple signals. Quote from
+  // GPTZero: "biases the detector to prefer making less-harmful
+  // false-negative errors over false-positive errors."
+  function classifyTrinary({ score, issues, regions, normFlags, wordCount, denseAIVocab }) {
+    // Strong corroborators — each is near-dispositive on its own:
+    //   - cutoff-disclaimer (LLM self-identifies as an AI)
+    //   - reasoning-artifact + chatbot-artifact co-occurrence
+    //   - normalization-flag at threshold (≥2 ZWSP or homoglyphs).
+    //     Threshold parity prevents a single stray ZWSP in copy-paste
+    //     from Word/Notion from flipping to AI_ONLY at score 0.
+    //   - denseAIVocab: ≥4 distinct tier1 hits AND ≥1 tier2 cluster AND
+    //     ≥1 transition phrase — the trifecta that saturated ChatGPT
+    //     prose triggers without needing whitelisted stylometric hits.
+    const hasCutoff = issues.some((i) => i.type === 'cutoff-disclaimer');
+    const hasNormFlag = normFlags.zeroWidth >= 2 || normFlags.homoglyph >= 2;
+    const hasReasoning = issues.some((i) => i.type === 'reasoning-artifact');
+    const hasChatbot = issues.some((i) => i.type === 'chatbot');
+    const strongCorrob =
+      (hasCutoff ? 1 : 0) +
+      (hasNormFlag ? 1 : 0) +
+      (hasReasoning && hasChatbot ? 1 : 0) +
+      (denseAIVocab ? 1 : 0);
+
+    // Weak (stylometric) corroborators — suggestive on their own,
+    // dispositive in combination. Smart-punct-signature matches
+    // Word-edited human prose so doesn't count without other support.
+    const stylometricHits = ['punct-distribution', 'cross-para-burstiness', 'fnword-trigram-entropy']
+      .filter((t) => issues.some((i) => i.type === t)).length;
+    const hasSmartPunct = issues.some((i) => i.type === 'smart-punct-signature');
+    const weakCorrob = (stylometricHits >= 2 ? 1 : 0) + (hasSmartPunct ? 1 : 0);
+
+    // Thresholds:
+    //   score < 15 with no strong → HUMAN_ONLY
+    //   strong ≥ 1 OR score ≥ 70 → AI_ONLY (lowered from 80; high
+    //     density of AI vocab is sufficient evidence)
+    //   score ≥ 40 with any corroborator → AI_ONLY
+    //   everything else with score ≥ 15 → MIXED
+    const totalCorrob = strongCorrob + weakCorrob;
+    let classification;
+    if (score < 15 && strongCorrob === 0) classification = 'HUMAN_ONLY';
+    else if (strongCorrob >= 1 || score >= 70) classification = 'AI_ONLY';
+    else if (score >= 40 && totalCorrob >= 1) classification = 'AI_ONLY';
+    else classification = 'MIXED';
+
+    // Humanizer-flag escalation: presence of bypass-trick chars is
+    // adversarial signal. If a normalization-flag fired we already
+    // counted it in strongCorrob → AI_ONLY. Confidence also gets a
+    // floor of 'medium' in that case (an adversary actively evading
+    // detection should never read as low-confidence noise).
+
+    // Soft probability distribution. Not calibrated against a labeled
+    // corpus yet (TODO when corpus exists — see roadmap.md). Largest
+    // class is computed as `1 - others` after rounding to guarantee
+    // sum=1 exactly. Sub-1% drift would otherwise hide in toFixed.
+    const aiSoft = Math.min(0.97, score / 100 + totalCorrob * 0.06 + strongCorrob * 0.08);
+    let p;
+    if (classification === 'HUMAN_ONLY') p = { human: Math.max(0.6, 1 - aiSoft), mixed: Math.min(0.35, aiSoft * 0.8), ai: Math.min(0.1, aiSoft * 0.3) };
+    else if (classification === 'AI_ONLY') p = { human: Math.max(0.02, 1 - aiSoft - 0.05), mixed: 0.1, ai: aiSoft };
+    else p = { human: Math.max(0.15, 0.6 - aiSoft * 0.5), mixed: 0.5, ai: aiSoft * 0.7 };
+    const rawSum = p.human + p.mixed + p.ai;
+    p.human = +(p.human / rawSum).toFixed(3);
+    p.mixed = +(p.mixed / rawSum).toFixed(3);
+    // Assign ai as the remainder so the three values sum to exactly 1.
+    // Clamp to >= 0 in case rounding pushes human+mixed above 1 (the
+    // remainder would otherwise show as -0 or -0.001 — surfaces as a
+    // negative percentage in any UI doing Math.round(p.ai * 100)).
+    p.ai = Math.max(0, +(1 - p.human - p.mixed).toFixed(3));
+    const probabilities = p;
+
+    // Confidence band:
+    //   high   — strongCorrob ≥ 2, OR cutoff-disclaimer, OR score < 8 (clean long doc)
+    //   medium — strongCorrob ≥ 1, OR score ≥ 45 with weak corroborator, OR score < 20
+    //   low    — everything else
+    let confidence;
+    if (strongCorrob >= 2 || hasCutoff || (score < 8 && wordCount >= 100)) confidence = 'high';
+    else if (strongCorrob >= 1 || (score >= 45 && weakCorrob >= 1) || score < 20) confidence = 'medium';
+    else confidence = 'low';
+
+    return { classification, probabilities, confidence };
+  }
+
+  function getLabel(score) {
+    if (score === 0) return 'Clean';
+    if (score <= 15) return 'Minimal AI signals';
+    if (score <= 35) return 'Some AI patterns';
+    if (score <= 60) return 'Moderate AI signals';
+    if (score <= 80) return 'Strong AI signals';
+    return 'Heavy AI patterns';
+  }
+
+  function getColor(score) {
+    if (score <= 15) return '#44bb66';
+    if (score <= 35) return '#88bb44';
+    if (score <= 60) return '#ddaa00';
+    if (score <= 80) return '#ff8833';
+    return '#ff4444';
+  }
+
+  function deduplicateIssues(issues) {
+    const seen = new Set();
+    return issues.filter(issue => {
+      const key = `${issue.type}:${issue.text.toLowerCase()}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+
+  // ─── Severity labels ──────────────────────────────────────────
+  const SEVERITY_LABELS = {
+    critical: 'P0',
+    high: 'P1',
+    medium: 'P2',
+    low: 'P3',
+  };
+
+  const TYPE_LABELS = {
+    'tier1': 'AI vocabulary',
+    'tier2': 'Word cluster',
+    'tier3': 'Overused word',
+    'transition': 'AI transition',
+    'chatbot': 'Chatbot artifact',
+    'sycophantic': 'Sycophantic tone',
+    'filler': 'Filler phrase',
+    'generic-conclusion': 'Generic conclusion',
+    'lets-construction': '"Let\'s" opener',
+    'reasoning-artifact': 'Reasoning artifact',
+    'acknowledgment-loop': 'Acknowledgment loop',
+    'significance-inflation': 'Significance inflation',
+    'vague-attribution': 'Vague attribution',
+    'hollow-intensifier': 'Hollow intensifier',
+    'emotional-flatline': 'Emotional flatline',
+    'novelty-inflation': 'Novelty inflation',
+    'cutoff-disclaimer': 'Cutoff disclaimer',
+    'template-phrase': 'Template phrase',
+    'false-concession': 'False concession',
+    'rhetorical-question': 'Rhetorical question',
+    'confidence-calibration': 'Confidence stacking',
+    'em-dash': 'Em dash overuse',
+    'uniformity': 'Rhythm uniformity',
+    'formatting': 'Formatting',
+    'tier3-phrase': 'Boilerplate phrase',
+    'tier3-phrase-cluster': 'Boilerplate cluster',
+    'hashtag-stuff': 'Hashtag stuffing',
+    'bullet-np-list': 'Bullet-NP list',
+    'hedge-stack': 'Hedge-stacked prediction',
+    'future-narrative': 'Generic future narrative',
+    'real-actual-inflation': '"Real/actual" inflation',
+    'social-cta-closer': 'Engagement-bait closer',
+    'formulaic-opener': 'Formulaic opener',
+    'speculative-opener': 'Speculative scenario opener',
+    'title-case-header': 'Title Case header',
+    'parenthetical-hedge': 'Parenthetical hedge',
+    'smart-punct-signature': 'Smart-punct signature',
+    'punct-distribution': 'Punctuation distribution',
+    'fnword-trigram-entropy': 'Grammar repetition',
+    'cross-para-burstiness': 'Cross-paragraph rhythm',
+    'normalization-flag': 'Bypass-trick chars',
+    'low-ttr': 'Low vocabulary diversity',
+    'ai-placeholder': 'Unfilled placeholder',
+    'ai-citation-markup': 'Chatbot citation markup leak',
+    'ai-utm-source': 'AI-tool URL parameter',
+  };
+
+  return {
+    analyzeText,
+    normalizeText,
+    getLabel,
+    getColor,
+    SEVERITY_LABELS,
+    TYPE_LABELS,
+  };
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = AIDetector;
+}


### PR DESCRIPTION
## What

Adds a new `writing` plugin, available in **both** of this repo's marketplaces — Claude Code (`writing@cctools-plugins`) and Codex (`writing@cctools-codex-plugins`) — bundling two explicit-trigger prose-quality skills that were previously user-local:

- **agent-style** — 21 literature-backed rules for formal technical prose (papers, design docs, proposals, READMEs, commit messages). Compact directives live in the SKILL.md; full rule bodies (BAD/GOOD pairs, rationale) are vendored at `references/RULES.md` from [yzhao062/agent-style](https://github.com/yzhao062/agent-style) (CC BY 4.0, attribution + license included).
- **remove-ai-patterns** — removes AI-writing patterns at any register, with voice profiles and modes (detect-only, edit-in-place, iterate-to-convergence). Wraps a vendored snapshot of [conorbronsdon/avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) (MIT, license included) plus a deterministic JSON detector (`node scripts/detect.js FILE`, no npm install).

## Design notes

- **Vendored, pinned snapshots** instead of live git clones: skills work offline and identically on every machine; the exact upstream commit is recorded in an `UPSTREAM-PIN` file next to each snapshot. `plugins/writing/scripts/update-upstream.sh` refreshes both snapshots for maintainers (diff is to be reviewed before committing, since fetched rule text is third-party input). Users pick up refreshed catalogs via marketplace update/upgrade + reinstall.
- **Codex support** mirrors voxtype: `.codex-plugin/plugin.json` with an `interface` block, registered in `.agents/plugins/marketplace.json`.
- **Sanitized**: no machine-specific paths or personal-setup references from the original user-local installs (verified by grep).
- Both skills are **explicit-trigger only** (never auto-fire on ordinary writing tasks), and their SKILL.md docs delineate the two lanes (formal-prose rules vs. de-AI-ing) with a do-not-interleave note.

## Docs

- New Starlight page `plugins-detail/writing` + sidebar entry: tabbed Claude Code / Codex installation, usage in both agents, the deterministic-detector workflow, and an "Updating the vendored catalogs" section (user flow vs. maintainer flow).
- `getting-started/plugins`: overview table row, install commands for both agents (the Codex section was dynamic-workflow-only and is now generalized), and a `## writing Plugin` section.
- Docs site builds clean (`npm run build`, 42 pages).

## Verification

- `node scripts/detect.js` smoke-tested against the vendored detector.
- Both marketplace manifests and both plugin.json files validate as JSON and follow existing plugin conventions.
