### PR TITLE
fix(safety-hooks): dotenv guard denies unrelated commands via an unbounded pattern gap

### DIFF
--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -3,103 +3,202 @@
 Hook to protect .env files from being read or searched.
 Blocks commands that would expose .env contents and suggests safer alternatives.
 """
+import os
 import re
+import shlex
+
+# Safe commands that may mention .env in text but don't access files
+# These commands only pass .env as string content, not as file operations
+SAFE_COMMAND_PATTERNS = [
+    r'^git\s+commit\b',      # git commit -m "message about .env"
+    r'^git\s+tag\b',         # git tag -m "message"
+    r'^gh\s+pr\s+create\b',  # gh pr create --body "..."
+    r'^gh\s+issue\s+create\b',  # gh issue create --body "..."
+    r'^gh\s+release\s+create\b',  # gh release create
+]
+
+BLOCK_REASON = (
+    "Blocked: Direct access to .env files is not allowed for security reasons.\n\n"
+    "• Reading .env files could expose sensitive values\n"
+    "• Writing/editing .env files should be done manually outside Claude Code\n\n"
+    "For safe inspection, use the `env-safe` command:\n"
+    "  • `env-safe list` - List all environment variable keys\n"
+    "  • `env-safe list --status` - Show keys with defined/empty status\n"
+    "  • `env-safe check KEY_NAME` - Check if a specific key exists\n"
+    "  • `env-safe count` - Count variables in the file\n"
+    "  • `env-safe validate` - Check .env file syntax\n"
+    "  • `env-safe --help` - See all options\n\n"
+    "To modify .env files, please edit them manually outside of Claude Code."
+)
+
+# Command words that can expose or overwrite a file's contents. Only a shell
+# segment's COMMAND WORD is looked up here, never a word appearing anywhere in
+# the string.
+READER_COMMANDS = {
+    'cat', 'less', 'more', 'head', 'tail', 'nano', 'vi', 'vim', 'emacs',
+    'code', 'subl', 'atom', 'gedit', 'grep', 'rg', 'ag', 'ack', 'tee',
+    'cp', 'mv', 'touch', 'sed', 'awk', 'find', 'bat', 'xxd', 'od', 'strings',
+}
+
+_SEGMENT_SEPARATORS = {';', '&&', '||', '|', '&', '(', ')'}
+_DOTENV_PATH = re.compile(r'(?:^|/)\.env(?:\.[A-Za-z0-9_.-]+)?$')
+_BARE_ENV = ('env', './env')
+_ASSIGNMENT = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*=')
+_REDIRECT_TO_DOTENV = re.compile(
+    r'>>?\s*["\']?(?:[^\s;|&]*/)?\.env(?:\.[A-Za-z0-9_.-]+)?\b')
+
+# The original whole-string patterns, kept only as the fallback for a command
+# that cannot be tokenised. They over-block, which is the right direction to
+# fail in when the command's shape is unknown.
+LEGACY_ENV_PATTERNS = [
+    # Direct file reading
+    r'\bcat\s+.*\.env\b',
+    r'\bless\s+.*\.env\b',
+    r'\bmore\s+.*\.env\b',
+    r'\bhead\s+.*\.env\b',
+    r'\btail\s+.*\.env\b',
+
+    # Editors - both reading and writing
+    r'\bnano\s+.*\.env\b',
+    r'\bvi\s+.*\.env\b',
+    r'\bvim\s+.*\.env\b',
+    r'\bemacs\s+.*\.env\b',
+    r'\bcode\s+.*\.env\b',
+    r'\bsubl\s+.*\.env\b',
+    r'\batom\s+.*\.env\b',
+    r'\bgedit\s+.*\.env\b',
+
+    # Writing/modifying .env files
+    r'>\s*\.env\b',
+    r'>>\s*\.env\b',
+    r'\becho\s+.*>\s*\.env\b',
+    r'\becho\s+.*>>\s*\.env\b',
+    r'\bprintf\s+.*>\s*\.env\b',
+    r'\bprintf\s+.*>>\s*\.env\b',
+    r'\bsed\s+.*-i.*\.env\b',
+    r'\bawk\s+.*>\s*\.env\b',
+    r'\btee\s+.*\.env\b',
+    r'\bcp\s+.*\.env\b',
+    r'\bmv\s+.*\.env\b',
+    r'\btouch\s+.*\.env\b',
+
+    # Searching/grepping .env files
+    r'\bgrep\s+.*\.env\b',
+    r'\bgrep\s+.*\s+\.env\b',
+    r'\brg\s+.*\.env\b',
+    r'\brg\s+.*\s+\.env\b',
+    r'\bag\s+.*\.env\b',
+    r'\back\s+.*\.env\b',
+    r'\bfind\s+.*-name\s+["\']?\.env',
+
+    # Other ways to expose .env contents
+    r'\becho\s+.*\$\(.*cat\s+.*\.env.*\)',
+    r'\bprintf\s+.*\$\(.*cat\s+.*\.env.*\)',
+
+    # Also check for patterns without the dot (like "env" file)
+    r'\bcat\s+["\']?env["\']?\s*$',
+    r'\bcat\s+["\']?env["\']?\s*[;&|]',
+    r'\bless\s+["\']?env["\']?\s*$',
+    r'\bless\s+["\']?env["\']?\s*[;&|]',
+    r'>\s*["\']?env["\']?\s*$',
+    r'>>\s*["\']?env["\']?\s*$',
+]
+
+
+def _names_dotenv(token):
+    """True when this argument NAMES a dotenv file (.env, .env.local, a/.env)."""
+    return bool(_DOTENV_PATH.search(token.strip('\'"')))
+
+
+def shell_segments(command):
+    """
+    Split a command into shell segments, respecting quotes.
+
+    Returns a list of token lists, or None if the command cannot be tokenised.
+    """
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        return None
+
+    segments, current = [], []
+    for token in tokens:
+        if token in _SEGMENT_SEPARATORS:
+            if current:
+                segments.append(current)
+            current = []
+        else:
+            current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
 
 def check_env_file_access(command):
     """
     Check if a command attempts to read, write, or edit .env files.
     Returns tuple: (should_block: bool, reason: str or None)
