### PR TITLE
docs: update MiniMax model mappings

### DIFF
--- a/docs-site/src/content/docs/integrations/alt-llm-providers.mdx
+++ b/docs-site/src/content/docs/integrations/alt-llm-providers.mdx
@@ -3,7 +3,7 @@ title: "Alternative LLM Providers"
 description: >
   Use Claude Code with open-weight LLMs via
   Anthropic-compatible API providers like Kimi K2,
-  GLM-4.5, DeepSeek, and MiniMax M2.1.
+  GLM-4.5, DeepSeek, and MiniMax M3 / M2.7.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -122,9 +122,9 @@ dseek -p "explain X"   # one-shot prompt
 ```
 
 </TabItem>
-<TabItem label="MiniMax M2.1">
+<TabItem label="MiniMax M3 / M2.7">
 
-[MiniMax M2.1](https://platform.minimax.io/docs/guides/text-ai-coding-tools)
+[MiniMax M3 and M2.7](https://platform.minimax.io/docs/guides/text-ai-coding-tools)
 from MiniMax.
 
 ```bash
@@ -134,21 +134,22 @@ ccmm() {
         export ANTHROPIC_AUTH_TOKEN=$MINIMAX_API_KEY
         export API_TIMEOUT_MS=3000000
         export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
-        export ANTHROPIC_MODEL=MiniMax-M2.1
-        export ANTHROPIC_SMALL_FAST_MODEL=MiniMax-M2.1
-        export ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M2.1
-        export ANTHROPIC_DEFAULT_OPUS_MODEL=MiniMax-M2.1
-        export ANTHROPIC_DEFAULT_HAIKU_MODEL=MiniMax-M2.1
+        export ANTHROPIC_MODEL=MiniMax-M3
+        export ANTHROPIC_SMALL_FAST_MODEL=MiniMax-M2.7
+        export ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M3
+        export ANTHROPIC_DEFAULT_OPUS_MODEL=MiniMax-M3
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL=MiniMax-M2.7
         claude "$@"
     )
 }
 ```
 
-MiniMax requires mapping all model slots to
-`MiniMax-M2.1` and setting a longer timeout
+The function maps the main, Sonnet, and Opus slots to
+`MiniMax-M3`, and the small-fast and Haiku slots to
+`MiniMax-M2.7`. It also sets a longer timeout
 (`API_TIMEOUT_MS`) since responses can take longer.
-Non-essential traffic is disabled to avoid
-unnecessary requests.
+Non-essential traffic is disabled to avoid unnecessary
+requests.
 
 **Usage:**
 


### PR DESCRIPTION
Reason: Refresh the ccmm shell function with the current MiniMax text models.

Updated the documented model-slot mappings so the primary, Sonnet, and Opus slots use `MiniMax-M3`, while the small-fast and Haiku slots use `MiniMax-M2.7`.

Checks:
- `git diff --check`
- `npm run build`
- secret scan
