### PR TITLE
fix(port): emit the UI event stream so ported Codex sessions can rewind

### DIFF
--- a/claude_code_tools/port_claude_to_codex.py
+++ b/claude_code_tools/port_claude_to_codex.py
@@ -485,13 +485,54 @@ def _make_codex_item(
     }
 
 
+def _make_codex_event(
+    role: str, text: str, timestamp: str
+) -> dict[str, Any]:
+    """Build the UI event matching one synthesized response item.
+
+    Args:
+        role: Message role, either ``user`` or ``assistant``.
+        text: The exact flattened text used by the response item.
+        timestamp: The exact timestamp used by the response item.
+
+    Returns:
+        A Codex ``event_msg`` record for TUI transcript replay.
+    """
+    payload: dict[str, Any]
+    if role == "user":
+        payload = {
+            "type": "user_message",
+            "message": text,
+            "images": [],
+            "local_images": [],
+            "audio": [],
+            "local_audio": [],
+            "text_elements": [],
+        }
+    else:
+        # `phase` mirrors the response item this event pairs with, and
+        # `memory_citation` is always present (usually null) on real
+        # agent_message events; both are omitted by older rollouts.
+        payload = {
+            "type": "agent_message",
+            "message": text,
+            "phase": _ASSISTANT_PHASE,
+            "memory_citation": None,
+        }
+    return {
+        "timestamp": timestamp,
+        "type": "event_msg",
+        "payload": payload,
+    }
+
+
 def _iter_rollout_lines(
     messages: Iterator[dict[str, Any]],
     *,
     session_meta_line: dict[str, Any],
     fallback_timestamp: str,
 ) -> Iterator[dict[str, Any]]:
-    """Yield the session_meta line, then every response_item line.
+    """Yield session metadata and paired model/UI message records.
 
     Every item carries the UUIDv7 turn-id passthrough real rollouts
     have: a fresh turn id is minted whenever a user message starts a
@@ -516,7 +557,11 @@ def _iter_rollout_lines(
         ):
             turn_id = _new_codex_session_id()
         prev_role = msg["role"]
-        yield _make_codex_item(msg, fallback_timestamp, turn_id)
+        item = _make_codex_item(msg, fallback_timestamp, turn_id)
+        yield item
+        yield _make_codex_event(
+            msg["role"], msg["text"], item["timestamp"]
+        )
 
 
 def _rollback_history_append(

--- a/docs-site/src/content/docs/tools/aichat/port.mdx
+++ b/docs-site/src/content/docs/tools/aichat/port.mdx
@@ -135,6 +135,12 @@ metadata for `aichat` tooling.
 - The ported transcript is a **faithful flattening**, not a byte-level
   replay: the target agent sees every turn's text and all tool activity as
   labeled text, which is what matters for continuing the work.
+- **Rewind works in the ported session.** A Codex rollout carries two
+  streams: the conversation the model reads, and a UI event log the TUI
+  replays to rebuild your scrollback. Porting writes both, so a ported
+  session lets you step back through the sequence of user messages exactly
+  as a native one does. Porting the other way preserves the same ability in
+  Claude Code, which walks the transcript's own message chain.
 - Very long sessions port fine (conversion is streaming), but resuming a huge
   transcript consumes context in the target agent -- consider
   [trimming](./resume/) first.

--- a/tests/test_port_claude_to_codex.py
+++ b/tests/test_port_claude_to_codex.py
@@ -333,6 +333,15 @@ def _read_lines(path: Path) -> list[dict[str, Any]]:
         return [json.loads(line) for line in f if line.strip()]
 
 
+def _response_items(out_path: Path) -> list[dict[str, Any]]:
+    """Read only model-facing response items from a rollout."""
+    return [
+        line
+        for line in _read_lines(out_path)
+        if line.get("type") == "response_item"
+    ]
+
+
 def _item_pairs(out_path: Path) -> list[tuple[str, str]]:
     """Extract (role, text) pairs from a rollout's response items."""
     return [
@@ -340,7 +349,7 @@ def _item_pairs(out_path: Path) -> list[tuple[str, str]]:
             item["payload"]["role"],
             item["payload"]["content"][0]["text"],
         )
-        for item in _read_lines(out_path)[1:]
+        for item in _response_items(out_path)
     ]
 
 