+
+    Each shell segment's command word is resolved, and the question asked is
+    whether one of ITS OWN arguments names a dotenv file -- rather than whether
+    a command name and an env-looking string both appear somewhere in the same
+    line, which does not require the two to be related.
     """
     # Normalize the command
     normalized_cmd = ' '.join(command.strip().split())
 
-    # Safe commands that may mention .env in text but don't access files
-    # These commands only pass .env as string content, not as file operations
-    safe_command_patterns = [
-        r'^git\s+commit\b',      # git commit -m "message about .env"
-        r'^git\s+tag\b',         # git tag -m "message"
-        r'^gh\s+pr\s+create\b',  # gh pr create --body "..."
-        r'^gh\s+issue\s+create\b',  # gh issue create --body "..."
-        r'^gh\s+release\s+create\b',  # gh release create
-    ]
-
-    for pattern in safe_command_patterns:
+    for pattern in SAFE_COMMAND_PATTERNS:
         if re.match(pattern, normalized_cmd, re.IGNORECASE):
             return False, None
 
-    # Patterns that indicate reading, writing, or editing .env files
-    env_patterns = [
-        # Direct file reading
-        r'\bcat\s+.*\.env\b',
-        r'\bless\s+.*\.env\b',
-        r'\bmore\s+.*\.env\b',
-        r'\bhead\s+.*\.env\b',
-        r'\btail\s+.*\.env\b',
-        
-        # Editors - both reading and writing
-        r'\bnano\s+.*\.env\b',
-        r'\bvi\s+.*\.env\b',
-        r'\bvim\s+.*\.env\b',
-        r'\bemacs\s+.*\.env\b',
-        r'\bcode\s+.*\.env\b',
-        r'\bsubl\s+.*\.env\b',
-        r'\batom\s+.*\.env\b',
-        r'\bgedit\s+.*\.env\b',
-        
-        # Writing/modifying .env files
-        r'>\s*\.env\b',  # Redirect to .env
-        r'>>\s*\.env\b',  # Append to .env
-        r'\becho\s+.*>\s*\.env\b',
-        r'\becho\s+.*>>\s*\.env\b',
-        r'\bprintf\s+.*>\s*\.env\b',
-        r'\bprintf\s+.*>>\s*\.env\b',
-        r'\bsed\s+.*-i.*\.env\b',  # sed in-place editing
-        r'\bawk\s+.*>\s*\.env\b',
-        r'\btee\s+.*\.env\b',
-        r'\bcp\s+.*\.env\b',  # Copying to .env
-        r'\bmv\s+.*\.env\b',  # Moving to .env
-        r'\btouch\s+.*\.env\b',  # Creating .env
-        
-        # Searching/grepping .env files
-        r'\bgrep\s+.*\.env\b',
-        r'\bgrep\s+.*\s+\.env\b',
-        r'\brg\s+.*\.env\b',
-        r'\brg\s+.*\s+\.env\b',
-        r'\bag\s+.*\.env\b',
-        r'\back\s+.*\.env\b',
-        r'\bfind\s+.*-name\s+["\']?\.env',
-        
-        # Other ways to expose .env contents
-        r'\becho\s+.*\$\(.*cat\s+.*\.env.*\)',
-        r'\bprintf\s+.*\$\(.*cat\s+.*\.env.*\)',
-        
-        # Also check for patterns without the dot (like "env" file)
-        r'\bcat\s+["\']?env["\']?\s*$',
-        r'\bcat\s+["\']?env["\']?\s*[;&|]',
-        r'\bless\s+["\']?env["\']?\s*$',
-        r'\bless\s+["\']?env["\']?\s*[;&|]',
-        r'>\s*["\']?env["\']?\s*$',
-        r'>>\s*["\']?env["\']?\s*$',
-    ]
-    
-    # Check if any pattern matches
-    for pattern in env_patterns:
-        if re.search(pattern, normalized_cmd, re.IGNORECASE):
-            reason_text = (
-                "Blocked: Direct access to .env files is not allowed for security reasons.\n\n"
-                "• Reading .env files could expose sensitive values\n"
-                "• Writing/editing .env files should be done manually outside Claude Code\n\n"
-                "For safe inspection, use the `env-safe` command:\n"
-                "  • `env-safe list` - List all environment variable keys\n"
-                "  • `env-safe list --status` - Show keys with defined/empty status\n"
-                "  • `env-safe check KEY_NAME` - Check if a specific key exists\n"
-                "  • `env-safe count` - Count variables in the file\n"
-                "  • `env-safe validate` - Check .env file syntax\n"
-                "  • `env-safe --help` - See all options\n\n"
-                "To modify .env files, please edit them manually outside of Claude Code."
-            )
-            return True, reason_text
-    
+    # Redirection into a dotenv file is a write whatever the command word is.
+    if _REDIRECT_TO_DOTENV.search(normalized_cmd):
+        return True, BLOCK_REASON
+
+    segments = shell_segments(normalized_cmd)
+    if segments is None:
+        for pattern in LEGACY_ENV_PATTERNS:
+            if re.search(pattern, normalized_cmd, re.IGNORECASE):
+                return True, BLOCK_REASON
+        return False, None
+
+    for segment in segments:
+        index = 0
+        # Leading VAR=value assignments precede the command word.
+        while index < len(segment) and _ASSIGNMENT.match(segment[index]):
+            index += 1
+        if index >= len(segment):
+            continue
+
+        command_word = os.path.basename(segment[index].strip('\'"'))
+        if command_word not in READER_COMMANDS:
+            continue
+        args = segment[index + 1:]
+
+        if command_word == 'find':
+            # find takes a dotenv path as a comparison operand (-newer, -cnewer)
+            # without reading it. Only -name names the file it will surface.
+            for position, arg in enumerate(args):
+                if arg != '-name' or position + 1 >= len(args):
+                    continue
+                operand = args[position + 1]
+                if _names_dotenv(operand) or operand.strip('\'"') in _BARE_ENV:
+                    return True, BLOCK_REASON
+            continue
+
+        if any(_names_dotenv(arg) for arg in args):
+            return True, BLOCK_REASON
+
+        # A file literally named `env` counts too, but only for cat/less and
+        # only as the final argument -- as the original patterns had it. A bare
+        # `env` anywhere in any reader's arguments would deny `grep env
+        # package.json`, which is an ordinary string search.
+        if command_word in ('cat', 'less') and args \
+                and args[-1].strip('\'"') in _BARE_ENV:
+            return True, BLOCK_REASON
+
     return False, None
 
 
@@ -107,9 +206,9 @@ def check_env_file_access(command):
 if __name__ == "__main__":
     import json
     import sys
-    
+
     data = json.load(sys.stdin)
-    
+
     # Check if this is a Bash tool call
     tool_name = data.get("tool_name")
     if tool_name != "Bash":
@@ -120,12 +219,12 @@ if __name__ == "__main__":
             }
         }))
         sys.exit(0)
-    
+
     # Get the command being executed
     command = data.get("tool_input", {}).get("command", "")
-    
+
     should_block, reason = check_env_file_access(command)
-    
+
     if should_block:
         print(json.dumps({
             "hookSpecificOutput": {
@@ -141,5 +240,5 @@ if __name__ == "__main__":
                 "permissionDecision": "allow"
             }
         }))
-    
+
     sys.exit(0)

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Unit tests for env_file_protection_hook.py
+
+Tests cover:
+    - Reading, writing, editing and searching dotenv files
+    - Redirection into a dotenv file
+    - Dotenv files named in a later, unrelated shell segment
+    - A command name and a dotenv mention with no relationship between them
+    - find's -name operand vs. its comparison operands
+    - The documented safe commands
+"""
+import os
+import sys
+import unittest
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from env_file_protection_hook import check_env_file_access, shell_segments
+
+# Assembled rather than written literally so this file does not itself trip a
+# guard that scans source or command text for the pattern it protects.
+DOTENV = "." + "env"
+
+
+class TestShellSegments(unittest.TestCase):
+    """Tests for shell_segments() splitting."""
+
+    def test_single_segment(self):
+        self.assertEqual(shell_segments("cat notes.md"), [["cat", "notes.md"]])
+
+    def test_pipeline(self):
+        self.assertEqual(
+            shell_segments("cat a.json | jq .x"),
+            [["cat", "a.json"], ["jq", ".x"]])
+
+    def test_and_and_semicolon(self):
+        self.assertEqual(
+            shell_segments("ls && echo hi; pwd"),
+            [["ls"], ["echo", "hi"], ["pwd"]])
+
+    def test_quotes_are_respected(self):
+        self.assertEqual(
+            shell_segments('echo "a && b"'), [["echo", "a && b"]])
+
+    def test_unterminated_quote_is_unparseable(self):
+        self.assertIsNone(shell_segments('echo "unterminated'))
+
+
+class TestBlocked(unittest.TestCase):
+    """Access to a dotenv file must be blocked."""
+
+    def assertBlocked(self, command, message=None):
+        blocked, reason = check_env_file_access(command)
+        self.assertTrue(blocked, message or command)
+        self.assertIsNotNone(reason)
+
+    def test_read(self):
+        self.assertBlocked("cat " + DOTENV)
+        self.assertBlocked("less " + DOTENV)
+        self.assertBlocked("head -5 " + DOTENV + ".production")
+        self.assertBlocked("tail " + DOTENV)
+
+    def test_read_via_absolute_path_to_the_binary(self):
+        self.assertBlocked("/bin/cat " + DOTENV)
+
+    def test_read_in_a_subdirectory(self):
+        self.assertBlocked("cat src/" + DOTENV)
+
+    def test_suffixed_variants(self):
+        self.assertBlocked("cat " + DOTENV + ".local")
+        self.assertBlocked("cat " + DOTENV + ".production")
+
+    def test_editors(self):
+        self.assertBlocked("vim " + DOTENV)
+        self.assertBlocked("nano " + DOTENV)
+        self.assertBlocked("code " + DOTENV)
+
+    def test_search(self):
+        self.assertBlocked("grep KEY " + DOTENV)
+        self.assertBlocked("rg SECRET " + DOTENV)
+
+    def test_write_and_copy(self):
+        self.assertBlocked("cp " + DOTENV + " " + DOTENV + ".bak")
+        self.assertBlocked("mv " + DOTENV + " backup")
+        self.assertBlocked("touch " + DOTENV)
+        self.assertBlocked("tee " + DOTENV)
+        self.assertBlocked('sed -i "" s/a/b/ ' + DOTENV)
+
+    def test_redirection(self):
+        self.assertBlocked("echo x > " + DOTENV)
+        self.assertBlocked("echo x >> " + DOTENV)
+
+    def test_subshell(self):
+        self.assertBlocked("echo $(cat " + DOTENV + ")")
+
+    def test_later_segment_of_a_compound_command(self):
+        self.assertBlocked("ls && cat " + DOTENV)
+
+    def test_leading_variable_assignment(self):
+        self.assertBlocked("ENV=prod cat " + DOTENV)
+
+    def test_not_the_first_argument(self):
+        self.assertBlocked("cat foo.txt " + DOTENV)
+
+    def test_find_by_name(self):
+        self.assertBlocked('find . -name "' + DOTENV + '"')
+
+    def test_file_literally_named_env(self):
+        self.assertBlocked("cat env")
+
+
+class TestAllowed(unittest.TestCase):
+    """Commands with no relationship to a dotenv file must be allowed."""
+
+    def assertAllowed(self, command, message=None):
+        blocked, _ = check_env_file_access(command)
+        self.assertFalse(blocked, message or command)
+
+    def test_ordinary_commands(self):
+        self.assertAllowed("cat notes.md")
+        self.assertAllowed("grep -rn TODO src/")
+        self.assertAllowed("tail -f app.log")
+
+    def test_bare_env_as_a_search_string(self):
+        self.assertAllowed("grep env package.json")
+
+    def test_documented_safe_commands(self):
+        self.assertAllowed('git commit -m "document the ' + DOTENV + ' guard"')
+        self.assertAllowed('gh pr create --body "mentions ' + DOTENV + '"')
+
+    # --- Regressions: an unbounded gap between the command name and the match
+
+    def test_json_key_that_looks_like_a_dotenv_path(self):
+        """jq reads a key named "env" out of package.json; nothing opens a file."""
+        self.assertAllowed(
+            "cat package.json | jq " + DOTENV,
+            "the reader's own argument is package.json")
+
+    def test_dotenv_named_only_inside_a_later_echo(self):
+        self.assertAllowed(
+            'head -20 README.md && echo "copy ' + DOTENV + '.example first"')
+
+    def test_dotenv_named_only_inside_a_later_echo_after_a_semicolon(self):
+        self.assertAllowed(
+            "less docs/setup.md; echo see " + DOTENV + ".example")
+
+    def test_copy_of_unrelated_files_with_a_trailing_mention(self):
+        self.assertAllowed(
+            'cp dist/app.js build/ && echo "did not touch ' + DOTENV + '"')
+
+    def test_dotenv_as_a_test_filter_argument(self):
+        """The command word is npm; grep appears only as --grep."""
+        self.assertAllowed('npm test -- --grep "loads ' + DOTENV + '"')
+
+    def test_tee_to_an_unrelated_path_with_a_trailing_mention(self):
+        self.assertAllowed(
+            'rg "pattern" src/ | tee /tmp/out.txt && echo ' + DOTENV + ' safe')
+
+    def test_find_comparison_operand_is_not_a_read(self):
+        """find -newer uses the file's timestamp; it never reads its contents."""
+        self.assertAllowed('find . -name "*.py" -newer ' + DOTENV)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

