### PR TITLE
fix(safety-hooks): "git -C <dir> commit" skips the approval gate

### DIFF
--- a/plugins/safety-hooks/hooks/git_commit_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_commit_block_hook.py
@@ -5,6 +5,7 @@ Uses the "ask" decision type to prompt user in the UI.
 """
 import json
 import os
+import shlex
 import sys
 
 # Add plugin hooks directory to Python path for local imports
@@ -15,6 +16,49 @@ if PLUGIN_ROOT:
         sys.path.insert(0, hooks_dir)
 
 from command_utils import extract_subcommands
+
+# git's own global options that consume the NEXT token as their value. They sit
+# between "git" and the subcommand, which is why the subcommand is not always
+# argv[1] and a "starts with git commit" test is not enough.
+_GIT_GLOBAL_VALUE_OPTS = {
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path",
+    "--super-prefix", "--config-env",
+}
+
+
+# Subcommands that write a commit object. `commit-tree` is included because
+# the previous `startswith('git commit')` test matched it, and prompting for it
+# is consistent with this hook's purpose.
+COMMIT_SUBCOMMANDS = ('commit', 'commit-tree')
+
+
+def git_subcommand(command):
+    """
+    The git subcommand a command invokes, or None if it is not a git command.
+
+    git's global options sit between "git" and the subcommand, so the
+    subcommand is not always argv[1]: `git -C <dir> commit` invokes `commit`.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    if not tokens or os.path.basename(tokens[0]) != "git":
+        return None
+
+    i = 1
+    while i < len(tokens):
+        token = tokens[i]
+        if token in _GIT_GLOBAL_VALUE_OPTS:
+            i += 2
+            continue
+        if token.startswith("-"):
+            i += 1
+            continue
+        break
+
+    return tokens[i] if i < len(tokens) else None
 
 
 def check_git_commit_command(command, session_id: str = ""):
@@ -31,7 +75,7 @@ def check_git_commit_command(command, session_id: str = ""):
     # Check each subcommand in compound commands
     for subcmd in extract_subcommands(command):
         normalized = ' '.join(subcmd.strip().split())
