### PR TITLE
Refresh remove-ai-patterns snapshot to v3.22.1 (picks up our upstream fix)

### DIFF
--- a/plugins/writing/scripts/update-upstream.sh
+++ b/plugins/writing/scripts/update-upstream.sh
@@ -14,7 +14,10 @@ git clone --quiet --depth 1 \
 DEST="$ROOT/skills/remove-ai-patterns/upstream"
 mkdir -p "$DEST/detector"
 cp "$TMP/aaw/SKILL.md" "$TMP/aaw/LICENSE" "$TMP/aaw/CHANGELOG.md" "$DEST/"
+# validate.js is required by the upstream SKILL.md's edit-mode verification
+# step; it require()s ./patterns.js from the same directory.
 cp "$TMP/aaw/detector/patterns.js" "$TMP/aaw/detector/CATEGORIES.md" \
+  "$TMP/aaw/detector/validate.js" \
   "$DEST/detector/"
 git -C "$TMP/aaw" log -1 \
   --format='https://github.com/conorbronsdon/avoid-ai-writing %H %s' \

--- a/plugins/writing/skills/remove-ai-patterns/SKILL.md
+++ b/plugins/writing/skills/remove-ai-patterns/SKILL.md
@@ -75,7 +75,19 @@ vendored at `upstream/` inside this skill directory (commit recorded in
    that is a refused scan, not a clean document, so convergence must require
    a scored result (`document_classification` other than `"UNSCORED"`), not
    merely an empty issue list. Split or trim over-long inputs so they score.
-3. Respect the upstream skill's own guardrails (edit only what a pattern
+3. In edit mode, verify the rewrite preserved meaning with the bundled
+   validator. `upstream/SKILL.md` writes this as `node detector/validate.js`,
+   a relative path that fails from the user's working directory; use the
+   absolute form, as with the detector:
+
+   ```bash
+   node "$SKILL_DIR/upstream/detector/validate.js" ORIGINAL REWRITTEN
+   ```
+
+   It prints `PASS` when the preservation checks are clear, and otherwise
+   reports what changed. Treat a failure as a blocking problem with the
+   rewrite, not a style suggestion.
+4. Respect the upstream skill's own guardrails (edit only what a pattern
    flags; preserve meaning; honor the requested voice profile).
 
 ## Updating

--- a/plugins/writing/skills/remove-ai-patterns/upstream/CHANGELOG.md
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/CHANGELOG.md
@@ -4,6 +4,143 @@ All notable changes to this project are documented here.
 
 ---
 
