### PR TITLE
Address Codex review feedback on the writing plugin (#134, #135)

### DIFF
--- a/docs-site/src/content/docs/plugins-detail/writing.mdx
+++ b/docs-site/src/content/docs/plugins-detail/writing.mdx
@@ -158,7 +158,7 @@ directory once, then reuse it:
 SKILL_DIR="${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns"
 node "$SKILL_DIR/scripts/detect.js" FILE
 
-# technical documentation: suppress checks that are valid in technical prose
+# technical documentation: skip the title-case-header check (see below)
 node "$SKILL_DIR/scripts/detect.js" FILE technical
 ```
 
@@ -181,16 +181,22 @@ node "$SKILL_DIR/scripts/detect.js" FILE technical
 </Tabs>
 
 The optional second argument is the context mode (`general` (default),
-`technical`, `marketing`, `personal`). It reports an overall score, a
-label, a `document_classification`, and per-issue findings with
-severities and suggestions. For "iterate until clean" requests the agent
-loops revise → detect until findings stop improving; the detector is the
-objective stopping criterion, so the loop cannot argue with itself about
-whether the text is done. One caveat: on empty, very short (< ~10 words),
-or very long (> 10,000 words) input the detector returns
-`document_classification: "UNSCORED"` with no issues, which is a refused
-scan rather than a clean document, so an "iterate to clean" loop should
-require a scored result and split or trim over-long files.
+`technical`, `marketing`, `personal`). In this detector, `technical` has
+one concrete effect: it skips the `title-case-header` check, because Title
+Case section headings are legitimate in technical docs. It does not
+broadly relax vocabulary checks; the wider technical-prose exceptions
+(words like `robust` or `leverage`) live in the upstream skill's prose
+rules that the agent applies when rewriting, not in the detector.
+
+The detector reports an overall score, a label, a
+`document_classification`, and per-issue findings with severities and
+suggestions. For "iterate until clean" requests the agent repeats
+revise → detect using the same convergence rule as above: stop when a
+scored result has no issues, or at the 2-pass cap. One caveat: on empty,
+very short (< ~10 words), or very long (> 10,000 words) input the detector
+returns `document_classification: "UNSCORED"` with no issues, which is a
+refused scan rather than a clean document, so the loop must require a
+scored result and split or trim over-long files.
 
 ## Updating the vendored catalogs
 

--- a/docs-site/src/content/docs/plugins-detail/writing.mdx
+++ b/docs-site/src/content/docs/plugins-detail/writing.mdx
@@ -108,17 +108,22 @@ until clean). agent-style keeps its 21 compact rules in the SKILL.md
 itself and the full rule bodies (BAD/GOOD pairs, rationale) in a
 vendored `references/RULES.md`.
 
-### As acceptance gates in a workflow
+### As an acceptance gate in a workflow
 
-The skills are most useful as the **acceptance criteria** of a larger
-task: the agent keeps editing until both prose gates pass. Paired with
-the [dynamic-workflow](/claude-code-tools/plugins-detail/dynamic-workflow/)
-plugin, they become an automatic loop. Just describe the gate:
+A skill is most useful as the **acceptance criterion** of a larger task:
+the agent keeps editing until the prose gate passes. Pick ONE skill as
+the final gate (interleaving both on the same document churns the same
+sentences, per the two-lanes note above); if you want both to weigh in,
+run one as a single up-front pass and the other as the looping gate.
+Paired with the
+[dynamic-workflow](/claude-code-tools/plugins-detail/dynamic-workflow/)
+plugin, the gate becomes an automatic loop. Just describe it:
 
 :::tip[Tell Claude Code]
-"Set up a dynamic workflow to draft this blog post, where acceptance is
-gated on both writing skills: run remove-ai-patterns until the detector
-is clean, then an agent-style pass, and loop until both are satisfied."
+"Set up a dynamic workflow to draft this blog post. Do one agent-style
+pass first, then loop on remove-ai-patterns as the acceptance gate:
+re-run the detector after each revision and stop when it reports no
+issues or the score stops improving (cap at 5 rounds)."
 :::
 
 Simpler, without a workflow, you can name the gate inline on any writing
@@ -126,13 +131,15 @@ task:
 
 :::tip[Tell Claude Code]
 "Write the release notes from this changelog, then de-AI them with
-remove-ai-patterns and don't stop until the detector reports zero
-issues."
+remove-ai-patterns: iterate until the detector reports no issues or the
+score stops improving."
 :::
 
-The deterministic detector (below) is what makes such a loop terminate
-on its own: it is an objective pass/fail signal the agent cannot talk
-itself past.
+The deterministic detector (below) is what lets such a loop terminate on
+its own. Its convergence rule is to stop when issues reach zero **or**
+the score/label stalls, so a finding that cannot be removed without
+changing intended content ends the loop instead of spinning; keeping a
+round cap is still wise as a backstop.
 
 ### The deterministic detector
 

--- a/docs-site/src/content/docs/plugins-detail/writing.mdx
+++ b/docs-site/src/content/docs/plugins-detail/writing.mdx
@@ -145,15 +145,35 @@ round cap is still wise as a backstop.
 
 remove-ai-patterns includes a JSON-emitting detector that needs only a
 `node` binary. Resolve it by the skill's absolute path (the command runs
-from your working directory, so a bare relative path fails); under a
-Claude Code plugin install that is `${CLAUDE_PLUGIN_ROOT}`:
+from your working directory, so a bare relative path fails). Set that
+directory once, then reuse it:
+
+<Tabs>
+<TabItem label="Claude Code">
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns/scripts/detect.js" FILE
+SKILL_DIR="${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns"
+node "$SKILL_DIR/scripts/detect.js" FILE
 
 # technical documentation: suppress checks that are valid in technical prose
-node "${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns/scripts/detect.js" FILE technical
+node "$SKILL_DIR/scripts/detect.js" FILE technical
 ```
+
+</TabItem>
+<TabItem label="Codex">
+
+`${CLAUDE_PLUGIN_ROOT}` is unset under Codex, so use the absolute path of
+the installed skill directory (the agent already knows it from reading
+the skill):
+
+```bash
+SKILL_DIR="$HOME/.codex/plugins/<...>/plugins/writing/skills/remove-ai-patterns"
+node "$SKILL_DIR/scripts/detect.js" FILE
+node "$SKILL_DIR/scripts/detect.js" FILE technical
+```
+
+</TabItem>
+</Tabs>
 
 The optional second argument is the context mode (`general` (default),
 `technical`, `marketing`, `personal`). It reports an overall score, a

--- a/docs-site/src/content/docs/plugins-detail/writing.mdx
+++ b/docs-site/src/content/docs/plugins-detail/writing.mdx
@@ -144,17 +144,28 @@ round cap is still wise as a backstop.
 ### The deterministic detector
 
 remove-ai-patterns includes a JSON-emitting detector that needs only a
-`node` binary:
+`node` binary. Resolve it by the skill's absolute path (the command runs
+from your working directory, so a bare relative path fails); under a
+Claude Code plugin install that is `${CLAUDE_PLUGIN_ROOT}`:
 
 ```bash
-node <skill-dir>/scripts/detect.js FILE
+node "${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns/scripts/detect.js" FILE
+
+# technical documentation: suppress checks that are valid in technical prose
+node "${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns/scripts/detect.js" FILE technical
 ```
 