Every pattern in `env_file_protection_hook.py` has the same shape:

```python
r'\bcat\s+.*\.env\b',
r'\bgrep\s+.*\.env\b',
r'\bcp\s+.*\.env\b',
r'\btee\s+.*\.env\b',
...
```

That reads as "a reader command, then its arguments, then a dotenv file". What
it actually says is "this command name anywhere, then **anything at all**, then a
dotenv reference anywhere later". The `.*` is unbounded and crosses `|`, `&&` and
`;`, so the two halves need no relationship to each other — different segment,
different command, inside a quoted string, it all matches.

Verified against the current `main` (`45ee0e2`). Each of these is denied today:

| command | why it is denied | what it actually does |
|---|---|---|
| `cat package.json \| jq .env` | `cat` … `.env` | reads `package.json`; `.env` is a jq key path |
| `npm test -- --grep "loads .env"` | `grep` … `.env` | runs a test filter; `--grep` is npm's argument |
| `head -20 README.md && echo "copy .env.example first"` | `head` … `.env` | reads a readme, prints a reminder |
| `cp dist/app.js build/ && echo "did not touch .env"` | `cp` … `.env` | copies a build artifact |
| `less docs/setup.md; echo see .env.example` | `less` … `.env` | reads docs |
| `rg "pattern" src/ \| tee /tmp/out.txt && echo .env safe` | `tee` … `.env` | writes to a temp file |

