### PR TITLE
Install and verify the Node UI's dependencies for source checkouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install release patch minor major dev-install help clean publish all-patch all-minor all-major release-github lmsh lmsh-install lmsh-publish aichat-search aichat-search-install aichat-search-release aichat-search-patch aichat-search-minor aichat-search-major aichat-search-publish fix-session-metadata fix-session-metadata-apply delete-helper-sessions delete-helper-sessions-apply update-homebrew docs-dev docs-build docs-preview voxtype-version voxtype-test voxtype-install voxtype-build voxtype-release voxtype-publish voxtype-all voxtype-all-patch voxtype-all-minor voxtype-all-major
+.PHONY: install node-ui-deps release patch minor major dev-install help clean publish all-patch all-minor all-major release-github lmsh lmsh-install lmsh-publish aichat-search aichat-search-install aichat-search-release aichat-search-patch aichat-search-minor aichat-search-major aichat-search-publish fix-session-metadata fix-session-metadata-apply delete-helper-sessions delete-helper-sessions-apply update-homebrew docs-dev docs-build docs-preview voxtype-version voxtype-test voxtype-install voxtype-build voxtype-release voxtype-publish voxtype-all voxtype-all-patch voxtype-all-minor voxtype-all-major
 
 GIT_PRIMARY_WORKTREE := $(realpath $(shell git rev-parse \
 	--path-format=absolute --git-common-dir)/..)
@@ -8,6 +8,7 @@ help:
 	@echo "Available commands:"
 	@echo "  make install      - Install in editable mode (for development)"
 	@echo "  make dev-install  - Install with dev dependencies (includes commitizen)"
+	@echo "  make node-ui-deps - Install node_ui/ npm deps (needed by aichat menus)"
 	@echo "  make release      - Bump patch version and install globally"
 	@echo "  make patch        - Bump patch version (0.0.X) and install"
 	@echo "  make minor        - Bump minor version (0.X.0) and install"
@@ -40,10 +41,19 @@ help:
 	@echo "  make voxtype-publish - Publish dist/voxtype-* to PyPI"
 	@echo "  make voxtype-all [BUMP=...] - voxtype-release + voxtype-publish in one shot"
 
-install:
+node-ui-deps:
+	@if command -v npm >/dev/null 2>&1; then \
+		echo "[node-ui] Installing Node UI dependencies into node_ui/node_modules..."; \
+		npm ci --prefix node_ui --omit=dev --no-audit --no-fund || \
+			npm install --prefix node_ui --omit=dev --no-audit --no-fund; \
+	else \
+		echo "⚠️  [node-ui] npm not found - aichat's interactive menus will not run."; \
+		echo "   Install Node.js/npm, then run: make node-ui-deps"; \
+	fi
+
+install: node-ui-deps
 	uv tool install --force -e .
-	@echo "[node-ui] Note: Node-based alt UI uses node_ui/menu.js (no build step)."
-	@echo "[node-ui] If you haven't yet: cd node_ui && npm install"
+	@echo "[node-ui] Node-based UI runs from node_ui/menu.js (no build step)."
 	@if command -v cargo >/dev/null 2>&1; then \
 		echo "Building and installing lmsh..."; \
 		cd lmsh && cargo build --release; \

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,9 @@ install: node-ui-deps
 		echo "Building and installing lmsh..."; \
 		cd lmsh && cargo build --release; \
 		mkdir -p ~/.cargo/bin; \
-		cp target/release/lmsh ~/.cargo/bin/; \
+		cp target/release/lmsh ~/.cargo/bin/.lmsh.new; \
+		chmod 755 ~/.cargo/bin/.lmsh.new; \
+		mv -f ~/.cargo/bin/.lmsh.new ~/.cargo/bin/lmsh; \
 		echo "lmsh installed to ~/.cargo/bin/lmsh"; \
 		if ! echo "$$PATH" | grep -q ".cargo/bin"; then \
 			echo "⚠️  Add ~/.cargo/bin to your PATH if not already there"; \