-It reports an overall score, a label, a document classification, and
-per-issue findings with severities and suggestions. For "iterate until
-clean" requests the agent loops revise → detect until findings stop
-improving; the detector is the objective stopping criterion, so the loop
-cannot argue with itself about whether the text is done.
+The optional second argument is the context mode (`general` (default),
+`technical`, `marketing`, `personal`). It reports an overall score, a
+label, a `document_classification`, and per-issue findings with
+severities and suggestions. For "iterate until clean" requests the agent
+loops revise → detect until findings stop improving; the detector is the
+objective stopping criterion, so the loop cannot argue with itself about
+whether the text is done. One caveat: on empty, very short (< ~10 words),
+or very long (> 10,000 words) input the detector returns
+`document_classification: "UNSCORED"` with no issues, which is a refused
+scan rather than a clean document, so an "iterate to clean" loop should
+require a scored result and split or trim over-long files.
 
 ## Updating the vendored catalogs
 

--- a/docs-site/src/content/docs/plugins-detail/writing.mdx
+++ b/docs-site/src/content/docs/plugins-detail/writing.mdx
@@ -123,8 +123,8 @@ plugin, the gate becomes an automatic loop. Just describe it:
 "Set up a dynamic workflow to draft this blog post. Do one agent-style
 pass first, then loop on remove-ai-patterns as the acceptance gate:
 re-run the detector after each revision and stop when it returns a
