### PR TITLE
fix(aichat): make >trim timeouts diagnosable and size the CLI budget

### DIFF
--- a/plugins/aichat/hooks/aichat_resume_hook.py
+++ b/plugins/aichat/hooks/aichat_resume_hook.py
@@ -18,6 +18,8 @@ import json
 import math
 import os
 import re
+import shlex
+import shutil
 import stat
 import subprocess
 import sys
@@ -49,6 +51,23 @@ TRIM_PENDING_FUTURE_SLACK_SECS = 60
 AICHAT_BIN = os.environ.get("AICHAT_BIN", "aichat")
 
 TRIM_DEFAULT_THRESHOLD = 500
+
+# Time budget for one `aichat trim-in-place` run. The work is roughly
+# linear in transcript size (a 20 MB session previews in ~1s warm), so
+# the budget starts generous and grows with the file instead of being a
+# single fixed number that silently ran out on big sessions.
+TRIM_TIMEOUT_BASE_SECS = 25.0
+TRIM_TIMEOUT_PER_MB_SECS = 1.0
+TRIM_TIMEOUT_MAX_SECS = 60.0
+
+# Escape hatch (seconds) for pathological transcripts or slow machines.
+TRIM_TIMEOUT_ENV = "AICHAT_TRIM_TIMEOUT"
+
+# Ceiling on ANY child budget, override included. Claude Code gives the
+# whole hook the timeout in hooks.json (90s) and kills it without mercy
+# afterwards, so every budget must leave room for the hook to actually
+# report the timeout it just hit.
+TRIM_TIMEOUT_HARD_CAP_SECS = 75.0
 
 # ANSI colors
 BLUE = "\033[94m"
@@ -521,6 +540,134 @@ def _is_valid_trim_result(data) -> bool:
     return True
 
 
