### PR TITLE
docs(aichat): document the session lookup's operational details

### DIFF
--- a/docs-site/src/content/docs/tools/aichat/actions.mdx
+++ b/docs-site/src/content/docs/tools/aichat/actions.mdx
@@ -151,3 +151,17 @@ Codex name lives in the home-level
 `session_index.jsonl`, keyed by a session id that
 `move` never changes. Afterwards `move` offers to
 switch to the new directory and resume the session.
+
+Both rewrites are atomic: the new content is written
+to a temporary file beside the destination and then
+swapped into place, so a move interrupted partway
+cannot leave you with a truncated transcript.
+
+:::caution
+An ambiguous query aborts the move and lists the
+candidates — nothing is written or deleted. That
+matters more here than elsewhere, because a Claude
+move removes the old transcript once the new one is
+written. (A Codex move never does: the rollout is
+rewritten where it already lives.)
+:::

--- a/docs-site/src/content/docs/tools/aichat/resolve.mdx
+++ b/docs-site/src/content/docs/tools/aichat/resolve.mdx
@@ -141,13 +141,55 @@ Those commands search **both** agent homes and detect
 the agent themselves, so `--agent` there narrows the
 search rather than selecting a home. It may come
 before or after the session argument, and
-`--agent=codex` works as well as `--agent codex`. Pass a session
-file path and no home is searched at all: the agent
-comes from the file's content, and `--agent` then
-requires the file to be that agent's. An ambiguous
-query fails with the candidate list instead of acting
-on an arbitrary match. `delete` and `menu` still use
-the older id-or-path lookup.
+`--agent=codex` works as well as `--agent codex`.
+
+Pass a session file path and no home is searched at
+all: the agent comes from the file's own content, and
+`--agent` then requires the file to be that agent's.
+A file that sits inside an agent home but does not
+read as a session is rejected, rather than trusted
+because of where it lives.
+
+An ambiguous query fails with the candidate list
+instead of acting on an arbitrary match. `delete` and
+`menu` still use the older id-or-path lookup.
+
+### Home overrides
+
+`--claude-home` and `--codex-home` before the
+subcommand apply to any of these commands, and carry
+through the interactive menus into whatever action
+you pick:
+
+```bash
+aichat --claude-home ~/.claude-work info my-session
+```
+
+`resume` also takes both flags itself; `trim` and
+`smart-trim` take their own `--claude-home`. A
+command-local flag wins over the root-level one.
+
+### Speed
+
+The lookup avoids the resolver's full scan whenever
+it safely can, because that scan reads every
+transcript in both homes — on a home with a few
+thousand sessions it costs on the order of ten
+seconds.
+
+- A **unique full id** normally answers in well under
+  a second. It is the top match tier, so no weaker
+  tier can outrank it and nothing else has to be
+  read.
+- A **partial id** costs a second or two: before
+  trusting a filename match, the lookup rules out a
+  session whose exact *name* is that same string,
+  since an exact name outranks a partial id.
+- A **name**, or anything else, goes through the full
+  scan.
+
+None of this changes which session you get — it only
+changes how much work is done to be sure of it.
 
 [`port`](../port/) takes the same query forms but
 resolves them on its own path: no `--agent` (use

--- a/docs-site/src/content/docs/tools/aichat/resume.mdx
+++ b/docs-site/src/content/docs/tools/aichat/resume.mdx
@@ -214,6 +214,14 @@ fragment, or a file path, across both agents — see
 [Resolve](../resolve/). An ambiguous query lists the
 candidates instead of guessing.
 
+Cloning follows the transcript you actually named.
+Give `aichat clone` a file path and it copies **that
+file** into the configured Claude project's session
+directory under a fresh session id, even if the
+transcript lives outside the Claude home — it does
+not rebuild a path from the working directory the
+session happens to record.
+
 ## Rollover options
 
 The `rollover` subcommand gives direct access to


### PR DESCRIPTION
The v1.21.0 release note carried nuance the docs did not. All of it is behavior a user can actually hit, so it belongs in the docs rather than in a release note nobody re-reads.

## What's added

**`resolve.mdx` — Speed.** Why some queries are instant and others take a moment, stated in terms of what the lookup has to do:

- a **unique full id** answers in well under a second — it is the top match tier, so no weaker tier can outrank it and nothing else has to be read;
- a **partial id** costs a second or two, because before trusting a filename match it must rule out a session whose exact *name* is that same string (an exact name outranks a partial id);
- a **name**, or anything else, goes through the full scan, which reads every transcript in both homes and costs on the order of ten seconds on a home with a few thousand sessions.

With the point that matters: none of this changes *which* session you get, only how much work is done to be sure of it.

**`resolve.mdx` — Home overrides.** Root-level `--claude-home` / `--codex-home` apply to all these commands and carry through the interactive menus into whatever action you pick. `resume` also takes both flags itself; `trim` and `smart-trim` take their own `--claude-home`; a command-local flag wins over the root-level one.

**`resolve.mdx`** also now notes that a file sitting inside an agent home which doesn't read as a session is rejected, rather than trusted because of where it lives.

**`actions.mdx` — Move.** Both agents' rewrites are atomic (temp file beside the destination, swapped into place), so an interrupted move can't leave a truncated transcript. Plus a caution that an ambiguous query aborts with nothing written or deleted — which matters more here because a Claude move removes the old transcript once the new one is written, while a Codex move never does.

**`resume.mdx` — Clone.** Given a file path, `clone` copies *that* transcript into the configured Claude project directory under a fresh session id, including one stored outside the Claude home — it does not rebuild a path from the working directory the session records.

## Verification

Docs build clean at 42 pages. Every claim was fact-checked against the source by a cold reviewer, which caught one real error: the caution originally said `move` deletes its source, which is only true for Claude — a Codex rollout is rewritten where it already lives. Re-checked green after the fix.