### PR TITLE
fix(safety-hooks): git checkout guard is disarmed by any command containing "-b"

### DIFF
--- a/plugins/safety-hooks/hooks/git_checkout_safety_hook.py
+++ b/plugins/safety-hooks/hooks/git_checkout_safety_hook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import os
-import re
+import shlex
 import subprocess
 import sys
 
@@ -12,6 +12,97 @@ if PLUGIN_ROOT:
         sys.path.insert(0, hooks_dir)
 
 from command_utils import extract_subcommands
+
+# git's own global options that consume the NEXT token as their value. They sit
+# between "git" and the subcommand, so the subcommand is not always argv[1].
+_GIT_GLOBAL_VALUE_OPTS = {
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path",
+    "--super-prefix", "--config-env",
+}
+
+# Options that point git at a repository this module cannot compute. Honouring
+# them properly also means handling GIT_DIR / GIT_WORK_TREE and their
+# composition with -C; rather than guess, mark the target unknown and let the
+# caller decline to probe anything.
+_OPAQUE_TARGET_OPTS = ("--work-tree", "--git-dir")
+
+# Pathspecs that mean "everything", as opposed to a named file.
+_UNBOUNDED_PATHSPECS = {".", "./", "*", ":/"}
+
+_DANGER_TEMPLATE = (
+    "⚠️  DANGEROUS COMMAND DETECTED!\n\n{message}\n\n"
+    "This command will destroy uncommitted work without warning.\n\n"
+    "Safer alternatives:\n"
+    "- Use 'git stash' to save changes temporarily\n"
+    "- Use 'git diff' to see what would be lost\n"
+    "- Use 'git restore' for clearer syntax"
+)
+
+
+def _danger(message):
+    return _DANGER_TEMPLATE.format(message=message)
+
+
+def _tokenize(command):
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def parse_git_checkout(command):
+    """
+    Split ``git [global-opts] checkout <args...>`` into (args, repo_dir).
+
+    Returns ``(None, None)`` when the command is not a git checkout at all.
+
+    Returns ``(args, None)`` when it IS a git checkout but the repository it
+    would act on cannot be determined -- an unexpanded ``-C`` value such as
+    ``-C "$REPO"``, or ``--git-dir`` / ``--work-tree``. Checks that read only
+    the command still apply; nothing may probe a directory on that basis,
+    least of all the caller's own, which is a different repository.
+    """
+    tokens = _tokenize(command)
+    if not tokens or os.path.basename(tokens[0]) != "git":
+        return None, None
+
+    chdir = os.getcwd()
+    opaque = False
+    i = 1
+    while i < len(tokens):
+        token = tokens[i]
+        if token.split("=", 1)[0] in _OPAQUE_TARGET_OPTS:
+            opaque = True
+        if token in _GIT_GLOBAL_VALUE_OPTS:
+            # git applies repeated -C cumulatively, each relative to the last.
+            if token == "-C" and i + 1 < len(tokens):
+                value = tokens[i + 1]
+                chdir = value if os.path.isabs(value) else os.path.join(chdir, value)
+            i += 2
+            continue
+        if token.startswith("-"):
+            i += 1
+            continue
+        break
+
+    if i >= len(tokens) or tokens[i] != "checkout":
+        return None, None
+
+    args = tokens[i + 1:]
+    if opaque or not os.path.isdir(chdir):
+        return args, None
+    return args, chdir
+
+
+def _option_flags(tokens):
+    """Real option tokens, with short clusters split (-fb -> {-f, -b})."""
+    flags = set()
+    for token in tokens:
+        if token.startswith("--"):
+            flags.add(token.split("=", 1)[0])
+        elif token.startswith("-") and len(token) > 1:
+            flags.update("-" + char for char in token[1:])
+    return flags
 
 
 def check_git_checkout_command(command):
