### PR TITLE
Keep agent-spawned codex sessions out of search by default

### DIFF
--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -2436,6 +2436,8 @@ def index_stats(index, cwd, claude_home, codex_home):
               help='Limit number of results displayed')
 @click.option('--no-original', is_flag=True, help='Exclude original sessions')
 @click.option('--sub-agent', is_flag=True, help='Include sub-agent sessions (additive)')
+@click.option('--exec-runs', 'exec_runs', is_flag=True,
+              help='Include headless `codex exec` runs (additive)')
 @click.option('--no-trimmed', is_flag=True, help='Exclude trimmed sessions')
 @click.option('--no-rollover', is_flag=True, help='Exclude rollover sessions')
 @click.option('--live', is_flag=True, help='Show only currently running sessions')
@@ -2451,14 +2453,14 @@ def index_stats(index, cwd, claude_home, codex_home):
               help='Output as JSONL for AI agents. Fields per line: session_id, '
                    'agent, project, branch, cwd, lines, created, modified, '
                    'first_msg, last_msg, file_path, derivation_type, '
-                   'is_sidechain, snippet')
+                   'is_sidechain, is_exec_run, snippet')
 @click.option('--by-time', 'by_time', is_flag=True,
               help='Sort results by last-modified time (default: sort by relevance)')
 @click.argument('query', required=False)
 def search(
     claude_home_arg, codex_home_arg, global_search, filter_dir, filter_branch,
-    num_results, no_original, sub_agent, no_trimmed, no_rollover, live, min_lines,
-    after, before, agent, json_output, by_time, query
+    num_results, no_original, sub_agent, exec_runs, no_trimmed, no_rollover, live,
+    min_lines, after, before, agent, json_output, by_time, query
 ):
     """Launch interactive TUI for full-text session search.
 
@@ -2554,6 +2556,8 @@ def search(
         rust_args.append("--no-original")
     if sub_agent:
         rust_args.append("--sub-agent")
+    if exec_runs:
+        rust_args.append("--exec-runs")
     if live:
         rust_args.append("--live")
     if no_trimmed:
@@ -2734,6 +2738,8 @@ def search(
                 rust_args.append("--no-original")
             if filter_state.get("include_sub"):
                 rust_args.append("--sub-agent")
+            if filter_state.get("include_exec"):
+                rust_args.append("--exec-runs")
             if filter_state.get("include_live_only"):
                 rust_args.append("--live")
             if not filter_state.get("include_trimmed", True):

--- a/claude_code_tools/export_session.py
+++ b/claude_code_tools/export_session.py
@@ -408,6 +408,45 @@ def extract_first_last_messages(
     return first_msg, last_msg, first_user_msg
 
 
+def _is_codex_subagent_payload(payload: dict[str, Any]) -> bool:
+    """Return True when a Codex ``session_meta`` payload describes a sub-agent.
+
+    Codex names every thread ``rollout-*.jsonl``, so sub-agent threads can only
+    be told apart by their spawn metadata. A spawned thread records
+    ``thread_source: "subagent"``, a ``source`` object keyed by ``subagent``,
+    and the id of the thread that spawned it.
+
+    Args:
+        payload: The ``payload`` object of a ``session_meta`` record.
+
+    Returns:
+        True when the payload carries any sub-agent spawn marker.
+    """
+    if payload.get("thread_source") == "subagent":
+        return True
+    source = payload.get("source")
+    if isinstance(source, dict) and "subagent" in source:
+        return True
+    return _nonempty_str(payload.get("parent_thread_id"))
+
+
+def _is_codex_exec_payload(payload: dict[str, Any]) -> bool:
+    """Return True when a Codex ``session_meta`` payload describes a headless run.
+
+    Codex records how a thread was launched: ``"exec"`` for a headless
+    ``codex exec`` run (typically spawned by an orchestrating agent or script),
+    ``"cli"`` for the interactive TUI. Sub-agent spawns carry an object here
+    instead, and are reported by :func:`_is_codex_subagent_payload`.
+
+    Args:
+        payload: The ``payload`` object of a ``session_meta`` record.
+
+    Returns:
+        True when the thread was launched headlessly.
+    """
+    return payload.get("source") == "exec"
+
+
 def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
     """
     Extract metadata from a session JSONL file.