@@ -177,7 +179,10 @@ lmsh:
 lmsh-install: lmsh
 	@echo "Installing lmsh to ~/.cargo/bin..."
 	@mkdir -p ~/.cargo/bin
-	@cp lmsh/target/release/lmsh ~/.cargo/bin/
+	@# Same atomic replace as aichat-search: see the note there.
+	@cp lmsh/target/release/lmsh ~/.cargo/bin/.lmsh.new
+	@chmod 755 ~/.cargo/bin/.lmsh.new
+	@mv -f ~/.cargo/bin/.lmsh.new ~/.cargo/bin/lmsh
 	@echo "lmsh installed to ~/.cargo/bin/lmsh"
 	@if ! echo "$$PATH" | grep -q ".cargo/bin"; then \
 		echo "⚠️  Add ~/.cargo/bin to your PATH if not already there"; \
@@ -202,7 +207,12 @@ aichat-search:
 aichat-search-install: aichat-search
 	@echo "Installing aichat-search to ~/.cargo/bin..."
 	@mkdir -p ~/.cargo/bin
-	@cp rust-search-ui/target/release/aichat-search ~/.cargo/bin/
+	@# Replace via a temp file + mv, not cp: overwriting a Mach-O binary in
+	@# place leaves macOS holding a stale code signature for that inode, and
+	@# the next exec is SIGKILLed ("killed: 9"). mv swaps in a fresh inode.
+	@cp rust-search-ui/target/release/aichat-search ~/.cargo/bin/.aichat-search.new
+	@chmod 755 ~/.cargo/bin/.aichat-search.new
+	@mv -f ~/.cargo/bin/.aichat-search.new ~/.cargo/bin/aichat-search
 	@echo "aichat-search installed to ~/.cargo/bin/aichat-search"
 	@if ! echo "$$PATH" | grep -q ".cargo/bin"; then \
 		echo "⚠️  Add ~/.cargo/bin to your PATH if not already there"; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install node-ui-deps release patch minor major dev-install help clean publish all-patch all-minor all-major release-github lmsh lmsh-install lmsh-publish aichat-search aichat-search-install aichat-search-release aichat-search-patch aichat-search-minor aichat-search-major aichat-search-publish fix-session-metadata fix-session-metadata-apply delete-helper-sessions delete-helper-sessions-apply update-homebrew docs-dev docs-build docs-preview voxtype-version voxtype-test voxtype-install voxtype-build voxtype-release voxtype-publish voxtype-all voxtype-all-patch voxtype-all-minor voxtype-all-major
+.PHONY: install install-gdocs node-ui-deps release patch minor major dev-install help clean publish all-patch all-minor all-major release-github lmsh lmsh-install lmsh-publish aichat-search aichat-search-install aichat-search-release aichat-search-patch aichat-search-minor aichat-search-major aichat-search-publish fix-session-metadata fix-session-metadata-apply delete-helper-sessions delete-helper-sessions-apply update-homebrew docs-dev docs-build docs-preview voxtype-version voxtype-test voxtype-install voxtype-build voxtype-release voxtype-publish voxtype-all voxtype-all-patch voxtype-all-minor voxtype-all-major
 
 GIT_PRIMARY_WORKTREE := $(realpath $(shell git rev-parse \
 	--path-format=absolute --git-common-dir)/..)
@@ -68,10 +68,10 @@ install: node-ui-deps
 		echo "To install lmsh later, run: make lmsh-install"; \
 	fi
 
-install-gdocs:
+install-gdocs: node-ui-deps
 	uv tool install --force -e ".[gdocs]"
 
-dev-install:
+dev-install: node-ui-deps
 	uv pip install -e ".[dev]"
 
 release: patch

--- a/claude_code_tools/node_menu_ui.py
+++ b/claude_code_tools/node_menu_ui.py
@@ -63,6 +63,24 @@ def _missing_node_ui_packages(node_ui_dir: Path | None = None) -> List[str]:
     ]
 
 