-scored result (not UNSCORED) with no issues, or the score stops
-improving. Cap the loop at 2 passes, matching the skill's own limit."
+scored result (not UNSCORED) with no issues, or you have completed 2
+passes (the skill's own iterate cap)."
 :::
 
 Simpler, without a workflow, you can name the gate inline on any writing
@@ -133,16 +133,16 @@ task:
 :::tip[Tell Claude Code]
 "Write the release notes from this changelog, then de-AI them with
 remove-ai-patterns: iterate until the detector returns a scored result
-with no issues, or the score stops improving (at most 2 passes)."
+with no issues, or you have completed 2 passes."
 :::
 
 The deterministic detector (below) is what lets such a loop terminate on
-its own. Its convergence rule is to stop when a scored result has zero
-issues **or** the score/label stalls, so a finding that cannot be removed
-without changing intended content ends the loop instead of spinning. The
-2-pass cap matches the upstream skill's own iterate limit (a rewrite plus
-one corrective pass), so the gate does not contradict the instructions
-the agent is told to follow.
+its own. Its convergence rule, matching the upstream skill, is to repeat
+until a scored result has no issues or the cap of 2 passes is reached (a
+rewrite plus one corrective pass). A finding that cannot be removed
+without changing intended content simply survives to the cap, so the loop
+still ends; it does not use a separate "score stopped improving"
+criterion, which could stop before that corrective pass.
 
 ### The deterministic detector
 

--- a/docs-site/src/content/docs/plugins-detail/writing.mdx
+++ b/docs-site/src/content/docs/plugins-detail/writing.mdx
@@ -122,8 +122,9 @@ plugin, the gate becomes an automatic loop. Just describe it:
 :::tip[Tell Claude Code]
 "Set up a dynamic workflow to draft this blog post. Do one agent-style
 pass first, then loop on remove-ai-patterns as the acceptance gate:
-re-run the detector after each revision and stop when it reports no
-issues or the score stops improving (cap at 5 rounds)."
+re-run the detector after each revision and stop when it returns a
+scored result (not UNSCORED) with no issues, or the score stops
+improving. Cap the loop at 2 passes, matching the skill's own limit."
 :::
 
 Simpler, without a workflow, you can name the gate inline on any writing
@@ -131,15 +132,17 @@ task:
 
 :::tip[Tell Claude Code]
 "Write the release notes from this changelog, then de-AI them with
-remove-ai-patterns: iterate until the detector reports no issues or the
-score stops improving."
+remove-ai-patterns: iterate until the detector returns a scored result
+with no issues, or the score stops improving (at most 2 passes)."
 :::
 
 The deterministic detector (below) is what lets such a loop terminate on
-its own. Its convergence rule is to stop when issues reach zero **or**
-the score/label stalls, so a finding that cannot be removed without
-changing intended content ends the loop instead of spinning; keeping a
-round cap is still wise as a backstop.
+its own. Its convergence rule is to stop when a scored result has zero
+issues **or** the score/label stalls, so a finding that cannot be removed
+without changing intended content ends the loop instead of spinning. The
+2-pass cap matches the upstream skill's own iterate limit (a rewrite plus
+one corrective pass), so the gate does not contradict the instructions
+the agent is told to follow.
 
 ### The deterministic detector
 
@@ -163,11 +166,13 @@ node "$SKILL_DIR/scripts/detect.js" FILE technical
 <TabItem label="Codex">
 
 `${CLAUDE_PLUGIN_ROOT}` is unset under Codex, so use the absolute path of
-the installed skill directory (the agent already knows it from reading
-the skill):
+the installed skill directory. The agent already knows it from loading
+the skill; it lives under the Codex plugin cache and ends in
+`skills/remove-ai-patterns` (the plugin root is the `writing` plugin, so
+there is no extra `plugins/writing` segment). Discover it if unsure:
 
 ```bash
-SKILL_DIR="$HOME/.codex/plugins/<...>/plugins/writing/skills/remove-ai-patterns"
+SKILL_DIR="$(dirname "$(find "$HOME/.codex" -path '*/skills/remove-ai-patterns/scripts/detect.js' | head -1)")/.."
 node "$SKILL_DIR/scripts/detect.js" FILE
 node "$SKILL_DIR/scripts/detect.js" FILE technical
 ```