@@ -36,30 +127,61 @@ def _check_single_git_checkout_command(command):
     Check a single (non-compound) git checkout command.
     Returns tuple: (should_block: bool, reason: str or None)
     """
-    # Check if it's a git checkout command
-    if not command.strip().startswith("git checkout"):
+    # Check if it's a git checkout command. This also recognises the
+    # `git -C <dir> checkout ...` form, which a "starts with git checkout"
+    # test misses entirely.
+    args, repo_dir = parse_git_checkout(command)
+    if args is None:
         return False, None
 
-    # Safe patterns that we should allow without checking
-    if "-b" in command or "--help" in command or "-h" in command:
+    # Everything before a `--` separator is options and refs; everything after
+    # is pathspecs, even if it looks like an option.
+    if "--" in args:
+        separator = args.index("--")
+        head, pathspecs = args[:separator], args[separator + 1:]
+    else:
+        separator = None
+        head, pathspecs = args, []
+
+    flags = _option_flags(head)
+
+    if "-h" in flags or "--help" in flags:
         return False, None
 
-    # ALWAYS block these dangerous patterns
-    dangerous_patterns = [
-        (r'\bgit\s+checkout\s+(-f|--force)\b',
-         "'git checkout -f' FORCES checkout and DISCARDS all uncommitted changes!"),
-        (r'\bgit\s+checkout\s+\.',
-         "'git checkout .' will DISCARD ALL changes in current directory!"),
-        (r'\bgit\s+checkout\s+.*\s+--\s+\.',
-         "This will DISCARD ALL changes in current directory!"),
-        (r'\bgit\s+checkout\s+.*\s+--\s+',
-         "This will overwrite your local file with version from another branch/commit!"),
-    ]
+    # ALWAYS block these dangerous patterns.
+    #
+    # -f is checked BEFORE the -b allowance below. Testing for "-b" first --
+    # and as a substring of the whole command -- is what let `git checkout -f
+    # -b <name>` and `git checkout . -b <name>` through, and disarmed the guard
+    # for any command merely containing "-b", e.g. `git checkout --
+    # src/my-button.ts`.
+    if "-f" in flags or "--force" in flags:
+        return True, _danger(
+            "'git checkout -f' FORCES checkout and DISCARDS all uncommitted changes!")
 
-    for pattern, message in dangerous_patterns:
-        if re.search(pattern, command):
-            reason = f"⚠️  DANGEROUS COMMAND DETECTED!\n\n{message}\n\nThis command will destroy uncommitted work without warning.\n\nSafer alternatives:\n- Use 'git stash' to save changes temporarily\n- Use 'git diff' to see what would be lost\n- Use 'git restore' for clearer syntax"
-            return True, reason
+    if separator is not None:
+        if any(p in _UNBOUNDED_PATHSPECS for p in pathspecs):
+            return True, _danger(
+                "This will DISCARD ALL changes in current directory!")
+        return True, _danger(
+            "This will overwrite your local file with version from another branch/commit!")
+
+    positionals = [a for a in args if not a.startswith("-")]
+    if any(p in _UNBOUNDED_PATHSPECS for p in positionals):
+        return True, _danger(
+            "'git checkout .' will DISCARD ALL changes in current directory!")
+
+    # Creating a branch carries uncommitted work across rather than discarding
+    # it, so it stays exempt from the uncommitted-changes prompt below.
+    if "-b" in flags:
+        return False, None
+
+    # Everything above reads only the COMMAND. Everything below reads a
+    # REPOSITORY, and repo_dir is None when we could not work out which one.
+    # Probing the caller's own repo instead would report a verdict, and a list
+    # of at-risk files, belonging to a repository the command never touches.
+    if repo_dir is None:
+        return False, None
 
     try:
         # First, check if there are any uncommitted changes
@@ -67,7 +189,7 @@ def _check_single_git_checkout_command(command):
             ["git", "status", "--porcelain"],
             capture_output=True,
             text=True,
-            cwd=os.getcwd()
+            cwd=repo_dir
         )
 
         has_changes = bool(status_result.stdout.strip())
@@ -79,14 +201,14 @@ def _check_single_git_checkout_command(command):
                 ["git", "diff", "--name-only", "HEAD"],
                 capture_output=True,
                 text=True,
-                cwd=os.getcwd()
+                cwd=repo_dir
             )
 
             unstaged_result = subprocess.run(
                 ["git", "diff", "--name-only"],
                 capture_output=True,
                 text=True,
-                cwd=os.getcwd()
+                cwd=repo_dir
             )
 
             # Count changes

--- a/plugins/safety-hooks/hooks/test_git_checkout_safety_hook.py
+++ b/plugins/safety-hooks/hooks/test_git_checkout_safety_hook.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+Unit tests for git_checkout_safety_hook.py
+
+Tests cover:
+    - Destructive checkouts that also mention "-b" somewhere
+    - `git -C <dir> checkout` (the subcommand is not always argv[1])
+    - Option tokens vs. substrings of ordinary filenames
+    - Branch creation and --help staying exempt
+    - The uncommitted-changes probe reading the repository the command targets
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from git_checkout_safety_hook import (
+    check_git_checkout_command,
+    parse_git_checkout,
+)
+
+
+class TestParseGitCheckout(unittest.TestCase):
+    """Tests for parse_git_checkout() command splitting."""
+
+    def test_plain_checkout(self):
+        args, _ = parse_git_checkout("git checkout main")
+        self.assertEqual(args, ["main"])
+
+    def test_not_a_checkout(self):
+        self.assertEqual(parse_git_checkout("git status"), (None, None))
+        self.assertEqual(parse_git_checkout("ls checkout"), (None, None))
+        self.assertEqual(parse_git_checkout(""), (None, None))
+
+    def test_checkout_word_in_an_argument_is_not_the_subcommand(self):
+        """A branch named "checkout" is not a checkout subcommand."""
+        self.assertEqual(parse_git_checkout("git switch checkout"), (None, None))
+
+    def test_dash_c_retargets_the_repository(self):
+        """`git -C <dir>` runs in <dir>, so that is the repo to judge."""
+        with tempfile.TemporaryDirectory() as tmp:
+            args, repo_dir = parse_git_checkout(f"git -C {tmp} checkout main")
+            self.assertEqual(args, ["main"])
+            self.assertEqual(os.path.realpath(repo_dir), os.path.realpath(tmp))
+
+    def test_absolute_path_to_git_binary(self):
+        args, _ = parse_git_checkout("/usr/bin/git checkout main")
+        self.assertEqual(args, ["main"])
+
+    def test_unresolvable_target_reports_unknown_not_cwd(self):
+        """An unexpanded -C value must not fall back to the caller's repo."""
+        args, repo_dir = parse_git_checkout('git -C "$REPO" checkout main')
+        self.assertEqual(args, ["main"])
+        self.assertIsNone(repo_dir)
+
+    def test_work_tree_reports_unknown(self):
+        _, repo_dir = parse_git_checkout("git --work-tree=/somewhere checkout main")
+        self.assertIsNone(repo_dir)
+
+
+class TestAlwaysBlocked(unittest.TestCase):
+    """Destructive forms that must be blocked regardless of repo state."""
+
+    def test_force_checkout(self):
+        blocked, reason = check_git_checkout_command("git checkout -f")
+        self.assertTrue(blocked)
+        self.assertIn("FORCES checkout", reason)
+
+    def test_force_long_form(self):
+        blocked, _ = check_git_checkout_command("git checkout --force main")
+        self.assertTrue(blocked)
+
+    def test_checkout_dot(self):
+        blocked, reason = check_git_checkout_command("git checkout .")
+        self.assertTrue(blocked)
+        self.assertIn("DISCARD ALL", reason)
+
+    def test_checkout_double_dash_dot(self):
+        blocked, _ = check_git_checkout_command("git checkout HEAD -- .")
+        self.assertTrue(blocked)
+
+    def test_checkout_double_dash_path(self):
+        blocked, _ = check_git_checkout_command("git checkout HEAD -- src/app.ts")
+        self.assertTrue(blocked)
+
+    # --- Regressions: these are the forms a substring test for "-b" let through
+
+    def test_force_combined_with_branch_creation(self):
+        """`-f` discards work even when a branch is also being created."""
+        blocked, reason = check_git_checkout_command("git checkout -f -b feature")
+        self.assertTrue(blocked, "-f must be blocked even alongside -b")
+        self.assertIn("FORCES checkout", reason)
+
+    def test_force_in_a_short_option_cluster(self):
+        blocked, _ = check_git_checkout_command("git checkout -fb feature")
+        self.assertTrue(blocked, "-f inside a cluster must still be seen")
+
+    def test_checkout_dot_with_branch_creation(self):
+        blocked, _ = check_git_checkout_command("git checkout . -b feature")
+        self.assertTrue(blocked, "'.' pathspec must be blocked even alongside -b")
+
+    def test_filename_containing_dash_b_is_not_an_option(self):
+        """"-b" inside a filename must not disarm the guard."""
+        blocked, _ = check_git_checkout_command(
+            "git checkout HEAD -- src/my-button.ts")
+        self.assertTrue(blocked, "'my-button.ts' contains '-b' but is a filename")
+
+    def test_branch_name_containing_dash_b_is_not_an_option(self):
+        blocked, _ = check_git_checkout_command("git checkout -f my-branch")
+        self.assertTrue(blocked)
+
+    # --- Regressions: the `git -C <dir> <subcommand>` form
+
+    def test_dash_c_force_checkout(self):
+        blocked, reason = check_git_checkout_command(
+            "git -C /some/other/repo checkout -f")
+        self.assertTrue(blocked, "git -C <dir> checkout is still a checkout")
+        self.assertIn("FORCES checkout", reason)
+
+    def test_dash_c_checkout_dot(self):
+        blocked, _ = check_git_checkout_command("git -C /some/other/repo checkout .")
+        self.assertTrue(blocked)
+
+    def test_compound_command_with_dash_c(self):
+        blocked, _ = check_git_checkout_command(
+            "echo hi && git -C /some/other/repo checkout -f")
+        self.assertTrue(blocked)
+
+
+class TestAllowed(unittest.TestCase):
+    """Forms that must stay allowed."""
+
+    def test_branch_creation(self):
+        blocked, _ = check_git_checkout_command("git checkout -b feature")
+        self.assertFalse(blocked)
+
+    def test_help(self):
+        self.assertFalse(check_git_checkout_command("git checkout --help")[0])
+        self.assertFalse(check_git_checkout_command("git checkout -h")[0])
+
+    def test_non_checkout_commands(self):
+        self.assertFalse(check_git_checkout_command("git status")[0])
+        self.assertFalse(check_git_checkout_command("git commit -m 'x'")[0])
+        self.assertFalse(check_git_checkout_command("echo git checkout -f")[0])
+
+    def test_unresolvable_target_is_not_probed(self):
+        """Unknown target: command-level checks apply, no repo is probed."""
+        blocked, _ = check_git_checkout_command('git -C "$REPO" checkout main')
+        self.assertFalse(blocked)
+        blocked, _ = check_git_checkout_command('git -C "$REPO" checkout -f')
+        self.assertTrue(blocked, "command-level checks still apply")
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True,
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+@unittest.skipIf(shutil.which("git") is None, "git is not installed")
+class TestUncommittedChangesProbeTargetsTheRightRepo(unittest.TestCase):
+    """The warning must describe the repo the command targets, not the cwd."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.repo = os.path.join(self.tmp, "other-repo")
+        os.makedirs(self.repo)
+        _git("init", cwd=self.repo)
+        with open(os.path.join(self.repo, "dirty-file.txt"), "w") as handle:
+            handle.write("uncommitted\n")
+
+        self.clean = os.path.join(self.tmp, "clean-cwd")
+        os.makedirs(self.clean)
+        _git("init", cwd=self.clean)
+
+        self.original_cwd = os.getcwd()
+        os.chdir(self.clean)
+        self.addCleanup(os.chdir, self.original_cwd)
+
+    def test_warns_about_the_target_repo(self):
+        blocked, reason = check_git_checkout_command(
+            f"git -C {self.repo} checkout main")
+        self.assertTrue(blocked, "the target repo has uncommitted changes")
+        self.assertIn("dirty-file.txt", reason)
+
+    def test_clean_target_is_allowed_even_from_a_dirty_cwd(self):
+        with open(os.path.join(self.clean, "local-noise.txt"), "w") as handle:
+            handle.write("only in the cwd\n")
+        blocked, _ = check_git_checkout_command(
+            f"git -C {self.repo} checkout main")
+        self.assertTrue(blocked, "target repo is the dirty one here")
+
+        # And the mirror image: a clean target must not inherit the cwd's dirt.
+        pristine = os.path.join(self.tmp, "pristine")
+        os.makedirs(pristine)
+        _git("init", cwd=pristine)
+        blocked, _ = check_git_checkout_command(
+            f"git -C {pristine} checkout main")
+        self.assertFalse(blocked, "clean target must not inherit the cwd's dirt")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

`git_checkout_safety_hook.py` decides whether a checkout is destructive by
matching against the raw command string. Two of those matches are not looking at
what they appear to be looking at.

### 1. `"-b" in command` is a substring test, and it returns *before* the always-block list

```python
# Safe patterns that we should allow without checking
if "-b" in command or "--help" in command or "-h" in command:
    return False, None

# ALWAYS block these dangerous patterns
dangerous_patterns = [ ... ]
```

The exemption runs first, so anything containing the two characters `-b` anywhere
skips every dangerous-pattern check below it. Verified against the current `main`
(`45ee0e2`):

| command | current result | expected |
|---|---|---|
| `git checkout -f -b feature` | allowed | blocked (`-f` discards uncommitted work) |
| `git checkout -fb feature` | allowed | blocked |
| `git checkout . -b feature` | allowed | blocked (whole-tree pathspec) |
| `git checkout -f my-branch` | allowed | blocked |
| `git checkout HEAD -- src/my-button.ts` | allowed | blocked |

The last row is the one that worries me most in day-to-day use: `my-button.ts` is
an ordinary filename. Any repository with a `-b` in a path — `my-button`,
`side-bar`, `feature-branch`, a `-backup` suffix — silently disarms this guard for
every command that touches it.

`-f` is also reachable only *after* the `-b` exemption, so `-f` combined with
branch creation is allowed, which is the exact combination that discards work.

### 2. `command.strip().startswith("git checkout")` misses `git -C <dir> checkout`

`git -C <dir> <subcommand>` is the normal way to drive another repository without
`cd`, and the subcommand is then not `argv[1]`. The prefix test never matches it,
so `git -C /some/repo checkout -f` is not recognised as a checkout at all.

There is a second, quieter half to this. When the guard does reach its
uncommitted-changes probe, it runs:

```python
subprocess.run(["git", "status", "--porcelain"], cwd=os.getcwd())
```

`os.getcwd()` is the shell's directory, not the repository the command targets. So
once `-C` is recognised, probing the caller's own repo would produce a verdict —
and a list of "files you are about to lose" — belonging to a repository the
command never touches.

## The change

Tokenise the command with `shlex`, resolve git's global options (`-C` and
friends) to find the real subcommand, and classify actual option tokens rather
than substrings. `--` is honoured, so everything after it is treated as a pathspec
even when it looks like an option. Short clusters are split, so `-fb` is seen as
`-f` and `-b`.

`-f` / `--force` is now checked **before** the `-b` allowance, which is what
closes the forced-branch-creation hole.

The probe runs in the resolved directory. Where the target cannot be computed —
an unexpanded `-C "$REPO"`, or `--git-dir` / `--work-tree` — `parse_git_checkout`
reports the target as unknown and the hook declines to probe anything rather than
falling back to the caller's repository. Command-level checks still apply in that
case; only the repository-reading half is skipped. A guard that cannot see its
target should not judge it, and a false denial naming someone else's files is the
worse failure here.

**Blocking policy is unchanged.** Every form the hook blocks today it still
blocks, with the same messages. This PR only makes the detection match the
intent. In particular `git checkout <ref> -- <path>` remains blocked, even though
an explicit pathspec is arguably a bounded operation — that is a policy question,
and it did not belong in a parsing fix.

One deliberate widening: an absolute path to the binary (`/usr/bin/git checkout
-f`) is now recognised, matching how `rm_block_hook.py` already handles
`/bin/rm`.

## Tests

New file `plugins/safety-hooks/hooks/test_git_checkout_safety_hook.py`, following
the style of `test_rm_block_hook.py` — `unittest`, stdlib only, no new
dependencies. The two tests that need a real repository create throwaway ones
under `tempfile` and are skipped if `git` is not on PATH.

**Against `main` as it stands today, 11 of them fail:**

```
$ python3 -m unittest test_behaviour        # the behavioural classes, pre-fix code
FAIL: test_branch_name_containing_dash_b_is_not_an_option
FAIL: test_checkout_dot_with_branch_creation
FAIL: test_clean_target_is_allowed_even_from_a_dirty_cwd
FAIL: test_compound_command_with_dash_c
FAIL: test_dash_c_checkout_dot
FAIL: test_dash_c_force_checkout
FAIL: test_filename_containing_dash_b_is_not_an_option
FAIL: test_force_combined_with_branch_creation
FAIL: test_force_in_a_short_option_cluster
FAIL: test_unresolvable_target_is_not_probed
FAIL: test_warns_about_the_target_repo

Ran 19 tests in 0.098s
FAILED (failures=11)
```

The other 8 pass **before and after** — `git checkout -f`, `git checkout .`,
`git checkout HEAD -- .`, `git checkout HEAD -- src/app.ts`, `git checkout -b
feature`, `--help`, `-h`, and the non-checkout commands. That is deliberate: the
tests that fail are only the ones describing the defect, and the ones that already
passed pin the existing behaviour so this change cannot quietly move it.

**With the fix applied, the full file passes:**

```
$ python3 -m unittest test_git_checkout_safety_hook
Ran 26 tests in 0.217s
OK
```

(19 vs 26 is because the pre-fix run cannot import `parse_git_checkout`, which
does not exist yet, so the 7 parser-level tests were excluded from that run.)

## Notes

Two sibling issues in this plugin are filed separately so each stays reviewable on
its own — the same `git -C <dir>` blindness in `git_commit_block_hook.py`, and an
option-scanning bug in `git_add_block_hook.py`. Neither touches this file, so the
PRs do not conflict.

Happy to adjust anything here — style, the unknown-target policy, or splitting the
`-C` support out into its own PR if you would rather review the substring fix
alone.