+def _file_size(path: str) -> Optional[int]:
+    """Size of ``path`` in bytes, or None if it cannot be stat'ed.
+
+    ``ValueError`` is caught alongside ``OSError``: the path comes from
+    stdin, and an embedded NUL makes ``os.path.getsize`` raise it.
+    """
+    try:
+        return os.path.getsize(path)
+    except (OSError, ValueError):
+        return None
+
+
+def _trim_timeout_secs(transcript_path: str) -> float:
+    """Seconds to allow one trim CLI run, scaled by transcript size.
+
+    ``AICHAT_TRIM_TIMEOUT`` overrides the computed budget when it parses
+    to a positive, finite number of seconds; anything else (unset,
+    garbage, zero, NaN) falls back to the size-scaled default. Every
+    result is clamped to ``TRIM_TIMEOUT_HARD_CAP_SECS`` so the hook
+    always outlives its child and can report what happened.
+    """
+    override = os.environ.get(TRIM_TIMEOUT_ENV, "").strip()
+    if override:
+        try:
+            seconds = float(override)
+        except ValueError:
+            seconds = 0.0
+        if math.isfinite(seconds) and seconds > 0:
+            return min(seconds, TRIM_TIMEOUT_HARD_CAP_SECS)
+    size = _file_size(transcript_path) or 0
+    size_mb = size / (1024 * 1024)
+    return min(
+        TRIM_TIMEOUT_MAX_SECS,
+        TRIM_TIMEOUT_HARD_CAP_SECS,
+        TRIM_TIMEOUT_BASE_SECS + size_mb * TRIM_TIMEOUT_PER_MB_SECS,
+    )
+
+
+def _resolved_aichat() -> str:
+    """Where PATH resolves ``AICHAT_BIN`` to, for error messages.
+
+    A stale or shadowed CLI is a plausible cause of a failing trim, and
+    the hook's own PATH is not the interactive shell's - so the message
+    names the binary that actually ran.
+    """
+    try:
+        found = shutil.which(AICHAT_BIN)
+    except OSError:
+        found = None
+    return found or f"{AICHAT_BIN} (not found on PATH)"
+
+
+def _quoted_cmd(cmd: list) -> str:
+    """Shell-quoted form of an argv list, safe to paste into a shell.
+
+    Session paths routinely contain spaces, and every element here came
+    from stdin or the environment, so the printed command is quoted
+    rather than joined - a copied line must run the command that ran,
+    not something the shell re-splits or expands.
+    """
+    return " ".join(shlex.quote(str(arg)) for arg in cmd)
+
+
+def _decoded(stream) -> str:
+    """Best-effort text for a subprocess stream that may be bytes."""
+    if isinstance(stream, bytes):
+        return stream.decode("utf-8", "replace")
+    return stream if isinstance(stream, str) else ""
+
+
+def _fmt_secs(value: float) -> str:
+    """A duration as written: '25', '1.5' - never rounded into a lie."""
+    return f"{value:.4g}"
+
+
+def _timeout_error_message(
+    cmd: list,
+    transcript_path: str,
+    timeout: float,
+    dry_run: bool,
+    exc: subprocess.TimeoutExpired,
+) -> str:
+    """Explain a trim-CLI timeout in terms the user can act on.
+
+    The old catch-all ("timeout or error") left no way to tell a slow
+    trim from a wedged process, so this names the budget that ran out,
+    the transcript and binary involved, and the exact command to run by
+    hand (shell-quoted, so paths with spaces reproduce faithfully).
+
+    A killed APPLY may or may not have swapped the trimmed file in
+    before it died, so only a preview may promise that nothing changed.
+    """
+    size = _file_size(transcript_path)
+    lines = [
+        f"The trim CLI did not finish within {_fmt_secs(timeout)}s, so "
+        f"it was stopped."
+    ]
+    if dry_run:
+        lines.append("This was only a preview, so nothing was changed.")
+    else:
+        lines.append(
+            "It was applying the trim, so whether the file was rewritten "
+            "is UNKNOWN. Check the transcript and any "
+            "*.pre-trim-*.jsonl.bak backup beside it before retrying."
+        )
+    lines += [
+        f"  transcript: {transcript_path} "
+        f"({_fmt_size(size) if size is not None else 'size unknown'})",
+        f"  binary:     {_resolved_aichat()}",
+        "",
+        "Run the same command yourself to see the real failure:",
+        f"  {_quoted_cmd(cmd)}",
+        "",
+        "If that returns quickly, the trim was starved rather than slow "
+        "- just retry >trim.",
+        f"To allow more time, set {TRIM_TIMEOUT_ENV} (seconds, up to "
+        f"{_fmt_secs(TRIM_TIMEOUT_HARD_CAP_SECS)}) before starting "
+        f"Claude.",
+    ]
+    # Both streams, labelled: whichever one the CLI got a word out on
+    # is the only clue to where it wedged.
+    for label, stream in (("stderr", exc.stderr), ("stdout", exc.stdout)):
+        printed = _decoded(stream).strip()
+        if printed:
+            lines += ["", f"It had printed on {label}: {printed[:300]}"]
+    return "\n".join(lines)
+
+
 def run_trim_cli(transcript_path: str, opts: dict, dry_run: bool):
     """Run `aichat trim-in-place` and parse its JSON result.
 
@@ -547,9 +694,10 @@ def run_trim_cli(transcript_path: str, opts: dict, dry_run: bool):
     if dry_run:
         cmd.append("--dry-run")
 
+    timeout = _trim_timeout_secs(transcript_path)
     try:
         proc = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=25
+            cmd, capture_output=True, text=True, timeout=timeout
         )
     except FileNotFoundError:
         return None, (
@@ -564,8 +712,22 @@ def run_trim_cli(transcript_path: str, opts: dict, dry_run: bool):
             f"Check the aichat CLI installation:\n"
             f"  uv tool install --force claude-code-tools"
         )
-    except subprocess.SubprocessError:
-        return None, "Trim command failed to run (timeout or error)."
+    except ValueError as e:
+        # E.g. a transcript path carrying an embedded NUL (stdin is
+        # hostile): subprocess rejects such argv before spawning.
+        return None, f"Cannot run the trim command ({e})."
+    except subprocess.TimeoutExpired as e:
+        # A timeout is the one failure with no output to explain it, so
+        # it gets the detailed treatment.
+        return None, _timeout_error_message(
+            cmd, transcript_path, timeout, dry_run, e
+        )
+    except subprocess.SubprocessError as e:
+        return None, (
+            f"Trim command failed to run "
+            f"({type(e).__name__}: {str(e) or 'no detail'}).\n"
+            f"Binary: {_resolved_aichat()}"
+        )
 
     lines = [ln.strip() for ln in proc.stdout.splitlines() if ln.strip()]
     payload = None
@@ -590,7 +752,8 @@ def run_trim_cli(transcript_path: str, opts: dict, dry_run: bool):
     detail = proc.stderr.strip() or proc.stdout.strip()
     detail = detail[:400] if detail else f"exit code {proc.returncode}"
     return None, (
-        f"aichat trim-in-place failed: {detail}\n\n"
+        f"aichat trim-in-place failed: {detail}\n"
+        f"Binary: {_resolved_aichat()}\n\n"
         f"If your aichat CLI predates this feature, update it with:\n"
         f"  uv tool install --force claude-code-tools"
     )

--- a/plugins/aichat/hooks/hooks.json
+++ b/plugins/aichat/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "bash -c 'if test -f \"${CLAUDE_PLUGIN_ROOT}/hooks/aichat_resume_hook.py\"; then python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/aichat_resume_hook.py\"; else echo \"{\\\"decision\\\":\\\"approve\\\"}\"; fi'",
-            "timeout": 30
+            "timeout": 90
           }
         ]
       }

--- a/tests/test_trim_hook.py
+++ b/tests/test_trim_hook.py
@@ -10,6 +10,7 @@ pending-state directory is redirected via ``AICHAT_TRIM_STATE_DIR``.
 from __future__ import annotations
 
 import ast
+import importlib.util
 import json
 import os
 import re
@@ -44,7 +45,8 @@ ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 # integer sizes (float() would overflow), "negative" = negative
 # savings, "floatnum" = float-typed tokens_saved, "nobackup" =
 # applied without a backup_file, "noisy" = warning line before the
-# JSON, "exitfail" = valid result JSON but nonzero exit.
+# JSON, "exitfail" = valid result JSON but nonzero exit, "hang" =
+# prints to stderr then blocks forever (never returns a result).
 STUB_SOURCE = '''#!/usr/bin/env python3
 """Stub `aichat` CLI for hook tests (records argv, prints JSON)."""
 import json
@@ -58,6 +60,14 @@ with open(RECORD, "a") as f:
     f.write(json.dumps(args) + "\\n")
 
 mode = os.environ.get("STUB_MODE", "")
+if mode == "hang":
+    import time
+    sys.stdout.write("stub: partial stdout\\n")
+    sys.stdout.flush()
+    sys.stderr.write("stub: about to hang\\n")
+    sys.stderr.flush()
+    time.sleep(300)
+    sys.exit(0)
 if mode == "error":
     print(json.dumps({"error": "boom: simulated failure"}))
     sys.exit(1)
@@ -220,6 +230,22 @@ def _reason(proc: subprocess.CompletedProcess[str]) -> str:
     out = json.loads(proc.stdout)
     assert out["decision"] == "block"
     return ANSI_RE.sub("", out["reason"])
+
+
+def _load_hook_module() -> Any:
+    """Import the hook script as a module, for pure-function checks.
+
+    Everything else here drives the hook as a real subprocess; a couple
+    of side-effect-free helpers (timeout sizing) are cheaper to check
+    directly than to infer from a message.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "aichat_resume_hook_under_test", HOOK
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 # ---------------------------------------------------------------------------
@@ -576,6 +602,185 @@ def test_invalid_cli_output_at_apply_time_is_graceful(
     reason = _reason(proc)
     assert "Trim failed" in reason
     assert not hk.state_file().exists()
+
+
+def test_timeout_says_what_timed_out(hk: Harness) -> None:
+    """A hung CLI must produce an actionable message.
+
+    The previous catch-all ("Trim command failed to run (timeout or
+    error)") was indistinguishable from every other failure, so a
+    recurring timeout looked like an unknown error. The message now
+    names the budget that ran out, the binary that actually ran, the
+    command to reproduce it by hand, and whatever the CLI managed to
+    print first.
+    """
+    proc = hk.run(
+        ">trim", env={"STUB_MODE": "hang", "AICHAT_TRIM_TIMEOUT": "1"}
+    )
+    reason = _reason(proc)
+    assert "did not finish within 1s" in reason
+    assert str(hk.stub) in reason
+    assert "--dry-run" in reason
+    assert str(hk.transcript) in reason
+    assert "nothing was changed" in reason.lower()
+    # Whichever stream the CLI got a word out on is the only clue to
+    # where it wedged, so neither may be dropped.
+    assert "stub: about to hang" in reason
+    assert "stub: partial stdout" in reason
+    assert not hk.state_file().exists()
+
+
+def test_timeout_reports_the_budget_it_actually_used(hk: Harness) -> None:
+    """A fractional budget must be reported as it was set - rounding
+    1.5s to "2s" names a limit that was never applied."""
+    proc = hk.run(
+        ">trim", env={"STUB_MODE": "hang", "AICHAT_TRIM_TIMEOUT": "1.5"}
+    )
+
+    reason = _reason(proc)
+    assert "did not finish within 1.5s" in reason
+
+
+def test_preview_timeout_command_is_shell_quoted(tmp_path: Path) -> None:
+    """The reproduce-by-hand command must survive copy-paste.
+
+    Session paths routinely contain spaces, so an unquoted command
+    would silently reproduce something else (or nothing).
+    """
+    hk = Harness(tmp_path)
+    spacey = tmp_path / "a dir with spaces"
+    spacey.mkdir()
+    hk.transcript = spacey / "my session.jsonl"
+    hk.transcript.write_text('{"type": "user"}\n')
+
+    proc = hk.run(
+        ">trim", env={"STUB_MODE": "hang", "AICHAT_TRIM_TIMEOUT": "1"}
+    )
+
+    reason = _reason(proc)
+    assert f"'{hk.transcript}'" in reason
+    assert f"{hk.transcript} --dry-run" not in reason
+
+
+def test_timeout_at_apply_time_admits_it_may_have_written(
+    hk: Harness,
+) -> None:
+    """A timeout while APPLYING must not promise the file is untouched.
+
+    subprocess kills the child outright, so the trim may already have
+    swapped the rewritten transcript in. The message has to say the
+    outcome is unknown and point at the backup, and the stale preview
+    must not stay armed.
+    """
+    hk.run(">trim")
+    assert hk.state_file().exists()
+
+    proc = hk.run(
+        ">trim yes", env={"STUB_MODE": "hang", "AICHAT_TRIM_TIMEOUT": "1"}
+    )
+
+    reason = _reason(proc)
+    assert "Trim failed" in reason
+    assert "did not finish within 1s" in reason
+    assert "UNKNOWN" in reason
+    assert ".bak" in reason
+    assert "nothing was changed" not in reason.lower()
+    # It timed out applying, so the reproduce command must not be a
+    # dry run - that would exercise a different code path.
+    assert "--dry-run" not in reason
+    assert not hk.state_file().exists()
+
+
+def test_transcript_path_with_nul_is_a_graceful_error(hk: Harness) -> None:
+    """A transcript path carrying an embedded NUL makes subprocess
+    raise ValueError before spawning; the hook must still block with a
+    message instead of silently passing the prompt through."""
+    proc = hk.run(">trim", transcript="/tmp/bad\x00path.jsonl")
+
+    reason = _reason(proc)
+    assert "Trim preview failed" in reason
+    assert "Cannot run the trim command" in reason
+    assert not hk.state_file().exists()
+
+
+@pytest.mark.parametrize(
+    "value", ["", "   ", "0", "-5", "abc", "nan", "inf", "1e999"]
+)
+def test_unusable_timeout_override_falls_back(
+    hk: Harness, value: str
+) -> None:
+    """A malformed AICHAT_TRIM_TIMEOUT must fall back to the computed
+    budget, never to zero/NaN/infinity - a zero budget would make every
+    trim "time out" instantly."""
+    proc = hk.run(">trim", env={"AICHAT_TRIM_TIMEOUT": value})
+
+    reason = _reason(proc)
+    assert "Trim preview" in reason
+    assert hk.state_file().exists()
+
+
+def test_timeout_budget_grows_with_transcript_size(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The budget scales with the file (trimming is ~linear in size)
+    and stays bounded, so a big session gets room without letting a
+    wedged CLI hold the prompt open indefinitely."""
+    monkeypatch.delenv("AICHAT_TRIM_TIMEOUT", raising=False)
+    hook = _load_hook_module()
+    base = hook.TRIM_TIMEOUT_BASE_SECS
+    cap = hook.TRIM_TIMEOUT_MAX_SECS
+    assert cap > base and hook.TRIM_TIMEOUT_PER_MB_SECS > 0
+
+    small = tmp_path / "small.jsonl"
+    small.write_text('{"type": "user"}\n')
+    assert hook._trim_timeout_secs(str(small)) == pytest.approx(
+        base, abs=0.1
+    )
+
+    # Sparse files: size without the I/O of actually writing them.
+    big = tmp_path / "big.jsonl"
+    with open(big, "wb") as fh:
+        fh.truncate(20 * 1024 * 1024)
+    assert base < hook._trim_timeout_secs(str(big)) <= cap
+
+    huge = tmp_path / "huge.jsonl"
+    with open(huge, "wb") as fh:
+        fh.truncate(200 * 1024 * 1024)
+    assert hook._trim_timeout_secs(str(huge)) == cap
+
+    # A missing file must not raise; it just gets the base budget.
+    assert hook._trim_timeout_secs(
+        str(tmp_path / "gone.jsonl")
+    ) == pytest.approx(base)
+
+    # A NUL in the path must not raise out of the size lookup.
+    assert hook._trim_timeout_secs("/tmp/bad\x00path") == pytest.approx(
+        base
+    )
+
+
+def test_no_child_budget_can_outlive_the_hook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every child budget - env override included - must stay under the
+    hook's own timeout in hooks.json, or Claude Code kills the hook
+    before it can report the timeout it just hit."""
+    hook = _load_hook_module()
+    session = tmp_path / "s.jsonl"
+    session.write_text("{}\n")
+
+    hook_timeout = json.loads(
+        (HOOK.parent / "hooks.json").read_text()
+    )["hooks"]["UserPromptSubmit"][0]["hooks"][0]["timeout"]
+    assert hook.TRIM_TIMEOUT_HARD_CAP_SECS < hook_timeout
+    assert hook.TRIM_TIMEOUT_MAX_SECS <= hook.TRIM_TIMEOUT_HARD_CAP_SECS
+
+    for override in ("1e15", "999999", str(hook_timeout + 1)):
+        monkeypatch.setenv("AICHAT_TRIM_TIMEOUT", override)
+        assert (
+            hook._trim_timeout_secs(str(session))
+            == hook.TRIM_TIMEOUT_HARD_CAP_SECS
+        )
 
 
 def test_missing_cli_suggests_install(hk: Harness) -> None:


### PR DESCRIPTION
## The problem

`>trim` has failed five separate times since 2026-07-20 — rja-compliance,
observability-feat (twice, 34 seconds apart), proposalwriter, and safeval —
always with the same sentence:

```
Trim preview failed:
Trim command failed to run (timeout or error).
```

That message is produced by exactly one branch in the hook: the trim
subprocess exceeding its fixed 25-second budget. But it says nothing, which
is why it reads as an unknown error.

## Why the budget was not the real problem

Timing `aichat trim-in-place --dry-run` against the exact sessions that
failed:

| session | size | measured | budget |
|---|---|---|---|
| safeval `33724a1f` | 20 MB | 0.7 – 2.4 s | 25 s |
| proposalwriter `a5293ae4` | 15 MB | 0.67 s | 25 s |
| rja-compliance `59aba5d8` | 6 MB | 2.0 s | 25 s |

The trim finishes 10–35× under budget, and no orphaned `.trim-tmp` file was
left behind (a process killed mid-trim would leave one). So the CLI was
being *stalled*, not running slow — which is also why `aichat resume` →
trim works fine on the same session.

**The stall itself is not diagnosed.** It does not reproduce outside the
live hook process: running the hook script by hand from the same cwd and
config dir completes in 0.7 s every time. So this PR targets the blindness
rather than a guessed cause.

## What changed

`plugins/aichat/hooks/aichat_resume_hook.py`

- A timeout now names the budget that ran out, the transcript and its size,
  the binary PATH actually resolved to, the exact shell-quoted command to
  rerun by hand, and whatever the CLI printed on **either** stream before
  wedging. Other subprocess failures name their exception type.
- An apply-time timeout no longer claims "nothing was changed" — a killed
  apply may already have swapped the trimmed file in, so it reports the
  outcome as **UNKNOWN** and points at the `.pre-trim-*.jsonl.bak` backup.
- The child budget scales with transcript size (25 s base, +1 s/MB, capped
  at 60 s), with an `AICHAT_TRIM_TIMEOUT` override hard-capped at 75 s so no
  child can outlive the hook and die unreported.
- A transcript path carrying an embedded NUL now blocks with a message
  instead of letting `ValueError` escape and silently passing the prompt
  through.

`plugins/aichat/hooks/hooks.json` — hook timeout 30 s → 90 s, so Claude Code
cannot kill the hook before it reports.

`tests/test_trim_hook.py` — 8 new tests driving a stub CLI that genuinely
hangs: message content, both output streams, shell quoting of paths with
spaces, fractional budgets, the apply-time uncertainty wording, budget
scaling and the hard cap versus `hooks.json`, and the NUL path.

## Verification

- Full suite: **1609 passed, 7 skipped**.
- Codex adversarial review, two lenses (one contract-free cold diff, one
  contract-anchored), three rounds, both green at the end. They caught the
  false "nothing was changed" assurance, the unquoted reproduce command, the
  override exceeding the hook budget, the escaping `ValueError`, a fractional
  budget rounded into a lie, and discarded stdout — all fixed and
  re-reviewed.

## What this does not do

It will not stop `>trim` from failing, because the stall is still
unidentified. It guarantees the next failure names the budget, the binary
and the CLI's dying words, which should make the cause findable in one more
occurrence.