+def _quote_path(path: Path) -> str:
+    """Quote a path for the shell the user is most likely pasting into.
+
+    ``shlex.quote`` emits POSIX single quotes, which ``cmd.exe`` treats as
+    literal characters, so a Windows path containing spaces would be split.
+
+    Args:
+        path: Path to embed in a suggested command line.
+
+    Returns:
+        The path, quoted only when it needs to be.
+    """
+    text = str(path)
+    if os.name == "nt":
+        return f'"{text}"' if " " in text else text
+    return shlex.quote(text)
+
+
 def _no_node_message() -> str:
     """Build the message shown when the Node runtime is unavailable."""
     return (
@@ -81,8 +99,8 @@ def _node_ui_setup_message(missing: List[str], node_ui_dir: Path) -> str:
         "This happens when aichat runs from a source checkout (an editable\n"
         "install) whose Node dependencies were never installed. Install them\n"
         "with either of:\n"
-        f"  npm ci --prefix {shlex.quote(str(node_ui_dir))} --omit=dev\n"
-        "  make install   # from that checkout\n"
+        f"  npm ci --prefix {_quote_path(node_ui_dir)} --omit=dev\n"
+        "  make install   # from that checkout (needs GNU make)\n"
     )
 
 

--- a/claude_code_tools/node_menu_ui.py
+++ b/claude_code_tools/node_menu_ui.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -60,6 +61,14 @@ def _missing_node_ui_packages(node_ui_dir: Path | None = None) -> List[str]:
         for name in NODE_UI_REQUIRED_PACKAGES
         if not (node_modules / name).is_dir()
     ]
+
+
+def _no_node_message() -> str:
+    """Build the message shown when the Node runtime is unavailable."""
+    return (
+        "aichat could not start its interactive menu: 'node' was not found "
+        "on PATH.\nInstall Node.js (>=18) and try again."
+    )
 
 
 def _node_ui_setup_message(missing: List[str], node_ui_dir: Path) -> str:
@@ -119,6 +128,12 @@ def _run_node(data_path: Path, out_path: Path, stderr_mode: bool = False) -> int
     Returns the process return code. A missing Node runtime or missing Node UI
     dependencies are reported as an actionable message and return code 1.
     """
+    # Check the runtime before its packages: on a machine without Node, telling
+    # the user to run npm is useless advice.
+    if shutil.which("node") is None:
+        print(_no_node_message(), file=sys.stderr)
+        return 1
+
     node_ui_dir = _node_ui_dir()
     missing = _missing_node_ui_packages(node_ui_dir)
     if missing:
@@ -134,11 +149,8 @@ def _run_node(data_path: Path, out_path: Path, stderr_mode: bool = False) -> int
     try:
         proc = subprocess.run(cmd, env=env)
     except FileNotFoundError:
-        print(
-            "aichat could not start its interactive menu: 'node' was not found "
-            "on PATH.\nInstall Node.js (>=18) and try again.",
-            file=sys.stderr,
-        )
+        # Node disappeared between the check above and the spawn.
+        print(_no_node_message(), file=sys.stderr)
         return 1
     return proc.returncode
 

--- a/claude_code_tools/node_menu_ui.py
+++ b/claude_code_tools/node_menu_ui.py
@@ -77,7 +77,8 @@ def _quote_path(path: Path) -> str:
     """
     text = str(path)
     if os.name == "nt":
-        return f'"{text}"' if " " in text else text
+        # cmd.exe splits on & | ^ < > as well as spaces, so always quote.
+        return f'"{text}"'
     return shlex.quote(text)
 
 

--- a/claude_code_tools/node_menu_ui.py
+++ b/claude_code_tools/node_menu_ui.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -17,11 +18,63 @@ from typing import Any, Callable, Dict, Iterable, List
 
 SessionDict = Dict[str, Any]
 