--- a/plugins/writing/skills/remove-ai-patterns/SKILL.md
+++ b/plugins/writing/skills/remove-ai-patterns/SKILL.md
@@ -28,13 +28,21 @@ vendored at `upstream/` inside this skill directory (commit recorded in
    (requires Node.js, no npm install needed). Resolve it by the skill's own
    absolute path, NOT a bare relative path: the command runs from the
    user's current working directory, so `node scripts/detect.js` would fail
-   with `MODULE_NOT_FOUND`. When installed as a Claude Code plugin, use
-   `${CLAUDE_PLUGIN_ROOT}`; otherwise substitute this skill's directory:
+   with `MODULE_NOT_FOUND`. You already know this skill's directory (you
+   just read this SKILL.md from it), so set it once and reuse it. Under a
+   Claude Code plugin install `${CLAUDE_PLUGIN_ROOT}` gives the plugin root;
+   under Codex (where that variable is unset) or a direct skill install,
+   substitute the absolute path of the directory holding this file:
 
    ```bash
-   node "${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns/scripts/detect.js" FILE
-   # or, for a direct (non-plugin) skill install, the absolute path to it:
-   #   node /abs/path/to/remove-ai-patterns/scripts/detect.js FILE
+   # Claude Code plugin install:
+   SKILL_DIR="${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns"
+   # Codex plugin or direct skill install: use the absolute path of the
+   # directory this SKILL.md lives in, e.g.
+   #   SKILL_DIR="$HOME/.codex/plugins/.../plugins/writing/skills/remove-ai-patterns"
+   #   SKILL_DIR="$HOME/.local/share/agent-skills/remove-ai-patterns"
+
+   node "$SKILL_DIR/scripts/detect.js" FILE
    ```
 
    Pass a context mode as the second argument when the text is technical
