### PR TITLE
fix(safety-hooks): harden checkout, commit, add, and dotenv guards

### DIFF
--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python3
-"""
-Hook to protect .env files from being read or searched.
-Blocks commands that would expose .env contents and suggests safer alternatives.
-"""
+"""Protect dotenv files from commands that could expose their contents."""
 import fnmatch
 import os
 import re
@@ -537,11 +534,14 @@ def _command_position(
             while cursor < len(segment) and segment[cursor].startswith('-'):
                 option = segment[cursor]
                 cursor += 1
-                if option in (
-                        '-C', '-D', '-g', '-h', '-p', '-R', '-r', '-t', '-T',
-                        '-U', '-u', '--chdir', '--group', '--host',
+                value_index = next((index for index, char
+                                    in enumerate(option[1:])
+                                    if char in 'CDghpRrtTUu'), None)
+                if (option in (
+                        '--chdir', '--group', '--host',
                         '--other-user', '--prompt', '--role', '--type',
-                        '--user'):
+                        '--user') or not option.startswith('--')
+                        and value_index == len(option) - 2):
                     cursor += 1
             continue
         if command_word == 'time':

--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -3,103 +3,957 @@
 Hook to protect .env files from being read or searched.
 Blocks commands that would expose .env contents and suggests safer alternatives.
 """
+import fnmatch
+import os
 import re
+import shlex
+import string
+from typing import List, Optional, Tuple
 
-def check_env_file_access(command):
+BLOCK_REASON = (
+    "Blocked: Direct access to .env files is not allowed for security reasons.\n\n"
+    "• Reading .env files could expose sensitive values\n"
+    "• Writing/editing .env files should be done manually outside Claude Code\n\n"
+    "For safe inspection, use the `env-safe` command:\n"
+    "  • `env-safe list` - List all environment variable keys\n"
+    "  • `env-safe list --status` - Show keys with defined/empty status\n"
+    "  • `env-safe check KEY_NAME` - Check if a specific key exists\n"
+    "  • `env-safe count` - Count variables in the file\n"
+    "  • `env-safe validate` - Check .env file syntax\n"
+    "  • `env-safe --help` - See all options\n\n"
+    "To modify .env files, please edit them manually outside of Claude Code."
+)
+
+# Command words that can expose or overwrite a file's contents. Only a shell
+# segment's COMMAND WORD is looked up here, never a word appearing anywhere in
+# the string.
+READER_COMMANDS = {
+    'cat', 'less', 'more', 'head', 'tail', 'nano', 'vi', 'vim', 'emacs',
+    'code', 'subl', 'atom', 'gedit', 'grep', 'rg', 'ag', 'ack', 'tee',
+    'cp', 'mv', 'touch', 'sed', 'awk', 'find', 'bat', 'xxd', 'od', 'strings',
+    'source', '.',
+}
+
+_SEGMENT_SEPARATORS = {';', '&&', '||', '|', '&', '(', ')', '\n'}
+_DOTENV_PATH = re.compile(
+    r'(?:^|/)\.env(?=$|[^A-Za-z0-9_])', re.IGNORECASE)
+_BARE_ENV = ('env', './env')
+_ASSIGNMENT = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*=')
+_ENV_VALUE_OPTS = {'-a', '--argv0', '-u', '--unset', '-C', '--chdir', '-P'}
+_ENV_SHORT_VALUE_OPTS = 'auCP'
+_REDIRECTS = {'<', '>', '>>', '>|', '&>', '&>>', '<>', '>&'}
+_SHELLS = {'sh', 'bash', 'zsh', 'dash', 'ksh'}
+_MAX_NESTING = 8
+_SEARCH_PATTERN_OPTS = {'e', '--regexp'}
+_SEARCH_FILE_OPTS = {
+    'grep': {'f', '--exclude-from', '--file', '--include'},
+    'rg': {'f', 'g', '--file', '--glob', '--iglob', '--ignore-file'},
+    'ag': set(),
+    'ack': set(),
+}
+_SEARCH_GLOB_OPTS = {
+    'grep': {'--include'},
+    'rg': {'g', '--glob', '--iglob'},
+}
+_SEARCH_SHORT_VALUE_OPTS = {
+    'grep': {'A', 'B', 'C', 'D', 'd', 'm'},
+    'rg': {'A', 'B', 'C', 'E', 'j', 'M', 'm', 'r', 't', 'T'},
+}
+_SEARCH_LONG_VALUE_OPTS = {
+    'grep': {
+        '--after-context', '--before-context', '--binary-files', '--context',
+        '--devices', '--directories', '--exclude', '--exclude-dir', '--label',
+        '--group-separator', '--max-count',
+    },
+    'rg': {
+        '--after-context', '--before-context', '--color', '--colors',
+        '--context', '--context-separator', '--dfa-size-limit', '--encoding',
+        '--engine', '--field-context-separator', '--field-match-separator',
+        '--hostname-bin', '--hyperlink-format', '--max-columns', '--max-count',
+        '--max-depth', '--max-filesize', '--path-separator', '--pre',
+        '--pre-glob', '--regex-size-limit', '--replace', '--sort', '--sortr',
+        '--threads', '--type', '--type-add', '--type-clear', '--type-not',
+    },
+}
+_POSIX_GLOB_CHARS = {
+    'alnum': string.ascii_letters + string.digits,
+    'alpha': string.ascii_letters,
+    'ascii': ''.join(chr(code) for code in range(128)),
+    'blank': ' \t',
+    'cntrl': ''.join(chr(code) for code in (*range(32), 127)),
+    'digit': string.digits,
+    'graph': string.ascii_letters + string.digits + string.punctuation,
+    'lower': string.ascii_lowercase,
+    'print': ''.join(chr(code) for code in range(32, 127)),
+    'punct': string.punctuation,
+    'space': string.whitespace,
+    'upper': string.ascii_uppercase,
+    'word': string.ascii_letters + string.digits + '_',
+    'xdigit': string.hexdigits,
+}
+
+# The original whole-string patterns, kept only as the fallback for a command
+# that cannot be tokenised. They over-block, which is the right direction to
+# fail in when the command's shape is unknown.
+LEGACY_ENV_PATTERNS = [
+    # Direct file reading
+    r'\bcat\s+.*\.env\b',
+    r'\bless\s+.*\.env\b',
+    r'\bmore\s+.*\.env\b',
+    r'\bhead\s+.*\.env\b',
+    r'\btail\s+.*\.env\b',
+    # Editors - both reading and writing
+    r'\bnano\s+.*\.env\b',
+    r'\bvi\s+.*\.env\b',
+    r'\bvim\s+.*\.env\b',
+    r'\bemacs\s+.*\.env\b',
+    r'\bcode\s+.*\.env\b',
+    r'\bsubl\s+.*\.env\b',
+    r'\batom\s+.*\.env\b',
+    r'\bgedit\s+.*\.env\b',
+    # Writing/modifying .env files
+    r'>\s*\.env\b',
+    r'>>\s*\.env\b',
+    r'\becho\s+.*>\s*\.env\b',
+    r'\becho\s+.*>>\s*\.env\b',
+    r'\bprintf\s+.*>\s*\.env\b',
+    r'\bprintf\s+.*>>\s*\.env\b',
+    r'\bsed\s+.*-i.*\.env\b',
+    r'\bawk\s+.*>\s*\.env\b',
+    r'\btee\s+.*\.env\b',
+    r'\bcp\s+.*\.env\b',
+    r'\bmv\s+.*\.env\b',
+    r'\btouch\s+.*\.env\b',
+    # Searching/grepping .env files
+    r'\bgrep\s+.*\.env\b',
+    r'\bgrep\s+.*\s+\.env\b',
+    r'\brg\s+.*\.env\b',
+    r'\brg\s+.*\s+\.env\b',
+    r'\bag\s+.*\.env\b',
+    r'\back\s+.*\.env\b',
+    r'\bfind\s+.*-name\s+["\']?\.env',
+    # Other ways to expose .env contents
+    r'\becho\s+.*\$\(.*cat\s+.*\.env.*\)',
+    r'\bprintf\s+.*\$\(.*cat\s+.*\.env.*\)',
+    # Also check for patterns without the dot (like "env" file)
+    r'\bcat\s+["\']?env["\']?\s*$',
+    r'\bcat\s+["\']?env["\']?\s*[;&|]',
+    r'\bless\s+["\']?env["\']?\s*$',
+    r'\bless\s+["\']?env["\']?\s*[;&|]',
+    r'>\s*["\']?env["\']?\s*$',
+    r'>>\s*["\']?env["\']?\s*$',
+]
+
+
+def _names_dotenv(token: str) -> bool:
+    """True when this argument NAMES a dotenv file (.env, .env.local, a/.env)."""
+    stripped = token.strip('\'"')
+    if _DOTENV_PATH.search(stripped):
+        return True
+    for operator in (':-', ':=', ':+', ':?', '-', '=', '+', '?'):
+        _prefix, separator, fallback = stripped.partition(operator)
+        if separator and _DOTENV_PATH.search(fallback.rstrip('}')):
+            return True
+    return False
+
+
+def _glob_names_dotenv(pattern: str) -> bool:
+    """Return whether an inclusion glob can select a dotenv basename."""
+    tokens: List[str] = []
+    basename_pattern = pattern.rsplit('/', 1)[-1]
+    index = 0
+    while index < len(basename_pattern):
+        character = basename_pattern[index]
+        if character == '*':
+            if not tokens or tokens[-1] != '*':
+                tokens.append(character)
+            index += 1
+            continue
+        if character == '[':
+            end = index + 1
+            if end < len(basename_pattern) and basename_pattern[end] in '!^':
+                end += 1
+            if end < len(basename_pattern) and basename_pattern[end] == ']':
+                end += 1
+            end = basename_pattern.find(']', end)
+            while (end != -1 and basename_pattern[end - 1] == ':'
+                   and end + 1 < len(basename_pattern)):
+                end = basename_pattern.find(']', end + 1)
+            if end != -1:
+                tokens.append(basename_pattern[index:end + 1])
+                index = end + 1
+                continue
+        tokens.append(character)
+        index += 1
+    alphabet = {chr(code) for code in range(32, 127)}
+    alphabet.update(basename_pattern)
+    pending = [(0, 0)]
+    seen = set()
+    while pending:
+        token_index, dotenv_state = pending.pop()
+        state = (token_index, dotenv_state)
+        if state in seen:
+            continue
+        seen.add(state)
+        if token_index == len(tokens):
+            if dotenv_state in {4, 5}:
+                return True
+            continue
+        token = tokens[token_index]
+        if token == '*':
+            pending.append((token_index + 1, dotenv_state))
+        for candidate in alphabet:
+            negated = token.startswith(('[!', '[^'))
+            bracket_body = token[2:-1] if negated else token[1:-1]
+            classes = re.findall(r'\[:([a-z]+):\]', bracket_body)
+            ordinary = re.sub(r'\[:[a-z]+:\]', '', bracket_body)
+            bracket_match = any(
+                candidate in _POSIX_GLOB_CHARS.get(name, '')
+                for name in classes
+            )
+            if ordinary:
+                bracket_match |= fnmatch.fnmatchcase(
+                    candidate, f'[{ordinary}]')
+            if negated:
+                bracket_match = not bracket_match
+            matches = (
+                token in {'*', '?'}
+                or token.startswith('[') and bracket_match
+                or token == candidate
+            )
+            if not matches:
+                continue
+            if dotenv_state < 4:
+                expected = '.env'[dotenv_state]
+                if candidate.lower() != expected:
+                    continue
+                next_state = dotenv_state + 1
+            elif dotenv_state == 4:
+                if candidate.isalnum() or candidate == '_':
+                    continue
+                next_state = 5
+            else:
+                next_state = 5
+            next_token = token_index if token == '*' else token_index + 1
+            pending.append((next_token, next_state))
+    return False
+
+
+def shell_segments(command: str) -> Optional[List[List[str]]]:
+    """
+    Split a command into shell segments, respecting quotes.
+
+    Returns a list of token lists, or None if the command cannot be tokenised.
+    """
+    # shlex removes quotes, so protect quoted or escaped redirect characters
+    # before parsing. Otherwise a literal quoted ">" is indistinguishable from
+    # an output operator in the resulting token list.
+    protected = []
+    quote = None
+    escaped = False
+    literal_substitution = 0
+    literal_pending = False
+    for char in command:
+        if literal_substitution:
+            if char == '(':
+                literal_substitution += 1
+            elif char == ')':
+                literal_substitution -= 1
+            protected.append(
+                '\ue002' if char in ';&|()<>\n' else char)
+            continue
+        if literal_pending:
+            literal_pending = False
+            if char == '(':
+                literal_substitution = 1
+                protected.append('\ue002')
+                continue
+        if escaped:
+            protected.append('\ue000' if char == '>' else
+                             '\ue001' if char == '<' else char)
+            literal_pending = char == '$'
+            escaped = False
+        elif char == '\\' and quote != "'":
+            protected.append(char)
+            escaped = True
+        elif char in "'\"" and (quote is None or quote == char):
+            quote = None if quote == char else char
+            protected.append(char)
+        elif quote and char in '<>':
+            protected.append('\ue000' if char == '>' else '\ue001')
+        else:
+            protected.append(char)
+    try:
+        lexer = shlex.shlex(
+            ''.join(protected), posix=True, punctuation_chars=';&|()<>\n')
+        lexer.whitespace = ' \t\r'
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        return None
+    segments, current = [], []
+    for token in tokens:
+        if token in _SEGMENT_SEPARATORS:
+            if current:
+                segments.append(current)
+            current = []
+        else:
+            current.append(token)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _backtick_commands(command: str) -> List[str]:
+    """Return executable backtick bodies, ignoring single-quoted backticks."""
+    bodies = []
+    start = None
+    single_quoted = False
+    double_quoted = False
+    escaped = False
+    for index, char in enumerate(command):
+        if escaped:
+            escaped = False
+        elif char == '\\' and not single_quoted:
+            escaped = True
+        elif char == "'" and not double_quoted:
+            single_quoted = not single_quoted
+        elif char == '"' and not single_quoted:
+            double_quoted = not double_quoted
+        elif char == '`' and not single_quoted:
+            if start is None:
+                start = index + 1
+            else:
+                bodies.append(command[start:index])
+                start = None
+    return bodies
+
+
+def _substitution_commands(command: str) -> List[str]:
+    """Return executable command-substitution bodies in this shell text."""
+    bodies = []
+    index = 0
+    single_quoted = False
+    double_quoted = False
+    escaped = False
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            escaped = False
+        elif char == '\\' and not single_quoted:
+            escaped = True
+        elif char == "'" and not double_quoted:
+            single_quoted = not single_quoted
+        elif char == '"' and not single_quoted:
+            double_quoted = not double_quoted
+        elif (not single_quoted
+              and command.startswith(('$(', '<(', '>('), index)
+              and (not double_quoted or command.startswith('$(', index))
+              and not command.startswith('$((', index)):
+            depth = 1
+            cursor = index + 2
+            inner_quote = None
+            inner_escaped = False
+            while cursor < len(command) and depth:
+                inner = command[cursor]
+                if inner_escaped:
+                    inner_escaped = False
+                elif inner == '\\' and inner_quote != "'":
+                    inner_escaped = True
+                elif inner in "'\"" and (inner_quote is None
+                                           or inner_quote == inner):
+                    inner_quote = None if inner_quote == inner else inner
+                elif inner_quote is None:
+                    if inner == '(':
+                        depth += 1
+                    elif inner == ')':
+                        depth -= 1
+                cursor += 1
+            if depth == 0:
+                bodies.append(command[index + 2:cursor - 1])
+                index = cursor - 1
+        index += 1
+    return bodies
+
+
+def _heredoc_body(
+        command: str, start: int) -> Optional[Tuple[int, int, int, bool]]:
+    """Return body and delimiter bounds for one simple heredoc."""
+    index = start + 2
+    strip_tabs = index < len(command) and command[index] == '-'
+    if strip_tabs:
+        index += 1
+    while index < len(command) and command[index] in ' \t':
+        index += 1
+    delimiter_parts = []
+    quoted = False
+    while index < len(command) and command[index] not in ' \t\r\n;&|<>()':
+        character = command[index]
+        if character in "'\"":
+            quoted = True
+            end = command.find(character, index + 1)
+            if end == -1:
+                return None
+            delimiter_parts.append(command[index + 1:end])
+            index = end + 1
+        elif character == '\\':
+            if index + 1 >= len(command):
+                return None
+            quoted = True
+            delimiter_parts.append(command[index + 1])
+            index += 2
+        else:
+            delimiter_parts.append(character)
+            index += 1
+    delimiter = ''.join(delimiter_parts)
+    if not delimiter:
+        return None
+    body_start = command.find('\n', index)
+    if body_start == -1:
+        return None
+    body_start += 1
+    line_start = body_start
+    while line_start <= len(command):
+        line_end = command.find('\n', line_start)
+        if line_end == -1:
+            line_end = len(command)
+        line = command[line_start:line_end].removesuffix('\r')
+        if strip_tabs:
+            line = line.lstrip('\t')
+        if line == delimiter:
+            body_end = min(line_end + 1, len(command))
+            return body_start, line_start, body_end, quoted
+        if line_end == len(command):
+            return None
+        line_start = line_end + 1
+    return None
+
+
+def _without_heredoc_bodies(command: str) -> Tuple[str, List[str]]:
+    """Blank heredoc bodies and return bodies whose expansions execute."""
+    executable_bodies = []
+    pieces = []
+    copied_to = 0
+    index = 0
+    quote = None
+    while index < len(command):
+        character = command[index]
+        if character == '\\' and quote != "'":
+            index += 2
+            continue
+        if character in "'\"":
+            quote = None if quote == character else character \
+                if quote is None else quote
+            index += 1
+            continue
+        if (quote is None and command.startswith('<<', index)
+                and not command.startswith('<<<', index)):
+            heredoc = _heredoc_body(command, index)
+            if heredoc is not None:
+                body_start, delimiter_start, body_end, quoted = heredoc
+                pieces.append(command[copied_to:body_start])
+                blanked = ''.join(
+                    '\n' if char == '\n' else ' '
+                    for char in command[body_start:body_end]
+                )
+                pieces.append(blanked)
+                if not quoted:
+                    executable_bodies.append(
+                        command[body_start:delimiter_start])
+                copied_to = body_end
+                index = body_end
+                continue
+        index += 1
+    pieces.append(command[copied_to:])
+    return ''.join(pieces), executable_bodies
+
+
+def _split_env_command(segment: List[str], index: int) -> Optional[List[str]]:
+    """Return the effective command assembled by env -S, when present."""
+    cursor = index + 1
+    while cursor < len(segment) and segment[cursor].startswith('-'):
+        option = segment[cursor]
+        if option in ('-S', '--split-string'):
+            if cursor + 1 >= len(segment):
+                return []
+            try:
+                words = shlex.split(segment[cursor + 1])
+            except ValueError:
+                words = [segment[cursor + 1]]
+            return [segment[index]] + words + segment[cursor + 2:]
+        if option.startswith('--split-string='):
+            try:
+                words = shlex.split(option.split('=', 1)[1])
+            except ValueError:
+                words = [option.split('=', 1)[1]]
+            return [segment[index]] + words + segment[cursor + 1:]
+        if option.startswith('-') and not option.startswith('--'):
+            option_chars = option[1:]
+            split_index = option_chars.find('S')
+            value_positions = [
+                option_chars.find(char) for char in _ENV_SHORT_VALUE_OPTS]
+            if any(0 <= position < split_index for position in value_positions):
+                split_index = -1
+            if split_index >= 0:
+                value = option_chars[split_index + 1:]
+                remainder = segment[cursor + 1:]
+                if not value:
+                    if not remainder:
+                        return []
+                    value = remainder[0]
+                    remainder = remainder[1:]
+                try:
+                    words = shlex.split(value)
+                except ValueError:
+                    words = [value]
+                return [segment[index]] + words + remainder
+        if (option in _ENV_VALUE_OPTS or not option.startswith('--')
+                and option[-1:] in _ENV_SHORT_VALUE_OPTS):
+            cursor += 1
+        cursor += 1
+    return None
+
+
+def _command_position(
+        segment: List[str], stop_at_env: bool = False) -> Optional[int]:
+    """Resolve the command word after assignments and supported wrappers."""
+    cursor = 0
+    while cursor < len(segment):
+        while cursor < len(segment) and _ASSIGNMENT.match(segment[cursor]):
+            cursor += 1
+        if cursor >= len(segment):
+            return None
+        command_word = os.path.basename(segment[cursor]).lower()
+        if command_word in ('command', 'exec', 'nohup'):
+            cursor += 1
+            while cursor < len(segment) and segment[cursor].startswith('-'):
+                option = segment[cursor]
+                cursor += 1
+                if command_word == 'exec' and option == '-a':
+                    cursor += 1
+            continue
+        if command_word == 'sudo':
+            cursor += 1
+            while cursor < len(segment) and segment[cursor].startswith('-'):
+                option = segment[cursor]
+                cursor += 1
+                if option in (
+                        '-C', '-D', '-g', '-h', '-p', '-R', '-r', '-t', '-T',
+                        '-U', '-u', '--chdir', '--group', '--host',
+                        '--other-user', '--prompt', '--role', '--type',
+                        '--user'):
+                    cursor += 1
+            continue
+        if command_word == 'time':
+            cursor += 1
+            while cursor < len(segment) and segment[cursor].startswith('-'):
+                option = segment[cursor]
+                cursor += 1
+                if option in ('-f', '-o', '--format', '--output'):
+                    cursor += 1
+            continue
+        if command_word == 'nice':
+            cursor += 1
+            while cursor < len(segment) and segment[cursor].startswith('-'):
+                option = segment[cursor]
+                cursor += 1
+                if option in ('-n', '--adjustment'):
+                    cursor += 1
+            continue
+        if command_word == 'timeout':
+            cursor += 1
+            while cursor < len(segment) and segment[cursor].startswith('-'):
+                option = segment[cursor]
+                cursor += 1
+                if option in ('-k', '-s', '--kill-after', '--signal'):
+                    cursor += 1
+            cursor += 1
+            continue
+        if command_word == 'xargs':
+            cursor += 1
+            while cursor < len(segment) and segment[cursor].startswith('-'):
+                option = segment[cursor]
+                cursor += 1
+                if option in ('-a', '-d', '-E', '-I', '-L', '-n', '-P',
+                              '-s', '--arg-file', '--delimiter', '--eof',
+                              '--replace', '--max-lines', '--max-args',
+                              '--max-procs', '--max-chars'):
+                    cursor += 1
+            continue
+        if command_word == 'env':
+            if stop_at_env:
+                return cursor
+            cursor += 1
+            while cursor < len(segment):
+                token = segment[cursor]
+                if _ASSIGNMENT.match(token):
+                    cursor += 1
+                elif token.startswith('-'):
+                    cursor += 1
+                    if (token in _ENV_VALUE_OPTS
+                            or not token.startswith('--')
+                            and token[-1:] in _ENV_SHORT_VALUE_OPTS):
+                        cursor += 1
+                else:
+                    break
+            continue
+        return cursor
+    return None
+
+
+def _command_word(token: str) -> str:
+    """Return a normalized command word, preserving the dot builtin."""
+    return '.' if token == '.' else os.path.basename(token).lower()
+
+
+def _normalize_search_option(command_word: str, name: str) -> str:
+    """Expand the unambiguous GNU grep abbreviations relevant to file access."""
+    if command_word == 'grep':
+        for option, shortest in (
+                ('--include', '--inc'), ('--exclude-from', '--exclude-f'),
+                ('--regexp', '--reg')):
+            if name.startswith(shortest) and option.startswith(name):
+                return option
+    return name
+
+
+def _search_glob_names_dotenv(command_word: str, pattern: str) -> bool:
+    """Apply ripgrep-only exclusion semantics before matching a search glob."""
+    positive = not (command_word == 'rg' and pattern.startswith('!'))
+    parts = pattern.split('/') if command_word == 'rg' else [pattern]
+    return positive and any(_glob_names_dotenv(part) for part in parts)
+
+
+def _search_accesses_dotenv(command_word: str, args: List[str]) -> bool:
+    """Check grep-like file operands without mistaking the pattern for a file."""
+    file_options = _SEARCH_FILE_OPTS[command_word]
+    glob_options = _SEARCH_GLOB_OPTS.get(command_word, set())
+    short_value_options = _SEARCH_SHORT_VALUE_OPTS.get(command_word, set())
+    long_value_options = _SEARCH_LONG_VALUE_OPTS.get(command_word, set())
+    pattern_supplied = False
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == '--':
+            index += 1
+            while index < len(args):
+                if not pattern_supplied:
+                    pattern_supplied = True
+                elif _names_dotenv(args[index]):
+                    return True
+                index += 1
+            break
+        if arg.startswith('--'):
+            name, separator, value = arg.partition('=')
+            name = _normalize_search_option(command_word, name)
+            if name in file_options:
+                if not separator:
+                    index += 1
+                    if index >= len(args):
+                        return False
+                    value = args[index]
+                names_dotenv = (
+                    _search_glob_names_dotenv(command_word, value)
+                    if name in glob_options else _names_dotenv(value)
+                )
+                if names_dotenv:
+                    return True
+                if name in {'--file'}:
+                    pattern_supplied = True
+            elif name in _SEARCH_PATTERN_OPTS:
+                if not separator:
+                    index += 1
+                pattern_supplied = True
+            elif name in long_value_options and not separator:
+                index += 1
+            index += 1
+            continue
+        if arg.startswith('-') and arg != '-':
+            cluster = arg[1:]
+            for position, option in enumerate(cluster):
+                if option not in {'e', 'f', 'g'} | short_value_options:
+                    continue
+                value = cluster[position + 1:]
+                if not value:
+                    index += 1
+                    if index >= len(args):
+                        return False
+                    value = args[index]
+                if option in file_options:
+                    names_dotenv = (
+                        _search_glob_names_dotenv(command_word, value)
+                        if option in glob_options else _names_dotenv(value)
+                    )
+                    if names_dotenv:
+                        return True
+                if option in {'e', 'f'}:
+                    pattern_supplied = True
+                break
+            index += 1
+            continue
+        if not pattern_supplied:
+            pattern_supplied = True
+        elif _names_dotenv(arg):
+            return True
+        index += 1
+    return False
+
+
+def _script_reader_accesses_dotenv(
+    command_word: str,
+    args: List[str],
+) -> bool:
+    """Distinguish sed/awk programs from the files they operate on."""
+    script_supplied = False
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == '--':
+            index += 1
+            continue
+        if arg.startswith('--'):
+            name, separator, value = arg.partition('=')
+            is_script_file = name == '--file'
+            is_script_text = name in {'--expression', '--source'}
+            takes_other_value = command_word == 'awk' and name == '--assign'
+            if is_script_file or is_script_text or takes_other_value:
+                if not separator:
+                    index += 1
+                    if index >= len(args):
+                        return False
+                    value = args[index]
+                if is_script_file and _names_dotenv(value):
+                    return True
+                if is_script_file or is_script_text:
+                    script_supplied = True
+            index += 1
+            continue
+        if arg.startswith('-') and arg != '-':
+            cluster = arg[1:]
+            if command_word == 'sed' and cluster.startswith('i'):
+                index += 1
+                continue
+            value_options = {'e', 'f'}
+            if command_word == 'awk':
+                value_options.update({'F', 'v'})
+            for position, option in enumerate(cluster):
+                if option not in value_options:
+                    continue
+                value = cluster[position + 1:]
+                if not value:
+                    index += 1
+                    if index >= len(args):
+                        return False
+                    value = args[index]
+                if option == 'f' and _names_dotenv(value):
+                    return True
+                if option in {'e', 'f'}:
+                    script_supplied = True
+                break
+            index += 1
+            continue
+        if command_word == 'awk' and _ASSIGNMENT.match(arg):
+            index += 1
+            continue
+        if not script_supplied:
+            script_supplied = True
+        elif _names_dotenv(arg):
+            return True
+        index += 1
+    return False
+
+
+def _reader_accesses_dotenv(command_word: str, args: List[str]) -> bool:
+    """Check whether one protected reader's own arguments name a dotenv."""
+    if command_word == 'find':
+        for root in args:
+            if root in {'-H', '-L', '-P', '-D', '--'} or root.startswith('-O'):
+                continue
+            if root.startswith('-') or root in {'!', '('}:
+                break
+            if _names_dotenv(root):
+                return True
+        path_predicates = {
+            '-name', '-iname', '-path', '-ipath', '-wholename', '-iwholename',
+        }
+        for position, arg in enumerate(args[:-1]):
+            pattern = args[position + 1]
+            if arg in path_predicates and (
+                    _names_dotenv(pattern)
+                    or _glob_names_dotenv(pattern)):
+                return True
+            if arg in {'-regex', '-iregex'}:
+                literal_dot_pattern = pattern.replace('[.]', '.')
+                literal_dot_pattern = literal_dot_pattern.replace(r'\.', '.')
+                literal_dot_pattern = re.sub(r'^\^?\.\*', '', literal_dot_pattern)
+                if _names_dotenv(literal_dot_pattern):
+                    return True
+        return False
+    if command_word in _SEARCH_FILE_OPTS:
+        return _search_accesses_dotenv(command_word, args)
+    if command_word in {'sed', 'awk'}:
+        return _script_reader_accesses_dotenv(command_word, args)
+    if any(_names_dotenv(arg) for arg in args):
+        return True
+    return bool(command_word in ('cat', 'less') and args
+                and args[-1].lower() in _BARE_ENV)
+
+
+def _find_exec_accesses_dotenv(args: List[str], depth: int) -> bool:
+    """Check commands supplied to find's -exec and related actions."""
+    for index, arg in enumerate(args):
+        if arg in ('-exec', '-execdir', '-ok', '-okdir'):
+            end = index + 1
+            while end < len(args) and args[end] not in (';', '+'):
+                end += 1
+            if _segment_accesses_dotenv(args[index + 1:end], depth):
+                return True
+    return False
+
+
+def _nesting_fallback(command: str) -> bool:
+    """Iteratively inspect nested command text after recursive parsing is capped."""
+    pending = [command]
+    for _ in range(256):
+        if not pending:
+            return False
+        current, heredoc_bodies = _without_heredoc_bodies(pending.pop())
+        pending.extend(_backtick_commands(current))
+        pending.extend(_substitution_commands(current))
+        for body in heredoc_bodies:
+            pending.extend(_backtick_commands(body))
+            pending.extend(_substitution_commands(body))
+        segments = shell_segments(current)
+        if segments is None:
+            normalized = ' '.join(current.strip().split())
+            if any(re.search(pattern, normalized, re.IGNORECASE)
+                   for pattern in LEGACY_ENV_PATTERNS):
+                return True
+            continue
+        for segment in segments:
+            for index, token in enumerate(segment[:-1]):
+                if token in _REDIRECTS:
+                    destination = segment[index + 1]
+                    if (_names_dotenv(destination)
+                            or destination.lower() in _BARE_ENV):
+                        return True
+            env_index = _command_position(segment, stop_at_env=True)
+            if (env_index is not None
+                    and _command_word(segment[env_index]) == 'env'):
+                effective = _split_env_command(segment, env_index)
+                if effective is not None:
+                    pending.append(shlex.join(effective))
+            index = _command_position(segment)
+            if index is not None:
+                command_word = _command_word(segment[index])
+                args = segment[index + 1:]
+                wrapped_by_xargs = any(
+                    _command_word(token) == 'xargs'
+                    for token in segment[:index]
+                )
+                if command_word in READER_COMMANDS:
+                    if wrapped_by_xargs:
+                        return True
+                    if _reader_accesses_dotenv(command_word, args):
+                        return True
+                if command_word == 'find' and _find_exec_accesses_dotenv(
+                        args, _MAX_NESTING):
+                    return True
+                if command_word in _SHELLS:
+                    for position, arg in enumerate(args):
+                        if (arg.startswith('-') and not arg.startswith('--')
+                                and 'c' in arg[1:]
+                                and position + 1 < len(args)):
+                            pending.append(args[position + 1])
+                if command_word == 'eval' and args:
+                    pending.append(' '.join(args))
+    normalized = ' '.join(' '.join(pending).strip().split())
+    return any(re.search(pattern, normalized, re.IGNORECASE)
+               for pattern in LEGACY_ENV_PATTERNS)
+
+
+def _segment_accesses_dotenv(segment: List[str], depth: int = 0) -> bool:
+    """Check one segment by scanning for executable protected-reader tokens."""
+    for index, token in enumerate(segment[:-1]):
+        if token in _REDIRECTS:
+            destination = segment[index + 1]
+            if (_names_dotenv(destination)
+                    or destination.lower() in _BARE_ENV):
+                return True
+    env_index = _command_position(segment, stop_at_env=True)
+    if (env_index is not None
+            and _command_word(segment[env_index]) == 'env'):
+        effective = _split_env_command(segment, env_index)
+        if effective is not None and _segment_accesses_dotenv(
+                effective, depth + 1):
+            return True
+    index = _command_position(segment)
+    if index is not None:
+        command_word = _command_word(segment[index])
+        args = segment[index + 1:]
+        wrapped_by_xargs = any(
+            _command_word(token) == 'xargs'
+            for token in segment[:index]
+        )
+        if command_word in _SHELLS:
+            for position, arg in enumerate(args):
+                if (arg.startswith('-') and not arg.startswith('--')
+                        and 'c' in arg[1:]):
+                    command_index = position + 1
+                    if (command_index < len(args)
+                            and check_env_file_access(
+                                args[command_index], depth + 1)[0]):
+                        return True
+        if command_word == 'eval' and args:
+            args = args[1:] if args[0] == '--' else args
+            if check_env_file_access(' '.join(args), depth + 1)[0]:
+                return True
+        if command_word == 'find' and _find_exec_accesses_dotenv(args, depth):
+            return True
+        if command_word in READER_COMMANDS:
+            if wrapped_by_xargs:
+                return True
+            if _reader_accesses_dotenv(command_word, args):
+                return True
+    return False
+
+
+def check_env_file_access(
+        command: str, depth: int = 0) -> Tuple[bool, Optional[str]]:
     """
     Check if a command attempts to read, write, or edit .env files.
     Returns tuple: (should_block: bool, reason: str or None)
+
+    Each shell segment's command word is resolved, and the question asked is
+    whether one of ITS OWN arguments names a dotenv file -- rather than whether
+    a command name and an env-looking string both appear somewhere in the same
+    line, which does not require the two to be related.
     """
-    # Normalize the command
-    normalized_cmd = ' '.join(command.strip().split())
+    if depth >= _MAX_NESTING:
+        if _nesting_fallback(command):
+            return True, BLOCK_REASON
+        return False, None
+    command, heredoc_bodies = _without_heredoc_bodies(command)
+    nested_commands = _backtick_commands(command)
+    nested_commands.extend(_substitution_commands(command))
+    for body in heredoc_bodies:
+        nested_commands.extend(_backtick_commands(body))
+        nested_commands.extend(_substitution_commands(body))
+    for nested_command in nested_commands:
+        if check_env_file_access(nested_command, depth + 1)[0]:
+            return True, BLOCK_REASON
+    segments = shell_segments(command)
+    if segments is None:
+        normalized_cmd = ' '.join(command.strip().split())
+        for pattern in LEGACY_ENV_PATTERNS:
+            if re.search(pattern, normalized_cmd, re.IGNORECASE):
+                return True, BLOCK_REASON
+        return False, None
 
-    # Safe commands that may mention .env in text but don't access files
-    # These commands only pass .env as string content, not as file operations
-    safe_command_patterns = [
-        r'^git\s+commit\b',      # git commit -m "message about .env"
-        r'^git\s+tag\b',         # git tag -m "message"
-        r'^gh\s+pr\s+create\b',  # gh pr create --body "..."
-        r'^gh\s+issue\s+create\b',  # gh issue create --body "..."
-        r'^gh\s+release\s+create\b',  # gh release create
-    ]
+    for segment in segments:
+        if _segment_accesses_dotenv(segment, depth):
+            return True, BLOCK_REASON
 
-    for pattern in safe_command_patterns:
-        if re.match(pattern, normalized_cmd, re.IGNORECASE):
-            return False, None
-
-    # Patterns that indicate reading, writing, or editing .env files
-    env_patterns = [
-        # Direct file reading
-        r'\bcat\s+.*\.env\b',
-        r'\bless\s+.*\.env\b',
-        r'\bmore\s+.*\.env\b',
-        r'\bhead\s+.*\.env\b',
-        r'\btail\s+.*\.env\b',
-        
-        # Editors - both reading and writing
-        r'\bnano\s+.*\.env\b',
-        r'\bvi\s+.*\.env\b',
-        r'\bvim\s+.*\.env\b',
-        r'\bemacs\s+.*\.env\b',
-        r'\bcode\s+.*\.env\b',
-        r'\bsubl\s+.*\.env\b',
-        r'\batom\s+.*\.env\b',
-        r'\bgedit\s+.*\.env\b',
-        
-        # Writing/modifying .env files
-        r'>\s*\.env\b',  # Redirect to .env
-        r'>>\s*\.env\b',  # Append to .env
-        r'\becho\s+.*>\s*\.env\b',
-        r'\becho\s+.*>>\s*\.env\b',
-        r'\bprintf\s+.*>\s*\.env\b',
-        r'\bprintf\s+.*>>\s*\.env\b',
-        r'\bsed\s+.*-i.*\.env\b',  # sed in-place editing
-        r'\bawk\s+.*>\s*\.env\b',
-        r'\btee\s+.*\.env\b',
-        r'\bcp\s+.*\.env\b',  # Copying to .env
-        r'\bmv\s+.*\.env\b',  # Moving to .env
-        r'\btouch\s+.*\.env\b',  # Creating .env
-        
-        # Searching/grepping .env files
-        r'\bgrep\s+.*\.env\b',
-        r'\bgrep\s+.*\s+\.env\b',
-        r'\brg\s+.*\.env\b',
-        r'\brg\s+.*\s+\.env\b',
-        r'\bag\s+.*\.env\b',
-        r'\back\s+.*\.env\b',
-        r'\bfind\s+.*-name\s+["\']?\.env',
-        
-        # Other ways to expose .env contents
-        r'\becho\s+.*\$\(.*cat\s+.*\.env.*\)',
-        r'\bprintf\s+.*\$\(.*cat\s+.*\.env.*\)',
-        
-        # Also check for patterns without the dot (like "env" file)
-        r'\bcat\s+["\']?env["\']?\s*$',
-        r'\bcat\s+["\']?env["\']?\s*[;&|]',
-        r'\bless\s+["\']?env["\']?\s*$',
-        r'\bless\s+["\']?env["\']?\s*[;&|]',
-        r'>\s*["\']?env["\']?\s*$',
-        r'>>\s*["\']?env["\']?\s*$',
-    ]
-    
-    # Check if any pattern matches
-    for pattern in env_patterns:
-        if re.search(pattern, normalized_cmd, re.IGNORECASE):
-            reason_text = (
-                "Blocked: Direct access to .env files is not allowed for security reasons.\n\n"
-                "• Reading .env files could expose sensitive values\n"
-                "• Writing/editing .env files should be done manually outside Claude Code\n\n"
-                "For safe inspection, use the `env-safe` command:\n"
-                "  • `env-safe list` - List all environment variable keys\n"
-                "  • `env-safe list --status` - Show keys with defined/empty status\n"
-                "  • `env-safe check KEY_NAME` - Check if a specific key exists\n"
-                "  • `env-safe count` - Count variables in the file\n"
-                "  • `env-safe validate` - Check .env file syntax\n"
-                "  • `env-safe --help` - See all options\n\n"
-                "To modify .env files, please edit them manually outside of Claude Code."
-            )
-            return True, reason_text
-    
     return False, None
 
 
@@ -107,9 +961,9 @@ def check_env_file_access(command):
 if __name__ == "__main__":
     import json
     import sys
-    
+
     data = json.load(sys.stdin)
-    
+
     # Check if this is a Bash tool call
     tool_name = data.get("tool_name")
     if tool_name != "Bash":
@@ -120,12 +974,12 @@ if __name__ == "__main__":
             }
         }))
         sys.exit(0)