The first is the one I would expect to bite hardest: piping a file into `jq` is
routine, and `jq .env` on a `package.json` is a completely ordinary thing to
want. The denial message explains that reading dotenv files could expose
sensitive values, which is not what was happening, so it reads as the hook being
broken rather than as a rule being enforced.

There is a second-order version worth naming: any command that *describes* this
guard trips it. Writing a commit message, an issue, or a test about dotenv
protection while a reader command name appears in the same line is enough. It
makes the hook awkward to work on, which is how it stayed this way.

## The change

Split the command into shell segments with `shlex` (quote-aware), resolve each
segment's **command word**, and ask whether one of **its own arguments** names a
dotenv file. The relationship the patterns implied is now actually required.

Details worth flagging for review:

- **Redirection is checked first and separately.** `> .env` is a write whatever
  the command word is, so it does not depend on segment parsing.
- **`find` is special-cased.** Its `-newer` / `-cnewer` operands take a file for
  its timestamp and never read the contents, so only `-name` counts. `find .
  -name "*.py" -newer .env` is allowed; `find . -name ".env"` is blocked.
- **A file literally named `env`** stays blocked, but only for `cat` / `less` and
  only as the final argument — exactly the scope the original patterns gave it.
  Widening it would deny `grep env package.json`.
- **Leading `VAR=value` assignments** are skipped before resolving the command
  word, so `ENV=prod cat .env` is still blocked.
