### PR TITLE
fix(safety-hooks): commit-all check matches hyphenated words in paths, not option flags

### DIFF
--- a/plugins/safety-hooks/hooks/git_add_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_add_block_hook.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -13,6 +14,59 @@ if PLUGIN_ROOT:
         sys.path.insert(0, hooks_dir)
 
 from command_utils import extract_subcommands
+
+# `git commit` options that consume a SEPARATE following token as their value,
+# so that token must not itself be read as an option.
+#
+# -S/--gpg-sign are deliberately absent: their argument is optional and
+# attached-only (-S<keyid>), so consuming the next token would swallow the -m of
+# `git commit -aS -m "msg"`.
+_COMMIT_VALUE_OPTS = {
+    '-m', '--message', '-F', '--file', '-c', '--reedit-message',
+    '-C', '--reuse-message', '--author', '--date', '--cleanup',
+    '-t', '--template', '--trailer', '--fixup', '--squash',
+    '--pathspec-from-file',
+}
+
+# Options that mean a commit message is already supplied, so no blank editor
+# opens. --amend reuses the previous commit's message.
+_COMMIT_MESSAGE_OPTS = {
+    '-m', '--message', '-F', '--file', '-c', '--reedit-message',
+    '-C', '--reuse-message', '--fixup', '--squash', '--amend',
+}
+
+
+def _commit_option_tokens(normalized_cmd):
+    """
+    The real option tokens of a `git commit ...` command.
+
+    Short clusters are split (-am -> -a, -m), `--opt=value` is reduced to
+    `--opt`, values of value-taking options are skipped, and everything after a
+    `--` separator is a pathspec rather than an option.
+    """
+    try:
+        argv = shlex.split(normalized_cmd)
+    except ValueError:
+        argv = normalized_cmd.split()
+
+    options = []
+    i = 2  # skip "git commit"
+    while i < len(argv):
+        token = argv[i]
+        if token == '--':
+            break
+        if token.startswith('--'):
+            name = token.split('=', 1)[0]
+            options.append(name)
+            if name in _COMMIT_VALUE_OPTS and '=' not in token:
+                i += 1
+        elif token.startswith('-') and len(token) > 1:
+            cluster = ['-' + char for char in token[1:]]
+            options.extend(cluster)
+            if any(option in _COMMIT_VALUE_OPTS for option in cluster):
+                i += 1
+        i += 1
+    return options
 
 
 def _is_allowed(flag_name: str, session_id: str = "") -> bool:
