### PR TITLE
fix(port): respect compaction boundaries when porting sessions

### DIFF
--- a/claude_code_tools/export_session.py
+++ b/claude_code_tools/export_session.py
@@ -87,6 +87,14 @@ CODEX_WRAPPER_TEXT_PREFIXES: tuple = (
     "<apps_instructions>",
     "<plugins_instructions>",
     "<multi_agent_mode>",
+    # Two forms: the goal-context injection Codex re-injects as its
+    # own user message every turn carries attributes
+    # (<codex_internal_context source="goal">), so the attribute form
+    # ends at the space; a bare closing form is matched exactly.
+    # Never a bare "<codex_internal_context" prefix: that would also
+    # swallow genuine text starting with a longer tag name.
+    "<codex_internal_context ",
+    "<codex_internal_context>",
     "# AGENTS.md instructions",
 )
 

--- a/claude_code_tools/port_claude_to_codex.py
+++ b/claude_code_tools/port_claude_to_codex.py
@@ -34,6 +34,16 @@ Only flattened tool arguments/results are truncated (at
 ``TOOL_TEXT_CAP`` characters, with an explicit suffix); ordinary
 message text is preserved verbatim.
 
+Compaction: Claude session files are append-only logs, so a session
+that was compacted still contains its full pre-compaction history --
+history the live Claude session no longer sends to the model. Porting
+mirrors Claude Code's own resume semantics: when the session holds
+compact-summary lines (``type: user`` with ``isCompactSummary:
+true``, written right after a ``compact_boundary`` system line),
+everything before the LAST one is dropped and the transcript starts
+from that summary message (whose plaintext already summarizes the
+dropped history) followed by the lines recorded after it.
+
 Durability: the rollout is written to a temporary file in the
 destination directory and atomically renamed onto its final path only
 after the whole transcript was written (reusing the atomic writer of
@@ -358,15 +368,76 @@ def _flatten_claude_line(
     return _flatten_assistant_content(content)
 
 
+def _is_compact_summary_line(data: dict[str, Any]) -> bool:
+    """Check whether a record is a main-chain compact-summary line.
+
+    Claude Code writes a ``type: user`` line with ``isCompactSummary:
+    true`` right after each ``compact_boundary`` system line; its
+    plaintext summarizes the history the live session no longer sends
+    to the model. Sidechain lines are excluded: a summary inside a
+    subagent transcript must not truncate the main transcript. A
+    marked line that flattens to no usable text (malformed or empty)
+    is also excluded -- treating it as a boundary would drop the
+    whole preceding transcript while contributing no summary.
+
+    Args:
+        data: A parsed top-level Claude session record.
+
+    Returns:
+        True if the record is a usable main-chain compact-summary
+        line.
+    """
+    if (
+        data.get("type") != "user"
+        or data.get("isCompactSummary") is not True
+        or data.get("isSidechain") is True
+    ):
+        return False
+    return any(
+        text.strip() for _, text in _flatten_claude_line(data)
+    )
+
+
+def _find_last_compact_summary_index(
+    claude_session_file: Path,
+) -> Optional[int]:
+    """Locate the last compact-summary line of a Claude session.
+
+    Streaming pass over the parsed records. Compactions chain (each
+    summary already covers everything before it, including earlier
+    compactions), so only the LAST one matters.
+
+    Args:
+        claude_session_file: Path to the Claude session JSONL file.
+
+    Returns:
+        The index of the last compact-summary line within the stream
+        of parsed records, or None when the session was never
+        compacted. Indices are stable across passes because both
+        passes parse records with the same tolerant reader.
+    """
+    last: Optional[int] = None
+    for idx, data in enumerate(
+        _iter_claude_records(claude_session_file)
+    ):
+        if _is_compact_summary_line(data):
+            last = idx
+    return last
+
+
 def iter_flat_claude_messages(
     claude_session_file: Path, default_timestamp: Optional[str]
 ) -> Iterator[dict[str, Any]]:
     """Stream the flattened transcript messages of a Claude session.
 
-    Second streaming pass: records are flattened one at a time and
-    yielded immediately, so the full message list is never accumulated
-    in memory. Message text is NEVER truncated here: only tool
-    arguments/results were capped (at ``TOOL_TEXT_CAP``) during
+    Two streaming passes: the first locates the last compact-summary
+    line (if any), the second flattens records one at a time and
+    yields them immediately, so the full message list is never
+    accumulated in memory. When a compact summary exists, every
+    record before it is skipped and the transcript starts from the
+    summary line itself -- mirroring what Claude Code would send to
+    the model on resume. Message text is NEVER truncated here: only
+    tool arguments/results were capped (at ``TOOL_TEXT_CAP``) during
     flattening.
 
     Args:
@@ -377,7 +448,12 @@ def iter_flat_claude_messages(
         Dicts with ``role``, ``text`` and ``timestamp`` keys, in
         transcript order, with no empty texts.
     """
-    for data in _iter_claude_records(claude_session_file):
+    boundary = _find_last_compact_summary_index(claude_session_file)
+    for idx, data in enumerate(
+        _iter_claude_records(claude_session_file)
+    ):
+        if boundary is not None and idx < boundary:
+            continue
         pairs = _flatten_claude_line(data)
         if not pairs:
             continue

--- a/claude_code_tools/port_claude_to_codex.py
+++ b/claude_code_tools/port_claude_to_codex.py
@@ -398,9 +398,9 @@ def _is_compact_summary_line(data: dict[str, Any]) -> bool:
     )
 
 
-def _find_last_compact_summary_index(
+def _scan_claude_session(
     claude_session_file: Path,
-) -> Optional[int]:
+) -> tuple[Optional[int], int]:
     """Locate the last compact-summary line of a Claude session.
 
     Streaming pass over the parsed records. Compactions chain (each
@@ -411,18 +411,26 @@ def _find_last_compact_summary_index(
         claude_session_file: Path to the Claude session JSONL file.
 
     Returns:
-        The index of the last compact-summary line within the stream
-        of parsed records, or None when the session was never
-        compacted. Indices are stable across passes because both
-        passes parse records with the same tolerant reader.
+        Tuple ``(boundary, total)``. ``boundary`` is the index of the
+        last usable compact-summary line within the stream of parsed
+        records, or None when the session was never compacted.
+        ``total`` is the number of parsed records this pass saw: the
+        message pass must stop there, so records a LIVE session
+        appends between the two passes (possibly including a new
+        compaction that would make this scan's boundary stale) are
+        ignored rather than ported inconsistently. Indices are stable
+        across passes because the log is append-only and both passes
+        parse records with the same tolerant reader.
     """
     last: Optional[int] = None
+    total = 0
     for idx, data in enumerate(
         _iter_claude_records(claude_session_file)
     ):
+        total = idx + 1
         if _is_compact_summary_line(data):
             last = idx
-    return last
+    return last, total
 
 
 def iter_flat_claude_messages(
@@ -448,10 +456,14 @@ def iter_flat_claude_messages(
         Dicts with ``role``, ``text`` and ``timestamp`` keys, in
         transcript order, with no empty texts.
     """
-    boundary = _find_last_compact_summary_index(claude_session_file)
+    boundary, total = _scan_claude_session(claude_session_file)
     for idx, data in enumerate(
         _iter_claude_records(claude_session_file)
     ):
+        if idx >= total:
+            # Appended by a live session after the scan pass: porting
+            # these could straddle a compaction the scan never saw.
+            break
         if boundary is not None and idx < boundary:
             continue
         pairs = _flatten_claude_line(data)

--- a/claude_code_tools/port_codex_to_claude.py
+++ b/claude_code_tools/port_codex_to_claude.py
@@ -9,6 +9,28 @@ Tool calls and tool results are flattened into clearly labeled text on
 assistant lines; reasoning items, encrypted payloads, and Codex
 bookkeeping records are dropped entirely.
 
+Compaction: Codex rollout files are append-only logs, so a session
+that was compacted still contains its full pre-compaction history --
+history the live Codex session no longer sends to the model. Porting
+mirrors Codex's own resume semantics: when the rollout holds
+``compacted`` records, everything before the LAST one is dropped and
+the transcript starts from that record's ``replacement_history``
+(the messages Codex itself kept: preserved user messages; its
+encrypted summary item is dropped like all encrypted content),
+followed by the items recorded after the compaction. Legacy
+``compacted`` records carrying a plaintext ``message`` summary
+contribute that summary as a user message. Without this, a
+long-lived Codex session ports into a transcript far larger than any
+model context (a real 108-compaction rollout produced a ~6M-token
+"transcript" that could never be resumed).
+
+Goal context: Codex re-injects the session's active goal as a
+``<codex_internal_context source="goal">`` user message on every
+turn. These are internal wrappers, not user input, and are dropped --
+except the LAST one in the ported range, which is kept (labeled
+``[codex goal context]``) so the standing goal survives the port:
+Claude Code has no equivalent auto-injection mechanism.
+
 Memory bounds: the rollout is processed in two streaming passes (a
 metadata-harvesting pass, then a message pass), so the full transcript
 is never accumulated in memory -- at most one merged same-role turn is
@@ -46,6 +68,7 @@ from claude_code_tools.port_codex_flatten import (  # noqa: F401
     TOOL_TEXT_CAP,
     _flatten_payload,
     _join_text_blocks,
+    _text_block_parts,
 )
 from claude_code_tools.session_utils import (
     encode_claude_project_path,
@@ -61,14 +84,15 @@ CLAUDE_LINE_VERSION = "2.1.211"
 MAX_PROJECT_COMPONENT_BYTES = 255
 
 # Top-level line types in modern rollouts that carry no transcript
-# content and are dropped entirely.
+# content and are dropped entirely. ``compacted`` records are NOT
+# listed here: they are history-replacement points handled explicitly
+# by :func:`iter_flat_messages`.
 _DROPPED_LINE_TYPES = frozenset(
     {
         "event_msg",
         "turn_context",
         "world_state",
         "inter_agent_communication_metadata",
-        "compacted",
     }
 )
 
@@ -333,16 +357,224 @@ def harvest_rollout_meta(codex_session_file: Path) -> dict[str, Any]:
     return meta
 
 
+# Prefixes of Codex's per-turn goal-context injection: the attribute
+# form (<codex_internal_context source="goal">) ends at the space,
+# and the bare closing form is matched exactly -- never a bare
+# "<codex_internal_context" prefix, which would also swallow genuine
+# text starting with a longer tag name. Matches the entries in
+# export_session.CODEX_WRAPPER_TEXT_PREFIXES that drop these blocks
+# from extracted text.
+_GOAL_CONTEXT_PREFIXES = (
+    "<codex_internal_context ",
+    "<codex_internal_context>",
+)
+
+# Label prepended to the one goal-context block the port keeps.
+_GOAL_CONTEXT_LABEL = "[codex goal context]"
+
+
+def _goal_context_text(payload: dict[str, Any]) -> Optional[str]:
+    """Extract the text of a pure goal-context user message.
+
+    Codex injects the active goal as a standalone user message whose
+    every text block is a ``<codex_internal_context ...>`` wrapper.
+    Messages mixing goal wrappers with genuine text (which real Codex
+    rollouts do not produce) are conservatively NOT treated as goal
+    context, so genuine input is never relabeled.
+
+    Args:
+        payload: A Codex response-item payload (or a
+            ``replacement_history`` item).
+
+    Returns:
+        The joined wrapper text, or None when the payload is not a
+        pure goal-context user message.
+    """
+    if payload.get("type") != "message":
+        return None
+    if payload.get("role") != "user":
+        return None
+    parts = _text_block_parts(payload.get("content"))
+    if not parts:
+        return None
+    for part in parts:
+        if not part.lstrip().startswith(_GOAL_CONTEXT_PREFIXES):
+            return None
+    return "\n".join(parts).strip()
+
+
+def _is_compaction_boundary(data: dict[str, Any]) -> bool:
+    """Check whether a record is a usable history-replacement point.
+
+    A ``compacted`` record marks the point where Codex discarded its
+    live history and replaced it. It is usable as a boundary only when
+    it actually carries replacement content: a NON-EMPTY
+    ``replacement_history`` list (modern rollouts; real compactions
+    always keep at least the summary item, so an empty list means a
+    partial/corrupt record) or a non-empty plaintext ``message``
+    summary (legacy rollouts). A malformed ``compacted`` record with
+    neither is ignored -- treating it as a boundary would silently
+    drop the whole preceding transcript with nothing to replace it.
+
+    Args:
+        data: A parsed top-level rollout record.
+
+    Returns:
+        True if the record is a usable compaction boundary.
+    """
+    if data.get("type") != "compacted":
+        return False
+    payload = data.get("payload")
+    if not isinstance(payload, dict):
+        return False
+    history = payload.get("replacement_history")
+    if isinstance(history, list) and history:
+        return True
+    message = payload.get("message")
+    return isinstance(message, str) and bool(message.strip())
+
+
+def _scan_rollout(
+    codex_session_file: Path,
+) -> tuple[Optional[int], Optional[tuple[int, Optional[int], str]]]:
+    """Locate the compaction boundary and last goal context (one pass).
+
+    Streaming pass over the parsed records. Compactions chain (each
+    ``replacement_history`` already incorporates the effect of every
+    earlier compaction), so only the LAST usable boundary matters.
+    The last goal-context injection is tracked only within the ported
+    range: finding a new boundary discards any goal context recorded
+    before it, then rescans the boundary's own replacement history.
+
+    Args:
+        codex_session_file: Path to the Codex rollout JSONL file.
+
+    Returns:
+        Tuple ``(boundary, goal)``. ``boundary`` is the index of the
+        last usable ``compacted`` record within the stream of parsed
+        records (None when the rollout has none). ``goal`` is
+        ``(record_idx, item_idx, text)`` locating the last
+        goal-context message -- ``item_idx`` is its position inside
+        the boundary record's ``replacement_history``, or None when
+        the goal context is an ordinary record -- or None when the
+        ported range holds no goal context. Indices are stable across
+        passes because both passes parse records with the same
+        tolerant reader.
+    """
+    boundary: Optional[int] = None
+    goal: Optional[tuple[int, Optional[int], str]] = None
+    for idx, data in enumerate(
+        _iter_rollout_records(codex_session_file)
+    ):
+        if _is_compaction_boundary(data):
+            boundary = idx
+            goal = None
+            payload = data.get("payload")
+            if isinstance(payload, dict):
+                history = payload.get("replacement_history")
+                if isinstance(history, list):
+                    for item_idx, item in enumerate(history):
+                        if not isinstance(item, dict):
+                            continue
+                        text = _goal_context_text(item)
+                        if text:
+                            goal = (idx, item_idx, text)
+            continue
+        payload = _extract_item_payload(data)
+        if payload is not None:
+            text = _goal_context_text(payload)
+            if text:
+                goal = (idx, None, text)
+    return boundary, goal
+
+
+def _iter_compaction_messages(
+    data: dict[str, Any],
+    default_timestamp: Optional[str],
+    goal_item_idx: Optional[int] = None,
+) -> Iterator[dict[str, Any]]:
+    """Flatten the replacement content of one ``compacted`` record.
+
+    Yields the messages Codex itself kept as live context after the
+    compaction: each ``replacement_history`` item is flattened with
+    the same rules as ordinary response items (meta/developer
+    messages and the encrypted ``compaction`` summary item are
+    dropped), and a legacy non-empty plaintext ``message`` summary is
+    yielded as a user message. The history item at ``goal_item_idx``
+    (the kept goal-context injection, normally dropped as an internal
+    wrapper) is yielded as a labeled user message instead.
+
+    Args:
+        data: A ``compacted`` rollout record (payload known-dict).
+        default_timestamp: Fallback timestamp for the yielded
+            messages (replacement items carry no timestamps of their
+            own; the record's own timestamp is preferred).
+        goal_item_idx: Index into ``replacement_history`` of the goal
+            context to keep, or None to keep none.
+
+    Yields:
+        Dicts with ``role``, ``text`` and ``timestamp`` keys.
+    """
+    payload = data.get("payload")
+    if not isinstance(payload, dict):
+        return
+    timestamp = data.get("timestamp")
+    if not isinstance(timestamp, str):
+        timestamp = None
+    timestamp = timestamp or default_timestamp
+
+    history = payload.get("replacement_history")
+    if isinstance(history, list):
+        for item_idx, item in enumerate(history):
+            if not isinstance(item, dict):
+                continue
+            if item_idx == goal_item_idx:
+                text = _goal_context_text(item)
+                if text:
+                    yield {
+                        "role": "user",
+                        "text": f"{_GOAL_CONTEXT_LABEL}\n{text}",
+                        "timestamp": timestamp,
+                    }
+                continue
+            flattened = _flatten_payload(item)
+            if flattened is None:
+                continue
+            role, text = flattened
+            yield {
+                "role": role,
+                "text": text,
+                "timestamp": timestamp,
+            }
+
+    message = payload.get("message")
+    if isinstance(message, str) and message.strip():
+        # Legacy rollouts: the plaintext summary Codex injected as
+        # the user-side bridge after compacting.
+        yield {
+            "role": "user",
+            "text": message,
+            "timestamp": timestamp,
+        }
+
+
 def iter_flat_messages(
     codex_session_file: Path, default_timestamp: Optional[str]
 ) -> Iterator[dict[str, Any]]:
     """Stream the flattened transcript messages of a rollout file.
 
-    Second streaming pass: transcript items are flattened one at a
-    time and yielded immediately, so the full message list is never
-    accumulated in memory regardless of file size. Message text is
-    NEVER truncated here: only tool arguments/results were already
-    capped (at ``TOOL_TEXT_CAP``) during flattening.
+    Two streaming passes: the first locates the last usable
+    compaction boundary and the last goal-context injection (if
+    any), the second flattens transcript items one at a time and
+    yields them immediately, so the full message list is never
+    accumulated in memory regardless of file size. When a boundary
+    exists, every record before it is skipped and the transcript
+    starts from the boundary's replacement content -- mirroring what
+    Codex itself would send to the model on resume. The last
+    goal-context injection in the ported range is kept as a labeled
+    user message (all other copies are dropped as internal noise). Message text is NEVER truncated here: only tool
+    arguments/results were already capped (at ``TOOL_TEXT_CAP``)
+    during flattening.
 
     Args:
         codex_session_file: Path to the Codex rollout JSONL file.
@@ -352,13 +584,46 @@ def iter_flat_messages(
     Yields:
         Dicts with ``role``, ``text`` and ``timestamp`` keys.
     """
-    for data in _iter_rollout_records(codex_session_file):
+    boundary, goal = _scan_rollout(codex_session_file)
+    for idx, data in enumerate(
+        _iter_rollout_records(codex_session_file)
+    ):
+        if boundary is not None:
+            if idx < boundary:
+                continue
+            if idx == boundary:
+                goal_item_idx = (
+                    goal[1]
+                    if goal is not None and goal[0] == idx
+                    else None
+                )
+                yield from _iter_compaction_messages(
+                    data, default_timestamp, goal_item_idx
+                )
+                continue
+        if goal is not None and goal[0] == idx:
+            # The last goal-context injection in the ported range:
+            # kept (labeled) so the standing goal survives the port.
+            timestamp = data.get("timestamp")
+            if not isinstance(timestamp, str):
+                timestamp = None
+            yield {
+                "role": "user",
+                "text": f"{_GOAL_CONTEXT_LABEL}\n{goal[2]}",
+                "timestamp": timestamp or default_timestamp,
+            }
+            continue
         line_type = data.get("type")
         if not isinstance(line_type, str):
             # Every transcript item carries a string type (modern
             # response_item lines and legacy bare items alike);
             # non-string shapes are unrecognized records, and
             # unhashable ones would crash the set-membership test.
+            continue
+        if line_type == "compacted":
+            # A compacted record past the boundary (or any compacted
+            # record when no usable boundary exists) carries no
+            # transcript content of its own.
             continue
         if line_type == "session_meta" or line_type in _DROPPED_LINE_TYPES:
             continue

--- a/claude_code_tools/port_codex_to_claude.py
+++ b/claude_code_tools/port_codex_to_claude.py
@@ -436,7 +436,9 @@ def _is_compaction_boundary(data: dict[str, Any]) -> bool:
 
 def _scan_rollout(
     codex_session_file: Path,
-) -> tuple[Optional[int], Optional[tuple[int, Optional[int], str]]]:
+) -> tuple[
+    Optional[int], Optional[tuple[int, Optional[int], str]], int
+]:
     """Locate the compaction boundary and last goal context (one pass).
 
     Streaming pass over the parsed records. Compactions chain (each
@@ -450,22 +452,29 @@ def _scan_rollout(
         codex_session_file: Path to the Codex rollout JSONL file.
 
     Returns:
-        Tuple ``(boundary, goal)``. ``boundary`` is the index of the
-        last usable ``compacted`` record within the stream of parsed
-        records (None when the rollout has none). ``goal`` is
+        Tuple ``(boundary, goal, total)``. ``boundary`` is the index
+        of the last usable ``compacted`` record within the stream of
+        parsed records (None when the rollout has none). ``goal`` is
         ``(record_idx, item_idx, text)`` locating the last
         goal-context message -- ``item_idx`` is its position inside
         the boundary record's ``replacement_history``, or None when
         the goal context is an ordinary record -- or None when the
-        ported range holds no goal context. Indices are stable across
-        passes because both passes parse records with the same
-        tolerant reader.
+        ported range holds no goal context. ``total`` is the number
+        of parsed records this pass saw: the message pass must stop
+        there, so records a LIVE session appends between the two
+        passes (possibly including a new compaction that would make
+        this scan's boundary stale) are ignored rather than ported
+        inconsistently. Indices are stable across passes because the
+        log is append-only and both passes parse records with the
+        same tolerant reader.
     """
     boundary: Optional[int] = None
     goal: Optional[tuple[int, Optional[int], str]] = None
+    total = 0
     for idx, data in enumerate(
         _iter_rollout_records(codex_session_file)
     ):
+        total = idx + 1
         if _is_compaction_boundary(data):
             boundary = idx
             goal = None
@@ -485,7 +494,7 @@ def _scan_rollout(
             text = _goal_context_text(payload)
             if text:
                 goal = (idx, None, text)
-    return boundary, goal
+    return boundary, goal, total
 
 
 def _iter_compaction_messages(
@@ -584,10 +593,14 @@ def iter_flat_messages(
     Yields:
         Dicts with ``role``, ``text`` and ``timestamp`` keys.
     """
-    boundary, goal = _scan_rollout(codex_session_file)
+    boundary, goal, total = _scan_rollout(codex_session_file)
     for idx, data in enumerate(
         _iter_rollout_records(codex_session_file)
     ):
+        if idx >= total:
+            # Appended by a live session after the scan pass: porting
+            # these could straddle a compaction the scan never saw.
+            break
         if boundary is not None:
             if idx < boundary:
                 continue

--- a/tests/test_port_compaction.py
+++ b/tests/test_port_compaction.py
@@ -1,0 +1,493 @@
+"""Compaction-boundary tests for both port directions.
+
+Codex rollouts and Claude session files are append-only logs: a
+compacted session still contains its full pre-compaction history,
+which the live agent no longer sends to the model. Both porters must
+mirror the source agent's own resume semantics -- start from the last
+compaction's replacement content -- or a long session ports into a
+"transcript" far larger than any model context (a real 108-compaction
+rollout produced ~6M tokens and could never be resumed).
+
+Uses real functions and real tmp files (no mocks), following the
+conventions of the other tests in this directory.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_code_tools.port_claude_to_codex import (
+    port_claude_session_to_codex,
+)
+from claude_code_tools.port_codex_to_claude import (
+    port_codex_session_to_claude,
+)
+
+MODERN_UUID = "019f6d85-df3c-7c83-84f6-b97e73305bbb"
+CLAUDE_UUID = "1d18f22c-9a88-4ea9-ae77-4094c9f87bbb"
+
+
+def _ts(seconds: int) -> str:
+    """Build a deterministic ISO timestamp for fixture lines."""
+    return f"2026-07-16T20:42:{seconds:02d}.000Z"
+
+
+def _resp(seconds: int, payload: dict) -> str:
+    """Build a modern-format response_item line."""
+    return json.dumps(
+        {
+            "timestamp": _ts(seconds),
+            "type": "response_item",
+            "payload": payload,
+        }
+    )
+
+
+def _msg(role: str, text: str) -> dict:
+    """Build a codex message payload."""
+    block = "input_text" if role == "user" else "output_text"
+    return {
+        "type": "message",
+        "role": role,
+        "content": [{"type": block, "text": text}],
+    }
+
+
+def _compacted(
+    seconds: int,
+    history: list | None = None,
+    message: str = "",
+    payload_override: dict | None = None,
+) -> str:
+    """Build a modern-format compacted line."""
+    if payload_override is not None:
+        payload = payload_override
+    else:
+        payload = {"message": message}
+        if history is not None:
+            payload["replacement_history"] = history
+    return json.dumps(
+        {
+            "timestamp": _ts(seconds),
+            "type": "compacted",
+            "payload": payload,
+        }
+    )
+
+
+def _session_meta(seconds: int, cwd: str) -> str:
+    """Build a modern-format session_meta line."""
+    return json.dumps(
+        {
+            "timestamp": _ts(seconds),
+            "type": "session_meta",
+            "payload": {
+                "id": MODERN_UUID,
+                "timestamp": _ts(seconds),
+                "cwd": cwd,
+                "git": {"branch": "main"},
+                "originator": "codex_exec",
+            },
+        }
+    )
+
+
+def _write_rollout(codex_home: Path, lines: list) -> Path:
+    """Write raw fixture lines as a modern rollout under codex_home."""
+    day_dir = codex_home / "sessions" / "2026" / "07" / "16"
+    day_dir.mkdir(parents=True, exist_ok=True)
+    path = day_dir / f"rollout-2026-07-16T20-41-57-{MODERN_UUID}.jsonl"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _ported_texts(out_path: Path) -> list[str]:
+    """Read the message texts of a ported Claude session file."""
+    texts = []
+    for line in out_path.read_text(encoding="utf-8").splitlines():
+        data = json.loads(line)
+        texts.append(data["message"]["content"][0]["text"])
+    return texts
+
+
+def _port_codex(tmp_path: Path, lines: list) -> list[str]:
+    """Port a fixture rollout and return the flattened texts."""
+    codex_home = tmp_path / "codex"
+    claude_home = tmp_path / "claude"
+    project = tmp_path / "proj"
+    project.mkdir(exist_ok=True)
+    rollout = _write_rollout(codex_home, lines)
+    _, out_path = port_codex_session_to_claude(
+        rollout, claude_home=claude_home
+    )
+    return _ported_texts(out_path)
+
+
+class TestCodexToClaudeCompaction:
+    """Codex -> Claude: the last compacted record replaces history."""
+
+    def test_history_before_last_compaction_dropped(self, tmp_path):
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(1, _msg("user", "old question")),
+            _resp(2, _msg("assistant", "old answer")),
+            _compacted(
+                3, history=[_msg("user", "kept user prompt")]
+            ),
+            _resp(4, _msg("user", "new question")),
+            _resp(5, _msg("assistant", "new answer")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert "old question" not in joined
+        assert "old answer" not in joined
+        assert "kept user prompt" in joined
+        assert "new question" in joined
+        assert "new answer" in joined
+
+    def test_only_last_of_chained_compactions_matters(self, tmp_path):
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(1, _msg("user", "ancient question")),
+            _compacted(2, history=[_msg("user", "first-kept")]),
+            _resp(3, _msg("user", "middle question")),
+            _compacted(
+                4,
+                history=[
+                    _msg("user", "first-kept"),
+                    _msg("user", "middle question"),
+                ],
+            ),
+            _resp(5, _msg("user", "final question")),
+            _resp(6, _msg("assistant", "final answer")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert "ancient question" not in joined
+        # Kept via the LAST replacement history, exactly once.
+        assert joined.count("middle question") == 1
+        assert joined.count("first-kept") == 1
+        assert "final question" in joined
+
+    def test_replacement_history_drops_internal_items(self, tmp_path):
+        history = [
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [
+                    {"type": "input_text", "text": "dev instructions"}
+                ],
+            },
+            _msg("user", "kept user prompt"),
+            {
+                "type": "compaction",
+                "encrypted_content": "AAAA",
+            },
+        ]
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(1, _msg("user", "old question")),
+            _compacted(2, history=history),
+            _resp(3, _msg("assistant", "new answer")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert "dev instructions" not in joined
+        assert "AAAA" not in joined
+        assert "kept user prompt" in joined
+        assert "new answer" in joined
+
+    def test_legacy_plaintext_summary_becomes_user_message(
+        self, tmp_path
+    ):
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(1, _msg("user", "old question")),
+            _compacted(2, message="summary of earlier work"),
+            _resp(3, _msg("assistant", "new answer")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert "old question" not in joined
+        assert "summary of earlier work" in joined
+        assert "new answer" in joined
+
+    def test_unusable_compacted_record_is_ignored(self, tmp_path):
+        # No replacement_history list, no plaintext message: treating
+        # this as a boundary would drop history with no replacement.
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(1, _msg("user", "old question")),
+            _compacted(2, payload_override={"message": ""}),
+            _resp(3, _msg("assistant", "new answer")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert "old question" in joined
+        assert "new answer" in joined
+
+    def test_empty_replacement_history_is_ignored(self, tmp_path):
+        # Real compactions always keep at least the summary item; an
+        # empty list is a partial/corrupt record, and honoring it
+        # would drop all history with nothing to replace it.
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(1, _msg("user", "old question")),
+            _compacted(2, history=[]),
+            _resp(3, _msg("assistant", "new answer")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert "old question" in joined
+        assert "new answer" in joined
+
+    def test_longer_tag_name_is_not_goal_context(self, tmp_path):
+        # A genuine user message starting with a LONGER tag name must
+        # not be swallowed by the goal-context prefix match.
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(
+                1,
+                _msg(
+                    "user",
+                    "<codex_internal_contextual> is a tag I typed",
+                ),
+            ),
+            _resp(2, _msg("assistant", "answer")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert "<codex_internal_contextual> is a tag I typed" in joined
+        assert "[codex goal context]" not in joined
+
+    def test_no_compaction_ports_everything(self, tmp_path):
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(1, _msg("user", "q1")),
+            _resp(2, _msg("assistant", "a1")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert "q1" in joined
+        assert "a1" in joined
+
+    def test_goal_context_keeps_only_last_copy(self, tmp_path):
+        # Codex re-injects the active goal as its own user message
+        # every turn; only the LAST copy is kept, labeled, so the
+        # standing goal survives the port without per-turn bloat.
+        def goal(n: int) -> str:
+            return (
+                '<codex_internal_context source="goal">\n'
+                f"Goal text v{n}.\n"
+                "</codex_internal_context>"
+            )
+
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(1, _msg("user", "real question")),
+            _resp(2, _msg("user", goal(1))),
+            _resp(3, _msg("assistant", "answer one")),
+            _resp(4, _msg("user", goal(2))),
+            _resp(5, _msg("assistant", "answer two")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert "Goal text v1." not in joined
+        assert "Goal text v2." in joined
+        assert "[codex goal context]" in joined
+        assert "real question" in joined
+        assert "answer two" in joined
+
+    def test_goal_context_kept_from_replacement_history(
+        self, tmp_path
+    ):
+        goal = (
+            '<codex_internal_context source="goal">\n'
+            "Standing goal.\n"
+            "</codex_internal_context>"
+        )
+        history = [
+            _msg("user", "kept user prompt"),
+            _msg("user", goal),
+        ]
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(1, _msg("user", goal)),
+            _compacted(2, history=history),
+            _resp(3, _msg("assistant", "new answer")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert joined.count("Standing goal.") == 1
+        assert "[codex goal context]" in joined
+        assert "kept user prompt" in joined
+
+    def test_goal_context_before_boundary_discarded(self, tmp_path):
+        goal = (
+            '<codex_internal_context source="goal">\n'
+            "Stale goal.\n"
+            "</codex_internal_context>"
+        )
+        lines = [
+            _session_meta(0, str(tmp_path / "proj")),
+            _resp(1, _msg("user", goal)),
+            _compacted(2, history=[_msg("user", "kept")]),
+            _resp(3, _msg("assistant", "new answer")),
+        ]
+        joined = "\n".join(_port_codex(tmp_path, lines))
+        assert "Stale goal." not in joined
+        assert "kept" in joined
+
+
+def _claude_line(
+    seconds: int,
+    role: str,
+    text: str,
+    cwd: str,
+    **extra,
+) -> str:
+    """Build one Claude session user/assistant line."""
+    return json.dumps(
+        {
+            "parentUuid": None,
+            "isSidechain": extra.pop("isSidechain", False),
+            "userType": "external",
+            "cwd": cwd,
+            "sessionId": CLAUDE_UUID,
+            "version": "2.1.211",
+            "gitBranch": "main",
+            "type": role,
+            "message": {
+                "role": role,
+                "content": [{"type": "text", "text": text}],
+            },
+            "uuid": f"00000000-0000-4000-8000-{seconds:012d}",
+            "timestamp": _ts(seconds),
+            **extra,
+        }
+    )
+
+
+def _compact_boundary_line(seconds: int, cwd: str) -> str:
+    """Build a Claude compact_boundary system line."""
+    return json.dumps(
+        {
+            "parentUuid": None,
+            "isSidechain": False,
+            "type": "system",
+            "subtype": "compact_boundary",
+            "content": "",
+            "level": "info",
+            "cwd": cwd,
+            "sessionId": CLAUDE_UUID,
+            "timestamp": _ts(seconds),
+            "uuid": f"00000000-0000-4000-8000-{seconds:012d}",
+            "compactMetadata": {"trigger": "auto"},
+        }
+    )
+
+
+def _port_claude(tmp_path: Path, lines: list) -> str:
+    """Port a fixture Claude session and return the rollout text."""
+    codex_home = tmp_path / "codex"
+    codex_home.mkdir(exist_ok=True)
+    session_file = tmp_path / f"{CLAUDE_UUID}.jsonl"
+    session_file.write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+    _, out_path = port_claude_session_to_codex(
+        session_file, codex_home=codex_home
+    )
+    return out_path.read_text(encoding="utf-8")
+
+
+class TestClaudeToCodexCompaction:
+    """Claude -> Codex: the last compact summary replaces history."""
+
+    def test_history_before_last_summary_dropped(self, tmp_path):
+        cwd = str(tmp_path / "proj")
+        summary = (
+            "This session is being continued from a previous "
+            "conversation that ran out of context. Summary: did X."
+        )
+        lines = [
+            _claude_line(1, "user", "old question", cwd),
+            _claude_line(2, "assistant", "old answer", cwd),
+            _compact_boundary_line(3, cwd),
+            _claude_line(
+                4,
+                "user",
+                summary,
+                cwd,
+                isCompactSummary=True,
+                isVisibleInTranscriptOnly=True,
+            ),
+            _claude_line(5, "assistant", "post-compact answer", cwd),
+        ]
+        rollout = _port_claude(tmp_path, lines)
+        assert "old question" not in rollout
+        assert "old answer" not in rollout
+        assert "Summary: did X." in rollout
+        assert "post-compact answer" in rollout
+
+    def test_only_last_of_multiple_summaries_matters(self, tmp_path):
+        cwd = str(tmp_path / "proj")
+        lines = [
+            _claude_line(1, "user", "ancient question", cwd),
+            _compact_boundary_line(2, cwd),
+            _claude_line(
+                3, "user", "first summary", cwd, isCompactSummary=True
+            ),
+            _claude_line(4, "assistant", "middle answer", cwd),
+            _compact_boundary_line(5, cwd),
+            _claude_line(
+                6, "user", "second summary", cwd, isCompactSummary=True
+            ),
+            _claude_line(7, "assistant", "final answer", cwd),
+        ]
+        rollout = _port_claude(tmp_path, lines)
+        assert "ancient question" not in rollout
+        assert "first summary" not in rollout
+        assert "middle answer" not in rollout
+        assert "second summary" in rollout
+        assert "final answer" in rollout
+
+    def test_sidechain_summary_does_not_truncate(self, tmp_path):
+        cwd = str(tmp_path / "proj")
+        lines = [
+            _claude_line(1, "user", "main question", cwd),
+            _claude_line(
+                2,
+                "user",
+                "subagent summary",
+                cwd,
+                isCompactSummary=True,
+                isSidechain=True,
+            ),
+            _claude_line(3, "assistant", "main answer", cwd),
+        ]
+        rollout = _port_claude(tmp_path, lines)
+        assert "main question" in rollout
+        # Sidechain lines are dropped entirely, but must not act as
+        # a truncation boundary for the main transcript.
+        assert "subagent summary" not in rollout
+        assert "main answer" in rollout
+
+    def test_no_compaction_ports_everything(self, tmp_path):
+        cwd = str(tmp_path / "proj")
+        lines = [
+            _claude_line(1, "user", "q1", cwd),
+            _claude_line(2, "assistant", "a1", cwd),
+        ]
+        rollout = _port_claude(tmp_path, lines)
+        assert "q1" in rollout
+        assert "a1" in rollout
+
+    def test_empty_summary_line_is_not_a_boundary(self, tmp_path):
+        # A marked summary line with no usable text must not truncate
+        # the transcript: it would drop history while contributing
+        # no summary at all.
+        cwd = str(tmp_path / "proj")
+        lines = [
+            _claude_line(1, "user", "old question", cwd),
+            _claude_line(2, "assistant", "old answer", cwd),
+            _claude_line(
+                3, "user", "   ", cwd, isCompactSummary=True
+            ),
+            _claude_line(4, "assistant", "post answer", cwd),
+        ]
+        rollout = _port_claude(tmp_path, lines)
+        assert "old question" in rollout
+        assert "old answer" in rollout
+        assert "post answer" in rollout

--- a/tests/test_port_compaction.py
+++ b/tests/test_port_compaction.py
@@ -18,9 +18,11 @@ from pathlib import Path
 import pytest
 
 from claude_code_tools.port_claude_to_codex import (
+    iter_flat_claude_messages,
     port_claude_session_to_codex,
 )
 from claude_code_tools.port_codex_to_claude import (
+    iter_flat_messages,
     port_codex_session_to_claude,
 )
 
@@ -235,6 +237,35 @@ class TestCodexToClaudeCompaction:
         joined = "\n".join(_port_codex(tmp_path, lines))
         assert "old question" in joined
         assert "new answer" in joined
+
+    def test_records_appended_mid_port_are_ignored(self, tmp_path):
+        # A LIVE session can append records (even a new compaction)
+        # between the scan pass and the message pass; porting them
+        # could straddle a boundary the scan never saw. The message
+        # pass must stop at the scan-time record count.
+        codex_home = tmp_path / "codex"
+        rollout = _write_rollout(
+            codex_home,
+            [
+                _session_meta(0, str(tmp_path / "proj")),
+                _resp(1, _msg("user", "q1")),
+                _resp(2, _msg("assistant", "a1")),
+            ],
+        )
+        gen = iter_flat_messages(rollout, None)
+        first = next(gen)  # scan pass done, message pass started
+        with open(rollout, "a", encoding="utf-8") as f:
+            f.write(
+                _compacted(3, history=[_msg("user", "appended kept")])
+                + "\n"
+            )
+            f.write(_resp(4, _msg("user", "appended question")) + "\n")
+        texts = [first["text"]] + [m["text"] for m in gen]
+        joined = "\n".join(texts)
+        assert "q1" in joined
+        assert "a1" in joined
+        assert "appended kept" not in joined
+        assert "appended question" not in joined
 
     def test_longer_tag_name_is_not_goal_context(self, tmp_path):
         # A genuine user message starting with a LONGER tag name must
@@ -473,6 +504,47 @@ class TestClaudeToCodexCompaction:
         rollout = _port_claude(tmp_path, lines)
         assert "q1" in rollout
         assert "a1" in rollout
+
+    def test_records_appended_mid_port_are_ignored(self, tmp_path):
+        # A LIVE session can append records (even a new compaction)
+        # between the scan pass and the message pass; porting them
+        # could straddle a boundary the scan never saw. The message
+        # pass must stop at the scan-time record count.
+        cwd = str(tmp_path / "proj")
+        session_file = tmp_path / f"{CLAUDE_UUID}.jsonl"
+        session_file.write_text(
+            "\n".join(
+                [
+                    _claude_line(1, "user", "q1", cwd),
+                    _claude_line(2, "assistant", "a1", cwd),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        gen = iter_flat_claude_messages(session_file, None)
+        first = next(gen)  # scan pass done, message pass started
+        with open(session_file, "a", encoding="utf-8") as f:
+            f.write(
+                _claude_line(
+                    3,
+                    "user",
+                    "appended summary",
+                    cwd,
+                    isCompactSummary=True,
+                )
+                + "\n"
+            )
+            f.write(
+                _claude_line(4, "user", "appended question", cwd)
+                + "\n"
+            )
+        texts = [first["text"]] + [m["text"] for m in gen]
+        joined = "\n".join(texts)
+        assert "q1" in joined
+        assert "a1" in joined
+        assert "appended summary" not in joined
+        assert "appended question" not in joined
 
     def test_empty_summary_line_is_not_a_boundary(self, tmp_path):
         # A marked summary line with no usable text must not truncate

--- a/uv.lock
+++ b/uv.lock
@@ -449,7 +449,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.23.2"
+version = "1.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
## Problem

`aichat port` flattened the **entire append-only session log** in both directions, including all history the source agent no longer sends to the model after compaction. A real 108-compaction codex rollout (191MB) ported into a ~6M-token Claude "transcript" that could never be resumed — instant *context window full*, despite Claude's 1M window being 4x codex's 250k.

## Fix

Both porters now mirror the source agent's own resume semantics:

- **codex → claude**: the last usable `compacted` record is a history-replacement point. Everything before it is dropped; the transcript starts from its `replacement_history` (the user messages codex itself kept — the encrypted summary item is dropped like all encrypted content), followed by the post-compaction records. Legacy plaintext `message` summaries are kept as a user message.
- **claude → codex**: the porter starts from the last main-chain `isCompactSummary` user line, whose plaintext already summarizes the dropped history.

Also fixes a second junk source found during the investigation: codex re-injects the active goal as a `<codex_internal_context source="goal">` user message **every turn** (16% of the ported transcript). These are now filtered as internal wrappers, except the **last** one, kept as a labeled `[codex goal context]` message so the standing goal survives the port (Claude Code has no equivalent auto-injection).

Hardening (from cold-diff review): empty `replacement_history` lists, empty/whitespace summary lines, and sidechain compact summaries are not treated as boundaries; the goal-tag prefix match cannot swallow longer tag names.

## Results

- The 191MB / 108-compaction rollout now ports to **~24k tokens** and resumes cleanly (verified end-to-end by resuming the ported session in Claude Code).
- 16 new tests in `tests/test_port_compaction.py`; full suite green (1667 passed).
- Two cold-diff review rounds by codex; round-1 findings fixed, round-2's single finding deferred as synthetic (requires a corrupt compacted record shape unobserved across all 156 real compacted records scanned, and the suggested fallback would reintroduce the unresumable-transcript bug for encrypted-only replacements).