-    
+
     # Get the command being executed
     command = data.get("tool_input", {}).get("command", "")
-    
+
     should_block, reason = check_env_file_access(command)
-    
+
     if should_block:
         print(json.dumps({
             "hookSpecificOutput": {
@@ -141,5 +995,5 @@ if __name__ == "__main__":
                 "permissionDecision": "allow"
             }
         }))
-    
+
     sys.exit(0)

--- a/plugins/safety-hooks/hooks/git_add_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_add_block_hook.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import re
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -12,7 +13,492 @@ if PLUGIN_ROOT:
     if hooks_dir not in sys.path:
         sys.path.insert(0, hooks_dir)
 
-from command_utils import extract_subcommands
+# `git commit` options that consume a SEPARATE following token as their value,
+# so that token must not itself be read as an option.
+#
+# -S/--gpg-sign are deliberately absent: their argument is optional and
+# attached-only (-S<keyid>), so consuming the next token would swallow the -m of
+# `git commit -aS -m "msg"`.
+_COMMIT_VALUE_OPTS: set[str] = {
+    '-m', '--message', '-F', '--file', '-c', '--reedit-message',
+    '-C', '--reuse-message', '--author', '--date', '--cleanup',
+    '-t', '--template', '--trailer', '--fixup', '--squash',
+    '--pathspec-from-file',
+}
+
+_COMMIT_SHORT_VALUE_OPTS: set[str] = {'-m', '-F', '-c', '-C', '-t'}
+
+# These options take an optional attached value. Once one appears in a short
+# cluster, the rest of that token is its value rather than more option letters.
+_COMMIT_SHORT_OPTIONAL_VALUE_OPTS: set[str] = {'-S', '-u'}
+
+_COMMIT_MESSAGE_OPTION_FAMILIES = {
+    '-m': 'message',
+    '--message': 'message',
+    '-F': 'file',
+    '--file': 'file',
+    '-C': 'reuse-message',
+    '--reuse-message': 'reuse-message',
+}
+
+_COMMIT_NEGATED_MESSAGE_OPTIONS = {
+    '--no-message': 'message',
+    '--no-file': 'file',
+    '--no-reuse-message': 'reuse-message',
+}
+
+_COMMIT_LONG_OPTIONS = {
+    option for option in _COMMIT_VALUE_OPTS if option.startswith('--')
+} | set(_COMMIT_MESSAGE_OPTION_FAMILIES) | set(
+    _COMMIT_NEGATED_MESSAGE_OPTIONS
+) | {
+    '--all', '--allow-empty', '--allow-empty-message', '--amend', '--dry-run',
+    '--edit', '--gpg-sign', '--include', '--interactive', '--no-edit',
+    '--no-fixup', '--no-gpg-sign', '--no-post-rewrite', '--no-reedit-message',
+    '--no-signoff', '--no-status', '--no-verify', '--only', '--patch',
+    '--pathspec-file-nul', '--quiet', '--reset-author', '--signoff', '--status',
+    '--untracked-files', '--verbose',
+}
+
+_GIT_GLOBAL_VALUE_OPTS: set[str] = {
+    '-C', '-c', '--attr-source', '--config-env', '--git-dir', '--work-tree',
+    '--namespace',
+}
+
+_GIT_GLOBAL_FLAG_OPTS: set[str] = {
+    '-p', '-P', '--bare', '--no-pager', '--paginate', '--no-replace-objects',
+    '--literal-pathspecs', '--glob-pathspecs', '--noglob-pathspecs',
+    '--icase-pathspecs', '--no-optional-locks', '--no-lazy-fetch',
+}
+
+_ASSIGNMENT_WORD = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*=')
+_ENV_VALUE_OPTS: set[str] = {'-u', '--unset', '-C', '--chdir', '-P'}
+_ENV_SHORT_VALUE_OPTS = frozenset('uCPS')
+_UNRESOLVABLE_CHDIR_CHARS = frozenset('$`*?[')
+_REPOSITORY_ROUTING_VARS = {'GIT_DIR', 'GIT_WORK_TREE'}
+_UNVERIFIED_STAGING_REASON = (
+    'Could not safely resolve the target repository or inspect its status. '
+    'Approval is required before staging files.'
+)
+_ADD_ALL_LONG_OPTIONS = {'--a', '--al', '--all'}
+
+
+def _env_short_value(token: str) -> tuple[str, str | None] | None:
+    """Return the first value-taking option in a short ``env`` cluster."""
+    if not token.startswith('-') or token.startswith('--'):
+        return None
+    for index, option in enumerate(token[1:]):
+        if option in _ENV_SHORT_VALUE_OPTS:
+            attached = token[index + 2:] or None
+            return f'-{option}', attached
+    return None
+
+
+def _split_compound_command(command: str) -> list[str]:
+    """Split on unquoted, unescaped shell command operators."""
+    commands: list[str] = []
+    start = 0
+    quote: str | None = None
+    i = 0
+    while i < len(command):
+        char = command[i]
+        if quote:
+            if char == quote:
+                quote = None
+            elif char == '\\' and quote == '"':
+                i += 1
+        elif char in "'\"":
+            quote = char
+        elif char == '\\':
+            i += 1
+        elif char in ';|&\r\n':
+            part = command[start:i].strip()
+            if part:
+                commands.append(part)
+            if char == '\r' and i + 1 < len(command) and command[i + 1] == '\n':
+                i += 1
+            elif char in '|&' and i + 1 < len(command) and command[i + 1] == char:
+                i += 1
+            start = i + 1
+        i += 1
+    final = command[start:].strip()
+    if final:
+        commands.append(final)
+    return commands
+
+
+def _expand_env_split(argv: list[str]) -> list[str] | None:
+    """Expand the command string supplied through ``env -S``."""
+    i = 0
+    while i < len(argv) and _ASSIGNMENT_WORD.match(argv[i]):
+        i += 1
+    if i >= len(argv) or Path(argv[i]).name != 'env':
+        return argv
+
+    i += 1
+    while i < len(argv):
+        token = argv[i]
+        value: str | None = None
+        consumed = 1
+        if token == '--':
+            break
+        if token in {'-S', '--split-string'}:
+            if i + 1 >= len(argv):
+                return None
+            value = argv[i + 1]
+            consumed = 2
+        elif token.startswith('--split-string='):
+            value = token.split('=', 1)[1]
+        elif short_value := _env_short_value(token):
+            option, value = short_value
+            if option != '-S':
+                value = None
+            elif value is None:
+                if i + 1 >= len(argv):
+                    return None
+                value = argv[i + 1]
+                consumed = 2
+        if value is not None:
+            try:
+                expanded = shlex.split(value)
+            except ValueError:
+                return None
+            return argv[:i] + expanded + argv[i + consumed:]
+        if _ASSIGNMENT_WORD.match(token):
+            i += 1
+            continue
+        name = token.partition('=')[0]
+        short_value = _env_short_value(token)
+        if name in _ENV_VALUE_OPTS or short_value:
+            attached = short_value[1] if short_value else None
+            if '=' not in token and attached is None:
+                i += 1
+                if i >= len(argv):
+                    return None
+            i += 1
+            continue
+        if token.startswith('-'):
+            i += 1
+            continue
+        break
+    return argv
+
+
+def _resolve_git_commit_argv(command: str) -> list[str] | None:
+    """Return a canonical Git commit argv after valid global options."""
+    try:
+        argv = shlex.split(command)
+    except ValueError:
+        argv = command.split()
+    argv = _expand_env_split(argv)
+    if argv is None:
+        return None
+
+    i = 0
+    while i < len(argv) and _ASSIGNMENT_WORD.match(argv[i]):
+        i += 1
+
+    if i < len(argv) and Path(argv[i]).name == 'env':
+        i += 1
+        while i < len(argv):
+            token = argv[i]
+            name = token.partition('=')[0]
+            short_value = _env_short_value(token)
+            if _ASSIGNMENT_WORD.match(token):
+                i += 1
+                continue
+            if token == '--':
+                i += 1
+                while i < len(argv) and _ASSIGNMENT_WORD.match(argv[i]):
+                    i += 1
+                break
+            if name in _ENV_VALUE_OPTS or short_value:
+                needs_value = token in _ENV_VALUE_OPTS or (
+                    short_value is not None
+                    and short_value[1] is None
+                )
+                if '=' not in token and needs_value:
+                    i += 1
+                    if i >= len(argv):
+                        return None
+                i += 1
+                continue
+            if token.startswith('-'):
+                i += 1
+                continue
+            break
+
+    if i >= len(argv) or Path(argv[i]).name != 'git':
+        return None
+
+    i += 1
+    while i < len(argv):
+        token = argv[i]
+        name = token.partition('=')[0]
+        if name == '--list-cmds' or token == '--exec-path':
+            return None
+        if name == '--exec-path':
+            i += 1
+            continue
+        if token in _GIT_GLOBAL_FLAG_OPTS:
+            i += 1
+            continue
+        if token.startswith('-C') and token != '-C':
+            i += 1
+            continue
+        if token.startswith('-c') and token != '-c':
+            i += 1
+            continue
+        if name in _GIT_GLOBAL_VALUE_OPTS:
+            if '=' not in token:
+                i += 1
+                if i >= len(argv):
+                    return None
+            i += 1
+            continue
+        break
+
+    if i >= len(argv) or argv[i] != 'commit':
+        return None
+    return ['git', 'commit', *argv[i + 1:]]
+
+
+def _resolve_add_chdir(cwd: str | None, value: str) -> str | None:
+    """Resolve one chdir value without evaluating shell expansions."""
+    if cwd is None or any(char in value for char in _UNRESOLVABLE_CHDIR_CHARS):
+        return None
+    return os.path.abspath(os.path.join(cwd, value))
+
+
+def _is_repository_routing_assignment(token: str) -> bool:
+    """Return whether an assignment changes which repository Git targets."""
+    return token.partition('=')[0] in _REPOSITORY_ROUTING_VARS
+
+
+def _resolve_git_add_argv(
+    command: str,
+) -> tuple[list[str], str | None] | None:
+    """Return canonical add arguments and the Git working directory."""
+    try:
+        argv = shlex.split(command)
+    except ValueError:
+        argv = command.split()
+    argv = _expand_env_split(argv)
+    if argv is None:
+        return None
+
+    cwd = os.getcwd()
+    i = 0
+    while i < len(argv) and _ASSIGNMENT_WORD.match(argv[i]):
+        if _is_repository_routing_assignment(argv[i]):
+            cwd = None
+        i += 1
+
+    if i < len(argv) and Path(argv[i]).name == 'env':
+        i += 1
+        while i < len(argv):
+            token = argv[i]
+            name, separator, attached = token.partition('=')
+            short_value = _env_short_value(token)
+            if _ASSIGNMENT_WORD.match(token):
+                if _is_repository_routing_assignment(token):
+                    cwd = None
+                i += 1
+                continue
+            if token == '--':
+                i += 1
+                while i < len(argv) and _ASSIGNMENT_WORD.match(argv[i]):
+                    if _is_repository_routing_assignment(argv[i]):
+                        cwd = None
+                    i += 1
+                break
+            if name in _ENV_VALUE_OPTS or short_value:
+                value = attached if separator else (
+                    short_value[1] if short_value else None
+                )
+                needs_value = token in _ENV_VALUE_OPTS or (
+                    short_value is not None
+                    and short_value[1] is None
+                )
+                if value is None and needs_value:
+                    i += 1
+                    if i >= len(argv):
+                        return None
+                    value = argv[i]
+                option = short_value[0] if short_value else name
+                if option in {'-C', '--chdir'} and value:
+                    cwd = _resolve_add_chdir(cwd, value)
+                i += 1
+                continue
+            if token.startswith('-'):
+                i += 1
+                continue
+            break
+
+    if i >= len(argv) or Path(argv[i]).name != 'git':
+        return None
+
+    i += 1
+    while i < len(argv):
+        token = argv[i]
+        name, separator, attached = token.partition('=')
+        if name == '--list-cmds' or token == '--exec-path':
+            return None
+        if name == '--exec-path':
+            i += 1
+            continue
+        if token in _GIT_GLOBAL_FLAG_OPTS:
+            i += 1
+            continue
+        if token.startswith('-C') and token != '-C':
+            value = token[2:]
+            cwd = _resolve_add_chdir(cwd, value)
+            i += 1
+            continue
+        if token.startswith('-c') and token != '-c':
+            i += 1
+            continue
+        if name in _GIT_GLOBAL_VALUE_OPTS:
+            value = attached if separator else None
+            if value is None:
+                i += 1
+                if i >= len(argv):
+                    return None
+                value = argv[i]
+            if name == '-C' and value:
+                cwd = _resolve_add_chdir(cwd, value)
+            elif name in {'--git-dir', '--work-tree'}:
+                cwd = None
+            i += 1
+            continue
+        break
+
+    if i >= len(argv) or argv[i] != 'add':
+        return None
+    return ['git', 'add', *argv[i + 1:]], cwd
+
+
+def _canonical_commit_long_option(name: str) -> str:
+    """Resolve an unambiguous abbreviated ``git commit`` long option."""
+    if name in _COMMIT_LONG_OPTIONS:
+        return name
+    matches = [option for option in _COMMIT_LONG_OPTIONS
+               if option.startswith(name)]
+    return matches[0] if len(matches) == 1 else name
+
+
+def _parse_commit_options(
+    normalized_cmd: str,
+) -> list[tuple[str, str | None]]:
+    """Parse the real options of a ``git commit`` command.
+
+    Short clusters are read left to right. A required-value option consumes the
+    rest of its token or the following token, while an optional-value option
+    consumes only an attached remainder. Everything after ``--`` is a pathspec.
+
+    Args:
+        normalized_cmd: The normalized command string to inspect.
+
+    Returns:
+        Pairs containing each option name and its attached or separate value.
+    """
+    argv = _resolve_git_commit_argv(normalized_cmd)
+    if argv is None:
+        return []
+
+    options: list[tuple[str, str | None]] = []
+    i = 2  # skip "git commit"
+    while i < len(argv):
+        token = argv[i]
+        if token == '--':
+            break
+        if token.startswith('--'):
+            name, separator, attached_value = token.partition('=')
+            name = _canonical_commit_long_option(name)
+            value = attached_value if separator else None
+            if name in _COMMIT_VALUE_OPTS and not separator:
+                if i + 1 < len(argv):
+                    i += 1
+                    value = argv[i]
+            options.append((name, value))
+        elif token.startswith('-') and len(token) > 1:
+            cluster = token[1:]
+            position = 0
+            while position < len(cluster):
+                name = '-' + cluster[position]
+                remainder = cluster[position + 1:]
+                if name in _COMMIT_SHORT_VALUE_OPTS:
+                    value = remainder or None
+                    if value is None and i + 1 < len(argv):
+                        i += 1
+                        value = argv[i]
+                    options.append((name, value))
+                    break
+                if name in _COMMIT_SHORT_OPTIONAL_VALUE_OPTS:
+                    options.append((name, remainder or None))
+                    break
+                options.append((name, None))
+                position += 1
+        i += 1
+    return options
+
+
+def _commit_option_tokens(normalized_cmd: str) -> list[str]:
+    """Return the option names in a ``git commit`` command.
+
+    Args:
+        normalized_cmd: The normalized command string to inspect.
+
+    Returns:
+        Option names without their attached or separate values.
+    """
+    return [name for name, _value in _parse_commit_options(normalized_cmd)]
+
+
+def _commit_avoids_editor(
+    options: list[tuple[str, str | None]],
+) -> bool:
+    """Return whether parsed commit options avoid opening an editor.
+
+    Args:
+        options: Parsed option-name and value pairs in command order.
+
+    Returns:
+        Whether Git has a message source or explicit setting that avoids the
+        editor.
+    """
+    edit_setting: bool | None = None
+    for name, _value in options:
+        if name in {'-e', '--edit'}:
+            edit_setting = True
+        elif name == '--no-edit':
+            edit_setting = False
+
+    if edit_setting is not None:
+        return not edit_setting
+
+    message_sources: set[str] = set()
+    reedit_message = False
+    fixup_value: str | None = None
+    for name, value in options:
+        if family := _COMMIT_MESSAGE_OPTION_FAMILIES.get(name):
+            message_sources.add(family)
+        elif family := _COMMIT_NEGATED_MESSAGE_OPTIONS.get(name):
+            message_sources.discard(family)
+        elif name in {'-c', '--reedit-message'}:
+            reedit_message = True
+        elif name == '--no-reedit-message':
+            reedit_message = False
+        elif name == '--fixup':
+            fixup_value = value
+        elif name == '--no-fixup':
+            fixup_value = None
+
+    if reedit_message:
+        return False
+    if fixup_value and fixup_value.startswith(('amend:', 'reword:')):
+        return False
+    return bool(message_sources or fixup_value)
 
 
 def _is_allowed(flag_name: str, session_id: str = "") -> bool:
@@ -35,7 +521,7 @@ def check_git_add_command(command, session_id: str = ""):
     # Scan ALL subcommands to ensure blocks aren't hidden after asks
     first_ask_result = None
 
-    for subcmd in extract_subcommands(command):
+    for subcmd in _split_compound_command(command):
         result = _check_single_git_add_command(subcmd, session_id)
         decision, reason = result
 
@@ -59,8 +545,13 @@ def _check_single_git_add_command(command, session_id: str = ""):
     Check a single (non-compound) command for dangerous git add patterns.
     Returns tuple: (decision, reason) where decision is bool or "ask"/"block"/"allow"
     """
-    # Normalize the command - handle multiple spaces, tabs, etc.
+    # Normalize recognized add commands after stripping supported Git prefixes.
     normalized_cmd = ' '.join(command.strip().split())
+    resolved_add = _resolve_git_add_argv(command)
+    repo_cwd: str | None = os.getcwd()
+    if resolved_add is not None:
+        add_argv, repo_cwd = resolved_add
+        normalized_cmd = shlex.join(add_argv)
 
     # Always allow --dry-run (used internally to detect what would be staged)
     if '--dry-run' in normalized_cmd or '-n' in normalized_cmd.split():
@@ -90,7 +581,12 @@ This restriction prevents accidentally staging unwanted files."""
         r')', re.IGNORECASE
     )
 
-    if dangerous_pattern.search(normalized_cmd):
+    add_arguments = add_argv[2:] if resolved_add is not None else []
+    abbreviated_all = any(
+        argument.split('=', 1)[0] in _ADD_ALL_LONG_OPTIONS
+        for argument in add_arguments
+    )
+    if dangerous_pattern.search(normalized_cmd) or abbreviated_all:
         reason = """BLOCKED: Dangerous git add pattern detected!
 
 DO NOT use:
@@ -106,6 +602,17 @@ Instead, use:
 
 This restriction prevents accidentally staging unwanted files."""
         return True, reason
+
+    if resolved_add is not None and repo_cwd is None:
+        return 'ask', _UNVERIFIED_STAGING_REASON
+
+    if any(
+        argument.startswith('--pathspec-')
+        for argument in add_arguments
+    ):
+        if _is_allowed('staging', session_id):
+            return False, None
+        return 'ask', 'Staging paths supplied through a pathspec file.'
 
     # Check for git add with a directory
     # Match: git add <dirname>/ or git add <path/to/dir>/
@@ -126,8 +633,10 @@ This restriction prevents accidentally staging unwanted files."""
             try:
                 result = subprocess.run(
                     ['git', 'add', '--dry-run', dir_path + '/'],
-                    capture_output=True, text=True, cwd=os.getcwd()
+                    capture_output=True, text=True, cwd=repo_cwd
                 )
+                if result.returncode != 0:
+                    return 'ask', _UNVERIFIED_STAGING_REASON
                 # Parse dry-run output: "add 'filename'" lines
                 files = []
                 for line in result.stdout.strip().split('\n'):
@@ -146,8 +655,10 @@ This restriction prevents accidentally staging unwanted files."""
                 for f in files:
                     status_result = subprocess.run(
                         ['git', 'status', '--porcelain', f],
-                        capture_output=True, text=True, cwd=os.getcwd()
+                        capture_output=True, text=True, cwd=repo_cwd
                     )
+                    if status_result.returncode != 0:
+                        return 'ask', _UNVERIFIED_STAGING_REASON
                     status = status_result.stdout.strip()
                     if status:
                         status_code = status[:2]
@@ -167,7 +678,9 @@ This restriction prevents accidentally staging unwanted files."""
                 file_list = ", ".join(modified_files[:5])
                 if len(modified_files) > 5:
                     file_list += f" (+{len(modified_files) - 5} more)"
-                reason = f"Staging directory {dir_path}/ with modified files: {file_list}"
+                reason = (
+                    f"Staging directory {dir_path}/ with modified files: {file_list}"
+                )
                 return "ask", reason
 
             except Exception:
@@ -175,19 +688,33 @@ This restriction prevents accidentally staging unwanted files."""
                 reason = f"Staging directory {dir_path}/ (couldn't verify file status)"
                 return "ask", reason
 
-    # Also check for git commit -a without -m (which would open an editor)
-    # Check if command has -a flag but no -m flag
-    if re.search(r'^git\s+commit\s+', normalized_cmd):
-        has_a_flag = re.search(r'-[a-zA-Z]*a[a-zA-Z]*', normalized_cmd)
-        has_m_flag = re.search(r'-[a-zA-Z]*m[a-zA-Z]*', normalized_cmd)
-        if has_a_flag and not has_m_flag:
-            reason = """Avoid 'git commit -a' without a message flag. Use 'gcam "message"' instead, which is an alias for 'git commit -a -m'."""
+    # Also check for git commit -a without a message flag (which would open an
+    # editor).
+    #
+    # This used to scan the whole command string for `-[a-zA-Z]*a[a-zA-Z]*` and
+    # `-[a-zA-Z]*m[a-zA-Z]*`, which matched inside any hyphenated word rather
+    # than only real option tokens: a path containing "-a" looked like the
+    # stage-everything flag, and any hyphenated word containing an "m"
+    # cancelled it again. Parse actual option tokens instead.
+    if _resolve_git_commit_argv(normalized_cmd) is not None:
+        options = _parse_commit_options(normalized_cmd)
+        option_names = {name for name, _value in options}
+        has_a_flag = '-a' in option_names or '--all' in option_names
+        if has_a_flag and not _commit_avoids_editor(options):
+            reason = (
+                "Avoid 'git commit -a' when it opens an editor. Use "
+                "'gcam \"message\"' instead, which is an alias for "
+                "'git commit -a -m'."
+            )
             return True, reason
 
     # Check if staging modified files (not new/untracked) - requires permission
     # This check runs after all blocking patterns pass
     if normalized_cmd.startswith('git add'):
-        modified_files = get_modified_files_being_staged(normalized_cmd)
+        modified_files = get_modified_files_being_staged(
+            normalized_cmd, cwd=repo_cwd)
+        if modified_files is None:
+            return 'ask', _UNVERIFIED_STAGING_REASON
         if modified_files:
             # Check if staging is allowed via flag file
             if _is_allowed('staging', session_id):