+#: Runtime npm packages ``menu.js`` imports directly. A checkout that is
+#: missing any of them cannot render a menu, so we check before spawning Node
+#: rather than letting Node print a raw ``ERR_MODULE_NOT_FOUND`` stack trace.
+NODE_UI_REQUIRED_PACKAGES = (
+    "chalk",
+    "figures",
+    "ink",
+    "ink-select-input",
+    "meow",
+    "react",
+)
+
+
+def _node_ui_dir() -> Path:
+    """Return the directory holding the bundled Node UI."""
+    here = Path(__file__).resolve()
+    return here.parent.parent / "node_ui"
+
 
 def _node_script_path() -> Path:
     """Return path to the bundled Node UI script."""
-    here = Path(__file__).resolve()
-    return here.parent.parent / "node_ui" / "menu.js"
+    return _node_ui_dir() / "menu.js"
+
+
+def _missing_node_ui_packages(node_ui_dir: Path | None = None) -> List[str]:
+    """Return the required Node UI packages that are not installed.
+
+    Args:
+        node_ui_dir: Directory to inspect. Defaults to the bundled ``node_ui``.
+
+    Returns:
+        Names of missing packages, empty when every requirement is present.
+    """
+    root = node_ui_dir if node_ui_dir is not None else _node_ui_dir()
+    node_modules = root / "node_modules"
+    if not node_modules.is_dir():
+        return list(NODE_UI_REQUIRED_PACKAGES)
+    return [
+        name
+        for name in NODE_UI_REQUIRED_PACKAGES
+        if not (node_modules / name).is_dir()
+    ]
+
+
+def _node_ui_setup_message(missing: List[str], node_ui_dir: Path) -> str:
+    """Build an actionable message for a Node UI with missing dependencies."""
+    return (
+        "aichat could not start its interactive menu: the Node UI "
+        f"dependencies are missing ({', '.join(missing)}).\n"
+        f"Expected them in: {node_ui_dir / 'node_modules'}\n"
+        "\n"
+        "This happens when aichat runs from a source checkout (an editable\n"
+        "install) whose Node dependencies were never installed. Install them\n"
+        "with either of:\n"
+        f"  npm ci --prefix {shlex.quote(str(node_ui_dir))} --omit=dev\n"
+        "  make install   # from that checkout\n"
+    )
 
 
 def _write_payload(
@@ -63,15 +116,30 @@ def _write_payload(
 def _run_node(data_path: Path, out_path: Path, stderr_mode: bool = False) -> int:
     """Invoke the Node UI process.
 
-    Returns the process return code.
+    Returns the process return code. A missing Node runtime or missing Node UI
+    dependencies are reported as an actionable message and return code 1.
     """
+    node_ui_dir = _node_ui_dir()
+    missing = _missing_node_ui_packages(node_ui_dir)
+    if missing:
+        print(_node_ui_setup_message(missing, node_ui_dir), file=sys.stderr)
+        return 1
+
     script = _node_script_path()
     cmd = ["node", str(script), "--data", str(data_path), "--out", str(out_path)]
     env = os.environ.copy()
     if stderr_mode:
         env["NODE_UI_STDERR"] = "1"
 
-    proc = subprocess.run(cmd, env=env)
+    try:
+        proc = subprocess.run(cmd, env=env)
+    except FileNotFoundError:
+        print(
+            "aichat could not start its interactive menu: 'node' was not found "
+            "on PATH.\nInstall Node.js (>=18) and try again.",
+            file=sys.stderr,
+        )
+        return 1
     return proc.returncode
 
 

--- a/docs-site/src/content/docs/development/index.mdx
+++ b/docs-site/src/content/docs/development/index.mdx
@@ -76,13 +76,12 @@ New or modified session
 
    ```bash
    uv sync
-   cd node_ui && npm install && cd ..
    ```
 
 4. **Install in editable mode:**
 
    ```bash
-   make install              # Python (editable)
+   make install              # Python (editable) + node_ui deps
    make install-gdocs        # with Google Docs/Sheets extras
    make aichat-search-install  # Rust binary
    ```
@@ -93,6 +92,15 @@ After setup, Python changes apply immediately
 (editable mode). For Rust changes, re-run
 `make aichat-search-install`. Node.js runs directly
 from `node_ui/` -- no build step needed.
+
+Because `make install` is an *editable* install, the
+`aichat` on your PATH runs from this checkout and uses
+this checkout's `node_ui/node_modules`. A fresh clone or
+git worktree therefore needs its own copy of those npm
+packages; `make install` installs them, and
+`make node-ui-deps` installs them on their own. Without
+them, `aichat` reports which packages are missing and
+where it expected to find them instead of starting a menu.
 
 ## Starlight Docs
 

--- a/docs-site/src/content/docs/development/testing.md
+++ b/docs-site/src/content/docs/development/testing.md
@@ -41,8 +41,9 @@ The test suite covers:
 - **Python** -- Editable mode (`make install`), so
   changes apply immediately. No reinstall needed.
 - **Node.js** -- Runs directly from `node_ui/`. No
-  build step. Run `cd node_ui && npm install` if
-  you add new npm dependencies.
+  build step. Run `make node-ui-deps` if you add new
+  npm dependencies, or in a fresh clone or worktree
+  that has no `node_ui/node_modules` yet.
 - **Rust** -- Must rebuild after changes:
 
   ```bash

--- a/tests/test_node_menu_ui_deps.py
+++ b/tests/test_node_menu_ui_deps.py
@@ -1,0 +1,129 @@
+"""Tests for the Node UI dependency preflight check.
+
+A source checkout used via an editable install keeps its own
+``node_ui/node_modules``. When that directory is missing, spawning Node
+produces a raw ``ERR_MODULE_NOT_FOUND`` stack trace, so the bridge checks
+first and reports something actionable instead.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+import pytest
+
+from claude_code_tools import node_menu_ui
+
+
+def _make_node_ui(root: Path, packages: tuple[str, ...]) -> Path:
+    """Create a node_ui directory populated with the given packages.
+
+    Args:
+        root: Directory in which to create ``node_ui``.
+        packages: Package names to create under ``node_modules``.
+
+    Returns:
+        Path to the created ``node_ui`` directory.
+    """
+    node_ui = root / "node_ui"
+    node_ui.mkdir()
+    (node_ui / "menu.js").write_text("// stub\n", encoding="utf-8")
+    if packages:
+        node_modules = node_ui / "node_modules"
+        node_modules.mkdir()
+        for name in packages:
+            (node_modules / name).mkdir(parents=True)
+    return node_ui
+
+
+def test_missing_packages_when_node_modules_absent(tmp_path: Path) -> None:
+    """Every requirement is reported when node_modules does not exist."""
+    node_ui = _make_node_ui(tmp_path, ())
+
+    missing = node_menu_ui._missing_node_ui_packages(node_ui)
+
+    assert missing == list(node_menu_ui.NODE_UI_REQUIRED_PACKAGES)
+
+
+def test_missing_packages_reports_only_absent_ones(tmp_path: Path) -> None:
+    """A partially installed node_modules reports just the gaps."""
+    present = tuple(node_menu_ui.NODE_UI_REQUIRED_PACKAGES[:-1])
+    node_ui = _make_node_ui(tmp_path, present)
+
+    missing = node_menu_ui._missing_node_ui_packages(node_ui)
+
+    assert missing == [node_menu_ui.NODE_UI_REQUIRED_PACKAGES[-1]]
+
+
+def test_no_missing_packages_when_fully_installed(tmp_path: Path) -> None:
+    """A complete node_modules reports nothing missing."""
+    node_ui = _make_node_ui(tmp_path, node_menu_ui.NODE_UI_REQUIRED_PACKAGES)
+
+    assert node_menu_ui._missing_node_ui_packages(node_ui) == []
+
+
+def test_run_node_fails_fast_without_dependencies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Node is never spawned when its dependencies are missing."""
+    node_ui = _make_node_ui(tmp_path, ())
+    monkeypatch.setattr(node_menu_ui, "_node_ui_dir", lambda: node_ui)
+
+    def _fail(*args: object, **kwargs: object) -> None:
+        raise AssertionError("node should not be spawned")
+
+    monkeypatch.setattr(node_menu_ui.subprocess, "run", _fail)
+
+    code = node_menu_ui._run_node(tmp_path / "in.json", tmp_path / "out.json")
+
+    assert code == 1
+    message = capsys.readouterr().err
+    assert "meow" in message
+    assert str(node_ui / "node_modules") in message
+    assert f"npm ci --prefix {shlex.quote(str(node_ui))} --omit=dev" in message
+
+
+def test_setup_message_quotes_paths_with_spaces(tmp_path: Path) -> None:
+    """The suggested npm command survives a checkout path containing spaces."""
+    spaced = tmp_path / "my checkout"
+    spaced.mkdir()
+    node_ui = _make_node_ui(spaced, ())
+
+    message = node_menu_ui._node_ui_setup_message(["meow"], node_ui)
+
+    assert f"--prefix {shlex.quote(str(node_ui))} " in message
+    assert f"--prefix {node_ui} " not in message
+
+
+def test_run_node_reports_missing_node_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An absent 'node' binary produces a message, not a traceback."""
+    node_ui = _make_node_ui(tmp_path, node_menu_ui.NODE_UI_REQUIRED_PACKAGES)
+    monkeypatch.setattr(node_menu_ui, "_node_ui_dir", lambda: node_ui)
+
+    def _missing_binary(*args: object, **kwargs: object) -> None:
+        raise FileNotFoundError("node")
+
+    monkeypatch.setattr(node_menu_ui.subprocess, "run", _missing_binary)
+
+    code = node_menu_ui._run_node(tmp_path / "in.json", tmp_path / "out.json")
+
+    assert code == 1
+    assert "'node' was not found on PATH" in capsys.readouterr().err
+
+
+def test_repository_requirements_match_package_manifest() -> None:
+    """The checked requirements are real node_ui runtime dependencies."""
+    import json
+
+    manifest_path = Path(__file__).resolve().parent.parent / "node_ui" / "package.json"
+    dependencies = json.loads(manifest_path.read_text(encoding="utf-8"))["dependencies"]
+
+    for name in node_menu_ui.NODE_UI_REQUIRED_PACKAGES:
+        assert name in dependencies

--- a/tests/test_node_menu_ui_deps.py
+++ b/tests/test_node_menu_ui_deps.py
@@ -102,6 +102,12 @@ def test_windows_paths_use_double_quotes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """cmd.exe treats POSIX single quotes literally, so use its own quoting."""
+    plain = _make_node_ui(tmp_path, ())
+    monkeypatch.setattr(node_menu_ui.os, "name", "nt")
+    # cmd.exe splits on metacharacters, not just spaces, so quote regardless.
+    assert f'--prefix "{plain}" ' in node_menu_ui._node_ui_setup_message(["meow"], plain)
+    monkeypatch.undo()
+
     spaced = tmp_path / "my checkout"
     spaced.mkdir()
     node_ui = _make_node_ui(spaced, ())

--- a/tests/test_node_menu_ui_deps.py
+++ b/tests/test_node_menu_ui_deps.py
@@ -127,3 +127,21 @@ def test_repository_requirements_match_package_manifest() -> None:
 
     for name in node_menu_ui.NODE_UI_REQUIRED_PACKAGES:
         assert name in dependencies
+
+
+def test_missing_node_runtime_is_reported_before_packages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Without Node installed, telling the user to run npm would be useless."""
+    node_ui = _make_node_ui(tmp_path, ())
+    monkeypatch.setattr(node_menu_ui, "_node_ui_dir", lambda: node_ui)
+    monkeypatch.setattr(node_menu_ui.shutil, "which", lambda _name: None)
+
+    code = node_menu_ui._run_node(tmp_path / "in.json", tmp_path / "out.json")
+
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "'node' was not found on PATH" in err
+    assert "npm ci" not in err

--- a/tests/test_node_menu_ui_deps.py
+++ b/tests/test_node_menu_ui_deps.py
@@ -98,6 +98,21 @@ def test_setup_message_quotes_paths_with_spaces(tmp_path: Path) -> None:
     assert f"--prefix {node_ui} " not in message
 
 
+def test_windows_paths_use_double_quotes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cmd.exe treats POSIX single quotes literally, so use its own quoting."""
+    spaced = tmp_path / "my checkout"
+    spaced.mkdir()
+    node_ui = _make_node_ui(spaced, ())
+    monkeypatch.setattr(node_menu_ui.os, "name", "nt")
+
+    message = node_menu_ui._node_ui_setup_message(["meow"], node_ui)
+
+    assert f'--prefix "{node_ui}" ' in message
+    assert "'" not in message.split("npm ci")[1].splitlines()[0]
+
+
 def test_run_node_reports_missing_node_runtime(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_search_import.py
+++ b/tests/test_search_import.py
@@ -26,13 +26,16 @@ def test_export_session_import_error_handling():
         raise
 
 
-def test_search_command_without_deps_gives_helpful_error():
+def test_search_command_without_deps_gives_helpful_error(tmp_path):
     """
     When tantivy or yaml is not installed, 'aichat search' should give a
     helpful error message rather than a raw ImportError traceback.
     """
     # Run aichat search in a subprocess to simulate the user's environment
-    # We use --help since it should work even without deps if imports are lazy
+    # We use --help since it should work even without deps if imports are lazy.
+    # HOME is redirected at a temp dir: aichat auto-indexes on every command,
+    # and pointing it at the developer's real home makes this rebuild their
+    # live session index, which blows past the timeout.
     result = subprocess.run(
         [
             sys.executable,
@@ -43,7 +46,7 @@ def test_search_command_without_deps_gives_helpful_error():
         ],
         capture_output=True,
         text=True,
-        env={"PATH": ""},  # Minimal env
+        env={"PATH": "", "HOME": str(tmp_path)},  # Minimal, isolated env
         timeout=SUBPROCESS_TIMEOUT_SECONDS,
     )
 


### PR DESCRIPTION
## Problem

`make install` performs an **editable** install, so `aichat` runs from the checkout and loads its Node menu from *that checkout's* `node_ui/node_modules`. That directory is gitignored and is not created by `git worktree add`, and `make install` only *printed* a reminder to run npm by hand.

A fresh clone or worktree therefore produced an `aichat` whose every menu died like this, with nothing telling the user what to do:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'meow' imported from
  /Users/.../claude-code-tools.some-worktree/node_ui/menu.js
```

It surfaces at the worst moment — the menu is only reached after a session has been selected, so it reads like the *session* failed rather than the install.

## Change

- **Makefile**: new `node-ui-deps` target that runs `npm ci` (falling back to `npm install`) in `node_ui/`, and `make install` now depends on it. If npm is missing it warns instead of failing the whole install.
- **node_menu_ui**: before spawning Node, check the runtime and then the packages `menu.js` imports. If any are missing, report *which*, *where they were expected*, and the exact command to install them, shell-quoted so it survives a checkout path with spaces. The runtime is checked first, since telling someone to run npm is useless on a machine with no Node.
- **docs**: describe `make node-ui-deps` and the editable-install/worktree trap in the development and testing pages.

Instead of the stack trace above, you now get:

```
aichat could not start its interactive menu: the Node UI dependencies are
missing (chalk, figures, ink, ink-select-input, meow, react).
Expected them in: /Users/.../claude-code-tools.some-worktree/node_ui/node_modules
...
  npm ci --prefix /Users/.../node_ui --omit=dev
  make install   # from that checkout
```

Also isolates `test_search_import`, which ran aichat against the developer's real home directory and could rebuild the live session index and time out.

## Testing

New tests cover the missing-runtime path, the missing-package path, partial installs, path quoting, and that the checked package list matches `node_ui/package.json`. Verified end to end in a checkout with no `node_modules`: readable message instead of the stack trace, then `make node-ui-deps` fixes it.

Reviewed by repeated contract-free cold-diff passes until clean.

**Pre-existing failures:** four `test_tmux_cli_controller.py` tests fail on this branch. They also fail on `main` and are unrelated to this change — they are fixed in #147.