@@ -451,7 +460,7 @@ class TestConverter:
         same turn id, as in real rollouts.
         """
         _, _, out_path = ported
-        items = _read_lines(out_path)[1:]
+        items = _response_items(out_path)
         assert items, "no response items written"
         prev_role = None
         prev_turn_id = None
@@ -551,7 +560,7 @@ class TestConverter:
         self, ported: Ported
     ) -> None:
         _, _, out_path = ported
-        items = _read_lines(out_path)[1:]
+        items = _response_items(out_path)
         texts = [
             i["payload"]["content"][0]["text"] for i in items
         ]
@@ -575,7 +584,7 @@ class TestConverter:
         self, ported: Ported
     ) -> None:
         _, _, out_path = ported
-        items = _read_lines(out_path)[1:]
+        items = _response_items(out_path)
         texts = [
             i["payload"]["content"][0]["text"] for i in items
         ]
@@ -686,7 +695,7 @@ class TestConverter:
 
     def test_no_empty_messages(self, ported: Ported) -> None:
         _, _, out_path = ported
-        for item in _read_lines(out_path)[1:]:
+        for item in _response_items(out_path):
             assert item["payload"]["content"][0]["text"].strip()
 
     def test_history_jsonl_appended(
@@ -743,7 +752,7 @@ class TestConverter:
         _, out_path = port_claude_session_to_codex(
             path, codex_home=codex_home
         )
-        items = _read_lines(out_path)[1:]
+        items = _response_items(out_path)
         assert items[0]["payload"]["role"] == "user"
         assert (
             f"[Transcript ported from Claude Code session {CLAUDE_SID}]"

--- a/tests/test_port_claude_to_codex_events.py
+++ b/tests/test_port_claude_to_codex_events.py
@@ -1,0 +1,150 @@
+"""Tests for the Codex UI event stream synthesized during a port."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from claude_code_tools.port_claude_to_codex import (
+    port_claude_session_to_codex,
+)
+from tests.test_port_claude_to_codex import (
+    CLAUDE_SID,
+    _line,
+    _read_lines,
+)
+
+
+@pytest.fixture
+def codex_home(tmp_path: Path) -> Path:
+    """Create an empty Codex home."""
+    path = tmp_path / "codex-home"
+    path.mkdir()
+    return path
+
+
+def _port(tmp_path: Path, codex_home: Path, lines: list[str]) -> Path:
+    """Port a real temporary Claude JSONL file and return its rollout."""
+    source = tmp_path / f"{CLAUDE_SID}.jsonl"
+    source.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    _, rollout = port_claude_session_to_codex(
+        source, codex_home=codex_home
+    )
+    return rollout
+
+
+def _message_records(path: Path) -> list[dict[str, Any]]:
+    """Read rollout records after session metadata."""
+    return _read_lines(path)[1:]
+
+
+def test_events_pair_with_unchanged_response_sequence(
+    tmp_path: Path, codex_home: Path
+) -> None:
+    """Each response is immediately followed by its matching UI event."""
+    source_messages = [
+        ("user", "first question"),
+        ("assistant", "first answer"),
+        ("user", "second question"),
+        ("assistant", "second answer"),
+    ]
+    lines = [
+        _line(index, role, text)
+        for index, (role, text) in enumerate(source_messages)
+    ]
+    records = _message_records(_port(tmp_path, codex_home, lines))
+
+    responses = records[::2]
+    assert [
+        (
+            record["payload"]["role"],
+            record["payload"]["content"][0]["text"],
+        )
+        for record in responses
+    ] == source_messages
+
+    for response, event in zip(responses, records[1::2]):
+        role = response["payload"]["role"]
+        text = response["payload"]["content"][0]["text"]
+        expected_type = (
+            "user_message" if role == "user" else "agent_message"
+        )
+        assert response["type"] == "response_item"
+        assert event["type"] == "event_msg"
+        assert event["timestamp"] == response["timestamp"]
+        assert event["payload"]["type"] == expected_type
+        assert event["payload"]["message"] == text
+
+
+def test_event_payloads_have_exact_native_shapes(
+    tmp_path: Path, codex_home: Path
+) -> None:
+    """User and assistant UI payloads match native rollout shapes."""
+    records = _message_records(
+        _port(
+            tmp_path,
+            codex_home,
+            [_line(0, "user", "hello"), _line(1, "assistant", "hi")],
+        )
+    )
+    user_response, user_event, agent_response, agent_event = records
+    assert user_event == {
+        "timestamp": user_response["timestamp"],
+        "type": "event_msg",
+        "payload": {
+            "type": "user_message",
+            "message": "hello",
+            "images": [],
+            "local_images": [],
+            "audio": [],
+            "local_audio": [],
+            "text_elements": [],
+        },
+    }
+    assert agent_event == {
+        "timestamp": agent_response["timestamp"],
+        "type": "event_msg",
+        "payload": {
+            "type": "agent_message",
+            "message": "hi",
+            # Real agent_message events carry both of these; `phase`
+            # matches the paired response item, `memory_citation` is
+            # present and null unless Codex cited a memory.
+            "phase": agent_response["payload"]["phase"],
+            "memory_citation": None,
+        },
+    }
+
+
+def test_user_only_session_emits_only_user_events(
+    tmp_path: Path, codex_home: Path
+) -> None:
+    """A session without assistant replies emits one user event per turn."""
+    records = _message_records(
+        _port(
+            tmp_path,
+            codex_home,
+            [_line(0, "user", "one"), _line(1, "user", "two")],
+        )
+    )
+    event_types = [
+        record["payload"]["type"]
+        for record in records
+        if record["type"] == "event_msg"
+    ]
+    assert event_types == ["user_message", "user_message"]
+
+
+def test_assistant_only_session_emits_matching_events(
+    tmp_path: Path, codex_home: Path
+) -> None:
+    """An assistant-only source includes its synthetic opener event."""
+    records = _message_records(
+        _port(tmp_path, codex_home, [_line(0, "assistant", "hello")])
+    )
+    event_types = [
+        record["payload"]["type"]
+        for record in records
+        if record["type"] == "event_msg"
+    ]
+    assert event_types == ["user_message", "agent_message"]