@@ -42,7 +50,7 @@ vendored at `upstream/` inside this skill directory (commit recorded in
    technical prose (matches the skill's `technical` voice profile):
 
    ```bash
-   node "${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns/scripts/detect.js" FILE technical
+   node "$SKILL_DIR/scripts/detect.js" FILE technical
    ```
 
    Valid modes: `general` (default), `technical`, `marketing`, `personal`.

--- a/plugins/writing/skills/remove-ai-patterns/SKILL.md
+++ b/plugins/writing/skills/remove-ai-patterns/SKILL.md
@@ -25,17 +25,38 @@ vendored at `upstream/` inside this skill directory (commit recorded in
    edit-in-place for files, optional voice profile, and an
    iterate-to-convergence pass.
 2. For a deterministic, machine-checkable audit, run the bundled detector
-   (requires Node.js, no npm install needed):
+   (requires Node.js, no npm install needed). Resolve it by the skill's own
+   absolute path, NOT a bare relative path: the command runs from the
+   user's current working directory, so `node scripts/detect.js` would fail
+   with `MODULE_NOT_FOUND`. When installed as a Claude Code plugin, use
+   `${CLAUDE_PLUGIN_ROOT}`; otherwise substitute this skill's directory:
 
    ```bash
-   node scripts/detect.js FILE
+   node "${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns/scripts/detect.js" FILE
+   # or, for a direct (non-plugin) skill install, the absolute path to it:
+   #   node /abs/path/to/remove-ai-patterns/scripts/detect.js FILE
    ```
 
-   It prints JSON: an overall score, a label, a document classification with
-   class probabilities, and per-issue findings (`type`, matched `text`,
+   Pass a context mode as the second argument when the text is technical
+   documentation, so the detector suppresses checks that are legitimate in
+   technical prose (matches the skill's `technical` voice profile):
+
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns/scripts/detect.js" FILE technical
+   ```
+
+   Valid modes: `general` (default), `technical`, `marketing`, `personal`.
+
+   It prints JSON: an overall `score`, a `label`, a `document_classification`
+   with class probabilities, and per-issue findings (`type`, matched `text`,
    `severity`, `suggestion`). For "iterate until clean/green" requests, loop
-   revise -> detect until the score/label stops improving or issues hit zero;
-   the detector is the objective stopping criterion.
+   revise -> detect until the score/label stops improving or issues hit zero.
+   IMPORTANT: only treat a zero-issue result as clean when it is actually
+   scored. On empty input, under ~10 words, or over 10,000 words the detector
+   returns `document_classification: "UNSCORED"` with an empty `issues` list;
+   that is a refused scan, not a clean document, so convergence must require
+   a scored result (`document_classification` other than `"UNSCORED"`), not
+   merely an empty issue list. Split or trim over-long inputs so they score.
 3. Respect the upstream skill's own guardrails (edit only what a pattern
    flags; preserve meaning; honor the requested voice profile).
 

--- a/plugins/writing/skills/remove-ai-patterns/SKILL.md
+++ b/plugins/writing/skills/remove-ai-patterns/SKILL.md
@@ -47,10 +47,13 @@ vendored at `upstream/` inside this skill directory (commit recorded in
    ```
 
    Pass a context mode as the second argument when the text is technical
-   documentation, so the detector suppresses checks that are legitimate in
-   technical prose. (This sets the detector's `contextMode`, which is a
-   separate axis from the skill's voice profile; it does not select the
-   technical voice.)
+   documentation. In this detector, `technical` has one concrete effect: it
+   skips the `title-case-header` check (Title Case section headings are
+   legitimate in technical docs). It does not broadly relax vocabulary
+   checks, and it is not the same as selecting the skill's `technical`
+   VOICE profile (context and voice are separate axes); the wider
+   technical-prose word exceptions live in the upstream skill's rewrite
+   rules, not in the detector.
 
    ```bash
    node "$SKILL_DIR/scripts/detect.js" FILE technical

--- a/plugins/writing/skills/remove-ai-patterns/SKILL.md
+++ b/plugins/writing/skills/remove-ai-patterns/SKILL.md
@@ -60,10 +60,12 @@ vendored at `upstream/` inside this skill directory (commit recorded in
 
    It prints JSON: an overall `score`, a `label`, a `document_classification`
    with class probabilities, and per-issue findings (`type`, matched `text`,
-   `severity`, `suggestion`). For "iterate until clean/green" requests, loop
-   revise -> detect until the score/label stops improving or a scored
-   result has zero issues. Respect the upstream skill's iterate cap of 2
-   passes (see `upstream/SKILL.md`); do not invent a larger limit.
+   `severity`, `suggestion`). For "iterate until clean/green" requests,
+   follow the upstream skill's convergence rule (see `upstream/SKILL.md`):
+   repeat the audit -> revise cycle until a scored result has no issues, or
+   the cap of 2 passes is reached (the built-in corrective pass is pass 2).
+   Do not stop early on a "score stopped improving" heuristic and do not
+   invent a larger cap.
    IMPORTANT: only treat a zero-issue result as clean when it is actually
    scored. On empty input, under ~10 words, or over 10,000 words the detector
    returns `document_classification: "UNSCORED"` with an empty `issues` list;

--- a/plugins/writing/skills/remove-ai-patterns/SKILL.md
+++ b/plugins/writing/skills/remove-ai-patterns/SKILL.md
@@ -37,9 +37,10 @@ vendored at `upstream/` inside this skill directory (commit recorded in
    ```bash
    # Claude Code plugin install:
    SKILL_DIR="${CLAUDE_PLUGIN_ROOT}/skills/remove-ai-patterns"
-   # Codex plugin or direct skill install: use the absolute path of the
-   # directory this SKILL.md lives in, e.g.
-   #   SKILL_DIR="$HOME/.codex/plugins/.../plugins/writing/skills/remove-ai-patterns"
+   # Codex plugin or direct skill install: the absolute path of the
+   # directory this SKILL.md lives in (it ends in skills/remove-ai-patterns;
+   # the plugin root already is the writing plugin, so there is no extra
+   # plugins/writing segment). Direct installs are simpler, e.g.
    #   SKILL_DIR="$HOME/.local/share/agent-skills/remove-ai-patterns"
 
    node "$SKILL_DIR/scripts/detect.js" FILE
@@ -47,7 +48,9 @@ vendored at `upstream/` inside this skill directory (commit recorded in
 
    Pass a context mode as the second argument when the text is technical
    documentation, so the detector suppresses checks that are legitimate in
-   technical prose (matches the skill's `technical` voice profile):
+   technical prose. (This sets the detector's `contextMode`, which is a
+   separate axis from the skill's voice profile; it does not select the
+   technical voice.)
 
    ```bash
    node "$SKILL_DIR/scripts/detect.js" FILE technical
@@ -58,7 +61,9 @@ vendored at `upstream/` inside this skill directory (commit recorded in
    It prints JSON: an overall `score`, a `label`, a `document_classification`
    with class probabilities, and per-issue findings (`type`, matched `text`,
    `severity`, `suggestion`). For "iterate until clean/green" requests, loop
-   revise -> detect until the score/label stops improving or issues hit zero.
+   revise -> detect until the score/label stops improving or a scored
+   result has zero issues. Respect the upstream skill's iterate cap of 2
+   passes (see `upstream/SKILL.md`); do not invent a larger limit.
    IMPORTANT: only treat a zero-issue result as clean when it is actually
    scored. On empty input, under ~10 words, or over 10,000 words the detector
    returns `document_classification: "UNSCORED"` with an empty `issues` list;

--- a/plugins/writing/skills/remove-ai-patterns/scripts/detect.js
+++ b/plugins/writing/skills/remove-ai-patterns/scripts/detect.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 // JSON CLI over upstream/detector/patterns.js (vendored avoid-ai-writing).
+// Usage: detect.js <file> [contextMode]
+//   contextMode: general (default) | technical | marketing | personal
 const fs = require("fs");
 const path = require("path");
 
@@ -7,11 +9,23 @@ const AIDetector = require(
   path.join(__dirname, "..", "upstream", "detector", "patterns.js"),
 );
 
+const VALID_CONTEXT_MODES = ["general", "technical", "marketing", "personal"];
+
 const file = process.argv[2];
+const contextMode = process.argv[3];
 if (!file) {
-  console.error("usage: detect.js <file>");
+  console.error("usage: detect.js <file> [contextMode]");
+  console.error(`  contextMode: ${VALID_CONTEXT_MODES.join(" | ")}`);
+  process.exit(2);
+}
+if (contextMode && !VALID_CONTEXT_MODES.includes(contextMode)) {
+  console.error(
+    `invalid contextMode '${contextMode}'; ` +
+      `valid: ${VALID_CONTEXT_MODES.join(", ")}`,
+  );
   process.exit(2);
 }
 
-const result = AIDetector.analyzeText(fs.readFileSync(file, "utf8"));
+const options = contextMode ? { contextMode } : {};
+const result = AIDetector.analyzeText(fs.readFileSync(file, "utf8"), options);
 console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
Follow-up to the merged writing-plugin PRs, addressing the Codex review comments on both. **Please review before merging.**

## From PR #135 (docs gate examples)

- **[P2] Don't loop both skills on the same document.** The dynamic-workflow callout told the agent to loop until *both* remove-ai-patterns and agent-style are satisfied, which contradicts the page's own "pick one final gate" rule (interleaving churns the same sentences and can oscillate or exhaust the cap). Now: one agent-style pass up front, then remove-ai-patterns as the single looping gate.
- **[P2] Bound the detector loop.** "Don't stop until zero issues" could spin forever when a finding can't be removed without changing intended content. Both callouts now use the detector's real convergence rule (zero issues **or** score stalls) plus a round cap.

## From PR #134 (skill code)

- **[P1] Detector path resolution.** `node scripts/detect.js FILE` fails with `MODULE_NOT_FOUND` when the skill runs from a user's repo. SKILL.md and docs now resolve it by the skill's absolute path via `${CLAUDE_PLUGIN_ROOT}` (the repo's existing convention), with a non-plugin fallback.
- **[P2] Convergence must require a *scored* result.** The detector returns `document_classification: "UNSCORED"` with an empty `issues` list on empty / <10-word / >10,000-word input. "Stop at zero issues" wrongly treated a refused scan (e.g. a long README or paper) as clean. Guidance now requires a scored result and says to split/trim over-long files. (Verified: a 10,001-word file returns UNSCORED with no issues.)
- **[P2] Expose the detector's context mode.** `detect.js` only ever called `analyzeText` with the default `general` context, so the documented `technical` voice couldn't reach the detector's `contextMode: "technical"` suppression. `detect.js` now accepts an optional second arg (`general|technical|marketing|personal`) with validation; docs and SKILL.md show the technical invocation.

### Not changed (deliberately)

The Codex note about the `title-case-header` regex missing Markdown `#` prefixes is in **vendored upstream code** (`upstream/detector/patterns.js`). Patching it would break the pinned-snapshot contract and be overwritten by `update-upstream.sh`, so it belongs upstream ([conorbronsdon/avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing)). Happy to file it there if you'd like.

## Verification

- `detect.js`: general vs. technical mode, invalid-mode guard (exit 2), and UNSCORED on too-long / too-short inputs all behave as intended.
- Docs site builds clean (`npm run build`, 42 pages).