@@ -175,11 +229,18 @@ This restriction prevents accidentally staging unwanted files."""
                 reason = f"Staging directory {dir_path}/ (couldn't verify file status)"
                 return "ask", reason
 
-    # Also check for git commit -a without -m (which would open an editor)
-    # Check if command has -a flag but no -m flag
+    # Also check for git commit -a without a message flag (which would open an
+    # editor).
+    #
+    # This used to scan the whole command string for `-[a-zA-Z]*a[a-zA-Z]*` and
+    # `-[a-zA-Z]*m[a-zA-Z]*`, which matched inside any hyphenated word rather
+    # than only real option tokens: a path containing "-a" looked like the
+    # stage-everything flag, and any hyphenated word containing an "m"
+    # cancelled it again. Parse actual option tokens instead.
     if re.search(r'^git\s+commit\s+', normalized_cmd):
-        has_a_flag = re.search(r'-[a-zA-Z]*a[a-zA-Z]*', normalized_cmd)
-        has_m_flag = re.search(r'-[a-zA-Z]*m[a-zA-Z]*', normalized_cmd)
+        options = _commit_option_tokens(normalized_cmd)
+        has_a_flag = '-a' in options or '--all' in options
+        has_m_flag = any(option in _COMMIT_MESSAGE_OPTS for option in options)
         if has_a_flag and not has_m_flag:
             reason = """Avoid 'git commit -a' without a message flag. Use 'gcam "message"' instead, which is an alias for 'git commit -a -m'."""
             return True, reason

--- a/plugins/safety-hooks/hooks/test_git_add_commit_all_flag.py
+++ b/plugins/safety-hooks/hooks/test_git_add_commit_all_flag.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the `git commit -a` check in git_add_block_hook.py
+
+Tests cover:
+    - Option tokens vs. substrings of paths and quoted text
+    - Short option clusters (-am, -aS)
+    - Long options with attached and separate values
+    - Options that do and do not supply a commit message
+    - The `--` pathspec separator
+"""
+import os
+import sys
+import unittest
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from git_add_block_hook import _commit_option_tokens, check_git_add_command
+
+
+def _blocks(command):
+    """True when the hook blocks outright (as opposed to allowing or asking)."""
+    return check_git_add_command(command)[0] is True
+
+
+class TestCommitOptionTokens(unittest.TestCase):
+    """Tests for _commit_option_tokens() parsing."""
+
+    def test_short_cluster_is_split(self):
+        self.assertEqual(_commit_option_tokens("git commit -am 'x'"),
+                         ['-a', '-m'])
+
+    def test_value_of_a_value_option_is_not_an_option(self):
+        self.assertEqual(_commit_option_tokens("git commit -m -a"), ['-m'])
+
+    def test_long_option_with_attached_value(self):
+        self.assertEqual(_commit_option_tokens("git commit --message=hi"),
+                         ['--message'])
+
+    def test_long_option_with_separate_value(self):
+        self.assertEqual(_commit_option_tokens("git commit --file /tmp/m.txt"),
+                         ['--file'])
+
+    def test_pathspec_separator_ends_options(self):
+        self.assertEqual(
+            _commit_option_tokens("git commit -a -- src/-m-file.txt"), ['-a'])
+
+    def test_path_argument_is_not_an_option(self):
+        self.assertEqual(
+            _commit_option_tokens("git commit -F /tmp/claude-agent/msg.txt"),
+            ['-F'])
+
+
+class TestBlockedCommitAll(unittest.TestCase):
+    """`git commit -a` with no message opens an editor and must be blocked."""
+
+    def test_bare_commit_all(self):
+        self.assertTrue(_blocks("git commit -a"))
+
+    def test_commit_all_long_form(self):
+        self.assertTrue(_blocks("git commit --all"))
+
+    def test_commit_all_with_no_verify(self):
+        self.assertTrue(_blocks("git commit -a --no-verify"))
+
+    # --- Regressions: a hyphenated word containing "m" cancelled the check
+
+    def test_template_does_not_supply_a_message(self):
+        """--template seeds the editor; it does not avoid opening one."""
+        self.assertTrue(_blocks("git commit -a --template=/tmp/t.txt"),
+                        "'--template' contains an 'm' but supplies no message")
+
+    def test_allow_empty_message_does_not_supply_a_message(self):
+        self.assertTrue(_blocks("git commit -a --allow-empty-message"),
+                        "'--allow-empty-message' contains an 'm' but supplies none")
+
+    def test_pathspec_containing_dash_m_does_not_cancel_the_check(self):
+        self.assertTrue(_blocks("git commit -a -- src/-m-file.txt"))
+
+
+class TestAllowedCommits(unittest.TestCase):
+    """Commands that supply a message must not be blocked."""
+
+    def test_message_flag(self):
+        self.assertFalse(_blocks("git commit -m 'x'"))
+        self.assertFalse(_blocks("git commit -a -m 'x'"))
+        self.assertFalse(_blocks("git commit -am 'x'"))
+
+    def test_amend_reuses_the_previous_message(self):
+        self.assertFalse(_blocks("git commit -a --amend"))
+
+    def test_sign_option_does_not_swallow_the_message_flag(self):
+        self.assertFalse(_blocks("git commit -aS -m 'x'"),
+                         "-S takes an attached value only")
+
+    # --- Regressions: a path containing "-a" read as the stage-everything flag
+
+    def test_message_file_under_a_path_containing_dash_a(self):
+        """-F supplies the message; '-agent' in the path is not an option."""
+        self.assertFalse(_blocks("git commit -F /tmp/claude-agent/msg.txt"),
+                         "a path segment starting '-a' is not the -a flag")
+
+    def test_long_message_file_under_a_path_containing_dash_a(self):
+        self.assertFalse(_blocks("git commit --file=/tmp/branch-a/msg.txt"))
+
+    def test_message_file_alone_never_stages_everything(self):
+        self.assertFalse(_blocks("git commit -F /tmp/release-alpha/msg.txt"))
+
+    def test_dash_a_inside_a_quoted_message(self):
+        self.assertFalse(_blocks("git commit -m 'refactor -a handling'"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

`git_add_block_hook.py` decides whether a commit will open a blank editor with
two regexes run over the **whole command string**:

```python
if re.search(r'^git\s+commit\s+', normalized_cmd):
    has_a_flag = re.search(r'-[a-zA-Z]*a[a-zA-Z]*', normalized_cmd)
    has_m_flag = re.search(r'-[a-zA-Z]*m[a-zA-Z]*', normalized_cmd)
    if has_a_flag and not has_m_flag:
        # blocked
```

Neither pattern is anchored to an option position, so both match inside ordinary
hyphenated words anywhere in the command — most often a path. The result fails in
both directions. Verified against the current `main` (`45ee0e2`):

**False positives** — a correctly formed commit is denied, because a path segment
beginning `-a` reads as the stage-everything flag while nothing supplies the
letter that would cancel it:

| command | current | expected |
|---|---|---|
| `git commit -F /tmp/claude-agent/msg.txt` | blocked | allowed (`-F` supplies the message) |
| `git commit --file=/tmp/branch-a/msg.txt` | blocked | allowed |
| `git commit -F /tmp/release-alpha/msg.txt` | blocked | allowed |

This one is not hypothetical. Writing a commit message to a file and passing `-F`
is the standard way to get a multi-paragraph message past shell quoting, and
temporary directories routinely contain a hyphenated segment. The denial message
talks about `git commit -a`, which is not what was run, so it reads as the hook
malfunctioning rather than as a rule.

**False negatives** — the check is cancelled by an option that contains an `m`
but supplies no message, so an editor does open:

| command | current | expected |
|---|---|---|
| `git commit -a --template=/tmp/t.txt` | allowed | blocked |
| `git commit -a --allow-empty-message` | allowed | blocked |
| `git commit -a -- src/-m-file.txt` | allowed | blocked |

`--template` seeds the editor's initial content; it does not avoid opening one.

## The change

Parse the real option tokens with a small `_commit_option_tokens()` helper, then
test membership instead of searching text. It handles what the regexes could not:

- short clusters, so `-am` is `-a` plus `-m`;
- `--opt=value` and `--opt value`, with the separate value skipped so it is not
  itself read as an option (`git commit -m -a` has one option, not two);
- the `--` separator, after which everything is a pathspec;
- `-S` / `--gpg-sign` **not** treated as taking a separate value, because its
  argument is attached-only — consuming the next token there would swallow the
  `-m` of `git commit -aS -m "msg"` and re-introduce a false positive.

`--amend` is counted as supplying a message, since it reuses the previous
commit's. The old regex already allowed it (via the `m` in "amend"), so this
preserves behaviour rather than changing it.

Blocking policy is otherwise unchanged: `git commit -a` with no message is still
blocked, with the same message pointing at `gcam`.

## Tests

New file `plugins/safety-hooks/hooks/test_git_add_commit_all_flag.py`, following
the style of `test_rm_block_hook.py` — `unittest`, stdlib only, no new
dependencies, no repository or network needed.

**Against `main` as it stands today, 6 of them fail — three in each direction:**

```
$ python3 -m unittest test_behaviour        # the behavioural classes, pre-fix code
FAIL: test_long_message_file_under_a_path_containing_dash_a
FAIL: test_message_file_alone_never_stages_everything
FAIL: test_message_file_under_a_path_containing_dash_a
FAIL: test_allow_empty_message_does_not_supply_a_message
FAIL: test_pathspec_containing_dash_m_does_not_cancel_the_check
FAIL: test_template_does_not_supply_a_message

Ran 13 tests in 0.001s
FAILED (failures=6)
```

The other 7 pass **before and after** — `git commit -a`, `--all`, `-a
--no-verify`, `-m`, `-am`, `-a --amend`, and `-a -m`. Only the tests describing
the defect change colour; the rest pin the existing behaviour so this fix cannot
move it.

**With the fix applied, the full file passes, and so does everything already in
the plugin:**

```
$ python3 -m unittest test_git_add_commit_all_flag
Ran 19 tests in 0.001s
OK

$ python3 -m unittest test_command_utils test_rm_block_hook test_git_add_commit_all_flag
Ran 76 tests in 0.668s
OK
```

(13 vs 19 is because the pre-fix run cannot import `_commit_option_tokens`, which
does not exist yet, so the 6 parser-level tests were excluded from that run.)

## Notes

Scoped to the commit-all check only. The `git add` half of this file is
untouched.

Two sibling parsing bugs in this plugin are filed as separate PRs so each stays
reviewable on its own. They touch different files, so nothing here conflicts with
them.
