### PR TITLE
chore(aichat): bump plugin to 1.15.1 so the >trim timeout fix actually ships

### DIFF
--- a/docs-site/src/content/docs/tools/aichat/resume.mdx
+++ b/docs-site/src/content/docs/tools/aichat/resume.mdx
@@ -164,6 +164,32 @@ same session ID and writes a timestamped backup
 (`<id>.pre-trim-<ts>.jsonl.bak`) next to the file, which the
 truncation placeholders reference.
 
+### When a trim times out
+
+The hook gives the trim a time budget: 25 seconds, plus a second
+per megabyte of transcript, capped at 60. If that runs out, the
+trim is stopped and the message tells you the budget that
+expired, the transcript and its size, which `aichat` your PATH
+resolved to, a copy-pasteable command to reproduce it, and
+whatever the CLI printed before it stopped.
+
+A preview that times out changes nothing. An **apply** that times
+out is different: the subprocess is killed outright, so the
+rewrite may or may not have landed. That message says the outcome
+is unknown and points you at the timestamped
+`.pre-trim-<ts>.jsonl.bak` backup — check it before retrying.
+
+Set `AICHAT_TRIM_TIMEOUT` (seconds, hard-capped at 75) before
+starting Claude to widen the budget:
+
+```bash
+AICHAT_TRIM_TIMEOUT=70 claude
+```
+
+The cap exists so the trim can never outlive the hook itself —
+otherwise Claude Code would kill the hook first and you would get
+no explanation at all.
+
 ### Same engine on the command line
 
 `>trim` shells out to `aichat trim-in-place`, which you can run

--- a/plugins/aichat/.claude-plugin/plugin.json
+++ b/plugins/aichat/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aichat",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Provides an agent, skill, hook, and slash command related to the `aichat` tool-set for searching, resuming, and trimming CLI-agent sessions",
   "author": {
     "name": "Prasad Chalasani"


### PR DESCRIPTION
## Why

The `>trim` fix released in **v1.23.1** (PR #154) changed two files that both
live inside the **plugin**:

- `plugins/aichat/hooks/aichat_resume_hook.py`
- `plugins/aichat/hooks/hooks.json` (hook timeout 30s → 90s)

Claude Code does not run those from the repo. It runs the copy it caches at
`plugins/cache/cctools-plugins/aichat/<version>/`, and that cache directory is
keyed by the `version` field in `plugin.json` — which was still `1.15.0`.

So updating the CLI deployed nothing. Verified on disk after the v1.23.1
install:

| location | version | has the fix? |
|---|---|---|
| `aichat` CLI (uv tool) | 1.23.1 | n/a — the CLI was not what changed |
| `~/.claude/…/aichat/1.15.0/hooks/` | 1.15.0 | **no** — old message, `"timeout": 30` |
| `~/.claude-rja/…/aichat/1.15.0/hooks/` | 1.15.0 | **no** — old message, `"timeout": 30` |

Typing `>trim` would still have produced the old, uninformative
`Trim command failed to run (timeout or error)`.

## What this changes

- `plugins/aichat/.claude-plugin/plugin.json`: `1.15.0` → `1.15.1`, so Claude
  Code fetches a fresh cache directory containing the fixed hook.
- `docs-site/…/tools/aichat/resume.mdx`: a new **"When a trim times out"**
  section. The timeout budget, the `AICHAT_TRIM_TIMEOUT` override and its 75s
  hard cap, and — importantly — that a timed-out *preview* changes nothing
  while a timed-out *apply* leaves the outcome unknown and you should check the
  `.pre-trim-<ts>.jsonl.bak` backup. None of that was documented.

The marketplace entry needs no edit: it points at `./plugins/aichat` and takes
the version from `plugin.json`.

## Verification

- Confirmed this branch carries the merged hook fix and `"timeout": 90`.
- `docs-site` builds clean: 42 pages, no errors.

After merge, reinstall/update the `aichat` plugin and restart Claude — then a
`>trim` failure will finally report its own cause.
