### PR TITLE
fix(aichat): skip auto-indexing for trim-in-place (the real >trim timeout cause)

### DIFF
--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -226,9 +226,15 @@ def main(ctx, claude_home, codex_home):
     # 'port' is also skipped: its contract requires the detected
     # direction line to be the FIRST output, so the indexer's progress
     # bar must never print before it.
+    # 'trim-in-place' is skipped because it never queries the index
+    # (it resolves a path directly) and it runs under the >trim hook's
+    # time budget: indexing ~13.6k session files took 2-30s depending
+    # on the backlog, against a ~0.3s trim, which is what made >trim
+    # time out. Trimming also rewrites the file, so indexing its
+    # pre-trim content first is wasted work twice over.
     skip_auto_index_cmds = ['build-index', 'clear-index', 'index-stats']
     should_skip = (
-        ctx.invoked_subcommand in ('port', 'resolve')
+        ctx.invoked_subcommand in ('port', 'resolve', 'trim-in-place')
         or ctx.invoked_subcommand in skip_auto_index_cmds
         or any(cmd in sys.argv for cmd in skip_auto_index_cmds)
     )

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -1,0 +1,112 @@
+"""
+Regression tests for which subcommands skip auto-indexing.
+
+The bug: the `main` group callback ran `auto_index()` before every
+subcommand, walking every session file in both agent homes (~13.6k
+files on the reporter's machine, 2-30s depending on the backlog).
+`trim-in-place` paid that cost even though it never queries the index,
+and it runs under the `>trim` hook's time budget - so `>trim` timed
+out on indexing rather than on the ~0.3s trim itself.
+
+Commands that never read the index must not pay for it.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from claude_code_tools.aichat import main
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_auto_index():
+    """Mock auto_index so no real indexing runs."""
+    with patch("claude_code_tools.search_index.auto_index") as mock:
+        mock.return_value = {
+            "indexed": 0,
+            "skipped": 0,
+            "failed": 0,
+            "total_files": 0,
+        }
+        yield mock
+
+
+def _invoke(runner, argv):
+    """Run the CLI with sys.argv patched (the callback reads it)."""
+    with patch.object(sys, "argv", ["aichat"] + argv):
+        return runner.invoke(main, argv)
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["trim-in-place", "--help"],
+        ["port", "--help"],
+        ["resolve", "--help"],
+        ["build-index", "--help"],
+    ],
+)
+def test_index_free_commands_do_not_auto_index(
+    runner, mock_auto_index, argv
+):
+    """These never query the index, so they must not build it."""
+    _invoke(runner, argv)
+    mock_auto_index.assert_not_called()
+
+
+def test_search_still_auto_indexes(runner, mock_auto_index):
+    """The skip list must stay narrow: search reads the index, so it
+    still has to refresh it first."""
+    _invoke(runner, ["search", "--help"])
+    mock_auto_index.assert_called_once()
+
+
+def test_trim_in_place_skips_indexing_on_a_real_run(
+    runner, mock_auto_index, tmp_path
+):
+    """Not just --help: an actual trim must skip indexing too.
+
+    A skip keyed off `--help` alone would leave the real `>trim` path
+    paying the full cost, which is the bug this guards.
+    """
+    session = tmp_path / "s.jsonl"
+    session.write_text(
+        '{"type":"user","message":{"role":"user","content":"hi"},'
+        '"uuid":"a","timestamp":"2026-01-01T00:00:00Z"}\n'
+    )
+
+    result = _invoke(
+        runner,
+        ["trim-in-place", str(session), "--json", "--dry-run"],
+    )
+
+    mock_auto_index.assert_not_called()
+    assert result.exit_code == 0, result.output
+    assert '"dry_run": true' in result.output
+
+
+def test_trim_in_place_still_works_without_the_index(
+    runner, mock_auto_index, tmp_path
+):
+    """Skipping the index must not break path resolution - the command
+    resolves a path directly and never consults the index."""
+    session = tmp_path / "s.jsonl"
+    session.write_text(
+        '{"type":"user","message":{"role":"user","content":"hi"},'
+        '"uuid":"a","timestamp":"2026-01-01T00:00:00Z"}\n'
+    )
+
+    result = _invoke(
+        runner,
+        ["trim-in-place", str(session), "--json", "--dry-run"],
+    )
+
+    assert str(Path(session).resolve()) in result.output


### PR DESCRIPTION
## Root cause of the `>trim` timeouts

The `main` group callback runs `auto_index()` before **every** subcommand,
walking every session file in both agent homes — **13,656 files** on my
machine. `trim-in-place` was not on the skip list, so every `>trim` paid for
a full incremental index scan before doing any trimming.

Measured on the reporting machine:

| | time |
|---|---|
| `auto_index`, essentially nothing changed (22 files) | **4.46 s** |
| the actual trim of a 20 MB session | **0.29 s** |
| `aichat trim-in-place` end to end, quiet index | 4.49 s |
| same, with the fix | **0.36 s** |

With any real backlog the scan ran far longer — I observed 30 s+ — which is
what blew the `>trim` hook's budget.

This explains the observations that broke every size-based theory:

- **A one-line transcript was just as slow as a 20 MB one.** The cost is the
  13.6k-file walk, not the file being trimmed.
- **`aichat --version` stayed fast.** Click's eager `--version` exits before
  the group callback runs.
- **`aichat resume` "worked fine".** It pays exactly the same indexing cost,
  but interactively there is no timeout — it just feels like a slow start.
- **It was intermittent.** It depends entirely on how much churned since the
  last `aichat` call, and a live session churns constantly.

## The change

`trim-in-place` joins `port` and `resolve` in the skip tuple. It never queries
the index — it resolves a path directly — so it has no reason to pay for one.
Trimming also rewrites the file, so indexing its pre-trim content immediately
beforehand is wasted work twice over. The next `aichat` command re-indexes the
trimmed file normally.

## Tests

New `tests/test_aichat_autoindex_skip.py`:

- index-free commands (`trim-in-place`, `port`, `resolve`, `build-index`) do
  not call `auto_index`
- `search` **still** does — the skip list must stay narrow
- a *real* `trim-in-place --dry-run` skips indexing and still succeeds, not
  just `--help` (a skip keyed off `--help` would leave the actual `>trim` path
  paying the full cost, which is the bug being guarded)
- path resolution still works without the index

Full suite: **1616 passed, 7 skipped**.

## Relation to #154 / #155

Those made the failure *visible* — the diagnostic they added is what located
this, on its first real use. They are still worth having: the message now
names the budget, binary and partial output on any future timeout. This PR
removes the cause.