-        if normalized.startswith('git commit'):
+        if git_subcommand(normalized) in COMMIT_SUBCOMMANDS:
             # Check if commits are allowed via session-scoped flag
             if session_id and os.path.exists(
                 f'/tmp/claude/allow-git-commit.{session_id}'

--- a/plugins/safety-hooks/hooks/test_git_commit_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_git_commit_block_hook.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Unit tests for git_commit_block_hook.py
+
+Tests cover:
+    - `git -C <dir> commit` and other global-option forms reaching the gate
+    - Compound commands
+    - The session-scoped allow flag
+    - Commands that merely mention "git commit" staying allowed
+"""
+import os
+import sys
+import tempfile
+import unittest
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from git_commit_block_hook import check_git_commit_command, git_subcommand
+
+
+class TestGitSubcommand(unittest.TestCase):
+    """Tests for git_subcommand() resolution past git's global options."""
+
+    def test_plain(self):
+        self.assertEqual(git_subcommand("git commit -m 'x'"), "commit")
+
+    def test_dash_c_directory(self):
+        self.assertEqual(git_subcommand("git -C /tmp/repo commit -m 'x'"), "commit")
+
+    def test_dash_c_config(self):
+        self.assertEqual(
+            git_subcommand("git -c user.name=Bot commit -m 'x'"), "commit")
+
+    def test_combined_global_options(self):
+        self.assertEqual(
+            git_subcommand("git -C /tmp/repo -c core.pager=cat commit -m 'x'"),
+            "commit")
+
+    def test_no_verify_is_not_a_global_option(self):
+        self.assertEqual(git_subcommand("git commit --no-verify -m 'x'"), "commit")
+
+    def test_other_subcommands(self):
+        self.assertEqual(git_subcommand("git status"), "status")
+        self.assertEqual(git_subcommand("git -C /tmp/repo status"), "status")
+
+    def test_not_git(self):
+        self.assertIsNone(git_subcommand("echo git commit"))
+        self.assertIsNone(git_subcommand(""))
+
+    def test_absolute_path_to_git_binary(self):
+        self.assertEqual(git_subcommand("/usr/bin/git commit -m 'x'"), "commit")
+
+
+class TestAsksForApproval(unittest.TestCase):
+    """Commands that must reach the approval prompt."""
+
+    def assertAsks(self, command, message=None):
+        decision, reason = check_git_commit_command(command)
+        self.assertEqual(decision, "ask", message or command)
+        self.assertIsNotNone(reason)
+
+    def test_plain_commit(self):
+        self.assertAsks("git commit -m 'x'")
+
+    def test_commit_all(self):
+        self.assertAsks("git commit -am 'x'")
+
+    def test_compound_command(self):
+        self.assertAsks("cd /tmp && git commit -m 'x'")
+
+    def test_commit_tree(self):
+        self.assertAsks("git commit-tree abc123 -m 'x'")
+
+    # --- Regressions: git's global options put the subcommand past argv[1]
+
+    def test_dash_c_directory(self):
+        """`git -C <dir> commit` is a commit and must still be gated."""
+        self.assertAsks(
+            "git -C /tmp/some-repo commit -m 'x'",
+            "git -C <dir> commit bypassed the approval gate")
+
+    def test_dash_c_directory_relative(self):
+        self.assertAsks("git -C ../other-repo commit -m 'x'")
+
+    def test_dash_c_config_override(self):
+        self.assertAsks("git -c user.email=bot@example.com commit -m 'x'")
+
+    def test_git_dir_and_work_tree(self):
+        self.assertAsks(
+            "git --git-dir /tmp/r/.git --work-tree /tmp/r commit -m 'x'")
+
+    def test_dash_c_inside_a_compound_command(self):
+        self.assertAsks("echo hi && git -C /tmp/some-repo commit -m 'x'")
+
+    def test_absolute_git_path_with_dash_c(self):
+        self.assertAsks("/usr/bin/git -C /tmp/some-repo commit -m 'x'")
+
+
+class TestAllowed(unittest.TestCase):
+    """Commands that must not trigger the prompt."""
+
+    def assertAllows(self, command):
+        decision, _ = check_git_commit_command(command)
+        self.assertEqual(decision, "allow", command)
+
+    def test_other_git_commands(self):
+        self.assertAllows("git status")
+        self.assertAllows("git log --oneline")
+        self.assertAllows("git -C /tmp/some-repo status")
+
+    def test_commit_mentioned_but_not_run(self):
+        self.assertAllows("echo 'remember to git commit'")
+        self.assertAllows("grep -r 'git commit' docs/")
+
+    def test_empty(self):
+        self.assertAllows("")
+
+
+class TestSessionAllowFlag(unittest.TestCase):
+    """The session-scoped flag file bypasses the prompt."""
+
+    def test_flag_allows_commit(self):
+        flag_dir = "/tmp/claude"
+        os.makedirs(flag_dir, exist_ok=True)
+        session_id = "test-session-" + str(os.getpid())
+        flag = os.path.join(flag_dir, f"allow-git-commit.{session_id}")
+        with open(flag, "w") as handle:
+            handle.write(session_id)
+        self.addCleanup(lambda: os.path.exists(flag) and os.remove(flag))
+
+        decision, _ = check_git_commit_command(
+            "git commit -m 'x'", session_id=session_id)
+        self.assertEqual(decision, "allow")
+
+        # And the same flag must cover the -C form, or the bypass is
+        # inconsistent with the gate.
+        decision, _ = check_git_commit_command(
+            "git -C /tmp/some-repo commit -m 'x'", session_id=session_id)
+        self.assertEqual(decision, "allow")
+
+    def test_without_flag_still_asks(self):
+        decision, _ = check_git_commit_command(
+            "git commit -m 'x'", session_id="no-such-session-" + str(os.getpid()))
+        self.assertEqual(decision, "ask")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

`git_commit_block_hook.py` decides whether a command is a commit with a prefix
test on the normalised string:

```python
normalized = ' '.join(subcmd.strip().split())
if normalized.startswith('git commit'):
```

git's own global options sit *between* `git` and the subcommand, so the
subcommand is not always the second word. Any command that uses one skips the
approval gate completely. Verified against the current `main` (`45ee0e2`):

| command | current | expected |
|---|---|---|
| `git -C /tmp/some-repo commit -m 'x'` | allowed silently | ask |
| `git -C ../other-repo commit -m 'x'` | allowed silently | ask |
| `git -c user.email=bot@example.com commit -m 'x'` | allowed silently | ask |
| `git --git-dir /tmp/r/.git --work-tree /tmp/r commit -m 'x'` | allowed silently | ask |
| `/usr/bin/git -C /tmp/some-repo commit -m 'x'` | allowed silently | ask |

`git -C <dir> commit` is not an exotic form. It is the standard way to commit in
another repository without changing directory, and it is what an agent naturally
reaches for when it is working in one tree and needs to record something in
another. That is precisely the case where a human would most want the prompt, and
it is the one case that does not get it.

The failure is silent in the direction that matters: the hook returns `allow`, no
error, no output, and the commit goes through as if approved.

## The change

Resolve the subcommand past git's global options before comparing, in a small
`git_subcommand()` helper. `-C`, `-c`, `--git-dir`, `--work-tree`, `--namespace`,
`--exec-path`, `--super-prefix` and `--config-env` consume the next token as
their value, so they are skipped in pairs; other leading options are skipped
singly; the first remaining token is the subcommand.

**Policy is unchanged.** Everything that prompts today still prompts, with the
same message, and nothing new is added beyond the forms above. Two details worth
naming so nothing is lost quietly:

- `git commit-tree` is kept in the prompting set. The old prefix test matched it
  by accident, and it does write a commit object, so keeping it seemed better
  than silently dropping it as a side effect of a parsing fix.
- An absolute path to the binary (`/usr/bin/git commit`) is now recognised,
  matching how `rm_block_hook.py` already handles `/bin/rm`.

The session-scoped allow flag (`/tmp/claude/allow-git-commit.<session_id>`) is
untouched, and a test asserts it covers the newly-recognised forms too, so the
bypass stays consistent with the gate.

## Tests

New file `plugins/safety-hooks/hooks/test_git_commit_block_hook.py`, following the
style of `test_rm_block_hook.py` — `unittest`, stdlib only, no new dependencies,
no repository or network needed.

**Against `main` as it stands today, 6 of them fail:**

```
$ python3 -m unittest test_behaviour        # the behavioural classes, pre-fix code
FAIL: test_absolute_git_path_with_dash_c
FAIL: test_dash_c_config_override
FAIL: test_dash_c_directory
FAIL: test_dash_c_directory_relative
FAIL: test_dash_c_inside_a_compound_command
FAIL: test_git_dir_and_work_tree

Ran 15 tests in 0.001s
FAILED (failures=6)
```

The other 9 pass **before and after** — plain `git commit`, `git commit -am`,
compound commands, `git commit-tree`, the allow flag, and the commands that merely
mention the words. Only the tests describing the defect change colour; the rest
pin the existing behaviour so this fix cannot move it.

**With the fix applied, the full file passes, and so does everything already in
the plugin:**

```
$ python3 -m unittest test_git_commit_block_hook
Ran 23 tests in 0.002s
OK

$ python3 -m unittest test_command_utils test_rm_block_hook test_git_commit_block_hook
Ran 80 tests in 0.571s
OK
```

End to end through the wired entrypoint:

```
$ echo '{"tool_name":"Bash","session_id":"NF","tool_input":{"command":"git -C /tmp/some-repo commit -m hi"}}' | python3 bash_hook.py
{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "ask",
 "permissionDecisionReason": "Git commit requires your approval."}}
```

(15 vs 23 is because the pre-fix run cannot import `git_subcommand`, which does
not exist yet, so the 8 helper-level tests were excluded from that run.)

## Notes

The same blindness to `git -C <dir>` affects `git_checkout_safety_hook.py`; that
is a separate PR because it is tangled with a different bug in the same function
and I did not want to make either harder to review. The two PRs touch different
files and do not conflict.

They do each carry a small resolver of the same shape. If you would prefer one
copy in `command_utils.py`, say the word and I will hoist it — I kept them local
so the two PRs could be reviewed and merged in any order, or independently.