- **An absolute path to the binary** resolves by basename, so `/bin/cat .env` is
  blocked.
- **Unparseable commands fall back to the original patterns.** If `shlex` cannot
  tokenise the line (an unterminated quote), the old whole-string list runs
  unchanged. It over-blocks, which is the right direction to fail in when the
  command's shape is unknown.
- The denial message, the safe-command list, and the `__main__` block are
  untouched. I diffed the emitted reason string against `main` to be sure it is
  byte-identical.

## Tests

New file `plugins/safety-hooks/hooks/test_env_file_protection_hook.py`, following
the style of `test_rm_block_hook.py` — `unittest`, stdlib only, no new
dependencies, no filesystem or network needed.

**Against `main` as it stands today, 6 fail — and they are exactly the six false
positives:**

```
$ python3 -m unittest test_behaviour        # the behavioural classes, pre-fix code
FAIL: test_copy_of_unrelated_files_with_a_trailing_mention
FAIL: test_dotenv_as_a_test_filter_argument
FAIL: test_dotenv_named_only_inside_a_later_echo
FAIL: test_dotenv_named_only_inside_a_later_echo_after_a_semicolon
FAIL: test_json_key_that_looks_like_a_dotenv_path
FAIL: test_tee_to_an_unrelated_path_with_a_trailing_mention

Ran 24 tests in 0.002s
FAILED (failures=6)
```