### PR DESCRIPTION
Reported symptom: after `aichat port` moves a session from Claude to Codex, the conversation context is all there and Codex continues the work fine — but you **cannot rewind**. Stepping back through the sequence of user messages, the way you can in a native Codex session, does nothing.

## Cause

A Codex rollout carries **two parallel streams**:

- `response_item` records — the conversation the **model** reads;
- `event_msg` records — the **UI event log** the TUI replays to rebuild your scrollback, including one `event_msg` with `payload.type == "user_message"` for every turn you typed.

The porter synthesizes a rollout from scratch and wrote only the model stream. Counted on a freshly ported 802-line session, in a scratch Codex home:

| record | ported (before) | native session |
|---|---|---|
| `response_item/message` | 802 (66 `role=user`) | present |
| `event_msg/user_message` | **0** | one per user turn |
| `event_msg/agent_message` | **0** | one per assistant turn |

No `user_message` events means no rewind points. The context worked because that comes from the *other* stream.

This is specific to porting: `aichat trim` and `aichat clone` **copy** an existing rollout and only rewrite response items, so the original events survive and rewind still works there. Only the porter builds a rollout from nothing.

## Fix

Each response item is now paired with its event, emitted immediately after it — the ordering real rollouts use:

```
response_item/message role=user
event_msg/user_message
```

Payload shapes were taken from native rollouts on this machine: user events carry the empty `images` / `local_images` / `audio` / `local_audio` / `text_elements` lists; agent events carry `phase` (mirroring the paired response item) and `memory_citation`.

Conversion stays streaming and the write stays atomic. The `response_item` stream is untouched — resuming already worked and must keep behaving identically.

**Deliberately not synthesized:** `turn_context`, `world_state`, and the event types a ported transcript has no basis for (`token_count`, `agent_reasoning`, `task_started`, …). Ported sessions already resume correctly without them, so adding them would risk resume behavior for no gain against this bug.

## The other direction was fine

Checked before assuming: a ported Claude transcript has real `user`/`assistant` lines, every `uuid`/`parentUuid` link resolves, and there is exactly one root — which is what Claude Code walks to rewind. No change needed.

## Verification

End to end on a real session: **39 `user_message` events for 39 user turns, 218 `agent_message` events for 218 assistant turns**, with zero ordering, text, or timestamp mismatches against their response items.

Tests: 4 new cases covering counts, ordering, exact payload shape, timestamp pairing, and the user-only / assistant-only edge cases. Full suite **1620 passed, 7 skipped**.

A cold review caught one thing before this landed: my first pass omitted `phase` and `memory_citation` from agent events, because the native sample I copied the shape from had been truncated when I printed it.

Docs updated to state that rewind works in a ported session, in both directions.