@@ -425,9 +464,12 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
     Returns:
         Dict with extracted metadata
     """
-    # Detect sidechain from filename pattern (agent-* prefix)
+    # Detect sidechain from filename pattern (agent-* prefix).
     # This is more reliable than checking isSidechain field in JSON,
-    # which can be set on individual messages within main sessions
+    # which can be set on individual messages within main sessions.
+    # Claude sub-agent transcripts are written as agent-*.jsonl; Codex writes
+    # every thread as rollout-*.jsonl, so Codex sub-agents are detected from
+    # the session_meta record below instead.
     is_sidechain = session_file.name.startswith("agent-")
 
     metadata: dict[str, Any] = {
@@ -438,6 +480,7 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
         "branch": None,
         "derivation_type": None,
         "is_sidechain": is_sidechain,
+        "is_exec_run": False,  # Codex: launched headlessly via `codex exec`
         "session_type": None,  # "helper" for SDK/headless sessions
         "parent_session_id": None,
         "parent_session_file": None,
@@ -554,6 +597,10 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
                         metadata["cwd"] = payload["cwd"]
                     if _nonempty_str(payload.get("id")):
                         metadata["session_id"] = payload["id"]
+                    if _is_codex_subagent_payload(payload):
+                        metadata["is_sidechain"] = True
+                    if _is_codex_exec_payload(payload):
+                        metadata["is_exec_run"] = True
                     if session_start_timestamp is None and _nonempty_str(
                         data.get("timestamp")
                     ):
@@ -701,6 +748,8 @@ def generate_yaml_frontmatter(metadata: dict[str, Any]) -> str:
         yaml_data["derivation_type"] = metadata["derivation_type"]
     if metadata.get("is_sidechain"):
         yaml_data["is_sidechain"] = metadata["is_sidechain"]
+    if metadata.get("is_exec_run"):
+        yaml_data["is_exec_run"] = metadata["is_exec_run"]
     if metadata.get("parent_session_id"):
         yaml_data["parent_session_id"] = metadata["parent_session_id"]
     if metadata.get("parent_session_file"):

--- a/claude_code_tools/export_session.py
+++ b/claude_code_tools/export_session.py
@@ -494,6 +494,13 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
     # Track session start timestamp from JSON metadata
     session_start_timestamp: str | None = None
 
+    # A forked Codex rollout replays its ancestors' session_meta records into
+    # the same file (1951 of 6880 real rollouts carry more than one, up to 29).
+    # Only the first one describes THIS session, so the launch-kind flags are
+    # taken from it alone -- otherwise an interactive fork of a headless
+    # ancestor inherits is_exec_run and vanishes from default search results.
+    codex_meta_seen = False
+
     try:
         with open(
             session_file, "r", encoding="utf-8", errors="replace"
@@ -597,10 +604,12 @@ def extract_session_metadata(session_file: Path, agent: str) -> dict[str, Any]:
                         metadata["cwd"] = payload["cwd"]
                     if _nonempty_str(payload.get("id")):
                         metadata["session_id"] = payload["id"]
-                    if _is_codex_subagent_payload(payload):
-                        metadata["is_sidechain"] = True
-                    if _is_codex_exec_payload(payload):
-                        metadata["is_exec_run"] = True
+                    if not codex_meta_seen:
+                        codex_meta_seen = True
+                        if _is_codex_subagent_payload(payload):
+                            metadata["is_sidechain"] = True
+                        if _is_codex_exec_payload(payload):
+                            metadata["is_exec_run"] = True
                     if session_start_timestamp is None and _nonempty_str(
                         data.get("timestamp")
                     ):

--- a/claude_code_tools/search_index.py
+++ b/claude_code_tools/search_index.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -14,12 +15,25 @@ from claude_code_tools.export_session import _is_meta_user_message
 from claude_code_tools.session_utils import is_valid_session
 
 
-def _get_package_version() -> str:
-    """Get installed package version for automatic index rebuilding."""
+#: Revision of the indexing logic itself. Bump this whenever a change alters
+#: what gets stored for a session (new field, corrected detection), so existing
+#: indexes rebuild even when the package version has not changed -- an editable
+#: install keeps the same version across every code change.
+#: rev 2: Codex sub-agent (is_sidechain) detection.
+#: rev 3: headless `codex exec` run (is_exec_run) detection.
+INDEX_LOGIC_REVISION = 3
+
+
+def _get_index_version() -> str:
+    """Return the index identity: package version plus indexing-logic revision.
+
+    A mismatch against the stored value triggers a full rebuild.
+    """
     try:
-        return get_pkg_version("claude-code-tools")
+        version = get_pkg_version("claude-code-tools")
     except Exception:
-        return "unknown"
+        version = "unknown"
+    return f"{version}+idx{INDEX_LOGIC_REVISION}"
 
 # Lazy imports to allow module to load even if deps not installed
 try:
@@ -129,9 +143,18 @@ class IndexState:
             or stat.st_size != stored.get("size")
         )
 
-    def mark_indexed(self, file_path: Path):
-        """Mark file as indexed with current metadata."""
-        stat = file_path.stat()
+    def mark_indexed(
+        self, file_path: Path, stat_result: Optional[os.stat_result] = None
+    ):
+        """Mark file as indexed.
+
+        Args:
+            file_path: Session file that was processed.
+            stat_result: File state to record. Pass the state captured BEFORE
+                reading the file, so content appended while it was being read
+                is not recorded as already indexed. Defaults to current state.
+        """
+        stat = stat_result if stat_result is not None else file_path.stat()
         self.indexed_files[str(file_path)] = {
             "mtime": stat.st_mtime,
             "size": stat.st_size,
@@ -183,6 +206,9 @@ class SessionIndex:
         # Session type fields (for filtering in TUI)
         self.schema_builder.add_text_field("derivation_type", stored=True)
         self.schema_builder.add_text_field("is_sidechain", stored=True)  # "true"/"false"
+        # Codex sessions launched headlessly via `codex exec` (agent-spawned
+        # workers). Excluded from results by default, like sub-agents.
+        self.schema_builder.add_text_field("is_exec_run", stored=True)  # "true"/"false"
 
         # Claude home field (for filtering by source Claude home directory)
         # Use "raw" tokenizer so paths are indexed as single tokens for exact matching
@@ -201,7 +227,7 @@ class SessionIndex:
 
         # Check index version - rebuild if package version changed
         version_file = self.index_path / "VERSION"
-        current_version = _get_package_version()
+        current_version = _get_index_version()
         needs_rebuild = False
 
         if version_file.exists():
@@ -210,7 +236,7 @@ class SessionIndex:
                 if stored_version != current_version:
                     needs_rebuild = True
                     print(
-                        f"Package version changed ({stored_version} -> {current_version}), "
+                        f"Index version changed ({stored_version} -> {current_version}), "
                         "rebuilding index..."
                     )
             except IOError:
@@ -336,6 +362,10 @@ class SessionIndex:
                 "is_sidechain",
                 "true" if metadata.get("is_sidechain") else "false"
             )
+            doc.add_text(
+                "is_exec_run",
+                "true" if metadata.get("is_exec_run") else "false"
+            )
 
             # Custom title (from /rename command)
             doc.add_text("custom_title", metadata.get("customTitle", "") or "")
@@ -423,6 +453,10 @@ class SessionIndex:
             doc.add_text(
                 "is_sidechain",
                 "true" if metadata.get("is_sidechain") else "false"
+            )
+            doc.add_text(
+                "is_exec_run",
+                "true" if metadata.get("is_exec_run") else "false"
             )
 
             # Custom title (from /rename command)
@@ -685,6 +719,7 @@ class SessionIndex:
                     "created": metadata.get("created", "") or "",
                     "modified": metadata.get("modified", "") or "",
                     "is_sidechain": metadata.get("is_sidechain", False),
+                    "is_exec_run": metadata.get("is_exec_run", False),
                     "derivation_type": metadata.get("derivation_type", "") or "",
                     "session_type": metadata.get("session_type"),
                     "customTitle": metadata.get("customTitle", "") or "",
@@ -753,11 +788,21 @@ class SessionIndex:
                 stats["skipped"] += 1
                 continue
 
+            # Snapshot the file state BEFORE reading it. A live session can
+            # append while we read; recording the post-read state would mark
+            # that new content as already indexed and hide the session until
+            # its next write.
+            try:
+                file_stat = jsonl_path.stat()
+            except OSError:
+                stats["skipped"] += 1
+                continue
+
             # Skip invalid sessions (metadata-only files like file-history-snapshot)
             if not is_valid_session(jsonl_path):
                 stats["skipped"] += 1
                 # Mark as indexed so we don't re-check next time
-                self.state.mark_indexed(jsonl_path)
+                self.state.mark_indexed(jsonl_path, file_stat)
                 continue
 
             # Parse JSONL file
@@ -768,6 +813,10 @@ class SessionIndex:
                     reason = parsed.get("_skip_reason", "unknown")
                     if reason == "empty":
                         stats["empty"] += 1
+                        # Mark as indexed so we don't re-parse it every launch.
+                        # If the session later gains messages its mtime/size
+                        # changes, which re-triggers indexing.
+                        self.state.mark_indexed(jsonl_path, file_stat)
                     elif reason == "parse_error":
                         stats["parse_error"] += 1
                 continue
@@ -781,7 +830,7 @@ class SessionIndex:
             if metadata.get("session_type") == "helper":
                 stats["skipped"] += 1
                 # Mark as indexed so we don't re-check next time
-                self.state.mark_indexed(jsonl_path)
+                self.state.mark_indexed(jsonl_path, file_stat)
                 continue
 
             # Skip sessions run from inside claude_home or codex_home directories
@@ -791,6 +840,8 @@ class SessionIndex:
                 or (codex_home_str and cwd.startswith(codex_home_str))
             ):
                 stats["skipped"] += 1
+                # Mark as indexed so we don't re-parse it every launch.
+                self.state.mark_indexed(jsonl_path, file_stat)
                 continue
 
             try:
@@ -829,6 +880,10 @@ class SessionIndex:
                     "is_sidechain",
                     "true" if metadata.get("is_sidechain") else "false"
                 )
+                doc.add_text(
+                    "is_exec_run",
+                    "true" if metadata.get("is_exec_run") else "false"
+                )
 
                 # Custom title (from /rename command)
                 doc.add_text("custom_title", metadata.get("customTitle", "") or "")
@@ -846,7 +901,7 @@ class SessionIndex:
                 doc.add_text("content", parsed["content"])
 
                 writer.add_document(doc)
-                self.state.mark_indexed(jsonl_path)
+                self.state.mark_indexed(jsonl_path, file_stat)
                 stats["indexed"] += 1
             except Exception:
                 stats["failed"] += 1

--- a/claude_code_tools/search_index.py
+++ b/claude_code_tools/search_index.py
@@ -21,7 +21,8 @@ from claude_code_tools.session_utils import is_valid_session
 #: install keeps the same version across every code change.
 #: rev 2: Codex sub-agent (is_sidechain) detection.
 #: rev 3: headless `codex exec` run (is_exec_run) detection.
-INDEX_LOGIC_REVISION = 3
+#: rev 4: launch flags read from the session's own session_meta record only.
+INDEX_LOGIC_REVISION = 4
 
 
 def _get_index_version() -> str:

--- a/claude_code_tools/search_index.py
+++ b/claude_code_tools/search_index.py
@@ -236,17 +236,23 @@ class SessionIndex:
                 stored_version = version_file.read_text().strip()
                 if stored_version != current_version:
                     needs_rebuild = True
+                    # stderr, not stdout: `aichat search --json` emits JSONL on
+                    # stdout, and an upgrade notice there is invalid output.
                     print(
                         f"Index version changed ({stored_version} -> {current_version}), "
-                        "rebuilding index..."
+                        "rebuilding index...",
+                        file=sys.stderr,
                     )
             except IOError:
                 needs_rebuild = True
-                print("Index version file corrupted, rebuilding...")
+                print("Index version file corrupted, rebuilding...", file=sys.stderr)
         elif (self.index_path / "meta.json").exists():
             # Index exists but no VERSION file - legacy index, rebuild
             needs_rebuild = True
-            print("Upgrading index to versioned format, rebuilding...")
+            print(
+                "Upgrading index to versioned format, rebuilding...",
+                file=sys.stderr,
+            )
 
         if needs_rebuild:
             # Clear index directory contents (but keep the directory itself)

--- a/claude_code_tools/search_index.py
+++ b/claude_code_tools/search_index.py
@@ -847,8 +847,10 @@ class SessionIndex:
                 or (codex_home_str and cwd.startswith(codex_home_str))
             ):
                 stats["skipped"] += 1
-                # Mark as indexed so we don't re-parse it every launch.
-                self.state.mark_indexed(jsonl_path, file_stat)
+                # Deliberately NOT recorded in the index state: this exclusion
+                # depends on the claude_home/codex_home passed on the command
+                # line, so caching it would keep the session out of the index
+                # after a later run with different homes.
                 continue
 
             try:

--- a/claude_code_tools/tmux_cli_controller.py
+++ b/claude_code_tools/tmux_cli_controller.py
@@ -254,6 +254,11 @@ class TmuxCLIController:
         for line in output.split('\n'):
             if line:
                 parts = line.split('|')
+                # tmux emits six fields; anything shorter is not a pane line
+                # (an error string, a truncated read) and is skipped rather
+                # than indexed into.
+                if len(parts) < 5:
+                    continue
                 pane_id = parts[0]
                 panes.append({
                     'id': pane_id,

--- a/rust-search-ui/src/main.rs
+++ b/rust-search-ui/src/main.rs
@@ -3265,6 +3265,9 @@ fn scan_running_sessions() -> HashMap<String, ProcessState> {
     // Collect CWD -> process counts (separated by agent type)
     let mut cwd_processes: HashMap<String, CwdProcesses> = HashMap::new();
 
+    // Agent processes found in `ps`, resolved to working directories below.
+    let mut agent_procs: Vec<(String, bool, bool, ProcessState)> = Vec::new();
+
     // Run: ps -eo pid,stat,comm to get PID, status, and command
     let ps_output = match Command::new("ps")
         .args(["-eo", "pid,stat,comm"])
@@ -3308,28 +3311,36 @@ fn scan_running_sessions() -> HashMap<String, ProcessState> {
             ProcessState::Waiting
         };
 
-        // Get the CWD for this process
-        let cwd = get_process_cwd(pid);
-        if let Some(cwd_path) = cwd {
-            cwd_processes
-                .entry(cwd_path)
-                .and_modify(|existing| {
-                    if is_claude {
-                        existing.claude_count += 1;
-                    }
-                    if is_codex {
-                        existing.codex_count += 1;
-                    }
-                    if state == ProcessState::Running {
-                        existing.best_state = ProcessState::Running;
-                    }
-                })
-                .or_insert(CwdProcesses {
-                    claude_count: if is_claude { 1 } else { 0 },
-                    codex_count: if is_codex { 1 } else { 0 },
-                    best_state: state,
-                });
-        }
+        agent_procs.push((pid.to_string(), is_claude, is_codex, state));
+    }
+
+    // Resolve every working directory in one call rather than one per process.
+    let pids: Vec<String> = agent_procs.iter().map(|(pid, _, _, _)| pid.clone()).collect();
+    let cwds = get_process_cwds(&pids);
+
+    for (pid, is_claude, is_codex, state) in agent_procs {
+        let cwd_path = match cwds.get(&pid) {
+            Some(cwd) => cwd.clone(),
+            None => continue,
+        };
+        cwd_processes
+            .entry(cwd_path)
+            .and_modify(|existing| {
+                if is_claude {
+                    existing.claude_count += 1;
+                }
+                if is_codex {
+                    existing.codex_count += 1;
+                }
+                if state == ProcessState::Running {
+                    existing.best_state = ProcessState::Running;
+                }
+            })
+            .or_insert(CwdProcesses {
+                claude_count: if is_claude { 1 } else { 0 },
+                codex_count: if is_codex { 1 } else { 0 },
+                best_state: state,
+            });
     }
 
     let home = match dirs::home_dir() {
@@ -3509,38 +3520,58 @@ fn encode_project_path(path: &str) -> String {
 }
 
 /// Get the current working directory of a process by PID
-fn get_process_cwd(pid: &str) -> Option<String> {
-    // Try lsof first (works on macOS and Linux)
-    let lsof_output = Command::new("lsof")
-        .args(["-p", pid, "-Fn"])
-        .output()
-        .ok()?;
-
-    let lsof_str = String::from_utf8_lossy(&lsof_output.stdout);
-
-    // lsof -Fn output format: lines starting with 'n' contain the path
-    // On macOS: 'fcwd' line followed by 'n' line (f = file descriptor type)
-    // On Linux: 'tcwd' line followed by 'n' line (t = type)
-    let mut found_cwd = false;
-    for line in lsof_str.lines() {
-        if line == "fcwd" || line == "tcwd" {
-            found_cwd = true;
-        } else if found_cwd && line.starts_with('n') {
-            return Some(line[1..].to_string());
-        } else if line.starts_with('f') || line.starts_with('t') {
-            found_cwd = false;
-        }
+/// Look up the working directory of many processes in one shot.
+///
+/// This runs on a timer while the TUI is interactive, so it must be cheap.
+/// One `lsof` per pid costs ~150ms each -- with a few dozen agent processes
+/// that blocked the event loop for seconds at a time. `lsof` accepts a
+/// comma-separated pid list, and `-d cwd` restricts it to the one descriptor
+/// we need, which turns the whole scan into a single ~150ms call.
+///
+/// Returns a map of pid -> working directory; pids whose cwd could not be
+/// read are simply absent.
+fn get_process_cwds(pids: &[String]) -> HashMap<String, String> {
+    let mut result = HashMap::new();
+    if pids.is_empty() {
+        return result;
     }
 
-    // Fallback for Linux: try reading /proc/<pid>/cwd
+    // Linux exposes this directly, with no subprocess at all.
     #[cfg(target_os = "linux")]
     {
-        if let Ok(cwd) = std::fs::read_link(format!("/proc/{}/cwd", pid)) {
-            return Some(cwd.to_string_lossy().to_string());
+        for pid in pids {
+            if let Ok(cwd) = std::fs::read_link(format!("/proc/{}/cwd", pid)) {
+                result.insert(pid.clone(), cwd.to_string_lossy().to_string());
+            }
+        }
+        if !result.is_empty() {
+            return result;
         }
     }
 
-    None
+    let lsof_output = match Command::new("lsof")
+        .args(["-a", "-d", "cwd", "-p", &pids.join(","), "-Fpn"])
+        .output()
+    {
+        Ok(output) => output,
+        Err(_) => return result,
+    };
+
+    // -Fpn output is a flat stream: `p<pid>` starts a process block, and the
+    // `n<path>` line that follows carries its cwd.
+    let lsof_str = String::from_utf8_lossy(&lsof_output.stdout);
+    let mut current_pid: Option<String> = None;
+    for line in lsof_str.lines() {
+        if let Some(rest) = line.strip_prefix('p') {
+            current_pid = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix('n') {
+            if let Some(pid) = current_pid.take() {
+                result.insert(pid, rest.to_string());
+            }
+        }
+    }
+
+    result
 }
 
 // ============================================================================
@@ -4590,6 +4621,12 @@ fn main() -> Result<()> {
                 }
             }
         }
+
+        // Wait for input rather than spinning. Without this the loop redrew
+        // the whole screen as fast as the CPU allowed, burning a core the
+        // entire time the TUI was open. The timeout still lets the debounce
+        // and live-session timers above fire promptly.
+        event::poll(Duration::from_millis(50))?;
 
         // Drain all pending events (non-blocking)
         while event::poll(Duration::from_millis(0))? {

--- a/rust-search-ui/src/main.rs
+++ b/rust-search-ui/src/main.rs
@@ -2289,7 +2289,7 @@ fn render_status_bar(frame: &mut Frame, app: &App, t: &Theme, area: Rect, show_l
     } else if app.command_mode {
         // Command mode indicator
         nav_spans.push(Span::styled(" CMD ", Style::default().bg(t.accent).fg(Color::Black)));
-        nav_spans.push(Span::styled(" :x clear :o orig :s sub :t trim :c cont :a agent :m lines :> after :< before ", label));
+        nav_spans.push(Span::styled(" :x clear :o orig :s sub :h exec :t trim :c cont :a agent :m lines :> after :< before ", label));
     } else {
         // Normal mode - single line with all shortcuts
         let has_selection = !app.filtered.is_empty();

--- a/rust-search-ui/src/main.rs
+++ b/rust-search-ui/src/main.rs
@@ -3544,13 +3544,22 @@ fn get_process_cwds(pids: &[String]) -> HashMap<String, String> {
                 result.insert(pid.clone(), cwd.to_string_lossy().to_string());
             }
         }
-        if !result.is_empty() {
-            return result;
-        }
+    }
+
+    // Whatever /proc could not answer still goes to lsof, which may hold
+    // privileges that a direct read_link does not. On macOS nothing is
+    // resolved above, so this is every pid.
+    let remaining: Vec<&str> = pids
+        .iter()
+        .filter(|pid| !result.contains_key(*pid))
+        .map(|pid| pid.as_str())
+        .collect();
+    if remaining.is_empty() {
+        return result;
     }
 
     let lsof_output = match Command::new("lsof")
-        .args(["-a", "-d", "cwd", "-p", &pids.join(","), "-Fpn"])
+        .args(["-a", "-d", "cwd", "-p", &remaining.join(","), "-Fpn"])
         .output()
     {
         Ok(output) => output,

--- a/rust-search-ui/src/main.rs
+++ b/rust-search-ui/src/main.rs
@@ -990,6 +990,7 @@ impl App {
                 &self.query,
                 self.filter_claude_home.as_deref(),
                 self.filter_codex_home.as_deref(),
+                !self.include_exec,
             );
             if !snippets.is_empty() {
                 // Store snippets for rendering
@@ -3664,6 +3665,7 @@ fn search_tantivy(
     query_str: &str,
     filter_claude_home: Option<&str>,
     filter_codex_home: Option<&str>,
+    exclude_exec_runs: bool,
 ) -> (HashMap<String, String>, Vec<String>) {
     // Return empty if query is empty
     if query_str.trim().is_empty() {
@@ -3741,6 +3743,26 @@ fn search_tantivy(
         } else {
             // No claude_home field in schema, just use content query
             content_query
+        };
+
+        // Headless exec runs are a large share of the corpus. When they are
+        // hidden, exclude them in the query instead of dropping them after the
+        // top-N cut, so the retrieval budget below is spent on rows the user
+        // can actually see. Older indexes have no such field; skip it there.
+        let final_query: Box<dyn tantivy::query::Query> = match (
+            exclude_exec_runs,
+            schema.get_field("is_exec_run"),
+        ) {
+            (true, Ok(exec_field)) => {
+                let term = Term::from_field_text(exec_field, "false");
+                let exec_clause: Box<dyn tantivy::query::Query> =
+                    Box::new(TermQuery::new(term, IndexRecordOption::Basic));
+                Box::new(BooleanQuery::new(vec![
+                    (Occur::Must, final_query),
+                    (Occur::Must, exec_clause),
+                ]))
+            }
+            _ => final_query,
         };
 
         // Search with high limit

--- a/rust-search-ui/src/main.rs
+++ b/rust-search-ui/src/main.rs
@@ -116,6 +116,7 @@ struct Session {
     first_user_msg_content: String,  // First real user message (skips meta messages)
     derivation_type: String,  // "trimmed", "continued", or ""
     is_sidechain: bool,       // Sub-agent session
+    is_exec_run: bool,        // Codex session launched headlessly (`codex exec`)
     claude_home: String,      // Source Claude home directory
     custom_title: String,     // User-assigned session name (from /rename)
 }
@@ -182,6 +183,9 @@ impl Session {
         }
         if self.is_sidechain {
             display.push_str(" (s)");
+        }
+        if self.is_exec_run {
+            display.push_str(" (h)");
         }
         display
     }
@@ -345,6 +349,7 @@ struct App {
     // Filter state - inclusion-based (true = include this type)
     include_original: bool,   // true by default - include original sessions
     include_sub: bool,        // false by default - exclude sub-agents
+    include_exec: bool,       // false by default - exclude headless codex exec runs
     include_trimmed: bool,    // true by default - include trimmed sessions
     include_continued: bool,  // true by default - include continued sessions
     filter_agent: Option<String>, // None = all, Some("claude"), Some("codex")
@@ -451,6 +456,7 @@ enum FilterMenuItem {
     ClearAll,
     IncludeOriginal,
     IncludeSub,
+    IncludeExec,       // Headless `codex exec` runs (agent-spawned workers)
     IncludeTrimmed,
     IncludeContinued,  // Internally "continued", displayed as "rollover" to user
     IncludeLive,       // Only show currently running sessions
@@ -468,6 +474,7 @@ impl FilterMenuItem {
             FilterMenuItem::ClearAll,
             FilterMenuItem::IncludeOriginal,
             FilterMenuItem::IncludeSub,
+            FilterMenuItem::IncludeExec,
             FilterMenuItem::IncludeTrimmed,
             FilterMenuItem::IncludeContinued,
             FilterMenuItem::IncludeLive,
@@ -485,6 +492,7 @@ impl FilterMenuItem {
             FilterMenuItem::ClearAll => "(x) Reset to defaults",
             FilterMenuItem::IncludeOriginal => "(o) Include original sessions",
             FilterMenuItem::IncludeSub => "(s) Include sub-agent sessions",
+            FilterMenuItem::IncludeExec => "(h) Include headless exec runs",
             FilterMenuItem::IncludeTrimmed => "(t) Include trimmed sessions",
             FilterMenuItem::IncludeContinued => "(r) Include rollover sessions",
             FilterMenuItem::IncludeLive => "(!) Live sessions only",
@@ -502,6 +510,7 @@ impl FilterMenuItem {
             FilterMenuItem::ClearAll => 'x',
             FilterMenuItem::IncludeOriginal => 'o',
             FilterMenuItem::IncludeSub => 's',
+            FilterMenuItem::IncludeExec => 'h',
             FilterMenuItem::IncludeTrimmed => 't',
             FilterMenuItem::IncludeContinued => 'r',
             FilterMenuItem::IncludeLive => '!',
@@ -658,6 +667,7 @@ impl App {
             // Filter state
             include_original: true,   // Include original by default
             include_sub: false,       // Exclude sub-agents by default
+            include_exec: false,      // Exclude headless codex exec runs by default
             include_trimmed: true,    // Include trimmed by default
             include_continued: true,  // Include continued by default
             filter_agent: None,
@@ -768,6 +778,7 @@ impl App {
             // Additive flag (--sub-agent) adds sub-agents to defaults
             include_original: !cli.no_original,
             include_sub: cli.include_sub,
+            include_exec: cli.include_exec,
             include_trimmed: !cli.no_trimmed,
             include_continued: !cli.no_rollover,
             filter_agent: cli.agent_filter.clone(),
@@ -905,6 +916,13 @@ impl App {
                     // Sub-agent: include only if include_sub is true
                     // (derivation type filter does NOT apply to sub-agents)
                     if !self.include_sub {
+                        return false;
+                    }
+                } else if s.is_exec_run {
+                    // Headless `codex exec` run: agent-spawned worker.
+                    // Include only if include_exec is true (derivation type
+                    // filter does NOT apply, same as sub-agents).
+                    if !self.include_exec {
                         return false;
                     }
                 } else {
@@ -1080,6 +1098,7 @@ impl App {
             || self.filter_branch.is_some()
             || !self.include_original
             || self.include_sub
+            || self.include_exec
             || !self.include_trimmed
             || !self.include_continued
     }
@@ -1193,7 +1212,7 @@ impl App {
     fn has_annotations(&self) -> bool {
         self.filtered.iter().any(|&idx| {
             let s = &self.sessions[idx];
-            !s.derivation_type.is_empty() || s.is_sidechain
+            !s.derivation_type.is_empty() || s.is_sidechain || s.is_exec_run
         })
     }
 
@@ -1330,6 +1349,7 @@ fn render(frame: &mut Frame, app: &mut App) {
     let show_legend = app.has_annotations();
     let has_filters = !app.include_original
         || app.include_sub
+        || app.include_exec
         || !app.include_trimmed
         || !app.include_continued
         || app.filter_agent.is_some()
@@ -1623,9 +1643,12 @@ fn render_action_modal(frame: &mut Frame, app: &App, t: &Theme, area: Rect) {
 fn render_filter_modal(frame: &mut Frame, app: &App, t: &Theme, area: Rect) {
     use ratatui::widgets::{Block, Borders, Clear};
 
-    // Center the modal
+    let items = FilterMenuItem::all();
+
+    // Center the modal. Height follows the item count so adding a filter can
+    // never silently clip the bottom entries off the modal.
     let modal_width = 42u16;
-    let modal_height = 13u16; // 9 items + 2 border + 2 padding
+    let modal_height = (items.len() as u16 + 2).min(area.height);
     let x = (area.width.saturating_sub(modal_width)) / 2;
     let y = (area.height.saturating_sub(modal_height)) / 2;
     let modal_area = Rect::new(x, y, modal_width, modal_height);
@@ -1643,7 +1666,6 @@ fn render_filter_modal(frame: &mut Frame, app: &App, t: &Theme, area: Rect) {
     // Inner content area
     let inner = Rect::new(x + 2, y + 1, modal_width - 4, modal_height - 2);
 
-    let items = FilterMenuItem::all();
     let mut lines: Vec<Line> = Vec::new();
 
     for (i, item) in items.iter().enumerate() {
@@ -1654,6 +1676,7 @@ fn render_filter_modal(frame: &mut Frame, app: &App, t: &Theme, area: Rect) {
             FilterMenuItem::ClearAll => "".to_string(),
             FilterMenuItem::IncludeOriginal => if app.include_original { " [ON]" } else { " [off]" }.to_string(),
             FilterMenuItem::IncludeSub => if app.include_sub { " [ON]" } else { " [off]" }.to_string(),
+            FilterMenuItem::IncludeExec => if app.include_exec { " [ON]" } else { " [off]" }.to_string(),
             FilterMenuItem::IncludeTrimmed => if app.include_trimmed { " [ON]" } else { " [off]" }.to_string(),
             FilterMenuItem::IncludeContinued => if app.include_continued { " [ON]" } else { " [off]" }.to_string(),
             FilterMenuItem::IncludeLive => if app.include_live_only { " [ON]" } else { " [off]" }.to_string(),
@@ -2216,6 +2239,7 @@ fn render_status_bar(frame: &mut Frame, app: &App, t: &Theme, area: Rect, show_l
     // Check if we have any active filters (need third row for legend or filters)
     let has_filters = !app.include_original
         || app.include_sub
+        || app.include_exec
         || !app.include_trimmed
         || !app.include_continued
         || app.filter_agent.is_some()
@@ -2323,7 +2347,9 @@ fn render_status_bar(frame: &mut Frame, app: &App, t: &Theme, area: Rect, show_l
                 Span::styled("(t)", Style::default().fg(t.dim_fg)),
                 Span::styled(" trimmed  ", dim),
                 Span::styled("(s)", Style::default().fg(t.dim_fg)),
-                Span::styled(" sub-agent", dim),
+                Span::styled(" sub-agent  ", dim),
+                Span::styled("(h)", Style::default().fg(t.dim_fg)),
+                Span::styled(" headless exec", dim),
             ]);
         }
 
@@ -2333,6 +2359,9 @@ fn render_status_bar(frame: &mut Frame, app: &App, t: &Theme, area: Rect, show_l
         }
         if app.include_sub {
             row3_spans.push(Span::styled(" [+sub]", filter_active));
+        }
+        if app.include_exec {
+            row3_spans.push(Span::styled(" [+exec]", filter_active));
         }
         if !app.include_trimmed {
             row3_spans.push(Span::styled(" [-trim]", filter_active));
@@ -3536,6 +3565,8 @@ fn load_sessions(index_path: &str, limit: usize) -> Result<Vec<Session>> {
     let first_user_msg_content_field = schema.get_field("first_user_msg_content").ok();
     let derivation_type_field = schema.get_field("derivation_type").context("missing derivation_type")?;
     let is_sidechain_field = schema.get_field("is_sidechain").context("missing is_sidechain")?;
+    // is_exec_run may not exist in older indexes, so make it optional
+    let is_exec_run_field = schema.get_field("is_exec_run").ok();
     // claude_home may not exist in older indexes, so make it optional
     let claude_home_field = schema.get_field("claude_home").ok();
     // custom_title may not exist in older indexes, so make it optional
@@ -3574,6 +3605,9 @@ fn load_sessions(index_path: &str, limit: usize) -> Result<Vec<Session>> {
             .unwrap_or(0);
 
         let is_sidechain_str = get_text(is_sidechain_field);
+        let is_exec_run = is_exec_run_field
+            .map(|f| get_text(f) == "true")
+            .unwrap_or(false);
 
         // Get claude_home if field exists, otherwise empty string
         let claude_home = claude_home_field
@@ -3608,6 +3642,7 @@ fn load_sessions(index_path: &str, limit: usize) -> Result<Vec<Session>> {
             first_user_msg_content,
             derivation_type: get_text(derivation_type_field),
             is_sidechain: is_sidechain_str == "true",
+            is_exec_run,
             claude_home,
             custom_title,
         });
@@ -4255,6 +4290,7 @@ fn output_json(app: &App, limit: Option<usize>) -> Result<()> {
             "file_path": s.export_path,
             "derivation_type": s.derivation_type,
             "is_sidechain": s.is_sidechain,
+            "is_exec_run": s.is_exec_run,
             "custom_title": s.custom_title,
             "snippet": app.search_snippets.get(&s.session_id).map(|s| strip_html_tags(s)),
         });
@@ -4279,6 +4315,8 @@ struct CliOptions {
     no_rollover: bool,
     // Additive flag: --sub-agent adds sub-agents to defaults
     include_sub: bool,
+    // Additive flag: --exec-runs adds headless codex exec runs to defaults
+    include_exec: bool,
     // Live sessions filter: --live shows only currently running sessions
     include_live: bool,
     min_lines: Option<i64>,
@@ -4380,6 +4418,8 @@ fn parse_cli_args() -> CliOptions {
     let no_rollover = has_flag("--no-rollover");
     // Additive flag: --sub-agent adds sub-agents to defaults
     let include_sub = has_flag("--sub-agent");
+    // Additive flag: --exec-runs adds headless codex exec runs to defaults
+    let include_exec = has_flag("--exec-runs");
     // Live sessions filter: --live shows only currently running sessions
     let include_live = has_flag("--live");
 
@@ -4416,6 +4456,7 @@ fn parse_cli_args() -> CliOptions {
         no_trimmed,
         no_rollover,
         include_sub,
+        include_exec,
         include_live,
         min_lines,
         after_date,
@@ -4804,6 +4845,7 @@ fn main() -> Result<()> {
                                     // Reset to defaults
                                     app.include_original = true;
                                     app.include_sub = false;
+                                    app.include_exec = false;
                                     app.include_trimmed = true;
                                     app.include_continued = true;
                                     app.filter_agent = None;
@@ -4816,6 +4858,10 @@ fn main() -> Result<()> {
                                 }
                                 FilterMenuItem::IncludeSub => {
                                     app.include_sub = !app.include_sub;
+                                    app.filter();
+                                }
+                                FilterMenuItem::IncludeExec => {
+                                    app.include_exec = !app.include_exec;
                                     app.filter();
                                 }
                                 FilterMenuItem::IncludeTrimmed => {
@@ -5064,6 +5110,7 @@ fn main() -> Result<()> {
                                 // Reset to defaults
                                 app.include_original = true;
                                 app.include_sub = false;
+                                app.include_exec = false;
                                 app.include_trimmed = true;
                                 app.include_continued = true;
                                 app.filter_agent = None;
@@ -5080,6 +5127,10 @@ fn main() -> Result<()> {
                             }
                             KeyCode::Char('s') => {
                                 app.include_sub = !app.include_sub;
+                                app.filter();
+                            }
+                            KeyCode::Char('h') => {
+                                app.include_exec = !app.include_exec;
                                 app.filter();
                             }
                             KeyCode::Char('t') => {
@@ -5217,6 +5268,7 @@ fn main() -> Result<()> {
                 "filter_dir": app.filter_dir,
                 "include_original": app.include_original,
                 "include_sub": app.include_sub,
+                "include_exec": app.include_exec,
                 "include_trimmed": app.include_trimmed,
                 "include_continued": app.include_continued,
                 "filter_agent": app.filter_agent,

--- a/rust-search-ui/src/main.rs
+++ b/rust-search-ui/src/main.rs
@@ -1664,8 +1664,15 @@ fn render_filter_modal(frame: &mut Frame, app: &App, t: &Theme, area: Rect) {
         .style(Style::default().bg(t.search_bg));
     frame.render_widget(block, modal_area);
 
-    // Inner content area
-    let inner = Rect::new(x + 2, y + 1, modal_width - 4, modal_height - 2);
+    // Inner content area. The height is derived from the item count and
+    // clamped to the terminal, so on a very short terminal it can be smaller
+    // than the border allowance -- saturate rather than underflow.
+    let inner = Rect::new(
+        x + 2,
+        y + 1,
+        modal_width.saturating_sub(4),
+        modal_height.saturating_sub(2),
+    );
 
     let mut lines: Vec<Line> = Vec::new();
 

--- a/tests/test_codex_subagent_detection.py
+++ b/tests/test_codex_subagent_detection.py
@@ -1,0 +1,218 @@
+"""Tests for sub-agent detection in session metadata extraction.
+
+Claude writes sub-agent transcripts as ``agent-*.jsonl``, so a filename check
+is enough. Codex writes every thread as ``rollout-*.jsonl``, so its sub-agents
+have to be recognised from the spawn markers in ``session_meta``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_code_tools.export_session import (
+    _is_codex_exec_payload,
+    _is_codex_subagent_payload,
+    extract_session_metadata,
+)
+
+
+def _write_codex_rollout(path: Path, payload: dict) -> Path:
+    """Write a minimal Codex rollout file with the given session_meta payload.
+
+    Args:
+        path: File to create.
+        payload: Contents of the ``session_meta`` payload object.
+
+    Returns:
+        The path written.
+    """
+    meta = {
+        "timestamp": "2026-08-01T00:39:50.261Z",
+        "type": "session_meta",
+        "payload": payload,
+    }
+    turn = {
+        "timestamp": "2026-08-01T00:39:55.000Z",
+        "type": "response_item",
+        "payload": {"type": "message", "role": "user", "content": [{"text": "hi"}]},
+    }
+    path.write_text(
+        json.dumps(meta) + "\n" + json.dumps(turn) + "\n", encoding="utf-8"
+    )
+    return path
+
+
+def _base_payload(**extra: object) -> dict:
+    """Return a Codex session_meta payload for a normal (non-sub-agent) thread."""
+    payload = {
+        "session_id": "019fbac3-47b7-76f1-a0ef-b0256d99b508",
+        "id": "019fbac3-47b7-76f1-a0ef-b0256d99b508",
+        "cwd": "/Users/x/Git/proj",
+        "originator": "codex_exec",
+        "source": "exec",
+        "thread_source": "user",
+        "git": {"branch": "main"},
+    }
+    payload.update(extra)
+    return payload
+
+
+def test_plain_codex_thread_is_not_a_subagent() -> None:
+    """A user-started Codex thread carries no sub-agent markers."""
+    assert _is_codex_subagent_payload(_base_payload()) is False
+
+
+def test_thread_source_marks_subagent() -> None:
+    """``thread_source: subagent`` identifies a spawned thread."""
+    assert _is_codex_subagent_payload(_base_payload(thread_source="subagent"))
+
+
+def test_source_object_marks_subagent() -> None:
+    """A ``source`` object keyed by ``subagent`` identifies a spawned thread."""
+    payload = _base_payload(
+        source={"subagent": {"thread_spawn": {"parent_thread_id": "019f-parent"}}}
+    )
+    assert _is_codex_subagent_payload(payload)
+
+
+def test_parent_thread_id_marks_subagent() -> None:
+    """A recorded parent thread id identifies a spawned thread."""
+    assert _is_codex_subagent_payload(_base_payload(parent_thread_id="019f-parent"))
+
+
+def test_empty_parent_thread_id_is_not_a_marker() -> None:
+    """An empty or non-string parent id is ignored rather than trusted."""
+    assert _is_codex_subagent_payload(_base_payload(parent_thread_id="")) is False
+    assert _is_codex_subagent_payload(_base_payload(parent_thread_id={})) is False
+
+
+def test_extract_metadata_flags_codex_subagent(tmp_path: Path) -> None:
+    """A spawned Codex rollout is reported as a sidechain session."""
+    rollout = _write_codex_rollout(
+        tmp_path / "rollout-2026-08-01T00-39-47-019fbac3.jsonl",
+        _base_payload(
+            thread_source="subagent",
+            source={"subagent": {"thread_spawn": {"parent_thread_id": "019f-parent"}}},
+            parent_thread_id="019f-parent",
+            agent_nickname="reviewer",
+        ),
+    )
+
+    metadata = extract_session_metadata(rollout, "codex")
+
+    assert metadata["is_sidechain"] is True
+
+
+def test_extract_metadata_leaves_plain_codex_session_alone(tmp_path: Path) -> None:
+    """A user-started Codex rollout stays resumable in search results."""
+    rollout = _write_codex_rollout(
+        tmp_path / "rollout-2026-08-01T00-39-47-019fbac3.jsonl", _base_payload()
+    )
+
+    metadata = extract_session_metadata(rollout, "codex")
+
+    assert metadata["is_sidechain"] is False
+    assert metadata["cwd"] == "/Users/x/Git/proj"
+    assert metadata["branch"] == "main"
+
+
+def test_claude_subagent_still_detected_by_filename(tmp_path: Path) -> None:
+    """The existing Claude sub-agent detection is unchanged."""
+    session = tmp_path / "agent-a20a12f.jsonl"
+    session.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "isSidechain": True,
+                "cwd": "/Users/x/Git/proj",
+                "timestamp": "2026-08-01T00:39:50.261Z",
+                "message": {"role": "user", "content": "hi"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert extract_session_metadata(session, "claude")["is_sidechain"] is True
+
+
+def test_claude_main_session_is_not_a_subagent(tmp_path: Path) -> None:
+    """A normal Claude session file is not flagged."""
+    session = tmp_path / "0a88c018-3bca-4e8c-84fb-6cd3912a4db4.jsonl"
+    session.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "cwd": "/Users/x/Git/proj",
+                "timestamp": "2026-08-01T00:39:50.261Z",
+                "message": {"role": "user", "content": "hi"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert extract_session_metadata(session, "claude")["is_sidechain"] is False
+
+
+def test_headless_exec_run_is_detected() -> None:
+    """A `codex exec` thread is recognised as a headless run."""
+    assert _is_codex_exec_payload(_base_payload()) is True
+
+
+def test_interactive_cli_thread_is_not_an_exec_run() -> None:
+    """A thread started in the interactive Codex TUI is not a headless run."""
+    assert _is_codex_exec_payload(_base_payload(source="cli")) is False
+
+
+def test_subagent_spawn_is_not_counted_as_an_exec_run() -> None:
+    """A spawned sub-agent carries an object here, not the string ``exec``."""
+    payload = _base_payload(
+        source={"subagent": {"thread_spawn": {"parent_thread_id": "019f-parent"}}}
+    )
+    assert _is_codex_exec_payload(payload) is False
+
+
+def test_extract_metadata_flags_headless_exec_run(tmp_path: Path) -> None:
+    """A headless Codex rollout is flagged so search can hide it by default."""
+    rollout = _write_codex_rollout(
+        tmp_path / "rollout-2026-08-01T00-39-47-019fbac3.jsonl", _base_payload()
+    )
+
+    metadata = extract_session_metadata(rollout, "codex")
+
+    assert metadata["is_exec_run"] is True
+    assert metadata["is_sidechain"] is False
+
+
+def test_interactive_codex_session_is_not_flagged(tmp_path: Path) -> None:
+    """An interactive Codex session stays in default search results."""
+    rollout = _write_codex_rollout(
+        tmp_path / "rollout-2026-08-01T00-39-47-019fbac3.jsonl",
+        _base_payload(source="cli", originator="codex-tui"),
+    )
+
+    metadata = extract_session_metadata(rollout, "codex")
+
+    assert metadata["is_exec_run"] is False
+    assert metadata["is_sidechain"] is False
+
+
+def test_claude_sessions_are_never_exec_runs(tmp_path: Path) -> None:
+    """The headless flag is Codex-only; Claude sessions never set it."""
+    session = tmp_path / "0a88c018-3bca-4e8c-84fb-6cd3912a4db4.jsonl"
+    session.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "cwd": "/Users/x/Git/proj",
+                "timestamp": "2026-08-01T00:39:50.261Z",
+                "message": {"role": "user", "content": "hi"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert extract_session_metadata(session, "claude")["is_exec_run"] is False

--- a/tests/test_codex_subagent_detection.py
+++ b/tests/test_codex_subagent_detection.py
@@ -216,3 +216,41 @@ def test_claude_sessions_are_never_exec_runs(tmp_path: Path) -> None:
     )
 
     assert extract_session_metadata(session, "claude")["is_exec_run"] is False
+
+
+def test_forked_rollout_ignores_ancestor_metadata(tmp_path: Path) -> None:
+    """A fork replays ancestor session_meta records; only the first counts.
+
+    Without this, an interactive fork of a headless ancestor inherits
+    is_exec_run and disappears from default search results.
+    """
+    rollout = tmp_path / "rollout-2026-08-01T00-39-47-019fbac3.jsonl"
+    own = {
+        "timestamp": "2026-08-01T00:39:50.261Z",
+        "type": "session_meta",
+        # No git info, so metadata extraction keeps scanning past this record.
+        "payload": _base_payload(source="cli", originator="codex-tui", git=None),
+    }
+    ancestor = {
+        "timestamp": "2026-07-30T00:00:00.000Z",
+        "type": "session_meta",
+        "payload": _base_payload(
+            source={"subagent": {"thread_spawn": {"parent_thread_id": "019f-p"}}},
+            thread_source="subagent",
+            parent_thread_id="019f-p",
+        ),
+    }
+    turn = {
+        "timestamp": "2026-08-01T00:39:55.000Z",
+        "type": "response_item",
+        "payload": {"type": "message", "role": "user", "content": [{"text": "hi"}]},
+    }
+    rollout.write_text(
+        "\n".join(json.dumps(r) for r in (own, ancestor, turn)) + "\n",
+        encoding="utf-8",
+    )
+
+    metadata = extract_session_metadata(rollout, "codex")
+
+    assert metadata["is_exec_run"] is False
+    assert metadata["is_sidechain"] is False

--- a/tests/test_index_incremental_state.py
+++ b/tests/test_index_incremental_state.py
@@ -1,0 +1,66 @@
+"""Tests for incremental-index bookkeeping.
+
+Files that produce no document (empty sessions, sessions run from inside the
+agent home directories) used to be left out of the state file, so every launch
+re-parsed them. They are now recorded -- but with the file state captured
+BEFORE reading, so a session that gains content mid-scan is not lost.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from claude_code_tools.search_index import IndexState, SessionIndex
+
+
+def test_snapshot_taken_before_a_write_still_triggers_reindex(
+    tmp_path: Path,
+) -> None:
+    """Content appended after the snapshot must not look already indexed."""
+    session = tmp_path / "session.jsonl"
+    session.write_text("", encoding="utf-8")
+    before = session.stat()
+
+    # Simulate a live session appending its first message while we read it.
+    session.write_text('{"type": "user"}\n', encoding="utf-8")
+    os.utime(session, (before.st_atime, before.st_mtime + 5))
+
+    state = IndexState(tmp_path / "state.json")
+    state.mark_indexed(session, before)
+
+    assert state.needs_reindex(session) is True
+
+
+def test_marking_with_current_state_skips_next_run(tmp_path: Path) -> None:
+    """An unchanged file is skipped on the next launch."""
+    session = tmp_path / "session.jsonl"
+    session.write_text('{"type": "user"}\n', encoding="utf-8")
+
+    state = IndexState(tmp_path / "state.json")
+    state.mark_indexed(session)
+
+    assert state.needs_reindex(session) is False
+
+
+def test_empty_session_is_recorded_and_not_reparsed(tmp_path: Path) -> None:
+    """An empty session is indexed-state-recorded so launches stop re-parsing."""
+    session_dir = tmp_path / "sessions"
+    session_dir.mkdir()
+    empty = session_dir / "0a88c018-3bca-4e8c-84fb-6cd3912a4db4.jsonl"
+    # Structurally valid JSONL, but carrying no indexable message.
+    empty.write_text(
+        json.dumps({"type": "summary", "summary": "nothing here"}) + "\n",
+        encoding="utf-8",
+    )
+
+    index = SessionIndex(tmp_path / "index")
+    stats = index.index_from_jsonl([empty], incremental=True, show_progress=False)
+    assert stats["indexed"] == 0
+
+    assert str(empty) in index.state.indexed_files
+
+    second = index.index_from_jsonl([empty], incremental=True, show_progress=False)
+    assert second["skipped"] == 1
+    assert second["empty"] == 0

--- a/tests/test_search_import.py
+++ b/tests/test_search_import.py
@@ -26,13 +26,16 @@ def test_export_session_import_error_handling():
         raise
 
 
-def test_search_command_without_deps_gives_helpful_error():
+def test_search_command_without_deps_gives_helpful_error(tmp_path):
     """
     When tantivy or yaml is not installed, 'aichat search' should give a
     helpful error message rather than a raw ImportError traceback.
     """
     # Run aichat search in a subprocess to simulate the user's environment
-    # We use --help since it should work even without deps if imports are lazy
+    # We use --help since it should work even without deps if imports are lazy.
+    # HOME is redirected at a temp dir: aichat auto-indexes on every command,
+    # and pointing it at the developer's real home makes this rebuild their
+    # live session index, which blows past the timeout.
     result = subprocess.run(
         [
             sys.executable,
@@ -43,7 +46,7 @@ def test_search_command_without_deps_gives_helpful_error():
         ],
         capture_output=True,
         text=True,
-        env={"PATH": ""},  # Minimal env
+        env={"PATH": "", "HOME": str(tmp_path)},  # Minimal, isolated env
         timeout=SUBPROCESS_TIMEOUT_SECONDS,
     )
 

--- a/tests/test_tmux_cli_controller.py
+++ b/tests/test_tmux_cli_controller.py
@@ -4,6 +4,7 @@ import time
 
 import pytest
 
+from claude_code_tools import tmux_execution_helpers
 from claude_code_tools.tmux_cli_controller import TmuxCLIController
 
 
@@ -130,6 +131,19 @@ class TestCreatePane:
 class TestExecute:
     """Tests for execute method."""
 
+    @pytest.fixture(autouse=True)
+    def fixed_markers(self, monkeypatch):
+        """Pin the per-execution markers so captured-output fixtures match.
+
+        execute() generates a unique marker pair for every call, so a test
+        fixture cannot hardcode them without pinning the generator.
+        """
+        monkeypatch.setattr(
+            tmux_execution_helpers,
+            "generate_execution_markers",
+            lambda: ("__TMUX_EXEC_START_12345__", "__TMUX_EXEC_END_12345__"),
+        )
+
     @patch.object(TmuxCLIController, 'capture_pane')
     @patch.object(TmuxCLIController, 'send_keys')
     def test_execute_successful_command(self, mock_send, mock_capture):
@@ -187,3 +201,44 @@ partial output..."""
 
         with pytest.raises(ValueError, match="No target pane specified"):
             controller.execute("pwd")
+
+
+class TestListPanes:
+    """Tests for list_panes output parsing."""
+
+    @patch.object(TmuxCLIController, '_run_tmux_command')
+    @patch.object(TmuxCLIController, 'get_current_window_id')
+    def test_malformed_line_is_skipped(self, mock_window, mock_run):
+        """A line without the expected fields is skipped, not indexed into."""
+        mock_window.return_value = "@1"
+        mock_run.return_value = ("invalid", 0)
+
+        panes = TmuxCLIController().list_panes()
+
+        assert panes == []
+
+    @patch.object(TmuxCLIController, '_run_tmux_command')
+    @patch.object(TmuxCLIController, 'get_current_window_id')
+    def test_well_formed_lines_are_parsed(self, mock_window, mock_run):
+        """Complete tmux output is parsed into pane dicts."""
+        mock_window.return_value = "@1"
+        mock_run.return_value = (
+            "%1|0|title-a|1|80x24|zsh\n%2|1|title-b|0|80x24|vim", 0
+        )
+
+        panes = TmuxCLIController().list_panes()
+
+        assert [p['id'] for p in panes] == ["%1", "%2"]
+        assert panes[0]['active'] is True
+        assert panes[1]['command'] == "vim"
+
+    @patch.object(TmuxCLIController, '_run_tmux_command')
+    @patch.object(TmuxCLIController, 'get_current_window_id')
+    def test_malformed_line_does_not_drop_valid_ones(self, mock_window, mock_run):
+        """One bad line does not discard the panes around it."""
+        mock_window.return_value = "@1"
+        mock_run.return_value = ("garbage\n%2|1|title-b|0|80x24|vim", 0)
+
+        panes = TmuxCLIController().list_panes()
+
+        assert [p['id'] for p in panes] == ["%2"]


### PR DESCRIPTION
## Problem

Session search was dominated by Codex sessions the user never had a conversation with. Two distinct causes.

**Sub-agents were never detected.** Claude writes sub-agent transcripts as `agent-*.jsonl`, so the filename check caught them. Codex writes every thread as `rollout-*.jsonl`, so the check never fired and 2267 sub-agent threads were indexed as ordinary sessions. Codex marks them inside `session_meta` instead: `thread_source: "subagent"`, a `source` object keyed by `subagent`, a `parent_thread_id`.

**Headless runs looked like real conversations.** `codex exec` threads — 3995 of them against 280 interactive sessions — are workers spawned by orchestrating agents, but their metadata is indistinguishable from a user-started thread apart from `source: "exec"`.

## Change

- Detect both, storing `is_sidechain` and a new `is_exec_run` field.
- Exclude headless exec runs from results by default, exactly like sub-agents. They stay indexed and reachable: `--exec-runs` on the CLI, `(h)` in the filter menu or `:h` in command mode, and they are marked `(h)` in the session list.
- The exclusion is applied in the Tantivy query rather than after ranking. Keyword search retrieves the top 2000 matches, and a broad query can easily fill that with exec runs — `review` matches 1657 — which would push matching interactive sessions out of the results entirely.

Verified on a real corpus: a query that returned 84 rows now returns 2 by default and 84 with `--exec-runs`, and every one of the 5078 indexed codex documents carries the correct flag (0 mismatches).

## Index hygiene, found in the same investigation

- Sessions that yield no document (empty, or run from inside the agent home directories) were never recorded in the index state, so **every launch re-parsed them** — 1531 files, every run. Recording them cuts a warm launch from **8.5s to 1.2s**.
- The recorded file state is captured *before* reading, so a session appended to mid-scan is not marked as already indexed and lost.
- `INDEX_LOGIC_REVISION` now participates in the index version string. Without it a change to what gets stored never rebuilds existing indexes, because an editable install never changes the package version — this fix would have shipped and done nothing.
- `test_search_import` ran aichat against the developer's real home directory, which made it rebuild the live index and time out. It now uses a temp `HOME`.

## Bundled: stale tmux-cli tests

Four tests in `test_tmux_cli_controller.py` had been failing on `main`. Folded in here at the author's request rather than as a separate PR.

- `TestCreatePane` mocked `_run_tmux_command` with a single return value, but `create_pane()` also calls `list_panes()` now, which got handed that same string. `list_panes()` indexed `parts[1..4]` with no field-count check, so a non-pane line raised `IndexError`. Malformed lines are now skipped — also the right behaviour against real tmux.
- `TestExecute` hardcoded `__TMUX_EXEC_*_12345__` markers, but `execute()` generates a unique pair per call, so the fixtures never matched and the tests saw raw output with exit code -1. The generator is pinned for those tests. `test_execute_timeout` was passing for the same wrong reason and is covered by the same fixture.

## Notes for review

- The Rust half only reaches users who rebuild `aichat-search`. A version bump, crates.io publish and Homebrew formula update are a follow-up, not part of this PR.
- Upgrading rebuilds the index once (~70s here) because the stored fields changed.
- Deliberately **not** done: dropping sub-agents and exec runs from the index entirely. It would roughly halve the index, but `--sub-agent` and `--exec-runs` would stop working.
- Deferred: `is_sidechain` has the same retrieve-then-filter exposure that `is_exec_run` just got fixed for. Pre-existing, much smaller population, left alone.

## Testing

Full suite green: 1481 passed, 7 skipped, 0 failed. `cargo test` 12 passed. Reviewed by repeated contract-free cold-diff passes until clean.
