### PR TITLE
Fix Codex resume for ported Claude sessions

### DIFF
--- a/claude_code_tools/port_claude_to_codex.py
+++ b/claude_code_tools/port_claude_to_codex.py
@@ -76,6 +76,11 @@ from claude_code_tools.session_utils import (
 # rollout's provenance is visible in the file itself.
 PORT_ORIGINATOR = "aichat_port"
 
+# Codex persists the selected model provider in every native rollout.  The
+# built-in OpenAI provider is also Codex's documented default, and unlike a
+# custom provider it is available without depending on the user's config.
+CODEX_MODEL_PROVIDER = "openai"
+
 # Claude assistant content block types that are dropped entirely.
 _THINKING_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking"})
 
@@ -701,6 +706,7 @@ def port_claude_session_to_codex(
         "cwd": cwd,
         "originator": PORT_ORIGINATOR,
         "cli_version": "aichat-port",
+        "model_provider": CODEX_MODEL_PROVIDER,
     }
     if meta["branch"]:
         payload["git"] = {"branch": meta["branch"]}

--- a/tests/test_port_claude_to_codex.py
+++ b/tests/test_port_claude_to_codex.py
@@ -418,6 +418,7 @@ class TestConverter:
             "cwd",
             "originator",
             "cli_version",
+            "model_provider",
         }
         assert payload["id"] == new_id
         # a ported session is a fresh (non-forked) root thread
@@ -426,6 +427,7 @@ class TestConverter:
         assert payload["cwd"] == json.loads(
             session.read_text().splitlines()[-1]
         ).get("cwd")
+        assert payload["model_provider"] == "openai"
         assert payload["git"] == {"branch": "feat/x"}
         cm = first["continue_metadata"]
         assert cm["ported_from"] == "claude"


### PR DESCRIPTION
## Summary

- persist Codex's built-in `openai` model provider in Claude-to-Codex rollout metadata
- add regression coverage for the required provider field

## Root cause

`aichat port` generated a minimal Codex `session_meta` payload without a `model_provider`. Codex 0.145.0 restored the missing value as an empty provider name and rejected the session with `Model provider `` not found` during resume.

## User impact

Freshly ported Claude sessions now resume normally with `codex resume <session-id>` instead of failing during TUI bootstrap.

## Validation

- `uv run pytest -q tests/test_port*.py` — 245 passed
- ported the reported real Claude session and resumed it successfully in the Codex 0.145.0 TUI
- final cold-diff review reported no blocking findings

The broader `uv run pytest -q tests` run reached 842 passed and 3 skipped before an unrelated search test timed out while rebuilding an index of 12,512 local sessions; the run was then interrupted during a later long-running test.