### PR TITLE
docs: acceptance-gate usage examples for the writing plugin

### DIFF
--- a/docs-site/src/content/docs/plugins-detail/writing.mdx
+++ b/docs-site/src/content/docs/plugins-detail/writing.mdx
@@ -108,6 +108,32 @@ until clean). agent-style keeps its 21 compact rules in the SKILL.md
 itself and the full rule bodies (BAD/GOOD pairs, rationale) in a
 vendored `references/RULES.md`.
 
+### As acceptance gates in a workflow
+
+The skills are most useful as the **acceptance criteria** of a larger
+task: the agent keeps editing until both prose gates pass. Paired with
+the [dynamic-workflow](/claude-code-tools/plugins-detail/dynamic-workflow/)
+plugin, they become an automatic loop. Just describe the gate:
+
+:::tip[Tell Claude Code]
+"Set up a dynamic workflow to draft this blog post, where acceptance is
+gated on both writing skills: run remove-ai-patterns until the detector
+is clean, then an agent-style pass, and loop until both are satisfied."
+:::
+
+Simpler, without a workflow, you can name the gate inline on any writing
+task:
+
+:::tip[Tell Claude Code]
+"Write the release notes from this changelog, then de-AI them with
+remove-ai-patterns and don't stop until the detector reports zero
+issues."
+:::
+
+The deterministic detector (below) is what makes such a loop terminate
+on its own: it is an objective pass/fail signal the agent cannot talk
+itself past.
+
 ### The deterministic detector
 
 remove-ai-patterns includes a JSON-emitting detector that needs only a


### PR DESCRIPTION
Adds a short "As acceptance gates in a workflow" subsection to the Writing plugin page, showing users how to invoke the skills as acceptance criteria rather than one-off passes.

Two Starlight `:::tip[Tell Claude Code]` callouts with copy-pasteable prompts:

- Set up a **dynamic workflow** gated on both prose skills (remove-ai-patterns until the detector is clean, then agent-style, loop until both pass), cross-linked to the dynamic-workflow plugin.
- A simpler inline detector-gated pass on an ordinary writing task.

Notes that the deterministic detector is what lets such a loop terminate on its own. Docs build clean (`npm run build`, 42 pages).