@@ -201,12 +728,15 @@ This restriction prevents accidentally staging unwanted files."""
     return False, None
 
 
-def get_modified_files_being_staged(command):
+def get_modified_files_being_staged(command, cwd=None):
     """
     Extract files from git add command and return those that are modified
     (not new/untracked). Returns empty list if only staging new files.
     """
-    parts = command.split()
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
     if len(parts) < 3 or parts[0] != 'git' or parts[1] != 'add':
         return []
 
@@ -225,8 +755,10 @@ def get_modified_files_being_staged(command):
             # Check git status for this file
             result = subprocess.run(
                 ['git', 'status', '--porcelain', f],
-                capture_output=True, text=True, cwd=os.getcwd()
+                capture_output=True, text=True, cwd=cwd or os.getcwd()
             )
+            if result.returncode != 0:
+                return None
             status = result.stdout.strip()
             if status:
                 # Status codes: ?? = untracked, M = modified, A = staged
@@ -235,7 +767,7 @@ def get_modified_files_being_staged(command):
                 if '?' not in status_code:  # Not untracked = modified/staged
                     modified_files.append(f)
         except Exception:
-            pass
+            return None
 
     return modified_files
 

--- a/plugins/safety-hooks/hooks/git_checkout_safety_hook.py
+++ b/plugins/safety-hooks/hooks/git_checkout_safety_hook.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import os
 import re
+import shlex
 import subprocess
 import sys
+from typing import List, Optional, Set, Tuple
 
 # Add plugin hooks directory to Python path for local imports
 PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT')
@@ -11,10 +13,425 @@ if PLUGIN_ROOT:
     if hooks_dir not in sys.path:
         sys.path.insert(0, hooks_dir)
 
-from command_utils import extract_subcommands
+# git's own global options that consume the NEXT token as their value. They sit
+# between "git" and the subcommand, so the subcommand is not always argv[1].
+_GIT_GLOBAL_VALUE_OPTS = {
+    "-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path",
+    "--super-prefix", "--config-env", "--attr-source",
+}
+
+# These options print information and exit instead of dispatching a subcommand.
+_GIT_TERMINAL_OPTS = {
+    "-h", "-v", "--help", "--version", "--html-path", "--man-path",
+    "--info-path",
+}
+
+# Options that point git at a repository this module cannot compute. Honouring
+# them properly also means handling GIT_DIR / GIT_WORK_TREE and their
+# composition with -C; rather than guess, mark the target unknown and let the
+# caller decline to probe anything.
+_OPAQUE_TARGET_OPTS = ("--work-tree", "--git-dir")
+
+# Short checkout options whose remaining characters are their argument, rather
+# than more options in the same cluster. For example, ``-bfeature`` means
+# ``-b feature``; the ``f`` in ``feature`` is not ``--force``.
+_CHECKOUT_SHORT_VALUE_OPTS = {"b", "B"}
+
+# Shell expansions cannot be reproduced reliably after shlex has split the
+# command. Tilde expansion is handled separately because it has deterministic
+# local semantics for ordinary home-directory paths.
+_UNRESOLVABLE_CHDIR_CHARS = frozenset("$`*?[")
+
+# Pathspecs that mean "everything", as opposed to a named file.
+_UNBOUNDED_PATHSPECS = {".", "./", "*", ":/"}
+_FORCE_LONG_OPTIONS = {"--f", "--fo", "--for", "--forc", "--force"}
+
+_ENV_VALUE_OPTS = {
+    "-a", "--argv0", "-u", "--unset", "-C", "--chdir", "-S",
+    "--split-string",
+}
+_ENV_SHORT_VALUE_OPTS = {"a", "u", "C", "P", "S"}
+_REPOSITORY_ROUTING_VARS = {"GIT_DIR", "GIT_WORK_TREE"}
+_LEADING_REDIRECTION = re.compile(r"^\d*[<>].+")
+_LEADING_REDIRECTION_OPERATOR = re.compile(r"^\d*(?:<>|>>|>|<|>&|<&)\Z")
+
+_DANGER_TEMPLATE = (
+    "⚠️  DANGEROUS COMMAND DETECTED!\n\n{message}\n\n"
+    "This command will destroy uncommitted work without warning.\n\n"
+    "Safer alternatives:\n"
+    "- Use 'git stash' to save changes temporarily\n"
+    "- Use 'git diff' to see what would be lost\n"
+    "- Use 'git restore' for clearer syntax"
+)
+
+_UNVERIFIED_REPOSITORY_MESSAGE = (
+    "Could not safely resolve the target repository to verify its status.\n"
+    "Please manually check 'git status' in the target repository before "
+    "proceeding."
+)
 
 
-def check_git_checkout_command(command):
+def _danger(message: str) -> str:
+    return _DANGER_TEMPLATE.format(message=message)
+
+
+def _tokenize(command: str) -> List[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _raw_tokens(command: str) -> Optional[List[str]]:
+    """Tokenize while retaining quotes and escapes around token contents."""
+    try:
+        lexer = shlex.shlex(command, posix=False)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        return list(lexer)
+    except ValueError:
+        return None
+
+
+def _is_assignment(token: str) -> bool:
+    """Return whether a token is a simple shell assignment word."""
+    name, separator, _ = token.partition("=")
+    return bool(
+        separator
+        and name
+        and (name[0].isalpha() or name[0] == "_")
+        and all(char.isalnum() or char == "_" for char in name)
+    )
+
+
+def _is_repository_routing_assignment(token: str) -> bool:
+    """Return whether an assignment changes which repository Git targets."""
+    return token.partition("=")[0] in _REPOSITORY_ROUTING_VARS
+
+
+def _env_short_value_option(
+    token: str,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Return the first value-taking short env option and attached value."""
+    if not token.startswith("-") or token.startswith("--"):
+        return None, None
+    cluster = token[1:]
+    for position, option in enumerate(cluster):
+        if option in _ENV_SHORT_VALUE_OPTS:
+            return option, cluster[position + 1:] or None
+    return None, None
+
+
+def _expand_env_split(
+    tokens: List[str],
+) -> Tuple[Optional[List[str]], bool]:
+    """Expand an ``env -S`` command string into its effective argv."""
+    index = 0
+    while index < len(tokens) and _is_assignment(tokens[index]):
+        index += 1
+    if index >= len(tokens) or os.path.basename(tokens[index]) != "env":
+        return tokens, False
+
+    index += 1
+    while index < len(tokens):
+        token = tokens[index]
+        value: Optional[str] = None
+        consumed = 1
+        if token in ("-S", "--split-string"):
+            if index + 1 >= len(tokens):
+                return None, False
+            value = tokens[index + 1]
+            consumed = 2
+        elif token.startswith("--split-string="):
+            value = token.split("=", 1)[1]
+        elif token.startswith("-") and not token.startswith("--"):
+            option, attached = _env_short_value_option(token)
+            if option == "S":
+                value = attached
+                if not value:
+                    if index + 1 >= len(tokens):
+                        return None, False
+                    value = tokens[index + 1]
+                    consumed = 2
+            elif option is not None:
+                if attached is None:
+                    if index + 1 >= len(tokens):
+                        return None, False
+                    index += 2
+                else:
+                    index += 1
+                continue
+        if value is not None:
+            try:
+                expanded = shlex.split(value)
+            except ValueError:
+                return None, False
+            return tokens[:index] + expanded + tokens[index + consumed:], True
+        if _is_assignment(token):
+            index += 1
+            continue
+        if token in _ENV_VALUE_OPTS:
+            if index + 1 >= len(tokens):
+                return None, False
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    return tokens, False
+
+
+def _executable_index(tokens: List[str]) -> int:
+    index = 0
+    while index < len(tokens):
+        if _LEADING_REDIRECTION.match(tokens[index]):
+            index += 1
+            continue
+        if _LEADING_REDIRECTION_OPERATOR.match(tokens[index]):
+            index += 2
+            continue
+        break
+    while index < len(tokens) and _is_assignment(tokens[index]):
+        index += 1
+    if index >= len(tokens) or os.path.basename(tokens[index]) != "env":
+        return index
+    index += 1
+    while index < len(tokens):
+        token = tokens[index]
+        if _is_assignment(token):
+            index += 1
+            continue
+        if token in _ENV_VALUE_OPTS:
+            index += 2
+            continue
+        option, attached = _env_short_value_option(token)
+        if option is not None:
+            index += 1 if attached is not None else 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    return index
+
+
+def _split_compound_command(command: str) -> List[str]:
+    """Split on shell operators outside quotes and backslash escapes."""
+    subcommands: List[str] = []
+    start = 0
+    quote: Optional[str] = None
+    escaped = False
+    index = 0
+
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            escaped = False
+        elif char == "\\" and quote != "'":
+            escaped = True
+        elif char in ("'", '"'):
+            if quote == char:
+                quote = None
+            elif quote is None:
+                quote = char
+        elif (quote is None and char == "&" and index > 0
+              and command[index - 1] in "<>"):
+            pass
+        elif quote is None and char in ";&|\n":
+            subcommand = command[start:index].strip()
+            if subcommand:
+                subcommands.append(subcommand)
+            if char in "&|" and command[index:index + 2] == char * 2:
+                index += 1
+            start = index + 1
+        index += 1
+
+    subcommand = command[start:].strip()
+    if subcommand:
+        subcommands.append(subcommand)
+    return subcommands
+
+
+def _resolve_chdir(
+    current_dir: str,
+    value: str,
+    expand_tilde: Optional[bool] = False,
+) -> Optional[str]:
+    """Resolve one ``git -C`` value without evaluating shell syntax."""
+    if value.startswith("~") and expand_tilde is None:
+        return None
+    expanded = os.path.expanduser(value) if expand_tilde else value
+    if expand_tilde and expanded.startswith("~"):
+        return None
+    if any(char in expanded for char in _UNRESOLVABLE_CHDIR_CHARS):
+        return None
+    if expanded.startswith(("<(", ">(")):
+        return None
+    if os.path.isabs(expanded):
+        return expanded
+    return os.path.join(current_dir, expanded)
+
+
+def _env_chdir(
+    tokens: List[str],
+    raw_tokens: Optional[List[str]],
+) -> Optional[str]:
+    """Resolve a supported ``env -C`` prefix before its command."""
+    current: Optional[str] = os.getcwd()
+    index = 0
+    while index < len(tokens) and _is_assignment(tokens[index]):
+        index += 1
+    if index >= len(tokens) or os.path.basename(tokens[index]) != "env":
+        return current
+
+    index += 1
+    while index < len(tokens):
+        token = tokens[index]
+        if _is_assignment(token):
+            index += 1
+            continue
+        if token == "--":
+            break
+        name, separator, attached = token.partition("=")
+        value: Optional[str] = attached if separator else None
+        value_index = index
+        if name in ("-S", "--split-string"):
+            break
+        if name in ("-C", "--chdir"):
+            if value is None:
+                index += 1
+                if index >= len(tokens):
+                    return None
+                value = tokens[index]
+                value_index = index
+            if current is not None:
+                raw_value = raw_tokens[value_index] if raw_tokens else None
+                expand_tilde = raw_value.startswith("~") if raw_value else None
+                current = _resolve_chdir(current, value, expand_tilde)
+            index += 1
+            continue
+        if token.startswith("-C") and token != "-C":
+            value = token[2:]
+            if current is not None:
+                current = _resolve_chdir(current, value)
+            index += 1
+            continue
+        option, attached = _env_short_value_option(token)
+        if option is not None:
+            value = attached
+            if value is None:
+                index += 1
+                if index >= len(tokens):
+                    return None
+                value = tokens[index]
+            if option == "C" and current is not None:
+                current = _resolve_chdir(current, value)
+            if option == "S":
+                break
+            index += 1
+            continue
+        if token in _ENV_VALUE_OPTS:
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    return current
+
+
+def parse_git_checkout(
+    command: str,
+) -> Tuple[Optional[List[str]], Optional[str]]:
+    """
+    Split ``git [global-opts] checkout <args...>`` into (args, repo_dir).
+
+    Returns ``(None, None)`` when the command is not a git checkout at all.
+
+    Returns ``(args, None)`` when it IS a git checkout but the repository it
+    would act on cannot be determined -- an unexpanded ``-C`` value such as
+    ``-C "$REPO"``, or ``--git-dir`` / ``--work-tree``. Checks that read only
+    the command still apply; nothing may probe a directory on that basis,
+    least of all the caller's own, which is a different repository.
+    """
+    tokens = _tokenize(command)
+    raw_tokens = _raw_tokens(command)
+    if raw_tokens is not None and len(raw_tokens) != len(tokens):
+        raw_tokens = None
+    chdir = _env_chdir(tokens, raw_tokens)
+    tokens, env_split = _expand_env_split(tokens)
+    if tokens is None:
+        return None, None
+    if env_split:
+        raw_tokens = None
+        chdir = _env_chdir(tokens, raw_tokens)
+    if raw_tokens is not None and len(raw_tokens) != len(tokens):
+        raw_tokens = None
+    executable = _executable_index(tokens)
+    if executable >= len(tokens) or os.path.basename(tokens[executable]) != "git":
+        return None, None
+    if any(
+        _is_repository_routing_assignment(token)
+        for token in tokens[:executable]
+    ):
+        chdir = None
+
+    opaque = False
+    i = executable + 1
+    while i < len(tokens):
+        token = tokens[i]
+        if token in _GIT_TERMINAL_OPTS:
+            return None, None
+        if token.split("=", 1)[0] in _OPAQUE_TARGET_OPTS:
+            opaque = True
+        if token in _GIT_GLOBAL_VALUE_OPTS:
+            # git applies repeated -C cumulatively, each relative to the last.
+            if token == "-C" and i + 1 < len(tokens):
+                value = tokens[i + 1]
+                if chdir is not None:
+                    raw_value = raw_tokens[i + 1] if raw_tokens else None
+                    expand_tilde = (
+                        raw_value.startswith("~") if raw_value else None
+                    )
+                    chdir = _resolve_chdir(chdir, value, expand_tilde)
+            i += 2
+            continue
+        if token.startswith("-C") and len(token) > 2:
+            if chdir is not None:
+                chdir = _resolve_chdir(chdir, token[2:])
+            i += 1
+            continue
+        if token.startswith("-"):
+            i += 1
+            continue
+        break
+
+    if i >= len(tokens) or tokens[i] != "checkout":
+        return None, None
+
+    args = tokens[i + 1:]
+    if opaque or chdir is None or not os.path.isdir(chdir):
+        return args, None
+    return args, chdir
+
+
+def _option_flags(tokens: List[str]) -> Set[str]:
+    """Return option flags without parsing attached option arguments as flags."""
+    flags: Set[str] = set()
+    for token in tokens:
+        if token.startswith("--"):
+            name = token.split("=", 1)[0]
+            flags.add("--force" if name in _FORCE_LONG_OPTIONS else name)
+        elif token.startswith("-") and len(token) > 1:
+            for char in token[1:]:
+                flags.add("-" + char)
+                if char in _CHECKOUT_SHORT_VALUE_OPTS:
+                    break
+    return flags
+
+
+def check_git_checkout_command(command: str) -> Tuple[bool, Optional[str]]:
     """
     Check if a git checkout command is safe to execute.
     Handles compound commands (e.g., "cd /path && git checkout branch").
@@ -22,7 +439,7 @@ def check_git_checkout_command(command):
     Returns tuple: (should_block: bool, reason: str or None)
     """
     # Check each subcommand in compound commands
-    for subcmd in extract_subcommands(command):
+    for subcmd in _split_compound_command(command):
         result = _check_single_git_checkout_command(subcmd)
         should_block, reason = result
         if should_block:
@@ -31,35 +448,70 @@ def check_git_checkout_command(command):
     return False, None
 
 
-def _check_single_git_checkout_command(command):
+def _check_single_git_checkout_command(
+    command: str,
+) -> Tuple[bool, Optional[str]]:
     """
     Check a single (non-compound) git checkout command.
     Returns tuple: (should_block: bool, reason: str or None)
     """
-    # Check if it's a git checkout command
-    if not command.strip().startswith("git checkout"):
+    # Check if it's a git checkout command. This also recognises the
+    # `git -C <dir> checkout ...` form, which a "starts with git checkout"
+    # test misses entirely.
+    args, repo_dir = parse_git_checkout(command)
+    if args is None:
         return False, None
 
-    # Safe patterns that we should allow without checking
-    if "-b" in command or "--help" in command or "-h" in command:
+    # Everything before a `--` separator is options and refs; everything after
+    # is pathspecs, even if it looks like an option.
+    if "--" in args:
+        separator = args.index("--")
+        head, pathspecs = args[:separator], args[separator + 1:]
+    else:
+        separator = None
+        head, pathspecs = args, []
+
+    flags = _option_flags(head)
+
+    if "-h" in flags or "--help" in flags:
         return False, None
 
-    # ALWAYS block these dangerous patterns
-    dangerous_patterns = [
-        (r'\bgit\s+checkout\s+(-f|--force)\b',
-         "'git checkout -f' FORCES checkout and DISCARDS all uncommitted changes!"),
-        (r'\bgit\s+checkout\s+\.',
-         "'git checkout .' will DISCARD ALL changes in current directory!"),
-        (r'\bgit\s+checkout\s+.*\s+--\s+\.',
-         "This will DISCARD ALL changes in current directory!"),
-        (r'\bgit\s+checkout\s+.*\s+--\s+',
-         "This will overwrite your local file with version from another branch/commit!"),
-    ]
+    # ALWAYS block these dangerous patterns.
+    #
+    # -f is checked BEFORE the -b allowance below. Testing for "-b" first --
+    # and as a substring of the whole command -- is what let `git checkout -f
+    # -b <name>` and `git checkout . -b <name>` through, and disarmed the guard
+    # for any command merely containing "-b", e.g. `git checkout --
+    # src/my-button.ts`.
+    if "-f" in flags or "--force" in flags:
+        return True, _danger(
+            "'git checkout -f' FORCES checkout and DISCARDS all uncommitted changes!")
 
-    for pattern, message in dangerous_patterns:
-        if re.search(pattern, command):
-            reason = f"⚠️  DANGEROUS COMMAND DETECTED!\n\n{message}\n\nThis command will destroy uncommitted work without warning.\n\nSafer alternatives:\n- Use 'git stash' to save changes temporarily\n- Use 'git diff' to see what would be lost\n- Use 'git restore' for clearer syntax"
-            return True, reason
+    if separator is not None:
+        if any(p in _UNBOUNDED_PATHSPECS for p in pathspecs):
+            return True, _danger(
+                "This will DISCARD ALL changes in current directory!")
+        return True, _danger(
+            "This will overwrite your local file with version from another "
+            "branch/commit!"
+        )
+
+    positionals = [a for a in args if not a.startswith("-")]
+    if any(p in _UNBOUNDED_PATHSPECS for p in positionals):
+        return True, _danger(
+            "'git checkout .' will DISCARD ALL changes in current directory!")
+
+    # Creating a branch carries uncommitted work across rather than discarding
+    # it, so it stays exempt from the uncommitted-changes prompt below.
+    if {"-b", "-B"} & flags:
+        return False, None
+
+    # Everything above reads only the COMMAND. Everything below reads a
+    # REPOSITORY, and repo_dir is None when we could not work out which one.
+    # Probing the caller's own repo instead would report a verdict, and a list
+    # of at-risk files, belonging to a repository the command never touches.
+    if repo_dir is None:
+        return True, _UNVERIFIED_REPOSITORY_MESSAGE
 
     try:
         # First, check if there are any uncommitted changes
@@ -67,8 +519,10 @@ def _check_single_git_checkout_command(command):
             ["git", "status", "--porcelain"],
             capture_output=True,
             text=True,
-            cwd=os.getcwd()
+            cwd=repo_dir
         )
+        if status_result.returncode != 0:
+            return True, _UNVERIFIED_REPOSITORY_MESSAGE
 
         has_changes = bool(status_result.stdout.strip())
 
@@ -79,14 +533,14 @@ def _check_single_git_checkout_command(command):
                 ["git", "diff", "--name-only", "HEAD"],
                 capture_output=True,
                 text=True,
-                cwd=os.getcwd()
+                cwd=repo_dir
             )
 
             unstaged_result = subprocess.run(
                 ["git", "diff", "--name-only"],
                 capture_output=True,
                 text=True,
-                cwd=os.getcwd()
+                cwd=repo_dir
             )
 
             # Count changes
@@ -95,7 +549,10 @@ def _check_single_git_checkout_command(command):
             num_changes = len(modified_files)
 
             # Build warning message
-            warning = f"WARNING: You have {num_changes} uncommitted change(s) that may be lost!\n\n"
+            warning = (
+                f"WARNING: You have {num_changes} uncommitted change(s) that "
+                "may be lost!\n\n"
+            )
 
             if modified_files:
                 warning += "Modified files:\n"
@@ -112,13 +569,19 @@ def _check_single_git_checkout_command(command):
 
             # Special warning for checkout .
             if "checkout ." in command or "checkout -- ." in command:
-                warning += "\n⚠️  DANGER: 'git checkout .' will DISCARD ALL local changes!"
+                warning += (
+                    "\n⚠️  DANGER: 'git checkout .' will DISCARD ALL "
+                    "local changes!"
+                )
 
             return True, warning
 
-    except Exception as e:
+    except Exception as error:
         # If we can't determine status, err on the side of caution
-        reason = f"Could not verify repository status: {str(e)}\nPlease manually check 'git status' before proceeding."
+        reason = (
+            f"Could not verify repository status: {str(error)}\n"
+            "Please manually check 'git status' before proceeding."
+        )
         return True, reason
 
     # No uncommitted changes, safe to proceed

