### PR TITLE
Add interactive port choices, progress, and clipboard handoff

### DIFF
--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -1483,7 +1483,9 @@ def port_session(
     """
     import sys
 
+    from claude_code_tools.port_render import PortDisplay
     from claude_code_tools.port_service import (
+        PortAmbiguityError,
         PortSessionError,
         port_claude_session,
         port_codex_session,
@@ -1497,56 +1499,54 @@ def port_session(
     claude_home = claude_home or root_obj.get("claude_home")
     codex_home = codex_home or root_obj.get("codex_home")
 
+    display = PortDisplay(session)
+    display.start()
     try:
-        resolved = resolve_port_session(
-            session, claude_home=claude_home, codex_home=codex_home
-        )
+        with display.resolving():
+            resolved = resolve_port_session(
+                session,
+                claude_home=claude_home,
+                codex_home=codex_home,
+            )
+    except PortAmbiguityError as error:
+        try:
+            resolved = display.choose_candidate(error)
+        except (EOFError, KeyboardInterrupt):
+            display.error(str(error))
+            sys.exit(1)
+        if resolved is None:
+            display.cancelled()
+            sys.exit(1)
     except PortSessionError as e:
-        print(f"Error: {e}", file=sys.stderr)
+        display.error(str(e))
         sys.exit(1)
 
+    display.resolved(resolved)
     if resolved.agent == "claude":
-        print("Detected source agent: claude — porting to Codex")
         try:
-            result = port_claude_session(
-                resolved.session_file, codex_home=codex_home
-            )
+            with display.porting(resolved.agent):
+                result = port_claude_session(
+                    resolved.session_file,
+                    codex_home=codex_home,
+                )
         except PortSessionError as e:
-            print(f"Error: {e}", file=sys.stderr)
+            display.error(str(e))
             sys.exit(1)
-
-        print()
-        print(f"New Codex session id:  {result.new_session_id}")
-        print(f"Output file:           {result.output_file}")
-        print(f"Session cwd:           {result.cwd}")
-        print()
-        print("To resume:")
-        print(f"  {result.resume_hint}")
-        print()
-        print(
-            "Tip: codex's /import can also import Claude sessions "
-            "natively (interactive alternative)."
-        )
+        display.complete(result, resolved.agent)
         return
 
-    print("Detected source agent: codex — porting to Claude Code")
     try:
-        result = port_codex_session(
-            resolved.session_file, claude_home=claude_home
-        )
+        with display.porting(resolved.agent):
+            result = port_codex_session(
+                resolved.session_file,
+                claude_home=claude_home,
+            )
     except PortSessionError as e:
         # Expected failure modes (missing/empty session, filesystem
         # or encoding errors) become a clean error, not a traceback.
-        print(f"Error: {e}", file=sys.stderr)
+        display.error(str(e))
         sys.exit(1)
-
-    print()
-    print(f"New Claude session id: {result.new_session_id}")
-    print(f"Output file:           {result.output_file}")
-    print(f"Session cwd:           {result.cwd}")
-    print()
-    print("To resume:")
-    print(f"  {result.resume_hint}")
+    display.complete(result, resolved.agent)
 
 
 @main.command("query")

--- a/claude_code_tools/port_render.py
+++ b/claude_code_tools/port_render.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rich import box
 from rich.console import Console
 from rich.panel import Panel
-from rich.prompt import Prompt
+from rich.prompt import Confirm, Prompt
 from rich.status import Status
 from rich.table import Table
 from rich.text import Text
@@ -24,6 +28,82 @@ if TYPE_CHECKING:
 
 _AGENT_LABELS = {"claude": "Claude", "codex": "Codex"}
 _MAX_CANDIDATE_TITLE_CHARS = 120
+_MACOS_CLIPBOARD_COMMANDS = (("pbcopy",),)
+_LINUX_CLIPBOARD_COMMANDS = (
+    ("wl-copy",),
+    ("xclip", "-selection", "clipboard"),
+    ("xsel", "--clipboard", "--input"),
+)
+_POWERSHELL_CLIPBOARD_ARGS = (
+    "-NoProfile",
+    "-NonInteractive",
+    "-Command",
+    "Set-Clipboard -Value ([Console]::In.ReadToEnd())",
+)
+
+
+def _clipboard_commands(
+    platform_name: str,
+) -> tuple[tuple[str, ...], ...]:
+    """Return platform-specific clipboard commands in preference order."""
+    if platform_name == "darwin":
+        return _MACOS_CLIPBOARD_COMMANDS
+    if platform_name == "win32":
+        system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
+        system32 = system_root / "System32"
+        powershell = (
+            system32
+            / "WindowsPowerShell"
+            / "v1.0"
+            / "powershell.exe"
+        )
+        return (
+            (str(system32 / "clip.exe"),),
+            (
+                str(powershell),
+                *_POWERSHELL_CLIPBOARD_ARGS,
+            ),
+        )
+    return _LINUX_CLIPBOARD_COMMANDS
+
+
+def copy_to_clipboard(
+    text: str,
+    *,
+    platform_name: str | None = None,
+) -> bool:
+    """Copy text with the first available working clipboard command.
+
+    Windows commands use explicit system paths so the current directory is
+    never searched for a clipboard executable.
+
+    Args:
+        text: Text to place on the clipboard.
+        platform_name: Platform identifier. Defaults to ``sys.platform``.
+
+    Returns:
+        True when a clipboard command succeeds, otherwise False.
+    """
+    commands = _clipboard_commands(platform_name or sys.platform)
+    for command in commands:
+        executable = shutil.which(command[0])
+        if executable is None:
+            continue
+        try:
+            completed = subprocess.run(
+                [executable, *command[1:]],
+                input=text,
+                text=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if completed.returncode == 0:
+            return True
+    return False
 
 
 def _agent_label(agent: str) -> str:
@@ -145,6 +225,9 @@ class PortDisplay:
                 "Rerun with a full session ID to select one of them.[/dim]"
             )
 
+        if not sys.stdin.isatty():
+            raise EOFError
+
         choices = [str(index) for index in range(1, len(error.records) + 1)]
         choices.append("q")
         choice = Prompt.ask(
@@ -222,6 +305,52 @@ class PortDisplay:
                 "[dim]Tip: Codex's /import is also available as an "
                 "interactive alternative.[/dim]"
             )
+        self.offer_session_id_copy(result.new_session_id, target_agent)
+
+    def offer_session_id_copy(
+        self,
+        session_id: str,
+        target_agent: str,
+    ) -> None:
+        """Offer to copy a newly created session ID in interactive terminals."""
+        if not self.console.is_terminal or not sys.stdin.isatty():
+            return
+        self.console.print()
+        try:
+            should_copy = Confirm.ask(
+                "[bold]Copy the new session ID to your clipboard?[/bold] "
+                "[dim](Y/n)[/dim]",
+                default=True,
+                show_choices=False,
+                show_default=False,
+                console=self.console,
+            )
+        except (EOFError, KeyboardInterrupt):
+            should_copy = False
+        if not should_copy:
+            self.console.print("[dim]Clipboard left unchanged.[/dim]")
+            return
+        if copy_to_clipboard(session_id):
+            self.console.print(
+                "[bold green]✓ Session ID copied to clipboard.[/bold green]"
+            )
+            command = (
+                "codex resume"
+                if target_agent == "codex"
+                else "claude --resume"
+            )
+            self.console.print("[bold]Now you can run:[/bold]")
+            self.console.print(
+                Text(
+                    f"  {command} <paste session ID>",
+                    style="bold cyan",
+                )
+            )
+            return
+        self.console.print(
+            "[yellow]Could not find a working system clipboard command. "
+            "The session ID is still shown above.[/yellow]"
+        )
 
     def error(self, message: str) -> None:
         """Render an expected failure without a traceback."""

--- a/claude_code_tools/port_render.py
+++ b/claude_code_tools/port_render.py
@@ -1,0 +1,234 @@
+"""Rich terminal rendering for the ``aichat port`` command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich import box
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Prompt
+from rich.status import Status
+from rich.table import Table
+from rich.text import Text
+
+if TYPE_CHECKING:
+    from claude_code_tools.port_service import (
+        PortAmbiguityError,
+        PortResult,
+        ResolvedSession,
+    )
+    from claude_code_tools.resolve_session import SessionRecord
+
+
+_AGENT_LABELS = {"claude": "Claude", "codex": "Codex"}
+_MAX_CANDIDATE_TITLE_CHARS = 120
+
+
+def _agent_label(agent: str) -> str:
+    """Return the human-facing label for an agent identifier."""
+    return _AGENT_LABELS.get(agent, agent.title())
+
+
+def _target_agent(source_agent: str) -> str:
+    """Return the destination agent identifier for a source agent."""
+    return "codex" if source_agent == "claude" else "claude"
+
+
+def _target_label(source_agent: str) -> str:
+    """Return the product label for a destination agent."""
+    target = _target_agent(source_agent)
+    return "Claude Code" if target == "claude" else "Codex"
+
+
+def _match_reason(record: "SessionRecord", query: str) -> str:
+    """Explain why one resolver candidate matched the query."""
+    matched_by = record.matched_by
+    if matched_by == "id":
+        return "exact session ID"
+    if matched_by == "partial-id":
+        return "session ID prefix"
+    if matched_by == "id-substring":
+        return "session ID contains query"
+    if matched_by == "filename":
+        return "rollout filename contains query"
+    if matched_by == "name":
+        name = record.name or ""
+        if name.casefold() == query.casefold():
+            return "exact name/title"
+        return "name/title contains query"
+    return "resolver match"
+
+
+def _candidate_details(record: "SessionRecord") -> Text:
+    """Build a readable multi-line summary for one candidate."""
+    details = Text()
+    title = " ".join((record.name or "Untitled session").split())
+    if len(title) > _MAX_CANDIDATE_TITLE_CHARS:
+        title = title[: _MAX_CANDIDATE_TITLE_CHARS - 3] + "..."
+    details.append(title, style="bold")
+    details.append("\nProject  ", style="dim")
+    details.append(record.directory or "Unknown")
+    details.append("\nID       ", style="dim")
+    details.append(record.session_id)
+    details.append("\nModified ", style="dim")
+    details.append(record.modified)
+    return details
+
+
+class PortDisplay:
+    """Render progress, ambiguity choices, errors, and final results."""
+
+    def __init__(self, query: str) -> None:
+        """Create a display for one port query."""
+        self.query = query
+        self.console = Console()
+        self.error_console = Console(stderr=True)
+
+    def start(self) -> None:
+        """Print the command header and requested session query."""
+        content = Text()
+        content.append("Query  ", style="dim")
+        content.append(self.query, style="bold")
+        self.console.print(
+            Panel.fit(
+                content,
+                title="[bold cyan]Session port[/bold cyan]",
+                border_style="cyan",
+            )
+        )
+
+    def resolving(self) -> Status:
+        """Start the visible resolution phase and return its spinner."""
+        self.console.print("[bold cyan]1/3[/]  Resolving session")
+        return self.console.status(
+            "[dim]Searching Claude and Codex histories...[/dim]",
+            spinner="dots",
+        )
+
+    def choose_candidate(
+        self, error: "PortAmbiguityError"
+    ) -> "ResolvedSession | None":
+        """Present matching sessions and return the user's selection."""
+        from claude_code_tools.port_service import ResolvedSession
+
+        heading = Text()
+        heading.append(f"{error.match_count} sessions matched ", style="yellow")
+        heading.append(repr(error.query), style="bold yellow")
+        heading.append(". Choose the source session to port.", style="yellow")
+        self.console.print(heading)
+
+        table = Table(
+            box=box.ROUNDED,
+            header_style="bold cyan",
+            show_lines=True,
+            expand=True,
+        )
+        table.add_column("#", justify="right", no_wrap=True)
+        table.add_column("Agent", no_wrap=True)
+        table.add_column("Why it matched")
+        table.add_column("Session")
+        for index, record in enumerate(error.records, start=1):
+            table.add_row(
+                str(index),
+                _agent_label(record.agent),
+                _match_reason(record, error.query),
+                _candidate_details(record),
+            )
+        self.console.print(table)
+
+        if error.match_count > len(error.records):
+            hidden = error.match_count - len(error.records)
+            self.console.print(
+                f"[dim]{hidden} older matches are not shown. "
+                "Rerun with a full session ID to select one of them.[/dim]"
+            )
+
+        choices = [str(index) for index in range(1, len(error.records) + 1)]
+        choices.append("q")
+        choice = Prompt.ask(
+            "[bold]Which source session do you want to port?[/bold] "
+            "[dim](number or q to cancel)[/dim]",
+            choices=choices,
+            show_choices=False,
+            console=self.console,
+        )
+        if choice == "q":
+            return None
+        record = error.records[int(choice) - 1]
+        return ResolvedSession(
+            agent=record.agent,
+            session_file=Path(record.session_file),
+        )
+
+    def resolved(self, session: "ResolvedSession") -> None:
+        """Print the chosen source and detected direction."""
+        source = _agent_label(session.agent)
+        target = _target_label(session.agent)
+        self.console.print(
+            Text.assemble(
+                ("  ✓ ", "bold green"),
+                (f"Detected source agent: {session.agent}", "bold"),
+                f" — porting to {target}",
+            )
+        )
+        self.console.print(
+            Text.assemble(("    Source file  ", "dim"), str(session.session_file))
+        )
+        self.console.print(f"[bold cyan]2/3[/]  Porting {source} → {target}")
+
+    def porting(self, source_agent: str) -> Status:
+        """Return the conversion-phase spinner."""
+        target = _target_label(source_agent)
+        return self.console.status(
+            f"[dim]Converting transcript and creating {target} session...[/dim]",
+            spinner="dots",
+        )
+
+    def complete(self, result: "PortResult", source_agent: str) -> None:
+        """Render the final destination details and resume command."""
+        target_agent = _target_agent(source_agent)
+        target = _agent_label(target_agent)
+        self.console.print("[bold cyan]3/3[/]  Ready")
+
+        table = Table.grid(padding=(0, 2))
+        table.add_column(style="bold cyan", no_wrap=True)
+        table.add_column()
+        table.add_row(
+            f"New {target} session id:",
+            Text(result.new_session_id),
+        )
+        table.add_row("Session cwd:", Text(result.cwd or "Unknown"))
+        table.add_row("Output file:", Text(str(result.output_file)))
+        self.console.print(
+            Panel(
+                table,
+                title="[bold green]Port complete[/bold green]",
+                border_style="green",
+            )
+        )
+        self.console.print("[bold]To resume:[/bold]")
+        command = Text(
+            f"  {result.resume_hint}",
+            style="bold cyan",
+            no_wrap=True,
+            overflow="ignore",
+        )
+        self.console.print(command, soft_wrap=True)
+        if target_agent == "codex":
+            self.console.print()
+            self.console.print(
+                "[dim]Tip: Codex's /import is also available as an "
+                "interactive alternative.[/dim]"
+            )
+
+    def error(self, message: str) -> None:
+        """Render an expected failure without a traceback."""
+        self.error_console.print(
+            Text.assemble(("Error: ", "bold red"), message)
+        )
+
+    def cancelled(self) -> None:
+        """Render a user-requested cancellation."""
+        self.console.print("[yellow]Port cancelled.[/yellow]")

--- a/claude_code_tools/port_service.py
+++ b/claude_code_tools/port_service.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
-    from claude_code_tools.resolve_session import ResolveResult
+    from claude_code_tools.resolve_session import ResolveResult, SessionRecord
 
 from claude_code_tools.session_utils import (
     detect_agent_from_content,
@@ -45,6 +45,29 @@ class PortSessionError(Exception):
     The exception message is suitable for printing directly (the CLI
     prefixes it with ``Error:`` and exits non-zero).
     """
+
+
+class PortAmbiguityError(PortSessionError):
+    """A port query with more than one valid source session.
+
+    Attributes:
+        query: Original user query.
+        records: Newest matching records available for selection.
+        match_count: Total matches, including any omitted by the cap.
+    """
+
+    def __init__(
+        self,
+        query: str,
+        records: "tuple[SessionRecord, ...]",
+        match_count: int,
+        message: str,
+    ) -> None:
+        """Initialize an ambiguity with structured candidate data."""
+        super().__init__(message)
+        self.query = query
+        self.records = records
+        self.match_count = match_count
 
 
 @dataclass
@@ -169,7 +192,7 @@ def _resolve_query_for_agent(
 
 def _ambiguity_error(
     session: str, results: "list[ResolveResult]"
-) -> PortSessionError:
+) -> PortAmbiguityError:
     """Build the multi-candidate rejection error for a port lookup.
 
     Args:
@@ -201,11 +224,17 @@ def _ambiguity_error(
     if remaining > 0:
         lines.append(f"  ... and {remaining} more")
     listing = "\n".join(lines)
-    return PortSessionError(
+    message = (
         f"Ambiguous session '{session}' matches {total} sessions:\n"
         f"{listing}\n"
         "Use a longer unique id, the exact session name, or the "
         "full file path."
+    )
+    return PortAmbiguityError(
+        session,
+        tuple(records[:_MAX_AMBIGUITY_LINES]),
+        total,
+        message,
     )
 
 

--- a/docs-site/src/content/docs/tools/aichat/port.mdx
+++ b/docs-site/src/content/docs/tools/aichat/port.mdx
@@ -31,12 +31,9 @@ aichat port <session>
 - a **session file path** (inside or outside the agent homes)
 
 Lookup is global across **all projects** in both the Claude and Codex
-homes. The query must resolve to exactly one session; if several
-match (in one agent or across both), the command errors with the
-candidate list — one line per candidate showing the agent, session
-id, name (when known), and modification time. The listing shows at
-most 25 candidates and ends with a `... and N more` tail when the
-match set is larger.
+homes. When several sessions match, the command shows an interactive
+chooser instead of guessing. See [Ambiguous matches](#ambiguous-matches)
+below.
 
 The source agent is auto-detected from the resolved session (or file
 path content), and the session is ported to the *other* agent. The command
@@ -60,7 +57,18 @@ writes the destination session:
 
 To resume:
   cd /Users/you/myproject && claude --resume e8f54e2c-...
+
+Copy the new session ID to your clipboard? (Y/n): y
+✓ Session ID copied to clipboard.
+Now you can run:
+  claude --resume <paste session ID>
 ```
+
+The clipboard prompt defaults to **Yes**, but it never changes the clipboard
+until the user answers the prompt. It copies only the new session ID and
+supports the native clipboard tools on macOS, Linux, and Windows. The prompt is
+skipped when output or input is not connected to an interactive terminal, so
+scripts do not stop waiting for an answer.
 
 Options:
 

--- a/docs-site/src/content/docs/tools/aichat/port.mdx
+++ b/docs-site/src/content/docs/tools/aichat/port.mdx
@@ -39,18 +39,27 @@ most 25 candidates and ends with a `... and N more` tail when the
 match set is larger.
 
 The source agent is auto-detected from the resolved session (or file
-path content), and the session is ported to the *other* agent. The
-detected direction is always printed first:
+path content), and the session is ported to the *other* agent. The command
+shows progress while it resolves the source, converts the transcript, and
+writes the destination session:
 
 ```text
-Detected source agent: codex — porting to Claude Code
-
-New Claude session id: e8f54e2c-2607-416b-be11-aaf68ce8e3e6
-Output file:           ~/.claude/projects/-Users-you-myproject/e8f54e2c-....jsonl
-Session cwd:           /Users/you/myproject
+╭─ Session port ───────────────╮
+│ Query  my-session-name       │
+╰──────────────────────────────╯
+1/3  Resolving session
+  ✓ Detected source agent: codex — porting to Claude Code
+    Source file  ~/.codex/sessions/.../rollout-....jsonl
+2/3  Porting Codex → Claude Code
+3/3  Ready
+╭─ Port complete ───────────────────────────────────────╮
+│ New Claude session id:  e8f54e2c-2607-416b-be11-... │
+│ Session cwd:            /Users/you/myproject         │
+│ Output file:            ~/.claude/projects/...       │
+╰───────────────────────────────────────────────────────╯
 
 To resume:
-  cd /Users/you/myproject && claude --resume e8f54e2c-2607-416b-be11-aaf68ce8e3e6
+  cd /Users/you/myproject && claude --resume e8f54e2c-...
 ```
 
 Options:
@@ -59,6 +68,20 @@ Options:
 |--------|-------------|
 | `--claude-home PATH` | Override `~/.claude` |
 | `--codex-home PATH` | Override `~/.codex` |
+
+## Ambiguous matches
+
+Codex may use an automatic title derived from the first prompt. A query can
+therefore match both a session explicitly named with `/rename` and another
+session whose automatic title happens to contain the same text.
+
+When multiple sessions match, `aichat port` does not guess. It shows an
+interactive chooser with each candidate's agent, match reason, name or title,
+project directory, session ID, and modification time. Select a number to port
+that source session, or enter `q` to cancel.
+
+If no interactive input is available, the command exits without porting a
+session and prints the candidates so a later command can use a full session ID.
 
 ## Codex → Claude
 

--- a/tests/test_port_claude_to_codex_cli.py
+++ b/tests/test_port_claude_to_codex_cli.py
@@ -8,12 +8,16 @@ evidence lives in the comment block at the bottom of this file.
 
 import json
 import uuid as uuid_mod
+from io import StringIO
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner, Result
+from rich.console import Console
 
 from claude_code_tools.aichat import main
+from claude_code_tools.port_render import PortDisplay
+from claude_code_tools.port_service import PortResult
 from tests.test_port_claude_to_codex import (
     CLAUDE_SID,
     ROLLOUT_NAME_RE,
@@ -87,7 +91,8 @@ class TestCLI:
         )
         assert "New Codex session id:" in result.output
         assert "Output file:" in result.output
-        assert f"Session cwd:           {project_dir}" in result.output
+        assert "Session cwd:" in result.output
+        assert str(project_dir) in result.output
         assert (
             f"cd {project_dir} && codex resume " in result.output
         )
@@ -103,7 +108,7 @@ class TestCLI:
         m = ROLLOUT_NAME_RE.match(rollouts[0].name)
         assert m and m.group(1) in result.output
 
-    def test_claude_source_direction_line_first(
+    def test_claude_source_reports_progress_before_direction(
         self,
         runner: CliRunner,
         claude_home: Path,
@@ -115,9 +120,14 @@ class TestCLI:
             runner, ["port", CLAUDE_SID], claude_home, codex_home
         )
         assert result.exit_code == 0, result.output
-        assert result.output.splitlines()[0] == (
+        assert "Session port" in result.output
+        resolving = result.output.index("1/3  Resolving session")
+        detected = result.output.index(
             "Detected source agent: claude — porting to Codex"
         )
+        porting = result.output.index("2/3  Porting Claude → Codex")
+        ready = result.output.index("3/3  Ready")
+        assert resolving < detected < porting < ready
 
     def test_claude_source_conversion_error_is_clean(
         self,
@@ -198,6 +208,30 @@ class TestCLI:
         combined = result.output + stderr
         assert "Session not found in Claude or Codex" in combined
         assert unknown_id in combined
+
+    def test_completion_renders_bracketed_paths_literally(self) -> None:
+        """Rich markup-like path components remain visible verbatim."""
+        output = StringIO()
+        display = PortDisplay("session")
+        display.console = Console(
+            file=output,
+            color_system=None,
+            width=240,
+        )
+        cwd = "/tmp/project[red]name[/red]"
+        output_file = Path("/tmp/[blue]rollout[/blue].jsonl")
+        result = PortResult(
+            new_session_id="01234567-89ab-4def-8123-456789abcdef",
+            output_file=output_file,
+            cwd=cwd,
+            resume_hint=f"cd '{cwd}' && codex resume session-id",
+        )
+
+        display.complete(result, "claude")
+
+        rendered = output.getvalue()
+        assert cwd in rendered
+        assert str(output_file) in rendered
 
 
 class TestCodexHomeEnvVar:

--- a/tests/test_port_claude_to_codex_cli.py
+++ b/tests/test_port_claude_to_codex_cli.py
@@ -16,7 +16,7 @@ from click.testing import CliRunner, Result
 from rich.console import Console
 
 from claude_code_tools.aichat import main
-from claude_code_tools.port_render import PortDisplay
+from claude_code_tools.port_render import PortDisplay, copy_to_clipboard
 from claude_code_tools.port_service import PortResult
 from tests.test_port_claude_to_codex import (
     CLAUDE_SID,
@@ -24,6 +24,14 @@ from tests.test_port_claude_to_codex import (
     _ts,
     write_claude_session,
 )
+
+
+class TerminalInput(StringIO):
+    """String input stream that behaves like an interactive terminal."""
+
+    def isatty(self) -> bool:
+        """Report that the test input stream is interactive."""
+        return True
 
 
 @pytest.fixture
@@ -232,6 +240,163 @@ class TestCLI:
         rendered = output.getvalue()
         assert cwd in rendered
         assert str(output_file) in rendered
+
+    def test_noninteractive_completion_does_not_prompt(
+        self,
+        runner: CliRunner,
+        claude_home: Path,
+        codex_home: Path,
+        project_dir: Path,
+    ) -> None:
+        """Redirected and scripted commands never wait for clipboard input."""
+        write_claude_session(claude_home, project_dir)
+
+        result = self._invoke(
+            runner, ["port", CLAUDE_SID], claude_home, codex_home
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Copy the new session ID" not in result.output
+
+
+class TestPortClipboard:
+    """Clipboard support shared by both port directions."""
+
+    @pytest.mark.parametrize(
+        ("platform_name", "command"),
+        [
+            ("darwin", "pbcopy"),
+            ("linux", "wl-copy"),
+            ("win32", "clip.exe"),
+        ],
+    )
+    def test_platform_clipboard_commands_copy_exact_session_id(
+        self,
+        platform_name: str,
+        command: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Representative macOS, Linux, and Windows commands receive the ID."""
+        capture = tmp_path / "clipboard.txt"
+        if platform_name == "win32":
+            executable = tmp_path / "System32" / command
+            executable.parent.mkdir()
+            monkeypatch.setenv("SystemRoot", str(tmp_path))
+        else:
+            executable = tmp_path / command
+        executable.write_text(
+            "#!/bin/sh\n/bin/cat > \"$AICHAT_CLIPBOARD_CAPTURE\"\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        monkeypatch.setenv("PATH", str(tmp_path))
+        monkeypatch.setenv("AICHAT_CLIPBOARD_CAPTURE", str(capture))
+        session_id = "01234567-89ab-4def-8123-456789abcdef"
+
+        assert copy_to_clipboard(
+            session_id,
+            platform_name=platform_name,
+        )
+        assert capture.read_text(encoding="utf-8") == session_id
+
+    def test_windows_ignores_clip_executable_on_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Windows clipboard lookup never executes a project-local helper."""
+        capture = tmp_path / "untrusted-ran.txt"
+        planted = tmp_path / "clip.exe"
+        planted.write_text(
+            "#!/bin/sh\n/bin/cat > \"$AICHAT_CLIPBOARD_CAPTURE\"\n",
+            encoding="utf-8",
+        )
+        planted.chmod(0o755)
+        system_root = tmp_path / "windows"
+        system_root.mkdir()
+        monkeypatch.setenv("SystemRoot", str(system_root))
+        monkeypatch.setenv("PATH", str(tmp_path))
+        monkeypatch.setenv("AICHAT_CLIPBOARD_CAPTURE", str(capture))
+
+        copied = copy_to_clipboard(
+            "session-id",
+            platform_name="win32",
+        )
+
+        assert not copied
+        assert not capture.exists()
+
+    def test_explicit_no_leaves_clipboard_unchanged(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The default-safe decline path never invokes a clipboard command."""
+        capture = tmp_path / "clipboard.txt"
+        executable = tmp_path / "pbcopy"
+        executable.write_text(
+            "#!/bin/sh\n/bin/cat > \"$AICHAT_CLIPBOARD_CAPTURE\"\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        monkeypatch.setenv("PATH", str(tmp_path))
+        monkeypatch.setenv("AICHAT_CLIPBOARD_CAPTURE", str(capture))
+        monkeypatch.setattr("sys.stdin", TerminalInput("n\n"))
+        output = StringIO()
+        display = PortDisplay("session")
+        display.console = Console(
+            file=output,
+            color_system=None,
+            force_terminal=True,
+            width=120,
+        )
+
+        display.offer_session_id_copy("session-id", "codex")
+
+        assert not capture.exists()
+        assert "Clipboard left unchanged" in output.getvalue()
+
+    @pytest.mark.parametrize(
+        ("target_agent", "expected_command"),
+        [
+            ("codex", "codex resume <paste session ID>"),
+            ("claude", "claude --resume <paste session ID>"),
+        ],
+    )
+    def test_default_yes_copies_session_id_and_prints_resume_hint(
+        self,
+        target_agent: str,
+        expected_command: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An explicit yes copies only the newly created session ID."""
+        capture = tmp_path / "clipboard.txt"
+        executable = tmp_path / "pbcopy"
+        executable.write_text(
+            "#!/bin/sh\n/bin/cat > \"$AICHAT_CLIPBOARD_CAPTURE\"\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+        monkeypatch.setenv("PATH", str(tmp_path))
+        monkeypatch.setenv("AICHAT_CLIPBOARD_CAPTURE", str(capture))
+        monkeypatch.setattr("sys.stdin", TerminalInput("\n"))
+        output = StringIO()
+        display = PortDisplay("session")
+        display.console = Console(
+            file=output,
+            color_system=None,
+            force_terminal=True,
+            width=120,
+        )
+        session_id = "01234567-89ab-4def-8123-456789abcdef"
+
+        display.offer_session_id_copy(session_id, target_agent)
+
+        assert capture.read_text(encoding="utf-8") == session_id
+        assert "Session ID copied to clipboard" in output.getvalue()
+        assert expected_command in output.getvalue()
 
 
 class TestCodexHomeEnvVar:

--- a/tests/test_port_resolver_integration.py
+++ b/tests/test_port_resolver_integration.py
@@ -44,6 +44,11 @@ from tests.resolve_session_helpers import (
 )
 
 
+def _reports_stdin_tty(stream: object) -> bool:
+    """Make only Click's isolated stdin behave like a terminal in tests."""
+    return getattr(stream, "name", None) == "<stdin>"
+
+
 @pytest.fixture
 def project_dir(tmp_path: Path) -> Path:
     """Create the fake project directory ported sessions refer to."""
@@ -386,6 +391,7 @@ class TestRejections:
         claude_home: Path,
         codex_home: Path,
         project_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """An exact name and an incidental title match stay user-chosen."""
         query = "sasy-blog-21jul2026"
@@ -415,6 +421,10 @@ class TestRejections:
         # "1" exercises the intended source from the reported case.
         os.utime(rollout, (1_720_000_000, 1_720_000_000))
         os.utime(claude_session, (1_720_000_001, 1_720_000_001))
+        monkeypatch.setattr(
+            "click.testing._NamedTextIOWrapper.isatty",
+            _reports_stdin_tty,
+        )
 
         result = runner.invoke(
             main,
@@ -442,6 +452,48 @@ class TestRejections:
         )
         assert "Port complete" in result.output
         assert len(list((codex_home / "sessions").rglob("*.jsonl"))) == 2
+
+    def test_cli_ambiguity_does_not_accept_piped_selection(
+        self,
+        runner: CliRunner,
+        claude_home: Path,
+        codex_home: Path,
+        project_dir: Path,
+    ) -> None:
+        """Non-terminal stdin cannot select a source and create a port."""
+        query = "shared-piped-name"
+        first_id = "11111111-1111-4111-8111-111111111111"
+        second_id = "22222222-2222-4222-8222-222222222222"
+        _write_claude_session(
+            claude_home,
+            first_id,
+            project_dir,
+            title=query,
+        )
+        _write_claude_session(
+            claude_home,
+            second_id,
+            project_dir,
+            title=query,
+        )
+
+        result = runner.invoke(
+            main,
+            [
+                "--claude-home",
+                str(claude_home),
+                "--codex-home",
+                str(codex_home),
+                "port",
+                query,
+            ],
+            input="1\n",
+        )
+
+        assert result.exit_code != 0
+        assert "Ambiguous session" in result.output
+        assert "Which source session do you want to port?" not in result.output
+        assert not (codex_home / "sessions").exists()
 
     def test_ambiguity_listing_is_capped_with_tail(
         self, claude_home: Path, codex_home: Path, tmp_path: Path

--- a/tests/test_port_resolver_integration.py
+++ b/tests/test_port_resolver_integration.py
@@ -12,6 +12,7 @@ the new name-based lookup. Kept separate from
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import uuid
 from pathlib import Path
@@ -378,6 +379,69 @@ class TestRejections:
         assert MODERN_UUID in message
         assert "(xshared-name)" in message
         assert "modified" in message
+
+    def test_cli_ambiguity_explains_matches_and_ports_selection(
+        self,
+        runner: CliRunner,
+        claude_home: Path,
+        codex_home: Path,
+        project_dir: Path,
+    ) -> None:
+        """An exact name and an incidental title match stay user-chosen."""
+        query = "sasy-blog-21jul2026"
+        claude_id = str(uuid.uuid4())
+        claude_session = _write_claude_session(
+            claude_home,
+            claude_id,
+            project_dir,
+            title=query,
+        )
+        rollout = write_modern_rollout(codex_home, project_dir)
+        database = codex_home / "state_1.sqlite"
+        _create_threads_database(database)
+        _insert_codex_thread(
+            database,
+            MODERN_UUID,
+            rollout,
+            str(project_dir),
+            (
+                f"see how port works; source name {query}; "
+                + ("long automatic title " * 20)
+                + "NEVER_SHOW_THIS_TAIL"
+            ),
+            1_720_000_000,
+        )
+        # Candidate order is newest first. Keep Claude first so input
+        # "1" exercises the intended source from the reported case.
+        os.utime(rollout, (1_720_000_000, 1_720_000_000))
+        os.utime(claude_session, (1_720_000_001, 1_720_000_001))
+
+        result = runner.invoke(
+            main,
+            [
+                "--claude-home",
+                str(claude_home),
+                "--codex-home",
+                str(codex_home),
+                "port",
+                query,
+            ],
+            input="1\n",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "2 sessions matched" in result.output
+        assert "exact name/title" in result.output
+        assert "name/title contains query" in result.output
+        assert "see how port works" in result.output
+        assert "NEVER_SHOW_THIS_TAIL" not in result.output
+        assert "Which source session do you want to port?" in result.output
+        assert (
+            "Detected source agent: claude — porting to Codex"
+            in result.output
+        )
+        assert "Port complete" in result.output
+        assert len(list((codex_home / "sessions").rglob("*.jsonl"))) == 2
 
     def test_ambiguity_listing_is_capped_with_tail(
         self, claude_home: Path, codex_home: Path, tmp_path: Path

--- a/tests/test_port_session.py
+++ b/tests/test_port_session.py
@@ -756,20 +756,22 @@ class TestPortCLI:
         )
         assert list(proj.glob("*.jsonl"))
 
-    def test_detected_direction_is_first_output(
+    def test_port_progress_is_ordered_and_auto_index_is_silent(
         self, runner, codex_home, claude_home, project_dir
     ):
-        """Nothing (e.g. auto-index progress) may print before the
-        detected-direction line."""
+        """Port phases are ordered and auto-index output stays absent."""
         write_modern_rollout(codex_home, project_dir)
         result = self._invoke(
             runner, ["port", MODERN_UUID], claude_home, codex_home
         )
         assert result.exit_code == 0, result.output
-        first_line = result.output.splitlines()[0]
-        assert first_line == (
+        resolving = result.output.index("1/3  Resolving session")
+        detected = result.output.index(
             "Detected source agent: codex — porting to Claude Code"
         )
+        porting = result.output.index("2/3  Porting Codex → Claude Code")
+        ready = result.output.index("3/3  Ready")
+        assert resolving < detected < porting < ready
         try:
             stderr = result.stderr
         except ValueError:  # older click: stderr mixed into output


### PR DESCRIPTION
## Summary

- show visible Rich progress while `aichat port` resolves, converts, and writes a session
- replace terminal ambiguity errors with an interactive source-session chooser
- explain why each candidate matched and show its agent, title preview, project, ID, and modification time
- keep non-interactive ambiguity safe by refusing piped selections and exiting without porting
- offer to copy the new session ID after a successful port, with Yes as the default
- print the matching Codex or Claude resume command after copying
- support macOS, Linux, and Windows clipboard tools, with trusted system paths on Windows
- update the port documentation for the new interaction

## Root cause

The port command previously resolved Claude and Codex independently and rejected any combined ambiguity as a plain error. Codex automatic titles are often derived from the first prompt, so an explicitly named Claude session and an unrelated prompt-derived Codex title could both match the same query. The command also stayed silent during the potentially slow resolution scan and left users to copy a long generated session ID manually.

## User impact

When multiple sessions match, users now choose the intended source instead of rewriting the query or copying a UUID. The command shows meaningful progress, ends with a polished summary, and offers to place the generated session ID on the clipboard. After a successful copy, it shows the exact Codex or Claude resume form to run next. Scripts and redirected input remain non-interactive.

## Validation

- `uv run pytest -q tests/test_resolve_session*.py tests/test_port*.py` — 399 passed
- `make docs-build` — 42 pages and the Pagefind index built successfully
- manually verified the chooser against the reported real `sasy-blog-21jul2026` ambiguity
- final cold-diff review reported no actionable findings
- PRs #143 and #144 had no GitHub conversation comments, submitted reviews, or inline review comments to address