+## [3.22.1] — 2026-07-31
+
+### Fixed
+
+- **`title-case-header` never fired on a Markdown heading (#62).** The pattern was anchored `^[A-Z][a-z]+`, which requires the line to begin with a capital letter. A Markdown heading begins with `#`, so the anchor failed and `## Benefits And Strategic Considerations` produced no issue. The rule caught the bare-line form (`Benefits And Strategic Considerations`) while missing the commonest way a heading is actually written, which is also the form the bare line usually gets converted from. Now accepts and discards an optional `#{1,6}` prefix. Setext headings were already covered, since their text line is bare.
+- Reported by a downstream that vendors `detector/patterns.js` byte-identical to a pinned commit, so they filed rather than patching locally. Worth noting as the first externally-reported detection gap.
+- Two fixture groups pin it: the rule fires on `#`, `##` and `######` headings, and stays quiet on a sentence-case heading, on `##Text` with no space (not a heading), and on seven hashes (not a heading). Sentence case is the correct form, so flagging it would invert the rule.
+- **The false-positive claim in the first version of this entry was wrong, and worth recording as such.** It read "no measurable false-positive cost", citing `npm run fp` being byte-identical before and after. It is: `title-case-header` does not appear in that corpus at all, because the corpus is prose with no Markdown headings. An instrument that cannot see a change returning "no change" is not evidence, and the entry stated that limitation and drew the opposite conclusion from it in adjacent sentences. Adversarial review found the regression the measurement could not.
+
+
+### Fixed (follow-up, same day)
+
+- **The heading prefix leaked into the proper-noun guard.** `matchPatterns` reports `match[0]`, so a Markdown hit arrived as `## Terms Of Service` and `##` counted as a token — silently lowering the guard from four content words to three, for headings only. `## Terms Of Service`, `## Bank Of America`, `## Table Of Contents` and `## Pride And Prejudice` all flagged: ordinary human headings, on a detector whose first priority is not firing on human writing. The filter now strips the prefix and trims before counting.
+- **A `HUMAN_ONLY` → `MIXED` claim was removed from this entry rather than corrected.** It cited an unnamed README and could not be reproduced. Writing an unverifiable number into the entry that exists to retract an unverifiable number is the same mistake twice, so it is recorded rather than quietly deleted. The measured numbers below replace it.
+- **Headings opening with a function word are no longer flagged, and this is the measured part.** The proper-noun guard tested `/\b(?:And|Or|Of|The|…)\b/` against the whole title with no position constraint, so a leading `The` satisfied it — while the guard's own comment has always specified a *mid-sentence* "And". Across 989 real Markdown files this rule went from 0 hits on `main` (the `^[A-Z]` anchor made it dead on `#` headings) to 35. On an 81-file subcorpus that provably predates LLMs — 2018-19 eBooks stamped `year:`, 2020 posts — it produced **13 false positives against zero on main**, every one opening with `The`: "The New Security Landscape", "The Microsoft Approach to Identity", "The Four Keys to a Successful and Secure Modern Workplace". Requiring the function word to be interior eliminates all 13 and leaves the target case firing. Those six headings are now fixtures.
+- **Fence detection rewritten to track the opening delimiter instead of counting delimiters.** A parity count is wrong on the exact case the check exists for: a four-backtick fence wrapping a three-backtick example — how you document fences — inverts it. Also handles CommonMark's up-to-three-space indent and an unclosed fence running to end of document. Computed once per scan rather than re-slicing the document per candidate, which was quadratic on a heading-dense file.
+- **A latent off-by-one on the bare-line form is fixed as a side effect.** The pattern's trailing `\s*` swallowed the following newline, so `Terms Of Service` split into four tokens and fired on `main` despite having three content words. The `.trim()` corrects that, which means three-word Title Case lines are now quiet in both forms. This is a behaviour change beyond headings and a strict reduction in flags.
+- **Still fires, deliberately:** a four-content-word Title Case heading such as `# The Art Of War` or `## Notes On The Design`. The `>= 4` guard cannot distinguish those from `## Benefits And Strategic Considerations` — same shape. Pre-existing, identical for the bare-line form, out of scope here.
+- **Ten fixtures now pin this rule**, including a value assertion on `issue.text` (a presence-only check is what let the prefix defect through), the six pre-LLM human headings above, the four fence shapes a parity count gets wrong, and an indented-line case. Six mutations were run against the result — dropping the mid-title constraint, the token floor, the prefix strip, the trim, tab support, and the word anchors — and all six fail a test. The tab-support fixture had to be rewritten to catch its mutant: on a heading whose function word is interior, an unstripped `##` only raises the token count and the verdict is unchanged, so the probe has to open with a function word.
+
+### Note
+
+`#67` (em-dash carve-out for changelog headings and bold-lead parentheticals) and `#69` (hedge-stack over-matching `could not possibly`) were both fixed in 3.22.0 and verified here against the shipped detector. The issues are still open and can be closed.
+
+---
+
+## [3.22.0] — 2026-07-31
+
+### Added
+
+Two pieces of enforcement. No new detection categories: the catalog stays at 61 and the engine at 46 `type`s.
+
+- **Preservation validator** (`detector/validate.js`, `detector/validate.test.js`). Edit mode writes to files, and until now the promises it makes were prose instructions to a model with nothing checking them. `validate(original, rewritten)` errors when a rewrite modifies a fenced code block, YAML frontmatter, a blockquote, a table cell, inline code, a URL, a file path, or the heading count and nesting, and when the rewrite ends with more flagged patterns than it started with. Warnings cover reworded headings, figures that vanished, and rewrites that drop more than 40% of the words. There is a CLI (`node detector/validate.js before.md after.md`) that exits 1 on any error. 23 tests, no dependencies.
+- **Two carve-outs, because a validator that fires on its own skill's instructions gets switched off.** URLs are compared with AI tracking parameters stripped from both sides, since the skill tells you to strip them; heading text changing is a warning rather than an error, since the skill tells you to sentence-case Title Case headings and cut emoji from them.
+- **Self-scan and `PROOF.md`** (`scripts/self-scan.js`). Scores this repo's documentation with this repo's detector and publishes both numbers: raw, which counts every pattern quoted as an example, and exempt, which applies the self-reference escape hatch `SKILL.md` has documented in prose since v1 and never implemented. Budgets gate the exempt column in CI and only move down.
+- The scan found two gaps in our own work, both recorded in `PROOF.md` rather than quietly patched: the em-dash rule carves out list-item separators but not Keep-a-Changelog version headings (`## [3.21.0] — 2026-07-30`) or a bold lead term with a parenthetical before the dash, and roughly half of `CHANGELOG.md`'s residual score is release notes enumerating the very words each new rule catches.
+
+- **"Never inject these" guardrails** in `SKILL.md`, under Tone calibration. The instruction to put voice back on purpose has a predictable failure mode: the model installs a personality the author never had, trading one detectable register for a louder one. Seven additions are now out of bounds regardless of how the result scores: fake first person, manufactured stakes, forced contrarianism, performed candor, em-dash theatrics, staccato conversion, and invented specifics. The governing test is provenance: subtraction and sharpening are in scope, addition of stance, personality, or fact is not. These are constraints on the editor rather than detections on the text, which is why they sit with the rewrite instructions and do not change the catalog count. Adapted from `isatimur/de-slop`'s guardrails.
+- **False-positive issue template** (`.github/ISSUE_TEMPLATE/false_positive.yml`). A rule firing on human writing is the defect this project most wants reported, and the form collects what makes a report measurable rather than anecdotal: the shortest text that fires, the register, how the text was actually written, and whether it can become a public fixture. Register is the field that matters most, since false-positive rates differ sharply across blog, docs, academic, and chat prose.
+
+- **Human-control corpus and false-positive measurement** (`corpus/`, `scripts/corpus.js`, `scripts/fp-measure.js`). This repo has always asserted things about false positives — the tiering exists to reduce them, the tolerance matrix relaxes rules per register, `SKILL.md` opens with "signals, not proof" — and had never measured one. Every document in the corpus was written by a person, so every flag on it is a false positive by construction: no labelling, no judge, no model in the loop. The corpus is hash-only; text is fetched into a gitignored cache or read from wherever it already lives, and only hashes and metadata are committed. Register is the unit of analysis, following patina's finding that false-positive rates ran from 4% to 34% across registers inside one language.
+- **First measurement: 0.0% false positives at every threshold across 560 paragraphs, Wilson 95% CI 0.0–0.7%, worst paragraph 11 out of 100.** The corpus is nine public-domain works (1788–1907) plus 25 of the maintainer's own blog posts from 2019 to December 2022, read from pre-2023 `web.archive.org` captures rather than the live site. At the document-score level the detector does not fire on human prose. The same measurement against the current published versions of those posts also returned 0.0% across 628 paragraphs, so the result does not depend on which copy was measured.
+- **Provenance is verified, not assumed.** The old site used compressed slugs (`beveragetax`, `challengerfunnel`) that do not match current URLs, so archived candidates were found by slug similarity and then confirmed by content: a capture is accepted only at 0.45+ Jaccard similarity against the current text. Genuine matches land between 0.76 and 0.98; four slug guesses scored below 0.17 and were rejected by that check rather than silently accepted. Nine posts with no verifiable pre-2023 capture were dropped rather than included on their current-site text. Worth recording separately: the median archived capture is only 0.92 similar to its currently published counterpart, so the live site's posts have been edited since, and measuring "pre-2023 writing" against them would have measured the wrong thing.
+- **The flag level says something else, and `detect` mode shows users flags rather than scores.** On the maintainer's Wayback-verified pre-2023 posts, `em-dash` fires on 18.3% of paragraphs and `tier1` on 12.5%. The Tier 1 words responsible are `embrace` (7), `leverage` and inflections (7), `when it comes to` (5), `in order to` (4), `that said` (4). Those are not AI tells in that text; they are a marketer's ordinary 2019 vocabulary, written years before the models existed. Both rates are slightly higher on the verified originals than on the current published versions, which is what later editing passes would do. Recorded in `corpus/README.md` as a decision to make rather than a defect to patch.
+- Two defects surfaced and are filed rather than patched here: `hedge-stack` matches ordinary negation such as "could not possibly" (#69), and the `em-dash` flags on the public-domain leg are an artifact of era and Gutenberg transcription, so nineteenth-century text cannot test that rule at all.
+- Corpus hygiene worth recording: two guest posts were excluded by byline, and three posts carrying "Looking back from 2025" retrospective inserts were dropped because their pre-LLM provenance is broken. The second was caught by reading the worst-scoring paragraphs, not by any check in the tooling.
+- `scripts/corpus.test.js` covers the extraction helpers with 15 tests. A silent extraction bug would not crash anything; it would quietly change a published rate. Two tests exist purely to protect the measurement: em dashes must survive extraction, since the em-dash rule is scored against this corpus, and extraction must throw rather than return empty text, since an empty document would shrink the denominator without saying so.
+- **Tier 1 split into 1A frequency markers and 1B clarity edits.** Tier 1 is defined by an empirical claim — these words "appear 5–20x more often in AI text than human text" — and several members could not plausibly meet it. `in order to`, `utilize`, `serves as`, `features`, `boasts`, `commence`, `ascertain`, and `endeavor` are wordiness and formality edits: worth making, but not evidence that a machine wrote the sentence. They now emit `tier1-clarity`, are weighted like Tier 2, and are excluded from the dense-AI-vocabulary signal, so a wordiness fix can no longer push a document toward an AI classification. The edit advice is unchanged for every word; what changed is what a flag claims. Detect mode reports the two bands separately.
+- **The measurement that prompted it.** Against 257 paragraphs of the maintainer's verified pre-2023 writing, Tier 1 fired on 12.5%. Split, that is 8.9% markers and 3.5% clarity, with no paragraph triggering both. Roughly a quarter of Tier 1 hits on genuine human prose were wordiness being reported as an AI signal. `commence` and `ascertain` firing on the Federalist Papers and Faraday is the same problem from the formal-register end.
+- **The 5–20x claim is now labelled as inherited rather than measured.** It traces to `brandonwise/humanizer`, which asserts the ratio in two places and publishes no method or dataset. `SKILL.md` says so plainly and commits to re-deriving the ratios once a machine-written corpus exists. The conflation of wordiness with frequency evidence is inherited too: `in order to`, `utilize`, and `serves as` are on that upstream list.
+- **Machine-written corpus, and the first true-positive rate this project has ever had.** Two external datasets, neither generated by anyone with a stake in these numbers: RAID (Dugan et al. 2024, MIT — 11 model families, sampled by byte-range from an 11.8 GB CSV) and HC3 (Guo et al. 2023, CC-BY-SA-4.0 — paired human and ChatGPT answers to the same questions). Same hash-only design as the human half. `scripts/csv-lite.js` vendors a small RFC 4180 reader because the RAID generations contain commas, quotes, and newlines, and splitting on delimiters would silently corrupt the text being measured.
+- **The composite score does not separate the classes.** ROC-AUC 0.501 at paragraph level pooled (HC3 0.554, RAID 0.451) and 0.623 at document level (HC3 0.654, RAID 0.599). The best operating point found costs 12.8% false positives to catch 27.7% of machine text. 0.5 is a coin flip.
+- **The 0–100 scale uses about a tenth of its range.** No paragraph of either class scored above 11, so every threshold at or above 15 reports 0.0% on both sides, and `SKILL.md`'s own band puts everything at or under 15 in "Minimal AI signals". Category weights run 2–12 and `rawScore` is divided by `max(1, log2(words / 50))`. This is a calibration defect rather than a detection failure, and it is the most fixable finding on the page.
+- **The discriminating signal is structural, not lexical.** At document level `uniformity` fires on 2.1% of human text and 25.1% of machine text, a lift of 11.7x — the best discriminator in the engine by an order of magnitude. `filler` is 3.4x; `chatbot`, `hedge-stack`, and `fnword-trigram-entropy` are machine-only. The 112-entry vocabulary table has a lift of **0.9**: it fires slightly more often on human writing than on machine writing. That is what `NulightJens/humanizer-stack` argues from StoryScope and what `harshaneel/humanize` reaches independently, and on this engine they look right.
+- **`em-dash` is inverted as an authorship signal**, firing on 9.9% of human documents and 1.9% of machine ones (lift 0.2). It holds on both legs and is not a transcription artifact. Unchanged as writing advice; recorded because it points the wrong way as evidence.
+- Sampling note worth keeping: evenly spaced byte offsets across RAID returned *fewer* model families at 40 windows than at 16, having resonated with the file's domain-then-model sort order and missed gpt4, chatgpt, and cohere entirely. Offsets now follow a golden-ratio low-discrepancy sequence, and the builder warns at build time when model, domain, or unit coverage falls short.
+- **Fixed the two defects the measurement found.** `hedge-stack` allowed two words between the modal and the hedge adverb, so `could not possibly` and inverted questions like `could a savage possibly` both fired; it now allows at most one and never a negator (#69). The em-dash rule carved out list-item separators but not Keep-a-Changelog version headings (`## [3.21.0] — 2026-07-30`) or a bold lead term carrying a parenthetical (#67); both are carve-outs now. The version-heading pattern is deliberately narrow — a bracketed semver, a dash, an ISO date, nothing else — because `SKILL.md` applies the em-dash rule to headings too, and a prose dash in a heading still counts.
+- **Both fixes improved discrimination, measured on the corpus.** `hedge-stack` went from firing on 0.6% of human units with a lift below 1 (it fired more on human text than machine text) to 0.2% with a lift of 2.2. `em-dash` false hits on human text dropped from 17.9% to 13.7%. Its lift stays inverted at 0.1, which is a finding about the signal rather than a bug in the rule.
+
+### Changed
+
+- `npm test` now runs the preservation tests as well. `npm run self-scan` and `npm run self-scan:check` are new. CI runs the self-scan check as a step in the existing `detector` job rather than a second job, since branch protection pins required checks by job name.
+- Edit mode's output format in `SKILL.md` now points at the validator as an optional mechanical check.
+
+---
+
+## [3.21.0] — 2026-07-30
+
+### Added
+
+One judgment-only rule. Catalog goes from 60 to 61 detection categories; the engine stays at 46 `type`s.
+
+- **Narrated candor** — announcing your own disclosure instead of disclosing: `"Two caveats I would rather flag than let you discover later:"`, `"I want to be upfront:"`, `"rather than bury this"`, `"I could have left this out, but"`. The content is "Two caveats:"; the rest advertises the writer's forthrightness. Completes a set with two existing rules: **chatbot artifacts** perform helpfulness and **sycophantic tone** flatters the reader, while this performs candor about oneself. Usually arrives as a matched antithesis (*flag* rather than *let you discover*), which is a tell in its own right. Added to the P1 severity tier.
+- **Implemented as a detector, then reverted before release**, following the precedent set by wall-of-text replies. An adversarial review of the first implementation found it flagged idiomatic conflict-of-interest disclosure (`"In the interest of full disclosure, I own shares in the company discussed in this article"`) and the ordinary English comparative (`"I'd rather fix it than let you inherit the mess"`), and that the bounded-repeat pattern backtracked catastrophically on long `\w` runs — 36 seconds on a 4 KB input. Every regex tight enough to spare the carve-outs stopped matching the tell, so the rule ships as skill prose only. `detector/CATEGORIES.md` §C records the reasoning.
+- **Two carve-outs are now explicit in the rule**, because they are the cases the failed detector proved are hard: conflict-of-interest disclosure keeps its conventional opening, and the ordinary comparative is not this pattern. The tell requires that what follows the frame is the disclosure itself.
+
+---
+
+## [3.20.0] — 2026-07-29
+
+### Added
+
+One rule with detector coverage, found while drafting a podcast teaser post. Catalog goes from 59 to 60 detection categories; the engine goes from 45 to 46 `type`s.
+
+- **Lingering-attention claims** (`lingering-attention`) — the share-post frame that claims a thing has occupied the writer's mind rather than saying anything about the thing: `"the line I keep coming back to"`, `"I can't stop thinking about this"`, `"still thinking about this one"`, `"rattling around in my head all week"`, `"I've been chewing on this"`. Sits next to **emotional flatline** in the catalog but is a separate claim: flatline claims a *feeling* ("What surprised me most"), this claims *duration* of attention, which is unfalsifiable and self-flattering in a way a feeling isn't. It also opens a share post where **social endorsement closers** close one. Added to the P1 severity tier.
+- **Precision carve-out.** The bare verb phrase `"I keep coming back to X"` deliberately does *not* fire, because it is legitimate whenever a reason follows ("I keep coming back to the exit-voice framing because it predicts which engineers quit"), and the reason clause is not reliably regex-detectable. Only the noun-anchored frame (`the line/quote/bit/idea ... I keep coming back to`) is matched — the shape that introduces a subject instead of asserting something about it. The bare form stays an LLM-judgment call in the skill prose. Fixtures cover both directions, including the must-not-fire case.
+
+---
+
+## [3.19.0] — 2026-07-24
+
+### Added
+
+Two judgment-only rules (no detector `type`) found during a real audit. Catalog goes from 57 to 59 detection categories.
+
+- **Moral-adjective category errors** — AI glues moral adjectives (`honest`, `genuine`, `faithful`) onto non-agentic technical nouns (`shape`, `number`, `representation`) where the modifier cannot literally apply. Also covers passive-voice moral adverbs (`"described honestly"`), ontological slop on assumptions (`"stops being true"`), and gratuitous universal quantifiers (`"every first-year course"`).
+- **Invented contrast-pair mirroring** — AI fabricates the second half of a contrast pair for symmetry (`"false precision rather than genuine accuracy"`, where the first term is real and the second is phantom).
+- Both added to the P1 severity tier and the tolerance matrix (relaxed for `technical-blog` and `docs` profiles).
+
+---
+
+## [3.18.0] — 2026-07-22
+
+### Changed
+- **Em dashes** — carve-out for the definition-list separator position: an em dash after a bolded lead term or a markdown link opening a bulleted or numbered list item (`- **Term** — description`, `- [label](url) — description`) is typography, not a prose splice, and no longer counts toward the 1-per-1,000-words rate. The detector's exclusion requires the list marker — a line-initial `**Bold lead** — full sentence` outside a list is itself an AI tell and still counts, as do mid-sentence splices; the `--` substitute is never carved out. The same separator dashes no longer corroborate the `smart-punct-signature` co-occurrence check either — its em-dash leg now requires a non-separator dash. Fixtures added for all the boundaries: bulleted and numbered definition lists stay clean, markerless bold-lead splices and flowing-prose splices still fire, and a curly-quoted definition list with separator-only dashes no longer completes the smart-punct signature. This repo's own README and changelog use the separator convention throughout, which is what the strict-context false positive looks like in practice. (The same carve-out was independently proposed upstream in `blader/humanizer` PR #190.)
+
+---
+
+## [3.17.0] — 2026-07-20
+
+### Added
+
+Four categories harvested from [`blader/humanizer`](https://github.com/blader/humanizer) v2.8.2, the residue of a full cross-audit against its 33-pattern catalog (most were already covered here, several via earlier adaptations). Catalog goes from 53 to 57 detection categories. All four are LLM-judgment rules (no detector `type`): each needs reading for meaning, and the obvious regexes fail the precision-over-recall bar — "X is the Y of Z" matches "Paris is the capital of France."
+
+- **Subjectless fragments and agentless passives** — "No configuration file needed," plus the actor-hiding passive ("Support for nested queries was added"). Docs and changelog registers carved out — the fragment is the correct form there — plus a tolerance-matrix row so `docs`/`casual` skip it entirely. Adapted from `blader/humanizer` P13.
+- **Diff-anchored writing** — docs narrating the edit instead of the artifact ("This function was added to replace..."). Version-scoped documents (changelogs, release notes, migration guides, decision records) carved out. Adapted from `blader/humanizer` P30.
+- **Manufactured punchlines and staccato drama** — three or more same-shape reveal-fragments in a row. Reconciled with Rhythm and uniformity: one emphatic fragment is human variation, the drumroll is the tell. Adapted from `blader/humanizer` P31.
+- **Aphorism formulas** — "X is the language of Y." Quotations and established idioms carved out. Adapted from `blader/humanizer` P32.
+
+### Changed
+- **"It's not X — it's Y"** — extended with the **tailing negation**, the clipped fragment form of the same contrastive move ("The options come from the selected item, no guessing"). Spec-constraint lists ("no dependencies, no telemetry") stay clean. Adapted from `blader/humanizer` P9.
+- **Excessive structure** — extended with **fragmented headers**: a heading followed by a one-line warm-up that restates it ("## Performance", then "Speed matters."). Adapted from `blader/humanizer` P29.
+- **Infomercial engagement hooks** — extended with **fake-candid openers**: "Honestly?", "Look,", "Real talk:" as standalone pause-and-reveal stagers; mid-sentence "honestly" or "look" is ordinary English and stays unflagged. Adapted from `blader/humanizer` P33.
+- **Tone calibration** — gains a put-voice-back note adapted from humanizer's "Personality and soul" section: a rewrite that clears every flag but reads sterile is still recognizably machine output; when the genre carries a voice, re-inject one deliberately, and leave neutral registers neutral.
+
+### Source
+- Cross-audit run 2026-07-20 against `blader/humanizer` v2.8.2, which grounds its catalog in [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) (WikiProject AI Cleanup). Earlier releases had already absorbed P21, P26, and P27 directly, and P34/P35/P38/P41/P43 via `Aboudjem/humanizer-skill`; these additions are the remaining gaps that survived a false-positive review.
+
+---
+
+## [3.16.0] — 2026-07-15
+
+### Added
+- **"load-bearing" (metaphor) to Tier 1 word table** — LLMs, especially Claude, use "load-bearing" as a portable label for any dependency the argument rests on: "load-bearing assumption," "load-bearing claim," "load-bearing test," "load-bearing invariant." Added to both the SKILL.md Tier 1 table and the detector engine as a `TIER1_PHRASES` entry. Matches the hyphenated compound only — unhyphenated "load bearing" is ordinary English ("the load bearing down on the bridge"). Construction carve-out: literal uses before a structural noun (`wall`, `beam`, `column`, `joist`, `truss`, `member`, `footing`, `slab`, `stud`, `partition`, `masonry`, `lintel`, `pier`, `rafter`, `girder`, `capacity`) are exempt, including with one material or position adjective in between (`load-bearing structural wall`). Abstract-capable nouns (`structure`, `element`, `frame`, `foundation`) are excluded from the carve-out on purpose, so the metaphor still fires on them. Known gap: predicative use ("the wall is load-bearing") still flags — carve-out design tracked in #56. Replacement: essential, critical, necessary — or say what breaks if you remove it. Sources: [Marek Šuppa — "Load-bearing" is becoming LLM speak](https://mareksuppa.com/til/load-bearing/); [Yaniv Bernstein (LinkedIn)](https://www.linkedin.com/posts/ybernstein_opus-47-has-dropped-a-new-ai-slop-writing-activity-7452530977479774208-kbQA); [Developers Digest](https://www.developersdigest.tech/blog/stop-claude-saying-load-bearing).
+
+---
+
 ## [3.15.0] — 2026-07-08
 
 ### Added

--- a/plugins/writing/skills/remove-ai-patterns/upstream/SKILL.md
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: avoid-ai-writing
 description: Audit and rewrite content to remove AI writing patterns ("AI-isms"). Use this skill when asked to "remove AI-isms," "clean up AI writing," "edit writing for AI patterns," "audit writing for AI tells," or "make this sound less like AI." Supports a detect-only mode, an edit-in-place mode for files, an optional voice profile (casual / professional / technical / warm / blunt), and an iterate-to-convergence pass.
-version: 3.15.0
+version: 3.22.1
 license: MIT
 compatibility: Any AI coding assistant that supports agentskills.io SKILL.md format (Claude Code, Cursor, VS Code Copilot, Hermes Agent, OpenHands, etc.) or OpenClaw. No external tools or APIs required.
 metadata:
@@ -68,7 +68,7 @@ In **edit** mode, your job is to:
 ## What to remove or fix
 
 ### Formatting
-- **Em dashes (— and --)**: Replace with commas, periods, parentheses, or rewrite as two sentences. Target: zero. Hard max: one per 1,000 words. This applies to headings and section titles too, not just body prose. Catch both the Unicode em dash (—) and the double-hyphen substitute (--).
+- **Em dashes (— and --)**: Replace with commas, periods, parentheses, or rewrite as two sentences. Target: zero. Hard max: one per 1,000 words. This applies to headings and section titles too, not just body prose. Catch both the Unicode em dash (—) and the double-hyphen substitute (--). Carve-out: an em dash acting as the separator in a bulleted or numbered list item that opens with a bolded lead term or a markdown link (`- **Term** — description`, `- [label](url) — description`) is typography, not a prose splice — don't count it toward the rate. Only the list-item form qualifies: a mid-sentence splice still counts, as does a line-initial `**Bold lead** — full sentence` outside a list (itself an AI tell), and the double-hyphen substitute is never carved out.
 - **Bold overuse**: Strip bold from most phrases. One bolded phrase per major section at most, or none. If something's important enough to bold, restructure the sentence to lead with it instead.
 - **Emoji in headers**: Remove entirely. No `## 🚀 What This Means`. Exception: social posts may use one or two emoji sparingly — at the end of a line, never mid-sentence.
 - **Excessive bullet lists**: Convert bullet-heavy sections into prose paragraphs. Bullets only for genuinely list-like content (feature comparisons, step-by-step instructions, API parameters).
@@ -76,7 +76,7 @@ In **edit** mode, your job is to:
 - **Immaculate typography in casual registers**: Same tier as curly quotes — a *weak*, register-scoped signal, never conclusive alone. Perfect spacing, punctuation, and capitalization in a context where humans type fast (issue/PR comments, chat, DMs) is corroborating evidence, not proof: a careful human can type a flawless comment, and a rushed one can type a sloppy one. Judge it alongside other signals. Inverse case worth flagging the other direction: when editing a human's casual text (a Slack message, a quick reply), preserve their typos, contractions, and idiosyncratic capitalization rather than correcting them — smoothing away the rough edges erases the fingerprint that marks the text as theirs.
 
 ### Sentence structure
-- **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument. This includes the **split-sentence form**, where the negation and the correction fall in two separate sentences rather than pivoting on a single dash or comma: "The headline isn't the speed. The real story is Y." Read on its own, each sentence looks like an innocent declarative, which is exactly why the split version slips past a check tuned to the joined phrasing — flag it the same way. AI also stacks the negation across several options before the reveal ("It's not the price. It's not the features. It's the trust."). The multi-negation countdown is the same move inflated; flag it and cut straight to the positive claim.
+- **"It's not X — it's Y" / "This isn't about X, it's about Y"**: Rewrite as a direct positive statement. Max one per piece, and only if it serves the argument. This includes the **split-sentence form**, where the negation and the correction fall in two separate sentences rather than pivoting on a single dash or comma: "The headline isn't the speed. The real story is Y." Read on its own, each sentence looks like an innocent declarative, which is exactly why the split version slips past a check tuned to the joined phrasing — flag it the same way. AI also stacks the negation across several options before the reveal ("It's not the price. It's not the features. It's the trust."). The multi-negation countdown is the same move inflated; flag it and cut straight to the positive claim. The **tailing negation** is the clipped cousin: a bare negation fragment tacked onto the end of a sentence — "The options come from the selected item, no guessing." Write the constraint as a real clause ("without forcing the user to guess") or cut it. Carve-out: negations enumerating spec constraints in a list ("no dependencies, no telemetry") are list content, not a reveal. Adapted from `blader/humanizer` P9.
 - **Hollow intensifiers**: Cut `genuine` / `genuinely`, `real` (as in "a real improvement"), `truly`, `quite frankly`, `to be honest`, `let's be clear`, `it's worth noting that`. Just state the fact.
 - **Vague endorsement ("worth [verb]ing")**: Cut or replace `worth reading`, `worth paying attention to`, `worth a look`, `worth exploring`, `worth checking out`, `worth your time`. These substitute a generic thumbs-up for a specific reason. Say *why* something matters instead.
 - **Hedging**: Cut `perhaps`, `could potentially`, `it's important to note that`, `to be clear`. Make the point directly.
@@ -94,6 +94,18 @@ Words are organized into three tiers based on how reliably they signal AI-genera
 **Match inflected forms.** Each entry below covers the listed word *and its morphological variants* — adverb (`-ly`), gerund/participle (`-ing`), plural, comparative/superlative, and verb conjugations — unless a variant carries a distinct, legitimate meaning. So `genuine` also flags `genuinely`, `leverage` also flags `leveraging` / `leveraged`, `delve` covers `delving`, and `meticulous` covers `meticulously`. When a variant has a separate honest sense (e.g. `real` meaning factual, not the intensifier in "a real improvement"), judge by context rather than matching blindly.
 
 #### Tier 1 — Always replace
+
+Tier 1 splits into two bands. **Both are always replaced**; the edit is the same. What differs is what a flag *means*.
+
+**1A — AI frequency markers.** Words claimed to appear far more often in machine text than in human writing. A cluster of these is evidence about how a passage was produced.
+
+**1B — Clarity edits.** Wordiness and inflated formality. Replacing them is good writing regardless of who wrote the sentence, and a 1B hit is **not** evidence of machine authorship. Measured against 257 paragraphs of verified pre-2023 human prose, 1B entries fire on ordinary professional and formal writing at a meaningful rate — `in order to`, `utilize`, `commence`, `ascertain`, and `endeavor` are simply the words some people reach for. The detector emits these as `tier1-clarity`, weights them like Tier 2, and excludes them from the dense-AI-vocabulary signal so a wordiness fix can never push a document toward an AI classification.
+
+In `detect` mode, report the two bands separately. Presenting a wordiness fix as authorship evidence is the error this split exists to prevent.
+
+Caveat worth keeping visible: the "appears far more often in AI text" claim behind 1A is **inherited, not measured here**. It traces to [brandonwise/humanizer](https://github.com/brandonwise/humanizer), which states a 5–20x ratio without publishing a method or dataset. Treat 1A as a well-supported convention rather than a verified statistic until this repo measures the ratios itself against a machine-written corpus.
+
+##### Tier 1A — AI frequency markers
 
 | Replace | With |
 |---|---|
@@ -115,7 +127,6 @@ Words are organized into three tiers based on how reliably they signal AI-genera
 | seamless / seamlessly | smooth, easy, without friction |
 | game-changer / game-changing | describe what specifically changed and why it matters |
 | hit differently / hits different | (say what specifically changed, or cut) |
-| utilize | use |
 | watershed moment | turning point, shift (or describe what changed) |
 | marking a pivotal moment | (state what happened) |
 | the future looks bright | (cut — say something specific or nothing) |
@@ -142,6 +153,23 @@ Words are organized into three tiers based on how reliably they signal AI-genera
 | at its core | (cut — just state the thing) |
 | synergy / synergies | (describe the actual combined effect) |
 | interplay | relationship, connection, interaction |
+| keen (as intensifier) | interested, eager, enthusiastic (or cut — just state the interest) |
+| genuinely / genuine (as intensifier) | (cut — just state the fact) |
+| symphony (metaphor) | (describe the actual coordination or combination) |
+| embrace (metaphor) | adopt, accept, use, switch to |
+| load-bearing *(metaphor)* | essential, critical, necessary — or say what breaks if you remove it |
+
+**Hyphen required:** unhyphenated "load bearing" is ordinary English ("the load bearing down on the bridge") — only the hyphenated compound is the tell.
+
+**Construction carve-out:** `load-bearing` before a literal structural noun (`wall`, `beam`, `column`, `joist`, `truss`, `member`, `footing`, `slab`, `stud`, `partition`, `masonry`, `lintel`, `pier`, `rafter`, `girder`, `capacity`), optionally with one material or position adjective in between (`load-bearing structural wall`), is standard building terminology — don't flag. Abstract-capable nouns (`structure`, `element`, `frame`, `foundation`) are excluded on purpose, so "the load-bearing structure of his argument" still flags. Known gap: predicative use ("the wall is load-bearing") still flags — see issue #56.
+
+##### Tier 1B — Clarity edits
+
+Wordiness and formality, not authorship evidence. Same fix, weaker claim.
+
+| Replace | With |
+|---|---|
+| utilize | use |
 | in order to | to |
 | due to the fact that | because |
 | serves as | is |
@@ -151,10 +179,6 @@ Words are organized into three tiers based on how reliably they signal AI-genera
 | commence | start, begin |
 | ascertain | find out, determine, learn |
 | endeavor | effort, attempt, try |
-| keen (as intensifier) | interested, eager, enthusiastic (or cut — just state the interest) |
-| genuinely / genuine (as intensifier) | (cut — just state the fact) |
-| symphony (metaphor) | (describe the actual coordination or combination) |
-| embrace (metaphor) | adopt, accept, use, switch to |
 
 #### Tier 2 — Flag when 2+ appear in the same paragraph
 
@@ -221,6 +245,7 @@ These are normal words. Only flag them when the text is saturated with them — 
 | sophisticated | Describe the sophistication |
 | instrumental | Say what role it played |
 | world-class / state-of-the-art / best-in-class | Cite a benchmark or comparison |
+| verbatim | Usually redundant with the verb ("copies X verbatim" = "copies X") — cut it. If the exactness marks a contrast, name it: byte-for-byte, word for word, unchanged. Term of art in legal/research/QA registers ("verbatim transcript / record / testimony"), so weigh density in that context before flagging |
 
 #### Tier 3 phrases — Flag at density or in clusters
 
@@ -267,6 +292,12 @@ These slot-fill constructions signal that a sentence was generated, not written.
 - Phrases like "marking a pivotal moment in the evolution of..." or "a watershed moment for the industry" inflate routine events into history-making ones. State what happened and let the reader judge significance.
 - If the sentence still works after you delete the inflation clause, delete it.
 
+### Aphorism formulas
+- Slot-fill profundity: "X is the language of Y," "X is the currency of Z," "the architecture of trust," "X becomes a trap," "X is not a tool but a mirror." The formula turns an ordinary claim into something that sounds quotable without adding precision — the shape does the persuading instead of the evidence.
+- Fix: replace the formula with the concrete claim it gestures at. "Symmetry is the language of trust" → "symmetric layouts feel more predictable to users."
+- Distinct from significance inflation (which puffs up an event's importance) and from the persuasive-authority tropes under Confidence calibration (which announce depth): this pattern manufactures a general law out of a specific observation.
+- Carve-out: quotations and established idioms ("time is money") are attributed speech or common coin — leave them. Adapted from `blader/humanizer` P32.
+
 ### Generic future-narrative closers
 - "May become one of the most important narratives of the next market cycle," "could become the defining trend of the coming decade," "is poised to become the next major chapter in [X]." AI defaults to this shape when it needs to land a closing thought without committing to a falsifiable claim. The closer is grammatically a prediction but contains no testable content.
 - Pattern: modal (may / could / will / is poised to) + "become" + (one of) the most [adjective] + (narrative / story / trend / theme / chapter / movement / force).
@@ -282,6 +313,12 @@ These slot-fill constructions signal that a sentence was generated, not written.
 - **Carve-out — named contrast:** if the sentence explicitly names what the fake/superficial version is, leave it. "Real on-chain settlement, not bridged IOUs" or "actual revenue from paying customers, not grants" is honest contrastive writing. The AI tell is the unsaid contrast.
 - Fix when no contrast is named: drop the adjective and add the specific claim. "Reward sustainability" → "rewards funded from $X/mo in fees rather than emissions."
 
+### Moral-adjective category errors
+- AI glues moral or character adjectives (`honest`, `genuine`, `faithful`, `truthful`) onto non-agentic technical nouns (`shape`, `number`, `representation`, `accuracy`, `curve`, `output`) where the adjective cannot literally modify the noun. "An honest shape" — shapes are not moral agents; it is a category error. The same move appears as the adverb form: "described honestly," "flagged honestly" — the passive voice hides that there is no subject capable of honesty.
+- **Fix:** state the concrete property instead of the moral one. "An honest shape" → "a more realistic curve." "A more honest representation" → "a clearer picture." Cut moral adverbs from passive constructions entirely — "flagged honestly" → "noted." Let the evidence carry the honesty claim.
+- **Related — ontological slop on assumptions:** "The assumption stops being true." Assumptions do not flip from true to false; they degrade in adequacy. Write "the assumption breaks down" or "no longer holds."
+- **Related — gratuitous universal quantifiers:** "Taught in every first-year biochemistry course" instead of "taught in introductory biochemistry." The universal claim ("every") is unverifiable and unnecessary — it borrows authority from a scope the writer cannot check. Replace with the actual scope or drop the quantifier.
+
 ### Hashtag stuffing
 - Long trailing hashtag blocks (6+ hashtags on a single short post) are near-universal in LLM-generated social content and rare in thoughtful human posts. The block usually mixes a project-specific tag with broad category tags (#AI #Crypto #Web3 #Innovation #FutureTech #Technology) — the categorical ones do nothing for discoverability and read as bot output.
 - **Why 6?** Empirical floor. LinkedIn and X organic engagement plateaus or declines past 3-5 tags; human posts that exceed 5 are usually launch posts trading reach for engagement, while LLM-generated posts default to 10-15. Six is the threshold where false positives on legitimate human use start dropping below false negatives on AI output. The detector treats 6+ as a hard flag; the spec treats 5+ as a soft tell worth a second look on `linkedin` and `investor-email` profiles.
@@ -296,6 +333,11 @@ These slot-fill constructions signal that a sentence was generated, not written.
 ### Copula avoidance
 - AI text avoids "is" and "has" by substituting fancier verbs: "serves as," "features," "boasts," "presents," "represents." These sound like a press release.
 - Default to "is" or "has" unless a more specific verb genuinely adds meaning.
+
+### Subjectless fragments and agentless passives
+- Sentences with the subject dropped or the actor hidden: "No configuration file needed." "The results are preserved automatically." "Support for nested queries was added." The clipped no-subject form is a shape LLMs reach for when compressing feature descriptions, and the passive hides who does what.
+- Fix: name the actor when it clarifies — "You don't need a configuration file. The CLI preserves results automatically." Prefer active voice unless the actor is irrelevant.
+- Carve-out: terse reference registers where the fragment is the correct form — README feature lists, changelog entries, parameter docs, commit subjects ("No breaking changes"). Flag in flowing prose; skip in docs and casual registers (see the tolerance matrix). A single deliberate fragment for emphasis is rhythm, not a tell. Adapted from `blader/humanizer` P13.
 
 ### Synonym cycling
 - AI rotates synonyms to avoid repeating a word: "developers… engineers… practitioners… builders" in the same paragraph. Human writers repeat the clearest word.
@@ -390,6 +432,7 @@ These slot-fill constructions signal that a sentence was generated, not written.
 ### Infomercial engagement hooks
 - Punchy fragment-hooks that tee up a reveal: "The catch?", "The kicker?", "Here's the thing.", "But here's the kicker:", "The best part?", "Plot twist:", "The result?". AI uses these to fake momentum and manufacture suspense around ordinary information — the prose equivalent of a late-night infomercial.
 - Distinct from rhetorical-question openers (which stall before a point) and chatbot artifacts (which perform helpfulness): these are mid-flow teasers that pad the rhythm. The fix is to delete the hook and state the thing. "The catch? It only works on weekends." becomes "It only works on weekends." Adapted from `Aboudjem/humanizer-skill` P41.
+- The same move in a fake-candid register: "Honestly?", "Look,", "Real talk:", "Let's be honest —" as standalone openers that stage a pause before an ordinary point. The tell is the theatrical setup-and-reveal, not the word — "honestly" or "look" mid-sentence in casual prose is ordinary English and stays unflagged. Adapted from `blader/humanizer` P33.
 
 ### Social endorsement closers
 - The curatorial sign-off LLMs append to LinkedIn and X posts that share or recommend something — usually a colon teeing up a link: "This one is worth your time:", "This one's a must-read:", "I highly recommend giving this a read.", "Do yourself a favor and read this.", "You won't want to miss this one.", "Save this for later.", "Bookmark this.", "Don't sleep on this one.", "Trust me, you'll want to read this.", "Thank me later."
@@ -404,8 +447,18 @@ These slot-fill constructions signal that a sentence was generated, not written.
 - The fix isn't "never say surprised." It's: if you claim an emotion, the writing around it should earn it. Otherwise cut the claim and present the thing directly.
 - Related pattern: "hit differently" / "hits different." AI uses trendy colloquialisms as a shortcut to sound relatable without earning the emotional beat. If something genuinely affected you, describe how. Otherwise cut.
 
+### Lingering-attention claims
+- The share-post frame that claims a thing has occupied the writer's mind: "the line I keep coming back to," "I can't stop thinking about this," "still thinking about this one," "this has been rattling around in my head all week," "I've been chewing on this since Tuesday." The claim is about the writer's attention, not about the thing, and it arrives *before* the reader has any reason to care.
+- Distinct from emotional flatline, which claims a **feeling** ("What surprised me most"). This claims **duration** of attention, which is unfalsifiable and self-flattering in a way a feeling isn't: nobody can check whether you kept coming back to it, and the frame implies the quote earned repeat visits without showing what it earned them with. Also distinct from social endorsement closers, which vouch for a link at the end of a post; this opens one.
+- **Carve-out — reason attached.** Leave it when the sentence says *why* the thing recurred: "I keep coming back to Hirschman's exit-voice framing because it predicts which engineers quit and which ones file the RFC." That's a claim about the idea's explanatory reach. The tell is the bare frame with the reason missing.
+- Fix: delete the frame and open on the thing itself. "The line I keep coming back to: agents are teenagers." becomes "Jeetu describes AI agents as teenagers." The quote either lands or it doesn't, and the frame doesn't change which.
+
 ### False concession structure
 - "While X is impressive, Y remains a challenge" or "Although X has made strides, Y is still an open question." AI uses this to sound balanced without actually weighing anything. Both halves are vague. Either make the concession specific (name what's impressive, name the actual challenge) or pick a side and argue it.
+
+### Invented contrast-pair mirroring
+- An AI-specific form of forced symmetry: one half of a contrast pair is a legitimate term of art, and the other is the AI inventing its mirror to balance the sentence. "False precision rather than genuine accuracy" — "false precision" is a real statistical term; "genuine accuracy" is a phantom counterpart generated for parallelism. The asymmetry is invisible unless you know which half is real. The same pattern can produce pairs like "real data rather than theoretical models" (both real) or "practical results rather than abstract speculation" (both real), but the AI-specific tell is when one term is borrowed from the domain and the other is entirely fabricated.
+- **Fix:** if you need a contrast, reach for an actual opposite. If no real opposite exists, drop the contrast structure and state the positive claim directly. "May create a misleadingly exact number rather than a more accurate one" — the contrast works because both halves are real descriptions.
 
 ### Rhetorical question openers
 - "But what does this mean for developers?" / "So why should you care?" / "What's next?" — AI uses rhetorical questions to stall before the actual point. If you know the answer, just say it. Rhetorical questions are earned by strong setup, not dropped as section transitions.
@@ -423,6 +476,16 @@ These slot-fill constructions signal that a sentence was generated, not written.
 ### Sycophantic tone
 - "Great question!", "Excellent point!", "You're absolutely right!", "That's a really insightful observation" — these are conversational rewards from chat interfaces, not writing. Remove entirely.
 - Distinct from chatbot artifacts: sycophancy specifically validates the reader/questioner rather than just performing helpfulness.
+
+### Narrated candor
+- Announcing your own disclosure instead of disclosing: "Two caveats I would rather flag than let you discover later:", "I want to be upfront:", "To be fully transparent:", "Rather than bury this, I'll say it plainly:", "I could have left this out, but:", "Being honest about the limitations here:". The content is "Two caveats:"; the rest advertises the writer's forthrightness.
+- Completes the set with two neighbours. Chatbot artifacts perform **helpfulness** ("I hope this helps!"); sycophantic tone validates **the reader** ("Great question!"); this performs **candor about oneself**. Assistant training rewards visible transparency, so the model narrates being forthcoming rather than simply being it.
+- Note the shape is usually a matched antithesis (flag rather than let you discover, say plainly rather than bury), which is its own tell — the symmetry is doing the work that content should.
+- **The deletion test.** Cut the frame. If the sentence loses no information, it was never content: "Two caveats I would rather flag than let you discover later: X and Y" and "Two caveats: X and Y" say the same thing.
+- **Carve-out — the disclosure itself.** Substantive admissions stay, and are the point: "I haven't tested this on Windows", "the numbers in the commit message don't reproduce on my hardware", "this is a mitigation, not a fix". Those carry information. The tell is the separable clause *about* disclosing, not the disclosure.
+- **Carve-out — conflict-of-interest disclosure.** "In the interest of full disclosure, I own shares in the company discussed here" is not narrated candor. In journalism, academia, finance, and open-source governance that opening is the conventional label that makes a disclosure legible, and the sentence carries the material fact. Leave it. The same words with nothing behind them ("in the interest of full disclosure, I want to be upfront about my thinking here") are the tell.
+- **Not the ordinary comparative.** "I'd rather fix it than let you inherit the mess" is a preference about work, not an announcement about disclosing. The construction only counts when what follows the frame is the *disclosure itself*.
+- **Judgment-only, deliberately.** This was implemented as a detector and reverted: every regex tight enough to spare the two carve-outs above stopped matching the tell, and the phrasings are shared with idiomatic disclosure language. Deciding it requires reading whether the clause carries information or only announces that information is coming, which is what a reader can do and a pattern cannot.
 
 ### Acknowledgment loops
 - "You're asking about," "The question of whether," "To answer your question," "That's a great question. The..." — AI restates the prompt before answering. In writing, this is pure filler. The reader knows what they asked. Just answer.
@@ -460,6 +523,17 @@ These slot-fill constructions signal that a sentence was generated, not written.
 - Too many headers in short text: more than 3 headings in under 300 words is almost always AI trying to look organized. Merge sections or use prose transitions instead.
 - Too many list items: 8+ bullet points in under 200 words means the content should be a paragraph, not a list.
 - Formulaic section headers: "Overview," "Key Points," "Summary," "Conclusion," "Introduction" — these are default AI scaffolding. Use headers that tell the reader something specific about what follows.
+- Fragmented headers: a heading followed by a one-line warm-up that restates it ("## Performance", then "Speed matters.") before the real content starts. Cut the warm-up; the heading already did that job. Adapted from `blader/humanizer` P29.
+
+### Diff-anchored writing
+- Documentation or comments narrating a change instead of describing the thing as it is: "This function was added to replace the previous approach of iterating through all items." A reader without the commit history gets archaeology, not documentation. The tell comes from how assistants work — they write docs in the context of the edit they just made, so the prose anchors to the diff; a person documenting later writes from the artifact.
+- Fix: describe the current behavior and why it is that way — "This function uses a hash map for O(1) lookups." If the history matters, it belongs in the changelog or the commit message.
+- Carve-out: documents that are inherently version-scoped — changelogs, release notes, migration guides, decision records — narrate change correctly and stay unflagged. Adapted from `blader/humanizer` P30.
+
+### Manufactured punchlines and staccato drama
+- A run of clipped fragments engineered so every beat lands like a quotable closer: "It had no preference for symmetry. No aesthetic prior. No nostalgia for human taste. The old rules were gone." Each fragment poses as a reveal; stacked, they read as a drumroll.
+- This composes with Rhythm and uniformity below, which encourages fragments and varied lengths: variation is the human signal, and one short sentence that lands a point is exactly that. The tell here is the opposite of variation — three or more same-shape fragments in a row, each carrying manufactured drama.
+- Fix: keep the one fragment that earns its emphasis and fold the rest into ordinary sentences with the claim stated: "AlphaEvolve did not favor symmetry or human-looking designs, which made some of the older assumptions less useful." Adapted from `blader/humanizer` P31.
 
 ### Rhythm and uniformity
 
@@ -517,8 +591,12 @@ Not all AI-isms are equal. When doing a quick pass or triaging a large document,
 - Em dash frequency (above 1 per 1,000 words)
 - Generic future-narrative closers ("may become one of the most important narratives…")
 - Social endorsement closers ("This one is worth your time:", "thank me later")
+- Lingering-attention claims ("the line I keep coming back to," "I can't stop thinking about this")
+- Narrated candor ("I would rather flag this than let you discover it later", "in the interest of full disclosure")
 - Hedge-stacked predictions ("could potentially," "may eventually")
 - Real/actual adjective inflation ("real on-chain tokenomics")
+- Moral-adjective category errors ("honest shape," "flagged honestly")
+- Invented contrast-pair mirroring ("false precision rather than genuine accuracy")
 - Bullet lists of bare noun phrases (5+ short adj+noun items, no verbs)
 - Tier 3 phrase clustering (≥3 distinct boilerplate phrases in one piece)
 
@@ -581,6 +659,9 @@ Rules not listed in the table apply at full strength across all profiles.
 | Social endorsement closers | strict (the LinkedIn share-post tell) | strict | strict | strict | skip | relaxed (1 OK in a DM) |
 | Hedge-stacked predictions | strict | strict | relaxed ("could" is hedged accuracy) | **extra strict** | relaxed | skip |
 | Real/actual inflation | strict | strict | strict | **extra strict** | relaxed | skip |
+| Moral-adjective category errors | strict | strict | relaxed | strict | relaxed | skip |
+| Invented contrast-pair mirroring | strict | strict | relaxed | strict | relaxed | skip |
+| Subjectless fragments and agentless passives | relaxed (short-form fragments are the register) | strict | relaxed | strict | skip (fragment lists are docs) | skip |
 
 **Technical-blog word table exceptions:** These terms have legitimate technical meaning and should not be flagged in technical context: `robust`, `comprehensive`, `seamless`, `ecosystem`, `leverage` (when discussing actual platform leverage/APIs), `facilitate`, `underpin`, `streamline`. Still flag: `delve`, `tapestry`, `beacon`, `embark`, `testament to`, `game-changer`, `harness`.
 
@@ -650,7 +731,7 @@ Re-read the rewritten version from section 2. Identify any remaining AI tells th
 Return your response in two sections:
 
 **1. Issues found**
-A bulleted list of every AI-ism identified, with the offending text quoted. Group by severity (P0, P1, P2).
+A bulleted list of every AI-ism identified, with the offending text quoted. Group by severity (P0, P1, P2). Keep Tier 1B clarity edits visually separate from Tier 1A markers, and say which is which — a wordiness fix is a writing suggestion, not evidence about who wrote the text.
 
 **2. Assessment**
 For each flag, note whether it's a clear problem or a judgment call. Some AI-associated patterns are effective writing techniques — uniform paragraph length is a problem, but a well-placed "however" isn't. Call out which flags the writer should definitely fix vs. which ones are worth a second look but might be fine in context. If the text is clean, say so.
@@ -665,6 +746,14 @@ A bulleted list of the changes, each with the file location and the before → a
 **2. Verification**
 Confirm you re-read the file and the flagged patterns are resolved. Note anything you deliberately left alone because it was already human or intentional.
 
+**Mechanical check (optional, recommended for edit mode).** If the repo ships the detector engine, run the preservation validator against the before and after text:
+
+```bash
+node detector/validate.js <original> <rewritten>
+```
+
+It exits non-zero when a rewrite altered a fenced code block, YAML frontmatter, a blockquote, a table cell, inline code, a URL, a file path, or the heading structure, and when the rewrite introduced more flagged patterns than it removed. Those are the promises made above; this is what checks them. Rewording a heading to fix Title Case and stripping an AI tracking parameter from a URL are carved out, because this skill instructs both.
+
 ---
 
 ## Tone calibration
@@ -678,6 +767,26 @@ Five principles for human-sounding rewrites:
 4. **Cut the neutrality** — humans have opinions. If the piece is supposed to take a position, take it.
 5. **Earn your emphasis** — don't tell the reader something is interesting. Make it interesting.
 
+Removal is half the job. A rewrite that clears every flag but reads sterile — even sentence lengths, no stance, no first person where one belongs — is still recognizably machine output. When the genre carries a voice (essays, posts, personal writing), put voice back on purpose: a reaction, a stated preference, an aside, one thought left unresolved. For encyclopedic, technical, or legal text, neutral and plain is the correct human voice; don't inject personality there. Adapted from `blader/humanizer` ("Personality and soul").
+
 If the original writing is already strong, say so and make only the necessary cuts. Don't over-edit for the sake of it.
 
 The replacement table provides defaults, not mandates. If a flagged word is clearly the right choice in context, preserve it.
+
+### Never inject these
+
+The instruction above — put voice back on purpose — has a predictable failure mode: the model reaches for a stock kit of "human" moves and installs a personality the author never had. That trades one detectable register for a louder one. An independent stress test of `blader/humanizer` found exactly this: generic AI phrasing replaced by a recognizable *humanizer* voice of fragments and staccato rhythm. A new fingerprint, not the absence of one.
+
+None of the following may be **added** to a text that did not already contain it. Every one is a rewrite failure even when the result scores clean:
+
+- **Fake first person.** "I've seen this a hundred times," "in my experience," "I'll admit" dropped into prose that had no author presence. Voice comes from the author or not at all. If the source has no `I`, the rewrite has no `I`.
+- **Manufactured stakes.** "In a world where," "now more than ever," "the stakes have never been higher." Covered as a detection rule under Speculative scenario openers; listed again here because the rewrite side is where it gets *introduced*.
+- **Forced contrarianism.** "Everyone says X, but they're wrong," "the conventional wisdom is backwards." Only legitimate when the source actually argued it. Inventing a foil is inventing a claim.
+- **Performed candor.** "Let's be honest," "real talk," "here's the thing." See Narrated candor and Infomercial engagement hooks. A rewrite that adds one is failing two rules at once.
+- **Em-dash theatrics.** Dashes staged for drama the content has not earned. The rule elsewhere is a rate ceiling; this is about *adding* dashes during a rewrite, which should never happen.
+- **Staccato conversion.** Chopping ordinary sentences into fragments to manufacture rhythm. Vary sentence length by varying the sentences, not by breaking them.
+- **Invented specifics.** A number, name, date, tool, or mechanism the source never contained. Specificity is the most tempting fix because it always reads better, and a fabricated specific is worse than the vague phrasing it replaced. If the concrete detail is missing, flag the gap and leave it. Never fill it.
+
+**The test.** For each edit, ask whether the information in the rewrite came from the source. Subtraction and sharpening are in scope: cutting filler, making an existing claim concrete, surfacing a buried point. Addition of stance, personality, or fact is not. Adapted from `isatimur/de-slop`'s guardrails, which state the rule plainly: you may subtract and sharpen, you may not add.
+
+**Why it belongs here rather than in the pattern catalog.** These are constraints on the editor, not detections on the text. A first-person aside is not a flag when the author wrote it; it is a failure when the tool inserted it. The difference is provenance, which no pattern can see, so it lives with the rewrite instructions where the decision is actually made.

--- a/plugins/writing/skills/remove-ai-patterns/upstream/UPSTREAM-PIN
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/UPSTREAM-PIN
@@ -1,1 +1,1 @@
-https://github.com/conorbronsdon/avoid-ai-writing 500ff59006f19c27120c5ddbd9b56fc3d937b6bf v3.15.0: conversational-register patterns (wall-of-text, recap-flattery) (#53)
+https://github.com/conorbronsdon/avoid-ai-writing 3b5bbc119350668bf4f71eddc2b3b2616ba27855 Fix title-case-header on Markdown headings, and the FPs that fix introduced (#62)

--- a/plugins/writing/skills/remove-ai-patterns/upstream/detector/CATEGORIES.md
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/detector/CATEGORIES.md
@@ -6,14 +6,14 @@ the skill, decide here whether it's regex-detectable (give it a detector `type`)
 or LLM-only judgment (mark it so). When you add a detector `type`, point it back
 at the skill section it enforces.
 
-The engine exposes 45 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
+The engine exposes 46 issue `type`s (see `TYPE_LABELS` in `patterns.js`). The
 skill has more `###` sections than that — the gap is **not** missing coverage,
 it's rules that are judgment calls a regex can't make. The three groups below
 account for every entry on both sides.
 
 Three counts coexist on purpose and should not be forced to match: the README's
 **pattern-category count** (the human-facing prose catalog, derived from SKILL.md
-and guarded in CI), the engine's **45 `type`s** (which split the vocabulary tiers
+and guarded in CI), the engine's **46 `type`s** (which split the vocabulary tiers
 and add stylometric signals), and SKILL.md's `###` sections (which also include
 writer-side tests with no detectable form). The
 `categories.test.js` check enforces only the engine ↔ this-file mapping.
@@ -23,6 +23,7 @@ writer-side tests with no detectable form). The
 | Detector `type` | Label | SKILL.md section |
 |---|---|---|
 | `tier1` / `tier2` / `tier3` | AI vocabulary / Word cluster / Overused word | Words and phrases to replace |
+| `tier1-clarity` | Wordiness | Words and phrases to replace (Tier 1B) |
 | `transition` | AI transition | Transition phrases to remove or rewrite |
 | `template-phrase` | Template phrase | Template phrases (avoid) |
 | `tier3-phrase` / `tier3-phrase-cluster` | Boilerplate phrase / cluster | Template phrases (avoid) |
@@ -41,6 +42,7 @@ writer-side tests with no detectable form). The
 | `real-actual-inflation` | "Real/actual" inflation | "Real/actual" adjective inflation |
 | `vague-attribution` | Vague attribution | Vague attributions |
 | `emotional-flatline` | Emotional flatline | Emotional flatline / Superficial -ing analyses |
+| `lingering-attention` | Lingering-attention claim | Lingering-attention claims *(noun-anchored frames only — the bare "I keep coming back to X" stays LLM-judgment, since a following reason clause makes it legitimate and isn't regex-detectable)* |
 | `cutoff-disclaimer` | Cutoff disclaimer | Cutoff disclaimers |
 | `false-concession` | False concession | False concession structure |
 | `rhetorical-question` | Rhetorical question | Rhetorical question openers |
@@ -88,15 +90,22 @@ mistake their absence for a coverage gap:
 - Synonym cycling
 - Copula avoidance
 - Promotional language
-- Sentence structure: "It's not X — it's Y" / split-sentence form / multi-negation countdown
+- Sentence structure: "It's not X — it's Y" / split-sentence form / multi-negation countdown / tailing negation
 - Structural issues / Excessive structure / Inline-header lists / Numbered list inflation
+- Moral-adjective category errors (including ontological slop on assumptions, gratuitous universal quantifiers)
+- Invented contrast-pair mirroring
 - False ranges
 - Notability name-dropping
 - Vague third-party validation
 - Self-labeling significance
 - Wall-of-text replies (missing line breaks) *(tried as a detector — "reply-length, >=4 sentences, zero newlines" — and reverted; it fires on any ordinary short paragraph, not just conversational-reply register, so it stayed judgment-only. See the NOTE in `patterns.js` near the bullet-NP-list block)*
 - Recap-flattery opener
+- Narrated candor *(tried as a detector and reverted: the phrasings are shared with idiomatic conflict-of-interest disclosure ("in the interest of full disclosure, I own shares in...") and with the ordinary English comparative ("I'd rather die than let you drive"), so any regex tight enough to avoid those stopped matching the tell. Judging it needs reading whether the clause carries information or only announces that information is coming)*
 - Immaculate typography in casual registers *(folded into the Formatting section — same weak-signal tier as curly quotes, not a standalone category)*
+- Subjectless fragments and agentless passives *(docs and changelog registers are carve-outs — the fragment is the correct form there)*
+- Diff-anchored writing *(changelogs, release notes, and migration guides are carve-outs)*
+- Manufactured punchlines / staccato drama
+- Aphorism formulas *(a regex for "X is the Y of Z" would flag ordinary genitive copulas — "Paris is the capital of France")*
 - When to rewrite from scratch vs. patch
 - Severity tiers (P0 / P1 / P2)
 - Self-reference escape hatch

--- a/plugins/writing/skills/remove-ai-patterns/upstream/detector/patterns.js
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/detector/patterns.js
@@ -131,18 +131,33 @@ const AIDetector = (() => {
     { pattern: /\bthought\s+leader(?:ship)?\b/gi, replace: 'expert, authority' },
     { pattern: /\bbest\s+practices\b/gi, replace: 'what works, proven methods' },
     { pattern: /\bat\s+its\s+core\b/gi, replace: 'cut, just state it' },
-    { pattern: /\bin\s+order\s+to\b/gi, replace: 'to' },
-    { pattern: /\bdue\s+to\s+the\s+fact\s+that\b/gi, replace: 'because' },
-    { pattern: /\bserves\s+as\b/gi, replace: 'is' },
-    { pattern: /\bfeatures\b/gi, replace: 'has, includes', filter: true },
-    { pattern: /\bboasts\b/gi, replace: 'has' },
-    { pattern: /\butiliz(?:e|es|ing|ed)\b/gi, replace: 'use' },
+    { pattern: /\bin\s+order\s+to\b/gi, replace: 'to', clarity: true },
+    { pattern: /\bdue\s+to\s+the\s+fact\s+that\b/gi, replace: 'because', clarity: true },
+    { pattern: /\bserves\s+as\b/gi, replace: 'is', clarity: true },
+    { pattern: /\bfeatures\b/gi, replace: 'has, includes', filter: true, clarity: true },
+    { pattern: /\bboasts\b/gi, replace: 'has', clarity: true },
+    { pattern: /\butiliz(?:e|es|ing|ed)\b/gi, replace: 'use', clarity: true },
     { pattern: /\bshowcas(?:e|es|ing|ed)\b/gi, replace: 'show, demonstrate' },
     { pattern: /\bembark(?:s|ing|ed)?\b/gi, replace: 'start, begin' },
-    { pattern: /\bcommenc(?:e|es|ing|ed)\b/gi, replace: 'start, begin' },
-    { pattern: /\bascertain(?:s|ing|ed)?\b/gi, replace: 'find out, determine' },
-    { pattern: /\bendeavou?r(?:s|ing|ed)?\b/gi, replace: 'effort, attempt, try' },
+    { pattern: /\bcommenc(?:e|es|ing|ed)\b/gi, replace: 'start, begin', clarity: true },
+    { pattern: /\bascertain(?:s|ing|ed)?\b/gi, replace: 'find out, determine', clarity: true },
+    { pattern: /\bendeavou?r(?:s|ing|ed)?\b/gi, replace: 'effort, attempt, try', clarity: true },
     { pattern: /\bunderscor(?:es|ing|ed)\b/gi, replace: 'highlights, shows' },
+    // Hyphen required. The unhyphenated "load bearing" is ordinary English —
+    // "the load bearing down on the bridge" — where `bearing` is a participle,
+    // not part of a compound modifier. The tell is always hyphenated.
+    //
+    // Construction carve-out: exempt attributive `load-bearing` before a literal
+    // structural noun, with one optional material/position adjective in between
+    // ("load-bearing structural wall"). The noun list is limited to commonly
+    // physical nouns; the abstract-capable ones most likely to carry the
+    // metaphor (structure, element, frame, foundation) are omitted so "the
+    // load-bearing structure of the argument" still fires. Some listed nouns
+    // (member, column, partition) can still be used metaphorically and are
+    // silently exempt — a recall loss in the safe direction, tracked in #56.
+    // Predicative use ("the wall is load-bearing") is NOT exempt: the tell
+    // lives in the subject, which a lookahead cannot reach. Also #56.
+    { pattern: /\bload-bearing\b(?!\s+(?:(?:structural|exterior|interior|internal|external|concrete|steel|timber|wooden|brick|masonry|perimeter|basement|main|primary|existing|original)\s+)?(?:walls?|beams?|columns?|joists?|truss(?:es)?|members?|footings?|slabs?|studs?|partitions?|masonry|lintels?|piers?|rafters?|girders?|capacity|capacities)\b)/gi, replace: 'essential, critical, or say what breaks if you remove it' },
   ];
 
   // ─── Tier 2: Flag in clusters (2+ per paragraph) ──────────────────
@@ -215,6 +230,11 @@ const AIDetector = (() => {
     'exceptional', 'exceptionally', 'remarkable', 'remarkably',
     'sophisticated', 'instrumental',
     'world-class', 'state-of-the-art', 'best-in-class',
+    // `verbatim` is usually redundant with the verb it modifies ("copies X
+    // verbatim" = "copies X"). It has a genuine term-of-art sense in legal,
+    // research, and QA registers ("verbatim transcript"), so it lives at Tier 3:
+    // density-gated, it only fires on overuse, not on a single legitimate use.
+    'verbatim',
   ];
 
   // Multi-word Tier 3 phrases. Density-gated like single Tier 3 words because
@@ -252,6 +272,9 @@ const AIDetector = (() => {
   // though all three are tagged `critical`.
   const ISSUE_WEIGHTS = {
     tier1: 5,
+    // Wordiness, not an AI-frequency marker. Weighted like tier2 so a
+    // clarity fix cannot push a document toward an AI classification.
+    'tier1-clarity': 3,
     tier2: 3,
     tier3: 2,
     transition: 2,
@@ -266,6 +289,7 @@ const AIDetector = (() => {
     'vague-attribution': 5,
     'hollow-intensifier': 2,
     'emotional-flatline': 2,
+    'lingering-attention': 3,
     'novelty-inflation': 3,
     'cutoff-disclaimer': 10,
     'template-phrase': 3,
@@ -443,6 +467,30 @@ const AIDetector = (() => {
     /^\s*interesting\s+(?:part|thing|aspect|piece)(?:\s+of\s+(?:the\s+)?\w+)?\s*:/gim,
   ];
 
+  // ─── Lingering-attention claims ────────────────────────────────────
+  // The share-post opener that claims duration of attention instead of
+  // saying anything about the thing ("the line I keep coming back to").
+  //
+  // Precision note: the bare verb phrase "I keep coming back to X" is NOT
+  // matched on its own, because it is legitimate whenever a reason follows
+  // ("I keep coming back to Hirschman because it predicts who quits"), and
+  // the reason clause is not reliably detectable by regex. Only the
+  // noun-anchored frame ("the line/quote/bit ... I keep coming back to")
+  // fires, which is the shape that introduces a subject rather than
+  // asserting something about it. The bare form stays a skill-prose
+  // judgment call. See SKILL.md §Lingering-attention claims carve-out.
+  const LINGERING_ATTENTION = [
+    // "the line I keep coming back to", "the one quote that I keep coming back to"
+    // Noun-anchored frame only. "can't stop thinking about" is deliberately
+    // left to its own pattern below rather than folded into this alternation,
+    // so "the line I can't stop thinking about" scores once, not twice.
+    /\b(?:the|that|this)\s+(?:one\s+)?(?:line|quote|bit|part|idea|point|framing|comment|thing)\s+(?:that\s+)?i\s+keep\s+(?:coming\s+back\s+to|thinking\s+about)\b/gi,
+    /\bi\s+can'?t\s+stop\s+thinking\s+about\b/gi,
+    /\bstill\s+thinking\s+about\s+(?:this|that)\s+one\b/gi,
+    /\b(?:been|be)\s+rattling\s+around\s+(?:in\s+)?my\s+(?:head|brain)\b/gi,
+    /\bi'?ve\s+been\s+chewing\s+on\s+(?:this|that)\b/gi,
+  ];
+
   // ─── Novelty inflation ─────────────────────────────────────────────
   const NOVELTY_INFLATION = [
     /\bthe\s+failure\s+mode\s+nobody'?s?\s+naming\b/gi,
@@ -543,7 +591,12 @@ const AIDetector = (() => {
   // opportunities", "may eventually unlock value." Either word alone is
   // fine; the stack is the tell.
   const HEDGE_STACK = [
-    /\b(?:could|may|might)\s+(?:\w+\s+){0,2}(?:potentially|eventually|ultimately|possibly|conceivably)\b/gi,
+    // At most one intervening word, and never a negator. The old {0,2} gap
+    // matched ordinary English: "could not possibly" (plain emphatic
+    // negation) and inverted questions like "could a savage possibly" both
+    // fired. Measured on the human-control corpus, 3 of 4 hedge-stack flags
+    // were this over-match. See issue #69.
+    /\b(?:could|may|might)\s+(?:(?!not\b|never\b|hardly\b|scarcely\b|barely\b)\w+\s+)?(?:potentially|eventually|ultimately|possibly|conceivably)\b/gi,
     /\b(?:potentially|eventually|ultimately)\s+(?:could|may|might)\b/gi,
   ];
 
@@ -598,12 +651,71 @@ const AIDetector = (() => {
     /\b(?:imagine|picture|envision)(?:\s*,[^,\n]{1,30},)?\s+a\s+(?:world|future|reality)\s+(?:where|in\s+which)\b/gi,
   ];
 
+  // Function words whose presence MID-title marks the AI section-header shape.
+  // Word-anchored: without \b the "A" alternative matches inside any word and
+  // the guard silently degrades to "four tokens".
+  const FUNCTION_WORD = /\b(?:And|Or|Of|The|In|For|To|A|An)\b/;
+
+  // Must accept exactly what TITLE_CASE_HEADER accepts, or the prefix survives
+  // into the token count and reintroduces the ##-as-token bug.
+  const MD_HEADING_PREFIX = /^#{1,6}[ \t]+/;
+
+  /** Byte ranges covered by fenced code blocks, computed once per scan.
+   *
+   * A document that documents Markdown is the normal case for this rule -- a
+   * fenced `## Heading` example is illustration, not the author's own section
+   * header, and flagging it makes every docs page flag itself.
+   *
+   * This tracks the opening delimiter instead of counting them, because a
+   * parity count is wrong on the very case the rule exists for. CommonMark
+   * closes a fence only on the same character at the same length or longer, so
+   * a four-backtick fence wrapping a three-backtick example -- exactly how you
+   * document fences -- nests in practice, and counting delimiters inverts on
+   * it. Up to three spaces of indent are legal. An unclosed fence runs to end
+   * of document, matching how renderers treat it.
+   *
+   * Computed once per scan rather than rescanned per hit: the previous version
+   * sliced the whole document for every candidate, which is quadratic on a
+   * heading-dense file. */
+  function fenceRanges(text) {
+    const re = /^[ \t]{0,3}(`{3,}|~{3,})[^\n]*$/gm;
+    const ranges = [];
+    let open = null;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      const marker = m[1];
+      if (!open) {
+        open = { char: marker[0], len: marker.length, start: m.index };
+      } else if (marker[0] === open.char && marker.length >= open.len) {
+        ranges.push([open.start, m.index + m[0].length]);
+        open = null;
+      }
+    }
+    if (open) ranges.push([open.start, text.length]);
+
+    return ranges;
+  }
+
+  function inFenceRange(ranges, index) {
+    return typeof index === 'number' && ranges.some(([a, b]) => index >= a && index < b);
+  }
+
   // ─── Title Case Section Headers in non-technical prose ─────────────
   // "Strategic Negotiations And Key Partnerships" — every content word
   // capitalized. Acceptable in API docs, ML papers, news headlines. Tell
   // in marketing/personal/blog prose. Gated to "personal" / "marketing"
   // context modes (technical mode skips this check).
-  const TITLE_CASE_HEADER = /^([A-Z][a-z]+(?:\s+(?:[A-Z][a-z]+|and|or|of|the|in|for|to|a|an))+\s+[A-Z][a-z]+)\s*$/gm;
+  //
+  // The optional `#{1,6}` prefix is load-bearing (#62): without it the `^[A-Z]`
+  // anchor required the line to START with a capital, so `## Benefits And
+  // Strategic Considerations` never matched — the first character is `#`. The
+  // rule missed the single most common way a heading is actually written, while
+  // catching the bare-line form it is usually converted from. Reported by a
+  // downstream vendoring the detector.
+  //
+  // Setext headings (`Title`/`=====`) need no prefix: their text line is bare
+  // and already matched by this same pattern.
+  const TITLE_CASE_HEADER = /^(?:#{1,6}[ \t]+)?([A-Z][a-z]+(?:\s+(?:[A-Z][a-z]+|and|or|of|the|in|for|to|a|an))+\s+[A-Z][a-z]+)\s*$/gm;
 
   // ─── Parenthetical hedging asides ──────────────────────────────────
   // "(and increasingly, X)", "(or more precisely, Y)", "(though to be
@@ -815,9 +927,11 @@ const AIDetector = (() => {
         if (tier1Found.has(lower)) continue;
         tier1Found.add(lower);
         issues.push({
-          type: 'tier1',
+          // Clarity-band entries are wordiness edits, not frequency evidence.
+          // Same fix, weaker claim — see the Tier 1A/1B split in SKILL.md.
+          type: phrase.clarity ? 'tier1-clarity' : 'tier1',
           text: match[0],
-          severity: 'high',
+          severity: phrase.clarity ? 'medium' : 'high',
           suggestion: phrase.replace,
         });
       }
@@ -890,6 +1004,7 @@ const AIDetector = (() => {
     issues.push(...matchPatterns(text, VAGUE_ATTRIBUTIONS, 'vague-attribution', 'critical'));
     issues.push(...matchPatterns(text, HOLLOW_INTENSIFIERS, 'hollow-intensifier', 'medium'));
     issues.push(...matchPatterns(text, EMOTIONAL_FLATLINE, 'emotional-flatline', 'low'));
+    issues.push(...matchPatterns(text, LINGERING_ATTENTION, 'lingering-attention', 'medium'));
     issues.push(...matchPatterns(text, NOVELTY_INFLATION, 'novelty-inflation', 'medium'));
     issues.push(...matchPatterns(text, CUTOFF_DISCLAIMERS, 'cutoff-disclaimer', 'critical'));
     issues.push(...matchPatterns(text, AI_PLACEHOLDERS, 'ai-placeholder', 'critical'));
@@ -915,11 +1030,34 @@ const AIDetector = (() => {
       // Drop matches that look like proper-noun titles (single line, all
       // tokens capitalized incl. function words) — that's headline style,
       // not the AI-section-header tell which has mid-sentence "And".
+      //
+      // The prefix strip is load-bearing. matchPatterns reports match[0], so a
+      // Markdown hit arrives as "## Terms Of Service" and `##` counts as a
+      // token — silently lowering this guard from four content words to three
+      // for headings only, which is exactly the class it exists to protect.
+      // "## Terms Of Service", "## Bank Of America" and "## Table Of Contents"
+      // all flagged as a result: ordinary human headings, on a detector whose
+      // stated first priority is not firing on human writing.
       const filtered = titleHits.filter((h) => {
-        const tokens = h.text.split(/\s+/);
-        return tokens.length >= 4 && /\b(?:And|Or|Of|The|In|For|To|A|An)\b/.test(h.text);
+        const title = h.text.replace(MD_HEADING_PREFIX, '');
+        const tokens = title.trim().split(/\s+/);
+        if (tokens.length < 4) return false;
+
+        // The function word must be MID-title, which is what the comment above
+        // has always said and what the test never enforced. A leading "The"
+        // satisfied a bare /\bThe\b/, so ordinary human headings flagged:
+        // "## The New Security Landscape", "## The Microsoft Approach to
+        // Identity", "### The Four Keys to a Successful and Secure Modern
+        // Workplace". Measured across 81 files that provably predate LLMs
+        // (2018-19 eBooks, 2020 posts): 13 false positives, every one opening
+        // with "The", against zero on main.
+        //
+        // "## Benefits And Strategic Considerations" -- the actual tell, and
+        // this rule's own fixture -- is untouched: its "And" is interior.
+        return FUNCTION_WORD.test(tokens.slice(1).join(' '));
       });
-      issues.push(...filtered);
+      const fences = filtered.length ? fenceRanges(text) : [];
+      issues.push(...filtered.filter((h) => !inFenceRange(fences, h.index)));
     }
 
     // ── Normalization-trigger flag ───────────────────────────────────
@@ -944,15 +1082,37 @@ const AIDetector = (() => {
       });
     }
 
+    // Em dashes in list-item separator position — a bulleted or numbered
+    // list item opening with a bolded lead term or markdown link, then the
+    // dash ("- **Term** — desc", "- [label](url) — desc") — are
+    // definition-list typography, not prose punctuation. Shared by the
+    // smart-punct signature below and the em-dash frequency check (§22).
+    // An optional parenthetical or inline-code span may sit between the bold
+    // lead term and the dash — "- **Lingering-attention claims**
+    // (`lingering-attention`) — the share-post frame…" is the same definition
+    // typography as the bare form. Found by the self-scan (see PROOF.md, #67).
+    const SEPARATOR_DASH_RE = /^\s*(?:[-*+]|\d+[.)])\s+(?:\*\*[^*\n]+\*\*|\[[^\]\n]+\]\([^)\n]*\))(?:[ \t]*(?:\([^)\n]*\)|`[^`\n]+`))?[ \t]*—/gm;
+
+    // Keep-a-Changelog version headings (`## [3.21.0] — 2026-07-30`) join a
+    // label to a value exactly as a list separator does. Deliberately narrow:
+    // a bracketed or bare semver token, then a dash, then an ISO date, and
+    // nothing else on the line. Ordinary prose dashes in headings still count,
+    // because SKILL.md applies the em-dash rule to headings too.
+    const VERSION_HEADING_DASH_RE = /^#{1,6}[ \t]+\[?v?\d+\.\d+\.\d+[^\]\n]*\]?[ \t]*—[ \t]*\d{4}-\d{2}-\d{2}[ \t]*$/gm;
+
     // ── Smart-punctuation co-occurrence signature ────────────────────
     // Curly quotes + em-dash + Oxford comma all present + zero typos
     // (no double-spaces, no missing apostrophes in common contractions)
     // is a near-dispositive paste-from-LLM signature: humans typing
     // directly into a textarea don't produce all four. Standalone any of
-    // these is meaningless — co-occurrence is the signal.
+    // these is meaningless — co-occurrence is the signal. Separator-position
+    // dashes are typography and don't corroborate it.
     {
       const hasCurly = /[“”‘’]/.test(text);
-      const hasEmDash = /—/.test(text);
+      const totalEmDashes = (text.match(/—/g) || []).length;
+      const separatorEmDashes = (text.match(SEPARATOR_DASH_RE) || []).length
+        + (text.match(VERSION_HEADING_DASH_RE) || []).length;
+      const hasEmDash = totalEmDashes > separatorEmDashes;
       const oxfordHit = text.match(/\b\w+,\s+\w+,\s+and\s+\w+/g);
       const hasOxford = (oxfordHit?.length || 0) >= 1;
       const doubleSpaces = (text.match(/[^.!?]  +/g) || []).length;
@@ -1256,7 +1416,15 @@ const AIDetector = (() => {
     // ── 22. Em dash frequency ────────────────────────────────────
     // Match real em dashes, plus `--` only when surrounded by whitespace on at
     // least one side (skips CLI flags like --save-dev and YAML `---` blocks).
-    const emDashCount = (text.match(/—|(?<=\s)--(?=\s|$)|(?<=^|\s)--(?=\s)/gm) || []).length;
+    // Separator-position em dashes (SEPARATOR_DASH_RE above) are excluded
+    // from the rate. The list marker is required on purpose: a line-initial
+    // "**Bold lead** — full sentence" outside a list is itself an AI tell
+    // and still counts, as does a mid-sentence "**bold** — like this"
+    // splice. Em dash only — the `--` substitute is never carved out.
+    const rawEmDashCount = (text.match(/—|(?<=\s)--(?=\s|$)|(?<=^|\s)--(?=\s)/gm) || []).length;
+    const separatorDashCount = (text.match(SEPARATOR_DASH_RE) || []).length
+      + (text.match(VERSION_HEADING_DASH_RE) || []).length;
+    const emDashCount = rawEmDashCount - separatorDashCount;
     const emDashRate = emDashCount / (wordCount / 1000);
     if (emDashRate > 1) {
       issues.push({
@@ -1661,6 +1829,7 @@ const AIDetector = (() => {
 
   const TYPE_LABELS = {
     'tier1': 'AI vocabulary',
+    'tier1-clarity': 'Wordiness',
     'tier2': 'Word cluster',
     'tier3': 'Overused word',
     'transition': 'AI transition',
@@ -1675,6 +1844,7 @@ const AIDetector = (() => {
     'vague-attribution': 'Vague attribution',
     'hollow-intensifier': 'Hollow intensifier',
     'emotional-flatline': 'Emotional flatline',
+    'lingering-attention': 'Lingering-attention claim',
     'novelty-inflation': 'Novelty inflation',
     'cutoff-disclaimer': 'Cutoff disclaimer',
     'template-phrase': 'Template phrase',

--- a/plugins/writing/skills/remove-ai-patterns/upstream/detector/validate.js
+++ b/plugins/writing/skills/remove-ai-patterns/upstream/detector/validate.js
@@ -1,0 +1,340 @@
+/**
+ * Avoid AI Writing — preservation validator
+ *
+ * SKILL.md promises that a rewrite leaves certain things alone: "Don't edit
+ * quoted material, code blocks, or text attributed to someone else" (edit
+ * mode), "Preserve the original structure, intent, and all specific technical
+ * details" (rewrite mode). Nothing enforced those promises. This does.
+ *
+ * Usage:
+ *   const { validate } = require('./validate.js');
+ *   const result = validate(originalText, rewrittenText);
+ *   if (!result.ok) { console.error(result.errors); }
+ *
+ * Errors block: they mean the rewrite destroyed or altered content it had no
+ * business touching. Warnings inform: they mean something changed that is
+ * usually legitimate but occasionally a mistake.
+ *
+ * Two carve-outs exist because this skill *documents* the edit in question,
+ * and a validator that fires on its own skill's instructions is worse than no
+ * validator:
+ *
+ *   1. AI-tool URL parameters (`utm_source=chatgpt.com` and friends). SKILL.md
+ *      says "strip the parameter from every URL." So URLs are compared with
+ *      those parameters removed from both sides.
+ *   2. Heading text. SKILL.md says to convert Title Case headings to sentence
+ *      case, and to cut emoji from headings. So heading *text* changing is a
+ *      warning; heading count and nesting sequence changing is an error.
+ *
+ * Dependency-free. Runs on node >= 18. Mirrors the IIFE + module.exports shape
+ * of patterns.js so it can be loaded in a browser too.
+ */
+
+const AIDetectorValidate = (() => {
+  // ═══ Block extractors ══════════════════════════════════════════════
+  const FENCED_CODE = /^(?:```|~~~)[^\n]*\n[\s\S]*?^(?:```|~~~)[ \t]*$/gm;
+  const INLINE_CODE = /`[^`\n]+`/g;
+  const YAML_FRONTMATTER = /^---\n[\s\S]*?\n---(?=\n|$)/;
+  const BLOCKQUOTE_BLOCK = /(?:^[ \t]*>[^\n]*(?:\n[ \t]*>[^\n]*)*)/gm;
+  const TABLE_BLOCK = /(?:^[ \t]*\|[^\n]*\|[ \t]*(?:\n[ \t]*\|[^\n]*\|[ \t]*)+)/gm;
+  const MD_HEADING = /^(#{1,6})[ \t]+(.+?)[ \t]*$/gm;
+  const URL = /https?:\/\/[^\s)>\]"'`]+/g;
+  const MD_LINK_TARGET = /\[[^\]\n]*\]\(([^)\s]+)[^)]*\)/g;
+  const PATH = /(?:^|[\s(])((?:\.{0,2}\/)[A-Za-z0-9._~\-]+(?:\/[A-Za-z0-9._~\-]+)*|[A-Za-z]:\\[A-Za-z0-9._\\~\-]+)/g;
+  const NUMBER = /\b\d[\d,]*(?:\.\d+)?%?\b/g;
+
+  // Tracking parameters this skill is documented to strip (SKILL.md,
+  // "AI-tool URL parameters"). Kept in sync with the `ai-utm-source`
+  // detector category in patterns.js.
+  const AI_URL_PARAMS = /[?&](?:utm_source=(?:chatgpt\.com|openai(?:\.com)?|copilot\.com|claude\.ai|perplexity\.ai|gemini\.google\.com|grok\.com)|referrer=grok\.com)\b/gi;
+
+  function extractAll(re, text) {
+    const out = [];
+    const rx = new RegExp(re.source, re.flags.includes('g') ? re.flags : re.flags + 'g');
+    let m;
+    while ((m = rx.exec(text)) !== null) {
+      out.push(m[1] !== undefined ? m[1] : m[0]);
+      if (m.index === rx.lastIndex) rx.lastIndex++;
+    }
+    return out;
+  }
+
+  /**
+   * Blank out fenced code and inline code before scanning prose-level
+   * constructs. Without this, a URL inside a code sample counts twice and a
+   * `|` in a code block reads as a table row.
+   */
+  function maskCode(text) {
+    return text
+      .replace(FENCED_CODE, (block) => block.replace(/[^\n]/g, ' '))
+      .replace(INLINE_CODE, (span) => ' '.repeat(span.length));
+  }
+
+  function normalizeUrl(u) {
+    return u.replace(AI_URL_PARAMS, '').replace(/[?&]$/, '');
+  }
+
+  /** Collapse cell padding so a re-aligned table isn't reported as edited. */
+  function normalizeTable(block) {
+    return block
+      .split('\n')
+      .map((row) => row.trim().replace(/\s*\|\s*/g, '|').replace(/-{2,}/g, '-'))
+      .join('\n');
+  }
+
+  function normalizeQuote(block) {
+    return block
+      .split('\n')
+      .map((line) => line.replace(/^[ \t]*>[ \t]?/, '').trimEnd())
+      .join('\n')
+      .trimEnd();
+  }
+
+  /**
+   * Indented code blocks are deliberately warning-level, not error-level.
+   * Four-space indentation is also how markdown continues a list item, and a
+   * validator that blocks a legitimate rewrite is worse than one that reports
+   * a soft signal. Only blocks that follow a blank line and are not inside a
+   * list are counted.
+   */
+  function extractIndentedBlocks(text) {
+    const lines = text.split('\n');
+    const blocks = [];
+    let current = null;
+    let inList = false;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const isIndented = /^(?: {4}|\t)\S/.test(line);
+      const isBlank = /^\s*$/.test(line);
+      if (/^\s*(?:[-*+]|\d+[.)])\s/.test(line)) inList = true;
+      else if (!isBlank && !isIndented) inList = false;
+
+      if (isIndented && !inList) {
+        if (current === null) current = [];
+        current.push(line);
+      } else if (!isBlank && current !== null) {
+        blocks.push(current.join('\n'));
+        current = null;
+      }
+    }
+    if (current !== null) blocks.push(current.join('\n'));
+    return blocks;
+  }
+
+  function counts(list) {
+    const map = new Map();
+    for (const item of list) map.set(item, (map.get(item) || 0) + 1);
+    return map;
+  }
+
+  /** Items present in `a` more often than in `b`. */
+  function missingFrom(a, b) {
+    const have = counts(b);
+    const out = [];
+    for (const item of a) {
+      const n = have.get(item) || 0;
+      if (n === 0) out.push(item);
+      else have.set(item, n - 1);
+    }
+    return out;
+  }
+
+  function sample(list, n = 5) {
+    const shown = list.slice(0, n);
+    return shown.join(', ') + (list.length > n ? ` (+${list.length - n} more)` : '');
+  }
+
+  function wordCount(text) {
+    const words = maskCode(text).trim().match(/\S+/g);
+    return words ? words.length : 0;
+  }
+
+  /**
+   * @param {string} original   text as the writer supplied it
+   * @param {string} rewritten  text the skill produced
+   * @param {object} [options]
+   * @param {object} [options.detector]   AIDetector instance; defaults to
+   *                                      requiring ./patterns.js when available
+   * @param {boolean} [options.skipResidual]  skip the "patterns must not grow"
+   *                                      check (used by structure-only tests)
+   * @param {number} [options.maxShrinkRatio]  warn when the rewrite drops more
+   *                                      than this fraction of words (default 0.4)
+   * @returns {{ok: boolean, errors: Array, warnings: Array, stats: object}}
+   */
+  function validate(original, rewritten, options = {}) {
+    const errors = [];
+    const warnings = [];
+    const err = (code, message) => errors.push({ code, message });
+    const warn = (code, message) => warnings.push({ code, message });
+
+    if (typeof original !== 'string' || typeof rewritten !== 'string') {
+      throw new TypeError('validate(original, rewritten): both arguments must be strings');
+    }
+
+    // ── Fenced code: exact, in order. Code is never the skill's business. ──
+    const origFenced = extractAll(FENCED_CODE, original);
+    const newFenced = extractAll(FENCED_CODE, rewritten);
+    if (origFenced.length !== newFenced.length) {
+      err('code-block-count', `Fenced code blocks changed in number: ${origFenced.length} → ${newFenced.length}.`);
+    } else if (origFenced.some((block, i) => block !== newFenced[i])) {
+      const changed = origFenced.findIndex((block, i) => block !== newFenced[i]);
+      err('code-block-modified', `Fenced code block #${changed + 1} was modified.`);
+    }
+
+    // ── YAML frontmatter: exact. ──
+    const origYaml = original.match(YAML_FRONTMATTER);
+    const newYaml = rewritten.match(YAML_FRONTMATTER);
+    if ((origYaml ? origYaml[0] : null) !== (newYaml ? newYaml[0] : null)) {
+      err('frontmatter-modified', 'YAML frontmatter was modified, added, or removed.');
+    }
+
+    const origProse = maskCode(original);
+    const newProse = maskCode(rewritten);
+
+    // ── Blockquotes: someone else's words. ──
+    const origQuotes = extractAll(BLOCKQUOTE_BLOCK, origProse).map(normalizeQuote);
+    const newQuotes = extractAll(BLOCKQUOTE_BLOCK, newProse).map(normalizeQuote);
+    const lostQuotes = missingFrom(origQuotes, newQuotes);
+    if (lostQuotes.length) {
+      err('blockquote-modified', `Blockquote content was modified or removed (${lostQuotes.length} block(s)). Quoted material is attributed to someone else.`);
+    }
+
+    // ── Tables: reference content, not prose. ──
+    const origTables = extractAll(TABLE_BLOCK, origProse).map(normalizeTable);
+    const newTables = extractAll(TABLE_BLOCK, newProse).map(normalizeTable);
+    const lostTables = missingFrom(origTables, newTables);
+    if (lostTables.length) {
+      err('table-modified', `Markdown table content was modified or removed (${lostTables.length} table(s)).`);
+    }
+
+    // ── Inline code: identifiers, flags, filenames. ──
+    const lostInline = missingFrom(extractAll(INLINE_CODE, original), extractAll(INLINE_CODE, rewritten));
+    if (lostInline.length) {
+      err('inline-code-missing', `Inline code removed: ${sample(lostInline)}`);
+    }
+
+    // ── URLs, compared with AI tracking parameters stripped from both sides. ──
+    const origUrls = [
+      ...extractAll(URL, origProse),
+      ...extractAll(MD_LINK_TARGET, origProse),
+    ].map(normalizeUrl);
+    const newUrls = [
+      ...extractAll(URL, newProse),
+      ...extractAll(MD_LINK_TARGET, newProse),
+    ].map(normalizeUrl);
+    const lostUrls = missingFrom(origUrls, newUrls);
+    if (lostUrls.length) {
+      err('url-missing', `URL removed or altered: ${sample(lostUrls)}`);
+    }
+
+    // ── Filesystem paths. ──
+    const lostPaths = missingFrom(extractAll(PATH, origProse), extractAll(PATH, newProse));
+    if (lostPaths.length) {
+      err('path-missing', `File path removed or altered: ${sample(lostPaths)}`);
+    }
+
+    // ── Headings: structure is an error, wording is a warning. ──
+    const origHeadings = [];
+    const newHeadings = [];
+    for (const [, hashes, text] of original.matchAll(MD_HEADING)) origHeadings.push({ level: hashes.length, text });
+    for (const [, hashes, text] of rewritten.matchAll(MD_HEADING)) newHeadings.push({ level: hashes.length, text });
+    if (origHeadings.length !== newHeadings.length) {
+      err('heading-count', `Heading count changed: ${origHeadings.length} → ${newHeadings.length}. Restructuring the document is out of scope for a rewrite.`);
+    } else {
+      const levelDrift = origHeadings.findIndex((h, i) => h.level !== newHeadings[i].level);
+      if (levelDrift !== -1) {
+        err('heading-level', `Heading nesting changed at heading #${levelDrift + 1}: h${origHeadings[levelDrift].level} → h${newHeadings[levelDrift].level}.`);
+      }
+      const reworded = origHeadings.filter((h, i) => h.text !== newHeadings[i].text);
+      if (reworded.length) {
+        warn('heading-text', `${reworded.length} heading(s) reworded. Expected when fixing Title Case or removing emoji; check nothing else moved.`);
+      }
+    }
+
+    // ── Numbers: SKILL.md says preserve specific technical details. ──
+    const lostNumbers = missingFrom(extractAll(NUMBER, origProse), extractAll(NUMBER, newProse));
+    if (lostNumbers.length) {
+      warn('number-missing', `Figures present in the original are absent from the rewrite: ${sample(lostNumbers)}. Legitimate when a numeral was spelled out; a fabrication risk otherwise.`);
+    }
+
+    // ── Volume: a rewrite that halves the text probably dropped content. ──
+    const origWords = wordCount(original);
+    const newWords = wordCount(rewritten);
+    const maxShrink = options.maxShrinkRatio == null ? 0.4 : options.maxShrinkRatio;
+    if (origWords > 0 && newWords / origWords < 1 - maxShrink) {
+      warn('large-shrink', `Rewrite dropped ${Math.round((1 - newWords / origWords) * 100)}% of the words (${origWords} → ${newWords}). Check for lost content.`);
+    }
+
+    // ── Residual patterns: the rewrite must not introduce new tells. ──
+    let residual = null;
+    if (!options.skipResidual) {
+      let detector = options.detector;
+      if (!detector && typeof require === 'function') {
+        try {
+          detector = require('./patterns.js');
+        } catch (_) {
+          detector = null;
+        }
+      }
+      if (detector && typeof detector.analyzeText === 'function') {
+        const before = detector.analyzeText(original);
+        const after = detector.analyzeText(rewritten);
+        residual = {
+          issuesBefore: before.issues.length,
+          issuesAfter: after.issues.length,
+          scoreBefore: before.score,
+          scoreAfter: after.score,
+        };
+        if (after.issues.length > before.issues.length) {
+          err('residual-grew', `Rewrite introduced AI patterns: ${before.issues.length} → ${after.issues.length} flagged issues. A rewrite may leave patterns behind; it may not add them.`);
+        }
+      }
+    }
+
+    return {
+      ok: errors.length === 0,
+      errors,
+      warnings,
+      stats: {
+        wordsBefore: origWords,
+        wordsAfter: newWords,
+        fencedBlocks: origFenced.length,
+        headings: origHeadings.length,
+        indentedBlocks: extractIndentedBlocks(original).length,
+        residual,
+      },
+    };
+  }
+
+  /** Human-readable one-liner per finding, for CLI and skill output. */
+  function formatResult(result) {
+    const lines = [];
+    lines.push(result.ok ? 'PASS — preservation checks clear' : `FAIL — ${result.errors.length} preservation error(s)`);
+    for (const e of result.errors) lines.push(`  error   [${e.code}] ${e.message}`);
+    for (const w of result.warnings) lines.push(`  warning [${w.code}] ${w.message}`);
+    return lines.join('\n');
+  }
+
+  return { validate, formatResult, maskCode, extractIndentedBlocks };
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = AIDetectorValidate;
+}
+
+// CLI: node detector/validate.js <original> <rewritten>
+// Exits 1 on a preservation error so it can gate an edit-mode run in CI.
+if (typeof require !== 'undefined' && typeof module !== 'undefined' && require.main === module) {
+  const fs = require('node:fs');
+  const [origPath, newPath] = process.argv.slice(2);
+  if (!origPath || !newPath) {
+    console.error('usage: node detector/validate.js <original-file> <rewritten-file>');
+    process.exit(2);
+  }
+  const result = AIDetectorValidate.validate(
+    fs.readFileSync(origPath, 'utf8'),
+    fs.readFileSync(newPath, 'utf8'),
+  );
+  console.log(AIDetectorValidate.formatResult(result));
+  process.exit(result.ok ? 0 : 1);
+}


### PR DESCRIPTION
Refreshes the vendored `remove-ai-patterns` catalog and detector via `plugins/writing/scripts/update-upstream.sh`.

## Why now

Upstream fixed the bug we reported as [conorbronsdon/avoid-ai-writing#62](https://github.com/conorbronsdon/avoid-ai-writing/issues/62). The `title-case-header` check was anchored to `^[A-Z]`, so it never matched a Markdown heading (which begins with `#`) and silently missed exactly the case it exists to catch. Their fix makes the `#{1,6}` prefix optional — and goes further than the one-liner we suggested, suppressing the false positives that finally-firing check surfaced, with 181 lines of new tests.

## What moved

- `remove-ai-patterns`: `500ff59` (v3.15.0) → `3b5bbc11` (v3.22.1), spanning eight releases. Beyond the #62 fix, upstream added enforcement, a self-scan proof, and its first measured accuracy numbers.
- `agent-style`: no new commits upstream, unchanged.

## Verification

**The fix works in our copy** — same input, old detector vs. new:

| detector | result on `## Benefits And Strategic Considerations` |
|---|---|
| previously pinned (v3.15.0) | no issues |
| refreshed (v3.22.1) | `title-case-header` flagged |

Also checked:

- `technical` context mode still skips the title-case check, matching what our docs say.
- Detector still runs clean on an ordinary document.
- **Third-party content review** (the gate the maintainer flow calls for): the added `SKILL.md` prose is writing-rule content only. No tool invocations, network calls, credential handling, or scope changes were introduced — the only URLs added are citations to other repos inside explanatory prose.

## Downstream

Nothing to change in sasy-docs: it references the `writing` plugin rather than vendoring these skills. Users pick this up with a marketplace update and reinstall.

---

## Codex review follow-up (commit 9b82914)

**Fixed here — missing validator (P2).** The refreshed upstream `SKILL.md` advertises an edit-mode verification step, `node detector/validate.js <original> <rewritten>`, but `update-upstream.sh` copied only `patterns.js` and `CATEGORIES.md`, so following that instruction produced `MODULE_NOT_FOUND`. `validate.js` is new in the releases this refresh pulled in. Added it to the script's copy list, vendored it, and documented it in our wrapper `SKILL.md` using the absolute `$SKILL_DIR` path — upstream writes it relative, which fails from the user's working directory, the same defect we already fixed for `detect.js`. Verified from an unrelated cwd: `PASS — preservation checks clear`.

**Reported upstream — fence info-string bug (P2).** Codex also spotted that `fenceRanges()` treats a fence line carrying an info string as a valid *closing* fence. CommonMark allows an info string on an opener but not a closer, so an open code block ends early and content still inside it gets scanned. Reproduced on this snapshot:

```markdown
​```
​```js
## Benefits And Strategic Considerations
​```
```

→ emits `title-case-header` for a heading that is still inside the code block.

Not patched here: the defect is in vendored upstream code (introduced by the very #62 fix commit this PR pulls in), so editing our pinned copy would break the snapshot contract and be overwritten by the next `update-upstream.sh`. Filed as [conorbronsdon/avoid-ai-writing#77](https://github.com/conorbronsdon/avoid-ai-writing/issues/77) with a suggested fix.

Net effect: this refresh still fixes strictly more than it introduces — Markdown headings are now detected at all, with one narrow false-positive case awaiting the upstream fix.