--- a/plugins/safety-hooks/hooks/git_checkout_safety_hook.py
+++ b/plugins/safety-hooks/hooks/git_checkout_safety_hook.py
@@ -503,7 +503,7 @@ def _check_single_git_checkout_command(
 
     # Creating a branch carries uncommitted work across rather than discarding
     # it, so it stays exempt from the uncommitted-changes prompt below.
-    if {"-b", "-B"} & flags:
+    if "-b" in flags:
         return False, None
 
     # Everything above reads only the COMMAND. Everything below reads a

--- a/plugins/safety-hooks/hooks/git_commit_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_commit_block_hook.py
@@ -5,6 +5,8 @@ Uses the "ask" decision type to prompt user in the UI.
 """
 import json
 import os
+import re
+import shlex
 import sys
 
 # Add plugin hooks directory to Python path for local imports
@@ -14,10 +16,484 @@ if PLUGIN_ROOT:
     if hooks_dir not in sys.path:
         sys.path.insert(0, hooks_dir)
 
-from command_utils import extract_subcommands
+# git's own global options that consume the NEXT token as their value. They sit
+# between "git" and the subcommand, which is why the subcommand is not always
+# argv[1] and a "starts with git commit" test is not enough.
+_GIT_GLOBAL_VALUE_OPTS = {
+    "-C",
+    "-c",
+    "--attr-source",
+    "--config-env",
+    "--exec-path",
+    "--git-dir",
+    "--namespace",
+    "--super-prefix",
+    "--work-tree",
+}
+
+# Global flags that Git accepts before a subcommand without consuming a value.
+_GIT_GLOBAL_FLAGS = {
+    "-p",
+    "-P",
+    "--bare",
+    "--glob-pathspecs",
+    "--icase-pathspecs",
+    "--literal-pathspecs",
+    "--no-advice",
+    "--no-lazy-fetch",
+    "--no-optional-locks",
+    "--no-pager",
+    "--no-replace-objects",
+    "--noglob-pathspecs",
+    "--paginate",
+}
+
+# These options complete the Git invocation rather than preceding a subcommand.
+_GIT_TERMINAL_OPTS = {
+    "-h",
+    "-v",
+    "--help",
+    "--html-path",
+    "--info-path",
+    "--man-path",
+    "--version",
+}
 
 
-def check_git_commit_command(command, session_id: str = ""):
+# Subcommands that write a commit object. `commit-tree` is included because
+# the previous `startswith('git commit')` test matched it, and prompting for it
+# is consistent with this hook's purpose.
+COMMIT_SUBCOMMANDS = ('commit', 'commit-tree')
+_MAX_SUBSTITUTION_DEPTH = 12
+_ENV_VALUE_OPTS = {"-C", "-P", "-S", "-u", "--argv0", "--chdir", "--unset"}
+_ENV_SHORT_VALUE_OPTS = frozenset("uCPS")
+
+
+def _is_assignment(token: str) -> bool:
+    """Return whether a token is a simple shell assignment word."""
+    return bool(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token))
+
+
+def _env_short_value(token: str) -> tuple[str, str | None] | None:
+    """Return the first value-taking option in a short ``env`` cluster."""
+    if not token.startswith("-") or token.startswith("--"):
+        return None
+    for index, option in enumerate(token[1:]):
+        if option in _ENV_SHORT_VALUE_OPTS:
+            return f"-{option}", token[index + 2:] or None
+    return None
+
+
+def _expand_env_split(tokens: list[str]) -> list[str] | None:
+    """Expand an ``env -S`` command string into its effective argv."""
+    index = 0
+    while index < len(tokens) and _is_assignment(tokens[index]):
+        index += 1
+    if index >= len(tokens) or os.path.basename(tokens[index]) != "env":
+        return tokens
+
+    index += 1
+    while index < len(tokens):
+        token = tokens[index]
+        value: str | None = None
+        consumed = 1
+        if token in ("-S", "--split-string"):
+            if index + 1 >= len(tokens):
+                return None
+            value = tokens[index + 1]
+            consumed = 2
+        elif token.startswith("--split-string="):
+            value = token.split("=", 1)[1]
+        elif short_value := _env_short_value(token):
+            option, value = short_value
+            if value is None:
+                if index + 1 >= len(tokens):
+                    return None
+                value = tokens[index + 1]
+                consumed = 2
+            if option != "-S":
+                index += consumed
+                continue
+        if value is not None:
+            try:
+                expanded = shlex.split(value)
+            except ValueError:
+                return None
+            return tokens[:index] + expanded + tokens[index + consumed:]
+        if _is_assignment(token):
+            index += 1
+            continue
+        if token in _ENV_VALUE_OPTS:
+            if index + 1 >= len(tokens):
+                return None
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    return tokens
+
+
+def _skip_command_prefix(tokens: list[str]) -> int | None:
+    """Return the executable index after assignments and a simple env."""
+    index = 0
+    while index < len(tokens) and _is_assignment(tokens[index]):
+        index += 1
+    if index >= len(tokens) or os.path.basename(tokens[index]) != "env":
+        return index
+
+    index += 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token in _ENV_VALUE_OPTS:
+            if index + 1 >= len(tokens):
+                return None
+            index += 2
+            continue
+        if token.startswith(("--argv0=", "--chdir=", "--unset=")):
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    while index < len(tokens) and _is_assignment(tokens[index]):
+        index += 1
+    return index
+
+
+def _dollar_substitution_end(command: str, start: int) -> int | None:
+    """Return the closing parenthesis index for a ``$(`` substitution."""
+    depth = 1
+    quote: str | None = None
+    index = start
+    while index < len(command):
+        character = command[index]
+        if character == "\\" and quote != "'":
+            index += 2
+            continue
+        if character in {"'", '"'}:
+            if quote is None:
+                quote = character
+            elif quote == character:
+                quote = None
+        elif quote is None:
+            if character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+                if depth == 0:
+                    return index
+        index += 1
+    return None
+
+
+def _backtick_substitution_end(command: str, start: int) -> int | None:
+    """Return the closing index for an executable backtick substitution."""
+    index = start
+    while index < len(command):
+        if command[index] == "\\":
+            index += 2
+            continue
+        if command[index] == "`":
+            return index
+        index += 1
+    return None
+
+
+def _heredoc_body(
+    command: str,
+    start: int,
+) -> tuple[int, int, bool] | None:
+    """Return the body bounds and quoting state for a simple heredoc."""
+    index = start + 2
+    strip_tabs = index < len(command) and command[index] == "-"
+    if strip_tabs:
+        index += 1
+    while index < len(command) and command[index] in " \t":
+        index += 1
+    delimiter_parts: list[str] = []
+    quoted = False
+    while index < len(command) and command[index] not in " \t\r\n;&|<>()":
+        character = command[index]
+        if character in {"'", '"'}:
+            quoted = True
+            end = command.find(character, index + 1)
+            if end == -1:
+                return None
+            delimiter_parts.append(command[index + 1:end])
+            index = end + 1
+        elif character == "\\":
+            if index + 1 >= len(command):
+                return None
+            quoted = True
+            delimiter_parts.append(command[index + 1])
+            index += 2
+        else:
+            delimiter_parts.append(character)
+            index += 1
+    delimiter = "".join(delimiter_parts)
+    if not delimiter:
+        return None
+    body_start = command.find("\n", index)
+    if body_start == -1:
+        return None
+    body_start += 1
+    line_start = body_start
+    while line_start <= len(command):
+        line_end = command.find("\n", line_start)
+        if line_end == -1:
+            line_end = len(command)
+        line = command[line_start:line_end].removesuffix("\r")
+        if strip_tabs:
+            line = line.lstrip("\t")
+        if line == delimiter:
+            return body_start, min(line_end + 1, len(command)), quoted
+        if line_end == len(command):
+            return None
+        line_start = line_end + 1
+    return None
+
+
+def _heredoc_substitution_commands(body: str, depth: int) -> list[str]:
+    """Extract executable substitutions from an unquoted heredoc body."""
+    commands: list[str] = []
+    index = 0
+    while index < len(body):
+        if body[index] == "\\":
+            index += 2
+            continue
+        if body.startswith("$(", index):
+            end = _dollar_substitution_end(body, index + 2)
+            content_start = index + 2
+        elif body[index] == "`":
+            end = _backtick_substitution_end(body, index + 1)
+            content_start = index + 1
+        else:
+            index += 1
+            continue
+        if end is None:
+            index += 1
+            continue
+        content = body[content_start:end]
+        if depth >= _MAX_SUBSTITUTION_DEPTH:
+            if _commit_at_nesting_limit(content):
+                commands.append("git commit")
+        else:
+            commands.extend(_split_shell_commands(content, depth + 1))
+        index = end + 1
+    return commands
+
+
+def _commit_at_nesting_limit(command: str) -> bool:
+    """Conservatively find an unquoted commit at a shell command boundary."""
+    index = 0
+    quote: str | None = None
+    command_start = True
+    while index < len(command):
+        character = command[index]
+        if character == "\\" and quote != "'":
+            index += 2
+            continue
+        if character in {"'", '"'}:
+            if quote is None:
+                quote = character
+            elif quote == character:
+                quote = None
+            index += 1
+            continue
+        if quote is None:
+            if command_start and not character.isspace():
+                if git_subcommand(command[index:]) in COMMIT_SUBCOMMANDS:
+                    return True
+                command_start = character in "(<>{"
+            elif character in ";&|\r\n(":
+                command_start = True
+        index += 1
+    return False
+
+
+def _split_shell_commands(command: str, depth: int = 0) -> list[str]:
+    """Split a shell command on unquoted chaining operators.
+
+    This intentionally implements only the local behavior needed by this hook.
+    In particular, operators in quoted Git option values and escaped operators
+    stay within the command that contains them.
+
+    Args:
+        command: A shell command that may contain compound commands.
+
+    Returns:
+        Nonempty command segments with surrounding whitespace removed.
+    """
+    commands: list[str] = []
+    start = 0
+    index = 0
+    quote: str | None = None
+
+    while index < len(command):
+        character = command[index]
+        if character == "\\" and quote != "'":
+            index += 2
+            continue
+        if quote != "'" and command.startswith("$(", index):
+            end = _dollar_substitution_end(command, index + 2)
+            if end is not None:
+                if depth >= _MAX_SUBSTITUTION_DEPTH:
+                    if _commit_at_nesting_limit(command[index + 2:end]):
+                        commands.append("git commit")
+                else:
+                    commands.extend(
+                        _split_shell_commands(command[index + 2:end], depth + 1)
+                    )
+                index = end + 1
+                continue
+        if quote is None and command[index:index + 2] in {"<(", ">("}:
+            end = _dollar_substitution_end(command, index + 2)
+            if end is not None:
+                body = command[index + 2:end]
+                if depth >= _MAX_SUBSTITUTION_DEPTH:
+                    if _commit_at_nesting_limit(body):
+                        commands.append("git commit")
+                else:
+                    commands.extend(_split_shell_commands(body, depth + 1))
+                index = end + 1
+                continue
+        escaped_dollar = index >= 2 and command[index - 2:index] == "\\$"
+        if quote is None and character == "(" and not escaped_dollar:
+            end = _dollar_substitution_end(command, index + 1)
+            if end is not None:
+                body = command[index + 1:end]
+                if depth >= _MAX_SUBSTITUTION_DEPTH:
+                    if _commit_at_nesting_limit(body):
+                        commands.append("git commit")
+                else:
+                    commands.extend(_split_shell_commands(body, depth + 1))
+                index = end + 1
+                continue
+        if quote != "'" and character == "`":
+            end = _backtick_substitution_end(command, index + 1)
+            if end is not None:
+                body = command[index + 1:end].replace("\\`", "`")
+                if depth >= _MAX_SUBSTITUTION_DEPTH:
+                    if _commit_at_nesting_limit(body):
+                        commands.append("git commit")
+                else:
+                    commands.extend(
+                        _split_shell_commands(body, depth + 1)
+                    )
+                index = end + 1
+                continue
+        if character in {"'", '"'}:
+            if quote is None:
+                quote = character
+            elif quote == character:
+                quote = None
+            index += 1
+            continue
+        if quote is None and command.startswith("<<", index):
+            heredoc = _heredoc_body(command, index)
+            if heredoc is not None:
+                body_start, body_end, delimiter_quoted = heredoc
+                header_end = command.find("\n", index)
+                commands.extend(
+                    _split_shell_commands(command[start:header_end], depth)
+                )
+                if not delimiter_quoted:
+                    commands.extend(
+                        _heredoc_substitution_commands(
+                            command[body_start:body_end], depth
+                        )
+                    )
+                index = body_end
+                start = body_end
+                continue
+        if quote is None and character in ";&|\r\n":
+            segment = command[start:index].strip()
+            if segment:
+                commands.append(segment)
+            pair = command[index:index + 2]
+            operator_length = 2 if pair in {"&&", "||", "\r\n"} else 1
+            index += operator_length
+            start = index
+            continue
+        index += 1
+
+    segment = command[start:].strip()
+    if segment:
+        commands.append(segment)
+    return commands
+
+
+def git_subcommand(command: str) -> str | None:
+    """Return the Git subcommand invoked by a command, if one is resolved.
+
+    git's global options sit between "git" and the subcommand, so the
+    subcommand is not always argv[1]: `git -C <dir> commit` invokes `commit`.
+
+    Args:
+        command: A single shell command.
+
+    Returns:
+        The resolved Git subcommand, or ``None`` for non-Git commands and Git
+        invocations that do not unambiguously resolve a subcommand.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+
+    tokens = _expand_env_split(tokens)
+    if tokens is None:
+        return None
+
+    executable_index = _skip_command_prefix(tokens)
+    if executable_index is None or executable_index >= len(tokens):
+        return None
+    if os.path.basename(tokens[executable_index]) != "git":
+        return None
+
+    i = executable_index + 1
+    while i < len(tokens):
+        token = tokens[i]
+        if token in _GIT_TERMINAL_OPTS:
+            return None
+        if token in _GIT_GLOBAL_VALUE_OPTS:
+            if i + 1 >= len(tokens):
+                return None
+            i += 2
+            continue
+        if any(
+            token.startswith(f"{option}=")
+            for option in _GIT_GLOBAL_VALUE_OPTS
+            if option.startswith("--")
+        ):
+            i += 1
+            continue
+        if token.startswith("-C") and token != "-C":
+            i += 1
+            continue
+        if token.startswith("-c") and token != "-c":
+            i += 1
+            continue
+        if token in _GIT_GLOBAL_FLAGS:
+            i += 1
+            continue
+        if token.startswith("-"):
+            return None
+        break
+
+    return tokens[i] if i < len(tokens) else None
+
+
+def check_git_commit_command(
+    command: str,
+    session_id: str = "",
+) -> tuple[str, str | None]:
     """Check if a command contains a git commit and request
     user permission.
 
@@ -29,9 +505,8 @@ def check_git_commit_command(command, session_id: str = ""):
     decision is one of: "allow", "ask", "block"
     """
     # Check each subcommand in compound commands
-    for subcmd in extract_subcommands(command):
-        normalized = ' '.join(subcmd.strip().split())
-        if normalized.startswith('git commit'):
+    for subcmd in _split_shell_commands(command):
+        if git_subcommand(subcmd) in COMMIT_SUBCOMMANDS:
             # Check if commits are allowed via session-scoped flag
             if session_id and os.path.exists(
                 f'/tmp/claude/allow-git-commit.{session_id}'

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -215,6 +215,8 @@ class TestBlocked(unittest.TestCase):
     def test_supported_wrappers(self):
         self.assertBlocked("sudo command cat " + DOTENV)
         self.assertBlocked("sudo --user root cat " + DOTENV)
+        self.assertBlocked("sudo -nu root cat " + DOTENV)
+        self.assertBlocked("sudo -nuroot cat " + DOTENV)
         self.assertBlocked("env -i MODE=test cat " + DOTENV)
         self.assertBlocked("sudo sh -c 'cat " + DOTENV + "'")
 

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+Unit tests for env_file_protection_hook.py
+
+Tests cover:
+    - Reading, writing, editing and searching dotenv files
+    - Redirection into a dotenv file
+    - Dotenv files named in a later, unrelated shell segment
+    - A command name and a dotenv mention with no relationship between them
+    - find's -name operand vs. its comparison operands
+    - The documented safe commands
+"""
+import os
+import shlex
+import sys
+import unittest
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from env_file_protection_hook import check_env_file_access, shell_segments
+
+# Assembled rather than written literally so this file does not itself trip a
+# guard that scans source or command text for the pattern it protects.
+DOTENV = "." + "env"
+
+
+class TestShellSegments(unittest.TestCase):
+    """Tests for shell_segments() splitting."""
+
+    def test_single_segment(self):
+        self.assertEqual(shell_segments("cat notes.md"), [["cat", "notes.md"]])
+
+    def test_pipeline(self):
+        self.assertEqual(
+            shell_segments("cat a.json | jq .x"),
+            [["cat", "a.json"], ["jq", ".x"]])
+
+    def test_and_and_semicolon(self):
+        self.assertEqual(
+            shell_segments("ls && echo hi; pwd"),
+            [["ls"], ["echo", "hi"], ["pwd"]])
+
+    def test_quotes_are_respected(self):
+        self.assertEqual(
+            shell_segments('echo "a && b"'), [["echo", "a && b"]])
+
+    def test_newline_is_a_separator(self):
+        self.assertEqual(
+            shell_segments("echo ok\ncat notes.md"),
+            [["echo", "ok"], ["cat", "notes.md"]])
+
+    def test_unterminated_quote_is_unparseable(self):
+        self.assertIsNone(shell_segments('echo "unterminated'))
+
+
+class TestBlocked(unittest.TestCase):
+    """Access to a dotenv file must be blocked."""
+
+    def assertBlocked(self, command, message=None):
+        blocked, reason = check_env_file_access(command)
+        self.assertTrue(blocked, message or command)
+        self.assertIsNotNone(reason)
+
+    def test_read(self):
+        self.assertBlocked("cat " + DOTENV)
+        self.assertBlocked("less " + DOTENV)
+        self.assertBlocked("head -5 " + DOTENV + ".production")
+        self.assertBlocked("tail " + DOTENV)
+
+    def test_source_builtins(self):
+        self.assertBlocked("source " + DOTENV)
+        self.assertBlocked(". config/" + DOTENV + ".local")
+
+    def test_read_via_absolute_path_to_the_binary(self):
+        self.assertBlocked("/bin/cat " + DOTENV)
+
+    def test_read_in_a_subdirectory(self):
+        self.assertBlocked("cat src/" + DOTENV)
+
+    def test_suffixed_variants(self):
+        self.assertBlocked("cat " + DOTENV + ".local")
+        self.assertBlocked("cat " + DOTENV + ".production")
+
+    def test_editors(self):
+        self.assertBlocked("vim " + DOTENV)
+        self.assertBlocked("nano " + DOTENV)
+        self.assertBlocked("code " + DOTENV)
+
+    def test_search(self):
+        self.assertBlocked("grep KEY " + DOTENV)
+        self.assertBlocked("rg SECRET " + DOTENV)
+        self.assertBlocked("ag SECRET " + DOTENV)
+        self.assertBlocked("ack SECRET " + DOTENV)
+
+    def test_script_reader_file_operands(self):
+        self.assertBlocked("sed -n p " + DOTENV)
+        self.assertBlocked("sed -e p " + DOTENV)
+        self.assertBlocked("sed -f " + DOTENV + " README.md")
+        self.assertBlocked("awk '{print}' " + DOTENV)
+        self.assertBlocked("awk -f " + DOTENV + " README.md")
+
+    def test_search_options_with_attached_dotenv_values(self):
+        self.assertBlocked("grep -f" + DOTENV + " target.txt")
+        self.assertBlocked("grep -Hf" + DOTENV + " target.txt")
+        self.assertBlocked("rg -g" + DOTENV + " SECRET .")
+        self.assertBlocked("rg -ug" + DOTENV + " SECRET .")
+        self.assertBlocked("rg -f" + DOTENV + " target.txt")
+        self.assertBlocked("grep -r SECRET . --include=" + DOTENV)
+        self.assertBlocked("grep -r SECRET . --include=" + DOTENV + "*")
+        self.assertBlocked("grep --exclude-from=" + DOTENV + " SECRET .")
+        self.assertBlocked("rg --iglob=" + DOTENV + " SECRET .")
+        self.assertBlocked("rg --ignore-file " + DOTENV + " SECRET .")
+        self.assertBlocked("rg --ignore-file=" + DOTENV + " SECRET .")
+        self.assertBlocked("grep -r SECRET . --inc=" + DOTENV)
+        self.assertBlocked("grep --exclude-f=" + DOTENV + " SECRET .")
+        self.assertBlocked("grep --reg=SECRET " + DOTENV)
+
+    def test_search_inclusion_globs_that_select_dotenv(self):
+        self.assertBlocked("grep -r SECRET . --include='*.env*'")
+        self.assertBlocked("grep -r --include '*.env*' SECRET .")
+        self.assertBlocked("rg -g '*.env*' SECRET .")
+        self.assertBlocked("rg --iglob='[.]ENV*' SECRET .")
+        self.assertBlocked("rg --hidden --glob='.env/config' SECRET .")
+        self.assertBlocked("grep -r --include=.env.production SECRET .")
+        self.assertBlocked("rg -g '.[e]nv.[0-9]*' SECRET .")
+        self.assertBlocked("rg -g '[^a]env' SECRET .")
+        self.assertBlocked("grep --include='[^a]env' SECRET .")
+
+    def test_write_and_copy(self):
+        self.assertBlocked("cp " + DOTENV + " " + DOTENV + ".bak")
+        self.assertBlocked("mv " + DOTENV + " backup")
+        self.assertBlocked("touch " + DOTENV)
+        self.assertBlocked("tee " + DOTENV)
+        self.assertBlocked('sed -i "" s/a/b/ ' + DOTENV)
+
+    def test_redirection(self):
+        self.assertBlocked("echo x > " + DOTENV)
+        self.assertBlocked("echo x >> " + DOTENV)
+        self.assertBlocked("git commit > " + DOTENV)
+        self.assertBlocked("echo x > env")
+        self.assertBlocked("echo x &> " + DOTENV)
+        self.assertBlocked("echo x &>> " + DOTENV)
+        self.assertBlocked("echo x >&" + DOTENV)
+        self.assertBlocked("exec 3<> " + DOTENV)
+
+    def test_subshell(self):
+        self.assertBlocked("echo $(cat " + DOTENV + ")")
+
+    def test_process_substitutions(self):
+        self.assertBlocked("diff <(cat " + DOTENV + ") /dev/null")
+        self.assertBlocked("echo secret > >(tee " + DOTENV + ")")
+
+    def test_unquoted_heredoc_substitutions(self):
+        self.assertBlocked("cat <<EOF\n$(cat " + DOTENV + ")\nEOF")
+        self.assertBlocked("cat <<EOF\n`cat " + DOTENV + "`\nEOF")
+
+    def test_nested_and_double_quoted_subshells(self):
+        self.assertBlocked('echo "$(printf %s $(cat ' + DOTENV + '))"')
+        self.assertBlocked("echo $(echo $(cat " + DOTENV + "))")
+
+    def test_later_segment_of_a_compound_command(self):
+        self.assertBlocked("ls && cat " + DOTENV)
+
+    def test_leading_variable_assignment(self):
+        self.assertBlocked("ENV=prod cat " + DOTENV)
+
+    def test_not_the_first_argument(self):
+        self.assertBlocked("cat foo.txt " + DOTENV)
+
+    def test_find_by_name(self):
+        self.assertBlocked("find " + DOTENV + " -delete")
+        self.assertBlocked("find src " + DOTENV + ".local -delete")
+        for option in ('-H', '-L', '-P', '--'):
+            self.assertBlocked("find " + option + " " + DOTENV + " -delete")
+        self.assertBlocked('find . -name "' + DOTENV + '"')
+        self.assertBlocked("find . -iname " + DOTENV + " -delete")
+        self.assertBlocked("find . -path '*/" + DOTENV + "' -delete")
+        self.assertBlocked("find . -ipath '*/*.ENV.local' -delete")
+        self.assertBlocked("find . -wholename '*/.env' -delete")
+        self.assertBlocked("find . -iwholename '*/.ENV.local' -delete")
+        self.assertBlocked("find . -regex '.*/[.]env' -delete")
+        self.assertBlocked("find . -name '.?nv' -delete")
+        self.assertBlocked("find . -name '[.]e[n]v' -delete")
+        self.assertBlocked("find . -name '[[:punct:]]env' -delete")
+        self.assertBlocked("find . -name '[[:graph:]]env' -delete")
+        self.assertBlocked("find '!secrets' -path '!secrets/[.]env' -delete")
+        self.assertBlocked(r"find . -regex '.*/\.env' -delete")
+        self.assertBlocked("find . -regex '.*[.]env' -delete")
+        self.assertBlocked(r"find . -regex '.*\.env' -delete")
+
+    def test_file_literally_named_env(self):
+        self.assertBlocked("cat env")
+        self.assertBlocked("cat ENV")
+        self.assertBlocked("cat ./ENV")
+
+    def test_mixed_case_dotenv_name(self):
+        self.assertBlocked("cat " + DOTENV.upper() + ".LOCAL")
+
+    def test_literal_prefix_with_shell_suffix(self):
+        self.assertBlocked("cat " + DOTENV + "*")
+        self.assertBlocked("cat " + DOTENV + "$SUFFIX")
+        self.assertBlocked("cat " + DOTENV + "{,.local}")
+
+    def test_parameter_expansion_can_resolve_to_dotenv(self):
+        for operator in (':-', ':=', ':+', ':?'):
+            with self.subTest(operator=operator):
+                expansion = "${FILE" + operator + DOTENV + "}"
+                self.assertBlocked("cat " + expansion)
+                self.assertBlocked("echo value > " + expansion)
+
+    def test_newline_separates_commands(self):
+        self.assertBlocked("echo okay\ncat " + DOTENV)
+
+    def test_supported_wrappers(self):
+        self.assertBlocked("sudo command cat " + DOTENV)
+        self.assertBlocked("sudo --user root cat " + DOTENV)
+        self.assertBlocked("env -i MODE=test cat " + DOTENV)
+        self.assertBlocked("sudo sh -c 'cat " + DOTENV + "'")
+
+    def test_generic_wrappers(self):
+        for prefix in (
+                "exec ", "time ", "nohup ", "nice -n 5 ", "timeout 2 ",
+                "xargs "):
+            with self.subTest(prefix=prefix):
+                self.assertBlocked(prefix + "cat " + DOTENV)
+        self.assertBlocked("eval 'cat " + DOTENV + "'")
+
+    def test_eval_option_terminator(self):
+        self.assertBlocked("eval -- 'cat " + DOTENV + "'")
+
+    def test_xargs_reader_with_stdin_supplied_paths(self):
+        self.assertBlocked("printf '%s\\n' " + DOTENV + " | xargs cat")
+        self.assertBlocked("printf '%s\\n' " + DOTENV + " | xargs -n1 cat")
+
+    def test_env_split_string(self):
+        self.assertBlocked("env -S 'cat " + DOTENV + "'")
+        self.assertBlocked("env --split-string 'cat " + DOTENV + "'")
+        self.assertBlocked("env --split-string='cat " + DOTENV + "'")
+        self.assertBlocked("env -S 'cat' " + DOTENV)
+        self.assertBlocked("env --split-string='cat' " + DOTENV)
+        self.assertBlocked("env -iS 'cat " + DOTENV + "'")
+        self.assertBlocked("env -iS'cat " + DOTENV + "'")
+        self.assertBlocked("env -S '-- cat' " + DOTENV)
+        self.assertBlocked("env --split-string='-- cat' " + DOTENV)
+        self.assertBlocked("env -S '-i cat " + DOTENV + "'")
+        self.assertBlocked("env -S '-C /tmp cat " + DOTENV + "'")
+        self.assertBlocked("env -S '-u HOME cat " + DOTENV + "'")
+
+    def test_env_options_before_split_string(self):
+        for prefix in (
+                "-u UNUSED", "-uUNUSED", "--unset UNUSED",
+                "--unset=UNUSED", "-C /tmp", "-C/tmp",
+                "--chdir /tmp", "--chdir=/tmp", "-iu UNUSED",
+                "-a name", "-aname", "--argv0=name",
+                "-P /usr/bin", "-P/usr/bin"):
+            with self.subTest(prefix=prefix):
+                self.assertBlocked(
+                    "env " + prefix + " -S 'cat " + DOTENV + "'")
+
+    def test_shell_command_strings(self):
+        for shell in ("sh", "bash", "zsh", "dash", "ksh"):
+            with self.subTest(shell=shell):
+                self.assertBlocked(shell + " -ec 'cat " + DOTENV + "'")
+
+    def test_backticks(self):
+        self.assertBlocked("echo `cat " + DOTENV + "`")
+
+    def test_find_exec(self):
+        self.assertBlocked("find . -exec cat " + DOTENV + " \\;")
+
+    def test_input_redirection(self):
+        self.assertBlocked("wc -l < " + DOTENV)
+
+    def test_nesting_limit_fails_closed_for_protected_access(self):
+        command = "cat " + DOTENV
+        for _ in range(12):
+            command = "sh -c " + shlex.quote(command)
+        self.assertBlocked(command)
+
+
+class TestAllowed(unittest.TestCase):
+    """Commands with no relationship to a dotenv file must be allowed."""
+
+    def assertAllowed(self, command, message=None):
+        blocked, _ = check_env_file_access(command)
+        self.assertFalse(blocked, message or command)
+
+    def test_ordinary_commands(self):
+        self.assertAllowed("cat notes.md")
+        self.assertAllowed("grep -rn TODO src/")
+        self.assertAllowed("tail -f app.log")
+
+    def test_heredoc_literal_text_is_not_executed(self):
+        self.assertAllowed("cat <<'EOF'\n$(cat " + DOTENV + ")\nEOF")
+        self.assertAllowed("cat <<\\EOF\n`cat " + DOTENV + "`\nEOF")
+        self.assertAllowed("cat <<EOF\ncat " + DOTENV + "\nEOF")
+
+    def test_reader_name_as_non_executable_argument(self):
+        self.assertAllowed("echo cat " + DOTENV)
+        self.assertAllowed("false cat " + DOTENV)
+        self.assertAllowed("git commit -m cat " + DOTENV)
+
+    def test_bare_env_as_a_search_string(self):
+        self.assertAllowed("grep env package.json")
+
+    def test_dotenv_search_pattern_is_not_a_file_access(self):
+        self.assertAllowed("grep .env README.md")
+        self.assertAllowed(r"rg '\.env' docs/")
+        self.assertAllowed("grep -e .env README.md")
+        self.assertAllowed("rg --regexp=.env docs/")
+        self.assertAllowed("ag .env README.md")
+        self.assertAllowed("ack .env README.md")
+
+    def test_search_value_options_precede_dotenv_pattern(self):
+        self.assertAllowed("grep -A 2 .env README.md")
+        self.assertAllowed("grep -B2 .env README.md")
+        self.assertAllowed("grep --context 2 .env README.md")
+        self.assertAllowed("grep --max-count=1 .env README.md")
+        self.assertAllowed("rg -C 2 .env README.md")
+        self.assertAllowed("rg -j4 .env README.md")
+        self.assertAllowed("rg --threads 2 .env README.md")
+        self.assertAllowed("rg --max-columns=80 .env README.md")
+        self.assertAllowed("grep --label stdin .env README.md")
+        self.assertAllowed("rg --color never .env README.md")
+        self.assertAllowed("rg --replace replacement .env README.md")
+
+    def test_negated_search_globs_are_exclusions(self):
+        self.assertAllowed("rg -g '!.env*' SECRET .")
+        self.assertAllowed("rg --glob='!**/.env*' SECRET .")
+        self.assertAllowed("rg -g '[a-z]*.py' SECRET .")
+
+    def test_quoted_or_escaped_shell_globs_are_literal(self):
+        self.assertAllowed("cat '.[e]nv'")
+        self.assertAllowed(r"cat .\[e\]nv")
+        self.assertAllowed("echo x > '.[e]nv'")
+
+    def test_dotenv_script_text_is_not_a_file_access(self):
+        self.assertAllowed("sed -n '/.env/p' README.md")
+        self.assertAllowed("awk '/.env/ {print}' README.md")
+
+    def test_documented_safe_commands(self):
+        self.assertAllowed('git commit -m "document the ' + DOTENV + ' guard"')
+        self.assertAllowed('gh pr create --body "mentions ' + DOTENV + '"')
+
+    # --- Regressions: an unbounded gap between the command name and the match
+
+    def test_json_key_that_looks_like_a_dotenv_path(self):
+        """jq reads a key named "env" out of package.json; nothing opens a file."""
+        self.assertAllowed(
+            "cat package.json | jq " + DOTENV,
+            "the reader's own argument is package.json")
+
+    def test_dotenv_named_only_inside_a_later_echo(self):
+        self.assertAllowed(
+            'head -20 README.md && echo "copy ' + DOTENV + '.example first"')
+
+    def test_dotenv_named_only_inside_a_later_echo_after_a_semicolon(self):
+        self.assertAllowed(
+            "less docs/setup.md; echo see " + DOTENV + ".example")
+
+    def test_copy_of_unrelated_files_with_a_trailing_mention(self):
+        self.assertAllowed(
+            'cp dist/app.js build/ && echo "did not touch ' + DOTENV + '"')
+
+    def test_dotenv_as_a_test_filter_argument(self):
+        """The command word is npm; grep appears only as --grep."""
+        self.assertAllowed('npm test -- --grep "loads ' + DOTENV + '"')
+
+    def test_tee_to_an_unrelated_path_with_a_trailing_mention(self):
+        self.assertAllowed(
+            'rg "pattern" src/ | tee /tmp/out.txt && echo ' + DOTENV + ' safe')
+
+    def test_find_comparison_operand_is_not_a_read(self):
+        """find -newer uses the file's timestamp; it never reads its contents."""
+        self.assertAllowed('find . -name "README.md" -newer ' + DOTENV)
+
+    def test_quoted_redirect_explanation(self):
+        self.assertAllowed('echo "write > ' + DOTENV + ' manually"')
+        self.assertAllowed("echo '>' " + DOTENV)
+        self.assertAllowed("echo \\> " + DOTENV)
+
+    def test_single_quoted_backticks_are_literal(self):
+        self.assertAllowed("echo '`cat " + DOTENV + "`'")
+
+    def test_literal_substitution_text(self):
+        self.assertAllowed("echo '$(cat " + DOTENV + ")'")
+        self.assertAllowed("echo \\$(cat " + DOTENV + ")")
+        self.assertAllowed("echo '<(cat " + DOTENV + ")'")
+        self.assertAllowed('echo ">(tee ' + DOTENV + ')"')
+
+    def test_deeply_nested_harmless_text(self):
+        command = "echo " + DOTENV
+        for _ in range(12):
+            command = "sh -c " + shlex.quote(command)
+        self.assertAllowed(command)
+
+        quoted_command = 'echo "cat ' + DOTENV + ' is protected"'
+        for _ in range(12):
+            quoted_command = "sh -c " + shlex.quote(quoted_command)
+        self.assertAllowed(quoted_command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/safety-hooks/hooks/test_git_add_commit_all_flag.py
+++ b/plugins/safety-hooks/hooks/test_git_add_commit_all_flag.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the `git commit -a` check in git_add_block_hook.py
+
+Tests cover:
+    - Option tokens vs. substrings of paths and quoted text
+    - Short option clusters (-am, -aS)
+    - Long options with attached and separate values
+    - Options that do and do not supply a commit message
+    - The `--` pathspec separator
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from git_add_block_hook import _commit_option_tokens, check_git_add_command
+
+
+def _blocks(command: str) -> bool:
+    """True when the hook blocks outright (as opposed to allowing or asking)."""
+    return check_git_add_command(command)[0] is True
+
+
+class TestCommitOptionTokens(unittest.TestCase):
+    """Tests for _commit_option_tokens() parsing."""
+
+    def test_short_cluster_is_split(self) -> None:
+        self.assertEqual(_commit_option_tokens("git commit -am 'x'"),
+                         ['-a', '-m'])
+
+    def test_value_of_a_value_option_is_not_an_option(self) -> None:
+        self.assertEqual(_commit_option_tokens("git commit -m -a"), ['-m'])
+
+    def test_long_option_with_attached_value(self) -> None:
+        self.assertEqual(_commit_option_tokens("git commit --message=hi"),
+                         ['--message'])
+
+    def test_long_option_with_separate_value(self) -> None:
+        self.assertEqual(_commit_option_tokens("git commit --file /tmp/m.txt"),
+                         ['--file'])
+
+    def test_unambiguous_long_option_abbreviations_are_canonical(self) -> None:
+        self.assertEqual(_commit_option_tokens("git commit --edi"), ['--edit'])
+        self.assertEqual(
+            _commit_option_tokens("git commit --mess=x"), ['--message'])
+
+    def test_pathspec_separator_ends_options(self) -> None:
+        self.assertEqual(
+            _commit_option_tokens("git commit -a -- src/-m-file.txt"), ['-a'])
+
+    def test_path_argument_is_not_an_option(self) -> None:
+        self.assertEqual(
+            _commit_option_tokens("git commit -F /tmp/claude-agent/msg.txt"),
+            ['-F'])
+
+    def test_attached_short_value_ends_cluster(self) -> None:
+        self.assertEqual(
+            _commit_option_tokens("git commit -atmessage"), ['-a', '-t'])
+
+    def test_attached_signing_key_ends_cluster(self) -> None:
+        self.assertEqual(
+            _commit_option_tokens("git commit -aSalpha"), ['-a', '-S'])
+
+    def test_bare_sign_option_does_not_consume_next_option(self) -> None:
+        self.assertEqual(
+            _commit_option_tokens("git commit -aS -m 'x'"),
+            ['-a', '-S', '-m'])
+
+    def test_required_short_value_consumes_next_token(self) -> None:
+        self.assertEqual(
+            _commit_option_tokens("git commit -at /tmp/template -m 'x'"),
+            ['-a', '-t', '-m'])
+
+
+class TestBlockedCommitAll(unittest.TestCase):
+    """`git commit -a` with no message opens an editor and must be blocked."""
+
+    def test_bare_commit_all(self) -> None:
+        self.assertTrue(_blocks("git commit -a"))
+
+    def test_commit_all_long_form(self) -> None:
+        self.assertTrue(_blocks("git commit --all"))
+
+    def test_commit_all_with_no_verify(self) -> None:
+        self.assertTrue(_blocks("git commit -a --no-verify"))
+
+    # --- Regressions: a hyphenated word containing "m" cancelled the check
+
+    def test_template_does_not_supply_a_message(self) -> None:
+        """--template seeds the editor; it does not avoid opening one."""
+        self.assertTrue(_blocks("git commit -a --template=/tmp/t.txt"),
+                        "'--template' contains an 'm' but supplies no message")
+
+    def test_allow_empty_message_does_not_supply_a_message(self) -> None:
+        self.assertTrue(_blocks("git commit -a --allow-empty-message"),
+                        "'--allow-empty-message' contains an 'm' but supplies none")
+
+    def test_pathspec_containing_dash_m_does_not_cancel_the_check(self) -> None:
+        self.assertTrue(_blocks("git commit -a -- src/-m-file.txt"))
+
+    def test_reedit_message_short_form_opens_editor(self) -> None:
+        self.assertTrue(_blocks("git commit -ac HEAD"))
+
+    def test_reedit_message_long_form_opens_editor(self) -> None:
+        self.assertTrue(_blocks("git commit -a --reedit-message HEAD"))
+
+    def test_bare_amend_opens_editor(self) -> None:
+        self.assertTrue(_blocks("git commit -a --amend"))
+
+    def test_squash_opens_editor(self) -> None:
+        self.assertTrue(_blocks("git commit -a --squash HEAD"))
+
+    def test_fixup_amend_opens_editor(self) -> None:
+        self.assertTrue(_blocks("git commit -a --fixup=amend:HEAD"))
+        self.assertTrue(_blocks("git commit -a --fixup amend:HEAD"))
+
+    def test_fixup_reword_opens_editor(self) -> None:
+        self.assertTrue(_blocks("git commit -a --fixup=reword:HEAD"))
+        self.assertTrue(_blocks("git commit -a --fixup reword:HEAD"))
+
+    def test_edit_forces_editor_with_message(self) -> None:
+        self.assertTrue(_blocks("git commit -am 'x' --edit"))
+
+    def test_abbreviated_edit_and_negated_message_open_editor(self) -> None:
+        self.assertTrue(_blocks("git commit -am x --edi"))
+        self.assertTrue(_blocks("git commit -am x --no-mess"))
+
+    def test_negated_message_sources_open_editor(self) -> None:
+        commands = (
+            "git commit -a -m x --no-message",
+            "git commit -a -F msg.txt --no-file",
+            "git commit -a -C HEAD --no-reuse-message",
+            "git commit -a --fixup=HEAD --no-fixup",
+        )
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertTrue(_blocks(command))
+
+    def test_commit_all_after_working_directory_option(self) -> None:
+        self.assertTrue(_blocks("git -C repo commit -a"))
+        self.assertTrue(_blocks("git -Crepo commit -a"))
+
+    def test_commit_all_after_config_option(self) -> None:
+        self.assertTrue(_blocks("git -c core.editor=vim commit -a"))
+        self.assertTrue(_blocks("git -ccore.editor=vim commit -a"))
+
+    def test_quoted_operator_in_working_directory(self) -> None:
+        self.assertTrue(_blocks("git -C 'repo|archive' commit -a"))
+
+    def test_commit_all_after_attr_source(self) -> None:
+        self.assertTrue(_blocks("git --attr-source HEAD commit -a"))
+        self.assertTrue(_blocks("git --attr-source=HEAD commit -a"))
+
+    def test_commit_all_in_compound_command(self) -> None:
+        self.assertTrue(_blocks("echo ready && git commit -a"))
+
+    def test_commit_all_with_absolute_git_executable(self) -> None:
+        self.assertTrue(_blocks("/usr/bin/git commit -a"))
+
+    def test_commit_all_after_multiple_global_options(self) -> None:
+        self.assertTrue(
+            _blocks("/usr/bin/git -P -C repo -c x.y=z commit --all")
+        )
+
+    def test_commit_all_after_attached_exec_path(self) -> None:
+        self.assertTrue(_blocks("git --exec-path=/usr/lib/git-core commit -a"))
+
+    def test_commit_all_after_env_wrapper(self) -> None:
+        self.assertTrue(_blocks("GIT_EDITOR=vim git commit -a"))
+        self.assertTrue(_blocks("env -i GIT_EDITOR=vim git commit -a"))
+        self.assertTrue(_blocks("env -P /usr/bin git commit -a"))
+        self.assertTrue(_blocks("env -iP /usr/bin git commit -a"))
+        self.assertTrue(_blocks("env -S 'git commit -a'"))
+        self.assertTrue(_blocks("env -iS 'git commit -a'"))
+
+    def test_commit_all_after_attached_env_unset(self) -> None:
+        self.assertTrue(_blocks("env -uSHELL git commit -a"))
+
+    def test_commit_all_after_env_separator_assignment(self) -> None:
+        self.assertTrue(_blocks("env -- GIT_EDITOR=vim git commit -a"))
+
+
+class TestBlockedGitAdd(unittest.TestCase):
+    """Dangerous add forms remain blocked after supported Git prefixes."""
+
+    def test_add_all_after_working_directory_option(self) -> None:
+        self.assertTrue(_blocks("git -C . add -A"))
+        self.assertTrue(_blocks("git -C. add --all"))
+
+    def test_add_all_after_other_global_options(self) -> None:
+        self.assertTrue(_blocks("git -P -c core.pager=cat add -a"))
+        self.assertTrue(_blocks("/usr/bin/git --attr-source HEAD add ."))
+
+    def test_add_all_long_option_abbreviations(self) -> None:
+        self.assertTrue(_blocks("git add --a"))
+        self.assertTrue(_blocks("git add --al"))
+        self.assertTrue(_blocks("git add --all"))
+
+    def test_add_all_after_assignment_and_env_prefixes(self) -> None:
+        self.assertTrue(_blocks("GIT_OPTIONAL_LOCKS=0 git -C . add -A"))
+        self.assertTrue(_blocks("env -i git -C . add --all"))
+
+    def test_add_all_after_env_split_string(self) -> None:
+        self.assertTrue(_blocks("env -S 'git add .'"))
+        self.assertTrue(_blocks("env --split-string='git add -A'"))
+        self.assertTrue(_blocks("env -iS 'git add --all'"))
+        self.assertTrue(_blocks("env -S'git add .'"))
+
+    def test_env_split_preserves_prior_chdir(self) -> None:
+        self.assertTrue(_blocks("env -C /tmp -S 'git add .'"))
+
+    def test_attached_env_unset_does_not_hide_add(self) -> None:
+        self.assertTrue(_blocks("env -uSHELL git add -A"))
+        self.assertTrue(_blocks("env -uSSH_AUTH_SOCK git add ."))
+
+    def test_env_separator_assignments_do_not_hide_add(self) -> None:
+        self.assertTrue(_blocks("env -- X=1 git add -A"))
+        decision, _ = check_git_add_command(
+            "env -- GIT_DIR=/other/.git git add tracked.txt"
+        )
+        self.assertEqual(decision, "ask")
+
+    def test_env_split_checks_modified_file_in_chdir(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            subprocess.run(
+                ["git", "init"], cwd=repo, check=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            path = os.path.join(repo, "tracked.txt")
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("staged\n")
+            subprocess.run(
+                ["git", "add", "tracked.txt"], cwd=repo, check=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("modified\n")
+
+            decision, _ = check_git_add_command(
+                f"env --chdir={repo} -S 'git add tracked.txt'"
+            )
+            self.assertEqual(decision, "ask")
+
+    def test_attached_env_chdir_checks_target_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            subprocess.run(
+                ["git", "init"], cwd=repo, check=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            path = os.path.join(repo, "tracked.txt")
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("staged\n")
+            subprocess.run(
+                ["git", "add", "tracked.txt"], cwd=repo, check=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("modified\n")
+
+            commands = (
+                f"env -C{repo} git add tracked.txt",
+                f"env -iC {repo} git add tracked.txt",
+            )
+            for command in commands:
+                with self.subTest(command=command):
+                    decision, _ = check_git_add_command(command)
+                    self.assertEqual(decision, "ask")
+
+    def test_dynamic_chdir_requires_approval(self) -> None:
+        decision, _ = check_git_add_command(
+            'git -C "$REPO" add tracked.txt'
+        )
+        self.assertEqual(decision, "ask")
+
+    def test_repository_routing_requires_approval(self) -> None:
+        commands = (
+            "GIT_DIR=/other/.git GIT_WORK_TREE=/other git add tracked.txt",
+            "env GIT_DIR=/other/.git git add tracked.txt",
+            "git --git-dir=/other/.git --work-tree=/other add tracked.txt",
+        )
+        for command in commands:
+            with self.subTest(command=command):
+                decision, _ = check_git_add_command(command)
+                self.assertEqual(decision, "ask")
+
+    def test_uninspectable_repository_requires_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            decision, _ = check_git_add_command(
+                f"git -C {directory} add tracked.txt"
+            )
+        self.assertEqual(decision, "ask")
+
+    def test_pathspec_file_requires_approval(self) -> None:
+        for command in (
+            "git add --pathspec-from-file=paths.txt",
+            "git add --pathspec-from-file paths.txt",
+            "git add --pathspec-file-nul --pathspec-from-file=paths.txt",
+        ):
+            with self.subTest(command=command):
+                decision, _ = check_git_add_command(command)
+                self.assertEqual(decision, "ask")
+
+    def test_quoted_modified_filename_requires_approval(self) -> None:
+        with tempfile.TemporaryDirectory() as repo:
+            subprocess.run(
+                ["git", "init"], cwd=repo, check=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            path = os.path.join(repo, "tracked file.txt")
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("staged\n")
+            subprocess.run(
+                ["git", "add", "tracked file.txt"], cwd=repo, check=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("modified\n")
+
+            decision, _ = check_git_add_command(
+                f"git -C {repo} add 'tracked file.txt'"
+            )
+            self.assertEqual(decision, "ask")
+
+
+class TestAllowedCommits(unittest.TestCase):
+    """Commands that supply a message must not be blocked."""
+
+    def test_message_flag(self) -> None:
+        self.assertFalse(_blocks("git commit -m 'x'"))
+        self.assertFalse(_blocks("git commit -a -m 'x'"))
+        self.assertFalse(_blocks("git commit -am 'x'"))
+
+    def test_abbreviated_message_sources(self) -> None:
+        self.assertFalse(_blocks("git commit -a --mess=x"))
+        self.assertFalse(_blocks("git commit -a --reuse-mess=HEAD"))
+
+    def test_message_source_after_negation_avoids_editor(self) -> None:
+        self.assertFalse(_blocks("git commit -a --no-message -m x"))
+        self.assertFalse(_blocks("git commit -a --no-file -F msg.txt"))
+        self.assertFalse(
+            _blocks("git commit -a --no-reuse-message -C HEAD")
+        )
+        self.assertFalse(_blocks("git commit -a --no-fixup --fixup=HEAD"))
+
+    def test_amend_with_no_edit(self) -> None:
+        self.assertFalse(_blocks("git commit -a --amend --no-edit"))
+
+    def test_amend_with_message(self) -> None:
+        self.assertFalse(_blocks("git commit -a --amend -m 'x'"))
+
+    def test_reuse_message_does_not_open_editor(self) -> None:
+        self.assertFalse(_blocks("git commit -a -C HEAD"))
+
+    def test_plain_fixup_does_not_open_editor(self) -> None:
+        self.assertFalse(_blocks("git commit -a --fixup=HEAD"))
+        self.assertFalse(_blocks("git commit -a --fixup HEAD"))
+        self.assertFalse(_blocks("git commit -a --fixup=amend"))
+        self.assertFalse(_blocks("git commit -a --fixup reword"))
+
+    def test_sign_option_does_not_swallow_the_message_flag(self) -> None:
+        self.assertFalse(_blocks("git commit -aS -m 'x'"),
+                         "-S takes an attached value only")
+
+    # --- Regressions: a path containing "-a" read as the stage-everything flag
+
+    def test_message_file_under_a_path_containing_dash_a(self) -> None:
+        """-F supplies the message; '-agent' in the path is not an option."""
+        self.assertFalse(_blocks("git commit -F /tmp/claude-agent/msg.txt"),
+                         "a path segment starting '-a' is not the -a flag")
+
+    def test_long_message_file_under_a_path_containing_dash_a(self) -> None:
+        self.assertFalse(_blocks("git commit --file=/tmp/branch-a/msg.txt"))
+
+    def test_message_file_alone_never_stages_everything(self) -> None:
+        self.assertFalse(_blocks("git commit -F /tmp/release-alpha/msg.txt"))
+
+    def test_dash_a_inside_a_quoted_message(self) -> None:
+        self.assertFalse(_blocks("git commit -m 'refactor -a handling'"))
+
+    def test_prefixed_commit_with_message(self) -> None:
+        self.assertFalse(_blocks("git -C repo commit -am 'x'"))
+
+    def test_prefixed_non_commit_command(self) -> None:
+        self.assertFalse(_blocks("git -C repo status -a"))
+
+    def test_assignment_prefixed_message_and_non_commit_are_allowed(self) -> None:
+        self.assertFalse(_blocks("GIT_EDITOR=vim git commit -am 'x'"))
+        self.assertFalse(_blocks("GIT_EDITOR=vim git status -a"))
+
+        self.assertFalse(_blocks("env --ignore-environment git commit -am 'x'"))
+        self.assertFalse(_blocks("env -u GIT_EDITOR git status -a"))
+
+    def test_invalid_global_option_does_not_reveal_commit(self) -> None:
+        self.assertFalse(_blocks("git --unknown commit -a"))
+
+    def test_terminal_global_options_do_not_run_commit(self) -> None:
+        self.assertFalse(_blocks("git --exec-path foo commit -a"))
+        self.assertFalse(_blocks("git --list-cmds=main commit -a"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/safety-hooks/hooks/test_git_checkout_safety_hook.py
+++ b/plugins/safety-hooks/hooks/test_git_checkout_safety_hook.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+"""
+Unit tests for git_checkout_safety_hook.py
+
+Tests cover:
+    - Destructive checkouts that also mention "-b" somewhere
+    - `git -C <dir> checkout` (the subcommand is not always argv[1])
+    - Option tokens vs. substrings of ordinary filenames
+    - Branch creation and --help staying exempt
+    - The uncommitted-changes probe reading the repository the command targets
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from git_checkout_safety_hook import (
+    check_git_checkout_command,
+    parse_git_checkout,
+)
+
+
+class TestParseGitCheckout(unittest.TestCase):
+    """Tests for parse_git_checkout() command splitting."""
+
+    def test_plain_checkout(self):
+        args, _ = parse_git_checkout("git checkout main")
+        self.assertEqual(args, ["main"])
+
+    def test_not_a_checkout(self):
+        self.assertEqual(parse_git_checkout("git status"), (None, None))
+        self.assertEqual(parse_git_checkout("ls checkout"), (None, None))
+        self.assertEqual(parse_git_checkout(""), (None, None))
+
+    def test_checkout_word_in_an_argument_is_not_the_subcommand(self):
+        """A branch named "checkout" is not a checkout subcommand."""
+        self.assertEqual(parse_git_checkout("git switch checkout"), (None, None))
+
+    def test_dash_c_retargets_the_repository(self):
+        """`git -C <dir>` runs in <dir>, so that is the repo to judge."""
+        with tempfile.TemporaryDirectory() as tmp:
+            args, repo_dir = parse_git_checkout(f"git -C {tmp} checkout main")
+            self.assertEqual(args, ["main"])
+            self.assertEqual(os.path.realpath(repo_dir), os.path.realpath(tmp))
+
+    def test_dash_c_expands_an_ordinary_tilde_path(self):
+        """An ordinary home-relative path can be resolved without a shell."""
+        with tempfile.TemporaryDirectory() as tmp:
+            home = os.path.join(tmp, "home")
+            repo = os.path.join(home, "repo")
+            os.makedirs(repo)
+            old_home = os.environ.get("HOME")
+            os.environ["HOME"] = home
+            self.addCleanup(self._restore_home, old_home)
+            args, repo_dir = parse_git_checkout(
+                "git -C ~/repo checkout main"
+            )
+            self.assertEqual(args, ["main"])
+            self.assertEqual(os.path.realpath(repo_dir), os.path.realpath(repo))
+
+    @staticmethod
+    def _restore_home(old_home):
+        if old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = old_home
+
+    def test_dash_c_does_not_expand_quoted_or_escaped_tildes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            literal_repo = os.path.join(tmp, "~", "repo")
+            fake_home = os.path.join(tmp, "home")
+            os.makedirs(literal_repo)
+            os.makedirs(os.path.join(fake_home, "repo"))
+            old_home = os.environ.get("HOME")
+            os.environ["HOME"] = fake_home
+            self.addCleanup(self._restore_home, old_home)
+            old_cwd = os.getcwd()
+            os.chdir(tmp)
+            self.addCleanup(os.chdir, old_cwd)
+
+            for command in (
+                'git -C "~/repo" checkout main',
+                r"git -C \~/repo checkout main",
+            ):
+                _, repo_dir = parse_git_checkout(command)
+                self.assertEqual(
+                    os.path.realpath(repo_dir), os.path.realpath(literal_repo)
+                )
+
+    def test_absolute_path_to_git_binary(self):
+        args, _ = parse_git_checkout("/usr/bin/git checkout main")
+        self.assertEqual(args, ["main"])
+
+    def test_unresolvable_target_reports_unknown_not_cwd(self):
+        """An unexpanded -C value must not fall back to the caller's repo."""
+        args, repo_dir = parse_git_checkout('git -C "$REPO" checkout main')
+        self.assertEqual(args, ["main"])
+        self.assertIsNone(repo_dir)
+
+    def test_work_tree_reports_unknown(self):
+        _, repo_dir = parse_git_checkout("git --work-tree=/somewhere checkout main")
+        self.assertIsNone(repo_dir)
+
+    def test_attr_source_value_does_not_hide_checkout(self):
+        for command in (
+            "git --attr-source HEAD checkout -f",
+            "git --attr-source=HEAD checkout -f",
+        ):
+            with self.subTest(command=command):
+                args, _ = parse_git_checkout(command)
+                self.assertEqual(args, ["-f"])
+                blocked, _ = check_git_checkout_command(command)
+                self.assertTrue(blocked)
+
+    def test_terminal_global_options_do_not_dispatch_checkout(self):
+        for option in (
+            "-h",
+            "-v",
+            "--help",
+            "--version",
+            "--html-path",
+            "--man-path",
+            "--info-path",
+        ):
+            with self.subTest(option=option):
+                command = f"git {option} checkout -f"
+                self.assertEqual(parse_git_checkout(command), (None, None))
+                self.assertFalse(check_git_checkout_command(command)[0])
+
+
+class TestAlwaysBlocked(unittest.TestCase):
+    """Destructive forms that must be blocked regardless of repo state."""
+
+    def test_force_checkout(self):
+        blocked, reason = check_git_checkout_command("git checkout -f")
+        self.assertTrue(blocked)
+        self.assertIn("FORCES checkout", reason)
+
+    def test_force_long_form(self):
+        blocked, _ = check_git_checkout_command("git checkout --force main")
+        self.assertTrue(blocked)
+
+    def test_force_long_option_abbreviations(self):
+        for option in ("--f", "--fo", "--for", "--forc"):
+            with self.subTest(option=option):
+                blocked, reason = check_git_checkout_command(
+                    f"git checkout {option} main"
+                )
+                self.assertTrue(blocked)
+                self.assertIn("DANGEROUS", reason)
+
+    def test_assignment_prefixed_force_checkout(self):
+        for command in (
+            "MODE=prod git checkout -f",
+            "env MODE=prod git checkout -f",
+            "env -i -u DEBUG MODE=prod git checkout -f",
+        ):
+            with self.subTest(command=command):
+                self.assertTrue(check_git_checkout_command(command)[0])
+
+    def test_env_split_string_force_checkout(self):
+        for command in (
+            "env -S 'git checkout -f'",
+            "env --split-string='git checkout -f'",
+            "env -iS 'git checkout -f'",
+            "env -S'git checkout -f'",
+        ):
+            with self.subTest(command=command):
+                self.assertTrue(check_git_checkout_command(command)[0])
+
+    def test_env_split_string_can_begin_with_env_options(self):
+        for command in (
+            "env -S '-C /tmp git checkout -f'",
+            "env -S '-i git checkout -f'",
+            "env -S '-u DEBUG git checkout -f'",
+            "env -S '-- git checkout -f'",
+        ):
+            with self.subTest(command=command):
+                self.assertTrue(check_git_checkout_command(command)[0])
+
+    def test_clustered_env_value_options_before_force_checkout(self):
+        for command in (
+            "env -a harmless git checkout -f",
+            "env -aharmless git checkout -f",
+            "env --argv0 harmless git checkout -f",
+            "env -iC /tmp git checkout -f",
+            "env -iu PATH git checkout -f",
+            "env -iC/tmp git checkout -f",
+            "env -uSOMETHING git checkout -f",
+            "env -P/usr/bin git checkout -f",
+        ):
+            with self.subTest(command=command):
+                self.assertTrue(check_git_checkout_command(command)[0])
+
+    def test_checkout_dot(self):
+        blocked, reason = check_git_checkout_command("git checkout .")
+        self.assertTrue(blocked)
+        self.assertIn("DISCARD ALL", reason)
+
+    def test_checkout_double_dash_dot(self):
+        blocked, _ = check_git_checkout_command("git checkout HEAD -- .")
+        self.assertTrue(blocked)
+
+    def test_checkout_double_dash_path(self):
+        blocked, _ = check_git_checkout_command("git checkout HEAD -- src/app.ts")
+        self.assertTrue(blocked)
+
+    # --- Regressions: these are the forms a substring test for "-b" let through
+
+    def test_force_combined_with_branch_creation(self):
+        """`-f` discards work even when a branch is also being created."""
+        blocked, reason = check_git_checkout_command("git checkout -f -b feature")
+        self.assertTrue(blocked, "-f must be blocked even alongside -b")
+        self.assertIn("FORCES checkout", reason)
+
+    def test_force_in_a_short_option_cluster(self):
+        blocked, _ = check_git_checkout_command("git checkout -fb feature")
+        self.assertTrue(blocked, "-f inside a cluster must still be seen")
+
+    def test_attached_branch_name_does_not_create_force_flag(self):
+        """Characters in an attached -b argument are not more options."""
+        blocked, _ = check_git_checkout_command("git checkout -bfeature")
+        self.assertFalse(blocked)
+        blocked, _ = check_git_checkout_command("git checkout -bforce")
+        self.assertFalse(blocked)
+
+    def test_option_before_attached_branch_name_is_still_seen(self):
+        """Short options before -b remain active when its value is attached."""
+        blocked, _ = check_git_checkout_command("git checkout -fbfeature")
+        self.assertTrue(blocked)
+
+    def test_checkout_dot_with_branch_creation(self):
+        blocked, _ = check_git_checkout_command("git checkout . -b feature")
+        self.assertTrue(blocked, "'.' pathspec must be blocked even alongside -b")
+
+    def test_filename_containing_dash_b_is_not_an_option(self):
+        """"-b" inside a filename must not disarm the guard."""
+        blocked, _ = check_git_checkout_command(
+            "git checkout HEAD -- src/my-button.ts")
+        self.assertTrue(blocked, "'my-button.ts' contains '-b' but is a filename")
+
+    def test_branch_name_containing_dash_b_is_not_an_option(self):
+        blocked, _ = check_git_checkout_command("git checkout -f my-branch")
+        self.assertTrue(blocked)
+
+    # --- Regressions: the `git -C <dir> <subcommand>` form
+
+    def test_dash_c_force_checkout(self):
+        blocked, reason = check_git_checkout_command(
+            "git -C /some/other/repo checkout -f")
+        self.assertTrue(blocked, "git -C <dir> checkout is still a checkout")
+        self.assertIn("FORCES checkout", reason)
+
+    def test_dash_c_checkout_dot(self):
+        blocked, _ = check_git_checkout_command("git -C /some/other/repo checkout .")
+        self.assertTrue(blocked)
+
+    def test_compound_command_with_dash_c(self):
+        blocked, _ = check_git_checkout_command(
+            "echo hi && git -C /some/other/repo checkout -f")
+        self.assertTrue(blocked)
+
+    def test_quoted_dash_c_operators_are_not_command_separators(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            for operator in (";", "&&", "|"):
+                repo = os.path.join(tmp, f"repo{operator}name")
+                os.makedirs(repo)
+                command = f'git -C "{repo}" checkout -f'
+                with self.subTest(operator=operator):
+                    self.assertTrue(check_git_checkout_command(command)[0])
+
+    def test_escaped_dash_c_operator_is_not_a_command_separator(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = os.path.join(tmp, "repo;name")
+            os.makedirs(repo)
+            escaped_repo = repo.replace(";", r"\;")
+            command = f"git -C {escaped_repo} checkout -f"
+            self.assertTrue(check_git_checkout_command(command)[0])
+
+    def test_real_compound_operator_still_splits_commands(self):
+        command = 'printf "%s" "safe;value"; git checkout -f'
+        self.assertTrue(check_git_checkout_command(command)[0])
+
+    def test_file_descriptor_redirection_is_not_a_command_separator(self):
+        self.assertTrue(
+            check_git_checkout_command("2>&1 git checkout -f")[0]
+        )
+        self.assertTrue(
+            check_git_checkout_command("0<&1 git checkout -f")[0]
+        )
+        self.assertTrue(
+            check_git_checkout_command("> /dev/null git checkout -f")[0]
+        )
+        self.assertTrue(
+            check_git_checkout_command("2> /dev/null git checkout -f")[0]
+        )
+        self.assertTrue(
+            check_git_checkout_command("< /dev/null git checkout -f")[0]
+        )
+
+
+class TestAllowed(unittest.TestCase):
+    """Forms that must stay allowed."""
+
+    def test_branch_creation(self):
+        blocked, _ = check_git_checkout_command("git checkout -b feature")
+        self.assertFalse(blocked)
+
+    def test_help(self):
+        self.assertFalse(check_git_checkout_command("git checkout --help")[0])
+        self.assertFalse(check_git_checkout_command("git checkout -h")[0])
+
+    def test_non_checkout_commands(self):
+        self.assertFalse(check_git_checkout_command("git status")[0])
+        self.assertFalse(check_git_checkout_command("git commit -m 'x'")[0])
+        self.assertFalse(check_git_checkout_command("echo git checkout -f")[0])
+
+    def test_assignment_prefixed_non_checkout_is_allowed(self):
+        self.assertFalse(check_git_checkout_command("MODE=prod git status")[0])
+
+    def test_unresolvable_target_is_blocked_without_wrong_repo_details(self):
+        """An unknown target gets a generic warning and no caller-repo files."""
+        blocked, reason = check_git_checkout_command(
+            'git -C "$REPO" checkout main'
+        )
+        self.assertTrue(blocked)
+        self.assertIn("Could not safely resolve the target repository", reason)
+        self.assertNotIn("git_checkout_safety_hook.py", reason)
+        blocked, _ = check_git_checkout_command('git -C "$REPO" checkout -f')
+        self.assertTrue(blocked, "command-level checks still apply")
+
+    def test_non_repository_target_fails_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            blocked, reason = check_git_checkout_command(
+                f"git -C {directory} checkout main"
+            )
+        self.assertTrue(blocked)
+        self.assertIn("Could not safely resolve", reason)
+
+    def test_repository_routing_assignments_fail_closed(self):
+        commands = (
+            "GIT_DIR=/other/.git GIT_WORK_TREE=/other git checkout main",
+            "env GIT_DIR=/other/.git git checkout main",
+            "env -S 'GIT_WORK_TREE=/other git checkout main'",
+        )
+        for command in commands:
+            with self.subTest(command=command):
+                blocked, reason = check_git_checkout_command(command)
+                self.assertTrue(blocked)
+                self.assertIn("Could not safely resolve", reason)
+
+
+def _git(*args: str, cwd: str) -> None:
+    """Run Git quietly in a test repository."""
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=_git_environment(),
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _git_environment() -> dict[str, str]:
+    """Return an environment isolated from Git routing and user config."""
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_")
+    }
+    environment["GIT_CONFIG_GLOBAL"] = os.devnull
+    environment["GIT_CONFIG_NOSYSTEM"] = "1"
+    return environment
+
+
+def _commit_file(repo: str, filename: str, content: str) -> str:
+    """Create and commit one tracked file, returning its absolute path."""
+    path = os.path.join(repo, filename)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(content)
+    _git("add", filename, cwd=repo)
+    _git(
+        "-c",
+        "user.name=Safety Hooks Test",
+        "-c",
+        "user.email=safety-hooks@example.invalid",
+        "-c",
+        "commit.gpgSign=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "commit",
+        "-m",
+        "test fixture",
+        cwd=repo,
+    )
+    return path
+
+
+@unittest.skipIf(shutil.which("git") is None, "git is not installed")
+class TestUncommittedChangesProbeTargetsTheRightRepo(unittest.TestCase):
+    """The warning must describe the repo the command targets, not the cwd."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.repo = os.path.join(self.tmp, "other-repo")
+        os.makedirs(self.repo)
+        _git("init", cwd=self.repo)
+        dirty_file = _commit_file(
+            self.repo, "dirty-file.txt", "committed contents\n"
+        )
+        with open(dirty_file, "w", encoding="utf-8") as handle:
+            handle.write("uncommitted contents\n")
+
+        self.clean = os.path.join(self.tmp, "clean-cwd")
+        os.makedirs(self.clean)
+        _git("init", cwd=self.clean)
+        self.clean_file = _commit_file(
+            self.clean, "local-noise.txt", "committed contents\n"
+        )
+
+        self.original_cwd = os.getcwd()
+        os.chdir(self.clean)
+        self.addCleanup(os.chdir, self.original_cwd)
+
+    def test_fixture_git_environment_is_sanitized(self):
+        environment = _git_environment()
+        self.assertEqual(environment.get("PATH"), os.environ.get("PATH"))
+        self.assertEqual(environment["GIT_CONFIG_GLOBAL"], os.devnull)
+        self.assertEqual(environment["GIT_CONFIG_NOSYSTEM"], "1")
+        inherited_git_names = {
+            name for name in environment if name.startswith("GIT_")
+        }
+        self.assertEqual(
+            inherited_git_names,
+            {"GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM"},
+        )
+
+    def test_warns_about_the_target_repo(self):
+        blocked, reason = check_git_checkout_command(
+            f"git -C {self.repo} checkout main")
+        self.assertTrue(blocked, "the target repo has uncommitted changes")
+        self.assertIn("dirty-file.txt", reason)
+
+    def test_env_chdir_warns_for_dirty_target_from_clean_caller(self):
+        blocked, reason = check_git_checkout_command(
+            f"env -C {self.repo} git checkout main"
+        )
+        self.assertTrue(blocked)
+        self.assertIn("dirty-file.txt", reason)
+
+    def test_clustered_env_chdir_warns_for_dirty_target(self):
+        blocked, reason = check_git_checkout_command(
+            f"env -iC {self.repo} git checkout main"
+        )
+        self.assertTrue(blocked)
+        self.assertIn("dirty-file.txt", reason)
+
+    def test_split_string_chdir_warns_for_dirty_target(self):
+        blocked, reason = check_git_checkout_command(
+            f"env -S '-C {self.repo} git checkout main'"
+        )
+        self.assertTrue(blocked)
+        self.assertIn("dirty-file.txt", reason)
+
+    def test_attached_dash_c_warns_for_dirty_target_from_clean_caller(self):
+        blocked, reason = check_git_checkout_command(
+            f"git -C{self.tmp} -Cother-repo checkout main"
+        )
+        self.assertTrue(blocked)
+        self.assertIn("dirty-file.txt", reason)
+
+    def test_clean_target_is_allowed_even_from_a_dirty_cwd(self):
+        with open(self.clean_file, "w", encoding="utf-8") as handle:
+            handle.write("only in the cwd\n")
+        blocked, _ = check_git_checkout_command(
+            f"git -C {self.repo} checkout main")
+        self.assertTrue(blocked, "target repo is the dirty one here")
+
+        # And the mirror image: a clean target must not inherit the cwd's dirt.
+        pristine = os.path.join(self.tmp, "pristine")
+        os.makedirs(pristine)
+        _git("init", cwd=pristine)
+        blocked, _ = check_git_checkout_command(
+            f"git -C {pristine} checkout main")
+        self.assertFalse(blocked, "clean target must not inherit the cwd's dirt")
+
+    def test_attached_dash_c_allows_clean_target_from_dirty_caller(self):
+        with open(self.clean_file, "w", encoding="utf-8") as handle:
+            handle.write("only in the cwd\n")
+        pristine = os.path.join(self.tmp, "pristine-attached")
+        os.makedirs(pristine)
+        _git("init", cwd=pristine)
+        blocked, _ = check_git_checkout_command(
+            f"git -C{self.tmp} -Cpristine-attached checkout main"
+        )
+        self.assertFalse(blocked)
+
+    def test_env_chdir_allows_clean_target_from_dirty_caller(self):
+        with open(self.clean_file, "w", encoding="utf-8") as handle:
+            handle.write("only in the cwd\n")
+        pristine = os.path.join(self.tmp, "pristine-env")
+        os.makedirs(pristine)
+        _git("init", cwd=pristine)
+        blocked, _ = check_git_checkout_command(
+            f"env --chdir={pristine} git checkout main"
+        )
+        self.assertFalse(blocked)
+
+    def test_split_string_chdir_allows_clean_target(self):
+        with open(self.clean_file, "w", encoding="utf-8") as handle:
+            handle.write("only in the cwd\n")
+        pristine = os.path.join(self.tmp, "pristine-split-string")
+        os.makedirs(pristine)
+        _git("init", cwd=pristine)
+        blocked, _ = check_git_checkout_command(
+            f"env -S '--chdir={pristine} git checkout main'"
+        )
+        self.assertFalse(blocked)
+
+    def test_branch_reset_creation_carries_dirty_work(self):
+        for option in ("-B feature", "-Bfeature"):
+            with self.subTest(option=option):
+                blocked, _ = check_git_checkout_command(
+                    f"git -C {self.repo} checkout {option}"
+                )
+                self.assertFalse(blocked)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/safety-hooks/hooks/test_git_checkout_safety_hook.py
+++ b/plugins/safety-hooks/hooks/test_git_checkout_safety_hook.py
@@ -524,13 +524,14 @@ class TestUncommittedChangesProbeTargetsTheRightRepo(unittest.TestCase):
         )
         self.assertFalse(blocked)
 
-    def test_branch_reset_creation_carries_dirty_work(self):
+    def test_branch_reset_checks_dirty_work(self):
         for option in ("-B feature", "-Bfeature"):
             with self.subTest(option=option):
-                blocked, _ = check_git_checkout_command(
+                blocked, reason = check_git_checkout_command(
                     f"git -C {self.repo} checkout {option}"
                 )
-                self.assertFalse(blocked)
+                self.assertTrue(blocked)
+                self.assertIn("dirty-file.txt", reason)
 
 
 if __name__ == "__main__":

--- a/plugins/safety-hooks/hooks/test_git_commit_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_git_commit_block_hook.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Unit tests for git_commit_block_hook.py
+
+Tests cover:
+    - `git -C <dir> commit` and other global-option forms reaching the gate
+    - Compound commands
+    - The session-scoped allow flag
+    - Commands that merely mention "git commit" staying allowed
+"""
+import os
+import sys
+import unittest
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from git_commit_block_hook import check_git_commit_command, git_subcommand
+
+
+class TestGitSubcommand(unittest.TestCase):
+    """Tests for git_subcommand() resolution past git's global options."""
+
+    def test_plain(self) -> None:
+        self.assertEqual(git_subcommand("git commit -m 'x'"), "commit")
+
+    def test_dash_c_directory(self) -> None:
+        self.assertEqual(
+            git_subcommand("git -C /tmp/repo commit -m 'x'"), "commit"
+        )
+
+    def test_dash_c_config(self) -> None:
+        self.assertEqual(
+            git_subcommand("git -c user.name=Bot commit -m 'x'"), "commit")
+
+    def test_combined_global_options(self) -> None:
+        self.assertEqual(
+            git_subcommand("git -C /tmp/repo -c core.pager=cat commit -m 'x'"),
+            "commit")
+
+    def test_attr_source_forms(self) -> None:
+        self.assertEqual(
+            git_subcommand("git --attr-source HEAD commit -m 'x'"), "commit"
+        )
+        self.assertEqual(
+            git_subcommand("git --attr-source=HEAD commit -m 'x'"), "commit"
+        )
+
+    def test_no_verify_is_not_a_global_option(self) -> None:
+        self.assertEqual(
+            git_subcommand("git commit --no-verify -m 'x'"), "commit"
+        )
+
+    def test_other_subcommands(self) -> None:
+        self.assertEqual(git_subcommand("git status"), "status")
+        self.assertEqual(git_subcommand("git -C /tmp/repo status"), "status")
+
+    def test_terminal_and_unknown_global_options(self) -> None:
+        self.assertIsNone(git_subcommand("git --help commit"))
+        self.assertIsNone(git_subcommand("git --version commit"))
+        self.assertIsNone(git_subcommand("git --future-option commit"))
+
+    def test_not_git(self) -> None:
+        self.assertIsNone(git_subcommand("echo git commit"))
+        self.assertIsNone(git_subcommand(""))
+
+    def test_absolute_path_to_git_binary(self) -> None:
+        self.assertEqual(git_subcommand("/usr/bin/git commit -m 'x'"), "commit")
+
+class TestAsksForApproval(unittest.TestCase):
+    """Commands that must reach the approval prompt."""
+
+    def assertAsks(self, command: str, message: str | None = None) -> None:
+        decision, reason = check_git_commit_command(command)
+        self.assertEqual(decision, "ask", message or command)
+        self.assertIsNotNone(reason)
+
+    def test_plain_commit(self) -> None:
+        self.assertAsks("git commit -m 'x'")
+
+    def test_assignment_prefixes(self) -> None:
+        self.assertAsks("MODE=prod git commit -m x")
+
+    def test_env_prefixes(self) -> None:
+        self.assertAsks("env MODE=prod git commit -m x")
+        self.assertAsks("env -i --unset HOME MODE=prod git commit -m x")
+
+    def test_env_split_string_prefixes(self) -> None:
+        self.assertAsks("env -S 'git commit -m x'")
+        self.assertAsks("env --split-string='git commit -m x'")
+        self.assertAsks("env -iS 'git commit -m x'")
+        self.assertAsks("env -S'git commit -m x'")
+        self.assertAsks("env -S '-i git commit -m x'")
+        self.assertAsks("env -S '-C /tmp git commit -m x'")
+        self.assertAsks("env -S '-u HOME git commit -m x'")
+        self.assertAsks("env -S '-- git commit -m x'")
+
+    def test_attached_env_values_containing_s(self) -> None:
+        self.assertAsks("env -uSHELL git commit -m x")
+        self.assertAsks("env -uSSH_AUTH_SOCK git commit -m x")
+        self.assertAsks("env -CStore git commit -m x")
+
+    def test_commit_all(self) -> None:
+        self.assertAsks("git commit -am 'x'")
+
+    def test_compound_command(self) -> None:
+        self.assertAsks("cd /tmp && git commit -m 'x'")
+
+    def test_newline_separators(self) -> None:
+        self.assertAsks("echo first\ngit commit -m 'x'")
+        self.assertAsks("echo first\r\ngit commit -m 'x'")
+
+    def test_command_substitutions(self) -> None:
+        self.assertAsks("echo $(git commit -m 'x')")
+        self.assertAsks('echo "result: $(git commit -m \'x\')"')
+        self.assertAsks("echo $(printf '%s' $(git commit -m 'x'))")
+        self.assertAsks("echo `git commit -m 'x'`")
+        self.assertAsks("echo `printf '%s' $(git commit -m 'x')`")
+        self.assertAsks(r"echo `echo \`git commit -m x\``")
+
+    def test_unquoted_heredoc_substitutions(self) -> None:
+        self.assertAsks("cat <<EOF\n$(git commit -m x)\nEOF")
+        self.assertAsks("cat <<EOF\n`git commit -m x`\nEOF")
+        self.assertAsks("cat <<-EOF\n\t$(git commit -m x)\n\tEOF")
+
+    def test_subshells_and_process_substitutions(self) -> None:
+        self.assertAsks("(git commit -m 'x')")
+        self.assertAsks("diff <(git commit -m 'x') expected")
+        self.assertAsks("cat >(git commit -m 'x')")
+
+    def test_substitution_recursion_is_bounded(self) -> None:
+        deep_echo = "echo " + "$(echo " * 14 + "ok" + ")" * 14
+        deep_commit = "$(" * 14 + "git commit -m x" + ")" * 14
+        decision, _ = check_git_commit_command(deep_echo)
+        self.assertEqual(decision, "allow")
+        self.assertAsks(deep_commit)
+
+    def test_commit_tree(self) -> None:
+        self.assertAsks("git commit-tree abc123 -m 'x'")
+
+    # --- Regressions: git's global options put the subcommand past argv[1]
+
+    def test_dash_c_directory(self) -> None:
+        """`git -C <dir> commit` is a commit and must still be gated."""
+        self.assertAsks(
+            "git -C /tmp/some-repo commit -m 'x'",
+            "git -C <dir> commit bypassed the approval gate")
+
+    def test_dash_c_directory_relative(self) -> None:
+        self.assertAsks("git -C ../other-repo commit -m 'x'")
+
+    def test_dash_c_config_override(self) -> None:
+        self.assertAsks("git -c user.email=bot@example.com commit -m 'x'")
+
+    def test_attr_source_forms(self) -> None:
+        self.assertAsks("git --attr-source HEAD commit -m 'x'")
+        self.assertAsks("git --attr-source=HEAD commit -m 'x'")
+
+    def test_git_dir_and_work_tree(self) -> None:
+        self.assertAsks(
+            "git --git-dir /tmp/r/.git --work-tree /tmp/r commit -m 'x'")
+
+    def test_dash_c_inside_a_compound_command(self) -> None:
+        self.assertAsks("echo hi && git -C /tmp/some-repo commit -m 'x'")
+
+    def test_quoted_config_operator_values(self) -> None:
+        self.assertAsks(
+            "git -c 'alias.audit=!echo one && echo two' commit -m 'x'"
+        )
+        self.assertAsks(
+            'git -c "alias.audit=!echo one | echo two" commit -m \'x\''
+        )
+
+    def test_quoted_dash_c_path_with_operators(self) -> None:
+        self.assertAsks("git -C '/tmp/repo;archive' commit -m 'x'")
+        self.assertAsks("git -C '/tmp/repo && archive' commit -m 'x'")
+
+    def test_absolute_git_path_with_dash_c(self) -> None:
+        self.assertAsks("/usr/bin/git -C /tmp/some-repo commit -m 'x'")
+
+
+class TestAllowed(unittest.TestCase):
+    """Commands that must not trigger the prompt."""
+
+    def assertAllows(self, command: str) -> None:
+        decision, _ = check_git_commit_command(command)
+        self.assertEqual(decision, "allow", command)
+
+    def test_other_git_commands(self) -> None:
+        self.assertAllows("git status")
+        self.assertAllows("git log --oneline")
+        self.assertAllows("git -C /tmp/some-repo status")
+
+    def test_prefixed_non_commit_commands(self) -> None:
+        self.assertAllows("MODE=prod git status")
+        self.assertAllows("env -i MODE=prod git log --oneline")
+
+    def test_terminal_global_options(self) -> None:
+        self.assertAllows("git --help commit")
+        self.assertAllows("git --version commit")
+
+    def test_unknown_global_option(self) -> None:
+        self.assertAllows("git --future-option commit")
+
+    def test_commit_mentioned_but_not_run(self) -> None:
+        self.assertAllows("echo 'remember to git commit'")
+        self.assertAllows("grep -r 'git commit' docs/")
+
+    def test_literal_or_escaped_substitutions(self) -> None:
+        self.assertAllows("echo '$(git commit -m x)'")
+        self.assertAllows(r"echo \$(git commit -m x)")
+        self.assertAllows("echo '`git commit -m x`'")
+        self.assertAllows(r"echo \`git commit -m x\`")
+
+    def test_git_commit_in_heredoc_body(self) -> None:
+        self.assertAllows("cat <<EOF\ngit commit -m x\nEOF")
+        self.assertAllows("cat <<END-OF\ngit commit -m x\nEND-OF")
+        self.assertAllows("cat <<'EOF'\ngit commit -m x\nEOF")
+
+    def test_quoted_heredoc_substitutions_are_literal(self) -> None:
+        self.assertAllows("cat <<'EOF'\n$(git commit -m x)\nEOF")
+        self.assertAllows('cat <<"EOF"\n`git commit -m x`\nEOF')
+        self.assertAllows("cat <<\\EOF\n$(git commit -m x)\nEOF")
+        self.assertAllows("cat <<-'EOF'\n\t$(git commit -m x)\n\tEOF")
+
+    def test_escaped_heredoc_substitutions_are_literal(self) -> None:
+        self.assertAllows("cat <<EOF\n\\$(git commit -m x)\nEOF")
+        self.assertAllows("cat <<EOF\n\\`git commit -m x\\`\nEOF")
+
+    def test_empty(self) -> None:
+        self.assertAllows("")
+
+
+class TestSessionAllowFlag(unittest.TestCase):
+    """The session-scoped flag file bypasses the prompt."""
+
+    def test_flag_allows_commit(self) -> None:
+        flag_dir = "/tmp/claude"
+        os.makedirs(flag_dir, exist_ok=True)
+        session_id = "test-session-" + str(os.getpid())
+        flag = os.path.join(flag_dir, f"allow-git-commit.{session_id}")
+        with open(flag, "w", encoding="utf-8") as handle:
+            handle.write(session_id)
+        self.addCleanup(lambda: os.path.exists(flag) and os.remove(flag))
+
+        decision, _ = check_git_commit_command(
+            "git commit -m 'x'", session_id=session_id)
+        self.assertEqual(decision, "allow")
+
+        # And the same flag must cover the -C form, or the bypass is
+        # inconsistent with the gate.
+        decision, _ = check_git_commit_command(
+            "git -C /tmp/some-repo commit -m 'x'", session_id=session_id)
+        self.assertEqual(decision, "allow")
+
+    def test_without_flag_still_asks(self) -> None:
+        decision, _ = check_git_commit_command(
+            "git commit -m 'x'", session_id="no-such-session-" + str(os.getpid()))
+        self.assertEqual(decision, "ask")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Supersedes #137, #138, #139, and #140 by @tudorsss. This preserves the four
fixes as separate commits in their intended merge order, then adds the review
hardening and regression coverage needed for them to work safely together.

The stack:

1. #137 hardens checkout parsing and target-repository inspection.
2. #138 closes commit-approval bypasses through Git and `env` prefixes.
3. #139 fixes `git add` safety checks and commit-all option parsing.
4. #140 replaces unbounded dotenv matching with command-aware access checks.

Additional review fixes cover quoted operators, assignments and `env -S`,
repository-routing options, command substitutions and heredocs, Git long-option
abbreviations, dotenv redirects and search globs, and failure-closed behavior
when the target repository cannot be inspected.

## Validation

- All 286 safety-hook tests pass on the combined committed stack.
- Python syntax compilation passes for all changed hooks and tests.
- `git diff --check` passes.
- Changed Python lines are at most 88 characters.
- Every implementation file remains below 1,000 lines.
- A final cold review of `origin/main...HEAD` found no blocking defect.

## Scope

This intentionally does not attempt to implement a complete shell interpreter.
Recursive shell invocation, general shell control flow, arbitrary executable
wrappers, shell pathname expansion, exhaustive regex/glob semantics, ordered
multi-glob precedence, shell-state tracking, and exhaustive platform-specific
option emulation remain outside this change.
