### PR TITLE
Document the hidden-by-default sessions and the aichat-search binary split

### DIFF
--- a/docs-site/src/content/docs/development/make-commands.md
+++ b/docs-site/src/content/docs/development/make-commands.md
@@ -17,6 +17,7 @@ commands. Below they are grouped by category.
 | `make install` | Install Python in editable mode (for development) |
 | `make install-gdocs` | Install with Google Docs extras |
 | `make dev-install` | Install with dev dependencies (includes commitizen) |
+| `make node-ui-deps` | Install `node_ui/` npm packages (needed by aichat's menus) |
 
 ## Version Bumping
 

--- a/docs-site/src/content/docs/tools/aichat/search.mdx
+++ b/docs-site/src/content/docs/tools/aichat/search.mdx
@@ -130,9 +130,13 @@ agents spawned. Search hides two such kinds by default:
 - **Sub-agent sessions.** Claude names these
   `agent-*.jsonl`; Codex records the spawn in the
   session's own metadata.
-- **Headless `codex exec` runs.** Workers launched by
-  orchestrating agents, scripts and review loops, rather
-  than by you at a terminal.
+- **Headless `codex exec` runs.** Every `codex exec`
+  invocation, whichever way it was started. Most are
+  workers spawned by orchestrating agents, scripts and
+  review loops -- but a `codex exec` you run yourself is
+  hidden too, so reach for `--exec-runs` when a session
+  you started that way is missing. Interactive `codex`
+  sessions are unaffected.
 
 On a machine driving agents hard these can outnumber real
 sessions by ten to one, so leaving them in makes search
@@ -147,7 +151,7 @@ aichat search "query" --sub-agent    # add sub-agents
 aichat search "query" --exec-runs    # add headless runs
 ```
 
-In the TUI, open the filter menu with `|` and toggle
+In the TUI, open the filter menu with `Ctrl-F` and toggle
 `(s)` for sub-agents or `(h)` for headless runs; `:s` and
 `:h` do the same from command mode. When shown, these
 sessions are marked `(s)` and `(h)` in the session list.

--- a/docs-site/src/content/docs/tools/aichat/search.mdx
+++ b/docs-site/src/content/docs/tools/aichat/search.mdx
@@ -39,6 +39,20 @@ brew install pchalasani/tap/aichat-search
 cargo install aichat-search
 ```
 
+:::caution[It upgrades separately]
+Because it is a separate binary, upgrading
+`claude-code-tools` does **not** update the search engine.
+Changes to the TUI -- new filters, keybindings, speed
+work -- only arrive when you upgrade `aichat-search`
+itself (`brew upgrade`, `cargo install aichat-search`, or
+`make aichat-search-install` from a checkout).
+
+If more than one copy is installed, the first on your
+`PATH` wins: a Homebrew copy shadows one in
+`~/.cargo/bin`, so a locally built binary appears to have
+no effect. Check with `which -a aichat-search`.
+:::
+
 ## Demo
 
 ![aichat-search demo](/claude-code-tools/assets/aichat-search-asciinema.gif)
@@ -97,7 +111,8 @@ cargo install aichat-search
 | `--no-original` | Exclude original sessions |
 | `--no-trimmed` | Exclude trimmed sessions |
 | `--no-rollover` | Exclude rollover sessions |
-| `--sub-agent` | Include sub-agent sessions |
+| `--sub-agent` | Include sub-agent sessions (hidden by default) |
+| `--exec-runs` | Include headless `codex exec` runs (hidden by default) |
 | `--live` | Show only currently running sessions |
 | `--by-time` | Sort by last-modified (default: relevance) |
 | `--json` | JSONL output for agents |
@@ -105,6 +120,37 @@ cargo install aichat-search
 Date formats: `YYYYMMDD`, `YYYY-MM-DD`, `MM/DD/YY`,
 `MM/DD/YYYY`. Optional time suffix: `T16:45:23`,
 `T16:45`, `T16`.
+
+## What is hidden by default
+
+Most sessions on a machine that runs coding agents were
+never a conversation you had -- they are workers other
+agents spawned. Search hides two such kinds by default:
+
+- **Sub-agent sessions.** Claude names these
+  `agent-*.jsonl`; Codex records the spawn in the
+  session's own metadata.
+- **Headless `codex exec` runs.** Workers launched by
+  orchestrating agents, scripts and review loops, rather
+  than by you at a terminal.
+
+On a machine driving agents hard these can outnumber real
+sessions by ten to one, so leaving them in makes search
+close to useless.
+
+Nothing is deleted, and nothing is left out of the index
+-- it is only filtered out of the results, so you can ask
+for it at any time:
+
+```bash
+aichat search "query" --sub-agent    # add sub-agents
+aichat search "query" --exec-runs    # add headless runs
+```
+
+In the TUI, open the filter menu with `|` and toggle
+`(s)` for sub-agents or `(h)` for headless runs; `:s` and
+`:h` do the same from command mode. When shown, these
+sessions are marked `(s)` and `(h)` in the session list.
 
 ## What gets indexed
 
@@ -116,6 +162,14 @@ The search engine indexes JSONL session files from:
 Custom locations can be set with `--claude-home` and
 `--codex-home` flags, or the `CLAUDE_CONFIG_DIR` and
 `CODEX_HOME` environment variables.
+
+Sub-agent and headless sessions are indexed like any
+other; they are hidden from results, not skipped.
+
+The index rebuilds itself when the indexing logic changes
+-- after an upgrade that stores new information about
+each session, the first run takes about a minute for a
+large history, then returns to incremental updates.
 
 ## Examples
 

--- a/rust-search-ui/src/main.rs
+++ b/rust-search-ui/src/main.rs
@@ -1659,7 +1659,7 @@ fn render_filter_modal(frame: &mut Frame, app: &App, t: &Theme, area: Rect) {
 
     // Modal border
     let block = Block::default()
-        .title(" Filters (|) ")
+        .title(" Filters (C-f) ")
         .borders(Borders::ALL)
         .style(Style::default().bg(t.search_bg));
     frame.render_widget(block, modal_area);


### PR DESCRIPTION
v1.22.0 changed two things that were only ever written down in the release note, which is the wrong place for behavior someone meets a year from now.

## Search hides some sessions by default

`aichat search` now excludes sub-agent sessions and headless `codex exec` runs from results. That is a good default — on a machine driving agents hard they outnumber real sessions by roughly ten to one — but nothing in the docs said it was happening, so a missing session looks like a bug in the index.

The search page now explains what those two kinds are, why they are hidden, that they are **indexed rather than skipped**, and every way to bring them back: `--sub-agent`, `--exec-runs`, the `(s)`/`(h)` toggles in the filter menu, and `:s`/`:h` in command mode.

## aichat-search upgrades separately

The search engine is a separate Rust binary, so upgrading `claude-code-tools` does not update the TUI — new filters, keybindings and performance work only arrive when you upgrade `aichat-search` itself. And when more than one copy is installed, the first on `PATH` wins, so a Homebrew copy silently shadows a locally built one in `~/.cargo/bin` and your rebuild appears to do nothing.

Both are now called out in a caution box right where the install instructions are, with `which -a aichat-search` as the diagnostic.

## Also

- Documents that the index rebuilds itself after an upgrade that changes what is stored, so the one slow first run is expected rather than alarming.
- Adds `make node-ui-deps` to the make-commands reference.

Docs only — no code changes. `npm run build` in `docs-site/` succeeds: 42 pages built.