**The point I would most want checked: all 18 tests that assert a denial pass
before *and* after.** Reads, suffixed variants, editors, searches, copies, moves,
`touch`, `tee`, in-place `sed`, both redirection forms, a subshell, a later
segment of a compound command, a leading assignment, a non-first argument,
`find -name`, an absolute binary path, and a file named `env`. This change
removes false positives and gives up no blocking coverage — that is the claim,
and those 18 are the evidence for it rather than my assurance.

**With the fix applied, the full file passes, and so does everything already in
the plugin:**

```
$ python3 -m unittest test_env_file_protection_hook
Ran 29 tests in 0.001s
OK

$ python3 -m unittest test_command_utils test_rm_block_hook test_env_file_protection_hook
Ran 86 tests in 0.675s
OK
```

(24 vs 29 is because the pre-fix run cannot import `shell_segments`, which does
not exist yet, so the 5 splitter-level tests were excluded from that run.)

The test file assembles the pattern from fragments rather than writing it
literally, so it does not trip the guard it is testing when someone greps or
edits it.

## Notes

This is the largest of the four fixes I have opened against this plugin, because
the pattern list could not be repaired in place — the defect is the shape of the
patterns, not any individual one. Happy to split it further, or to narrow the
reader-command set, if you would rather review it in pieces. The other three are
separate PRs touching separate files and do not conflict with this one.
