### PR TITLE
feat(amux): see and jump between Claude/Codex agents across tmux panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ docs. Click a card below to jump to a feature, or
 </tr>
 <tr>
 <td align="center">
+<a href="https://pchalasani.github.io/claude-code-tools/tools/amux/">
+<img src="assets/card-amux.svg" alt="amux" width="200"/>
+</a>
+</td>
+<td align="center">
 <a href="https://pchalasani.github.io/claude-code-tools/tools/agent-tunnel/">
 <img src="assets/card-agent-tunnel.svg" alt="agent-tunnel" width="200"/>
 </a>

--- a/assets/card-amux.svg
+++ b/assets/card-amux.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="100">
+  <defs>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#2a1030"/>
+      <stop offset="100%" style="stop-color:#14071a"/>
+    </linearGradient>
+  </defs>
+  <rect width="200" height="100" rx="8" fill="url(#bg)"/>
+  <text x="100" y="37" font-family="monospace" font-size="26" font-weight="bold" fill="#d18aff" text-anchor="middle" filter="url(#glow)">amux</text>
+  <text x="100" y="60" font-family="monospace" font-size="14" fill="#e0b3ff" text-anchor="middle">Agents Tmux</text>
+  <text x="100" y="75" font-family="monospace" font-size="14" fill="#e0b3ff" text-anchor="middle">Dashboard</text>
+</svg>

--- a/claude_code_tools/amux/__init__.py
+++ b/claude_code_tools/amux/__init__.py
@@ -1,0 +1,5 @@
+"""amux: see and jump between coding agents running in tmux panes."""
+
+from .model import Agent, State, Kind
+
+__all__ = ["Agent", "State", "Kind"]

--- a/claude_code_tools/amux/__main__.py
+++ b/claude_code_tools/amux/__main__.py
@@ -1,0 +1,6 @@
+"""Allow ``python -m claude_code_tools.amux`` (used by fzf reload bindings)."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude_code_tools/amux/cache.py
+++ b/claude_code_tools/amux/cache.py
@@ -8,6 +8,7 @@ scan is noticeable; a warm one is not.
 from __future__ import annotations
 
 import json
+import math
 import os
 import time
 from pathlib import Path
@@ -45,9 +46,10 @@ def read(max_age: float | None = None) -> tuple[list[Agent], float]:
     try:
         stamp = float(raw.get("time", 0))
         age = time.time() - stamp
-        # A future timestamp (clock skew, hand-edited file) gives a negative
-        # age that silently passes every max_age check forever.
-        if age < 0:
+        # Python's json accepts the NaN literal, and every comparison against
+        # nan is False -- so a NaN age passed both the negative check and the
+        # max_age check, making the cache permanently "fresh".
+        if not math.isfinite(age) or age < 0:
             return [], -1.0
         if max_age is not None and age > max_age:
             return [], age

--- a/claude_code_tools/amux/cache.py
+++ b/claude_code_tools/amux/cache.py
@@ -1,0 +1,64 @@
+"""Cache of the last scan, so the picker opens instantly.
+
+The picker shows cached rows immediately and kicks off a fresh scan in the
+background, replacing the list when it lands. With hundreds of panes, a cold
+scan is noticeable; a warm one is not.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from .model import Agent
+
+_DEFAULT = Path.home() / ".cache" / "cc-tools" / "amux.json"
+
+
+def cache_path() -> Path:
+    """Location of the cache file (``AMUX_CACHE`` overrides)."""
+    override = os.environ.get("AMUX_CACHE")
+    return Path(override) if override else _DEFAULT
+
+
+def read(max_age: float | None = None) -> tuple[list[Agent], float]:
+    """Load cached agents.
+
+    Args:
+        max_age: If set, return an empty list when the cache is older than
+            this many seconds.
+
+    Returns:
+        ``(agents, age_seconds)``; ``age_seconds`` is ``-1`` when no usable
+        cache exists.
+    """
+    path = cache_path()
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return [], -1.0
+
+    stamp = float(raw.get("time", 0))
+    age = time.time() - stamp
+    if max_age is not None and age > max_age:
+        return [], age
+    agents = [Agent.from_dict(d) for d in raw.get("agents", [])]
+    return agents, age
+
+
+def write(agents: list[Agent]) -> None:
+    """Persist *agents* atomically, creating the cache directory if needed."""
+    path = cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "time": time.time(),
+            "agents": [a.to_dict() for a in agents],
+        }
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload))
+        tmp.replace(path)
+    except OSError:
+        pass  # a missing cache only costs speed, never correctness

--- a/claude_code_tools/amux/cache.py
+++ b/claude_code_tools/amux/cache.py
@@ -45,6 +45,10 @@ def read(max_age: float | None = None) -> tuple[list[Agent], float]:
     try:
         stamp = float(raw.get("time", 0))
         age = time.time() - stamp
+        # A future timestamp (clock skew, hand-edited file) gives a negative
+        # age that silently passes every max_age check forever.
+        if age < 0:
+            return [], -1.0
         if max_age is not None and age > max_age:
             return [], age
         parsed = (

--- a/claude_code_tools/amux/cache.py
+++ b/claude_code_tools/amux/cache.py
@@ -40,11 +40,16 @@ def read(max_age: float | None = None) -> tuple[list[Agent], float]:
     except (OSError, ValueError):
         return [], -1.0
 
-    stamp = float(raw.get("time", 0))
-    age = time.time() - stamp
-    if max_age is not None and age > max_age:
-        return [], age
-    agents = [Agent.from_dict(d) for d in raw.get("agents", [])]
+    # Syntactically valid JSON can still be the wrong shape (hand-edited file,
+    # a truncated write from an older version). Never crash over a cache.
+    try:
+        stamp = float(raw.get("time", 0))
+        age = time.time() - stamp
+        if max_age is not None and age > max_age:
+            return [], age
+        agents = [Agent.from_dict(d) for d in raw.get("agents", []) if isinstance(d, dict)]
+    except (AttributeError, TypeError, ValueError):
+        return [], -1.0
     return agents, age
 
 
@@ -57,7 +62,9 @@ def write(agents: list[Agent]) -> None:
             "time": time.time(),
             "agents": [a.to_dict() for a in agents],
         }
-        tmp = path.with_suffix(".tmp")
+        # Per-process temp name: two concurrent `amux scan` runs sharing one
+        # ".tmp" would race, and the loser died on a missing file.
+        tmp = path.with_suffix(f".{os.getpid()}.tmp")
         tmp.write_text(json.dumps(payload))
         tmp.replace(path)
     except OSError:

--- a/claude_code_tools/amux/cache.py
+++ b/claude_code_tools/amux/cache.py
@@ -47,7 +47,10 @@ def read(max_age: float | None = None) -> tuple[list[Agent], float]:
         age = time.time() - stamp
         if max_age is not None and age > max_age:
             return [], age
-        agents = [Agent.from_dict(d) for d in raw.get("agents", []) if isinstance(d, dict)]
+        parsed = (
+            Agent.from_dict(d) for d in raw.get("agents", []) if isinstance(d, dict)
+        )
+        agents = [a for a in parsed if a is not None]
     except (AttributeError, TypeError, ValueError):
         return [], -1.0
     return agents, age

--- a/claude_code_tools/amux/cli.py
+++ b/claude_code_tools/amux/cli.py
@@ -1,0 +1,167 @@
+"""amux -- see and jump between the coding agents running in your tmux panes.
+
+    amux              # interactive picker (fzf): jump to an agent
+    amux list         # table of every live agent
+    amux list --json  # machine-readable
+    amux scan         # refresh the cache (for cron / tmux hooks)
+
+The picker opens on cached rows and refreshes in the background, so it is
+instant even with hundreds of panes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+from . import cache, render, scan
+from .model import Agent
+
+_FZF_HEADER = (
+    "enter=jump  ctrl-r=refresh  esc=quit    "
+    "input=asking you  busy=working  bg=monitors  idle"
+)
+
+
+def _fresh(write_cache: bool = True) -> list[Agent]:
+    """Scan live panes and refresh the cache."""
+    agents = scan.scan()
+    if write_cache:
+        cache.write(agents)
+    return agents
+
+
+def _agents_for_display(max_age: float) -> tuple[list[Agent], bool]:
+    """Return agents to show now, plus whether they came from cache."""
+    cached, age = cache.read(max_age=max_age)
+    if cached:
+        return cached, True
+    return _fresh(), False
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    """Print every live agent as a table or JSON."""
+    agents = cache.read(max_age=args.max_age)[0] if args.cached else _fresh()
+    if not agents and args.cached:
+        agents = _fresh()
+    if args.json:
+        print(render.as_json(agents))
+    else:
+        colour = sys.stdout.isatty() and not args.no_color
+        print(render.table(agents, colour=colour))
+    return 0
+
+
+def cmd_scan(args: argparse.Namespace) -> int:
+    """Refresh the cache and report what was found."""
+    agents = _fresh()
+    print(f"cached {len(agents)} agents -> {cache.cache_path()}")
+    return 0
+
+
+def cmd_rows(args: argparse.Namespace) -> int:
+    """Emit picker rows (internal: used by fzf's reload binding)."""
+    agents = _fresh() if args.refresh else _agents_for_display(args.max_age)[0]
+    print(render.picker_lines(agents, colour=True))
+    return 0
+
+
+def cmd_pick(args: argparse.Namespace) -> int:
+    """Interactive picker; jumps to the chosen agent's pane."""
+    if not shutil.which("fzf"):
+        print("amux: fzf not found (brew install fzf)", file=sys.stderr)
+        return 1
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        print("amux: no tty -- use 'amux list' for scripted output", file=sys.stderr)
+        return 1
+
+    agents, from_cache = _agents_for_display(args.max_age)
+    if not agents:
+        print("no agents running")
+        return 0
+
+    self_cmd = f"{sys.executable} -m claude_code_tools.amux"
+    binds = [
+        f"ctrl-r:reload({self_cmd} rows --refresh)",
+        # Opening on cached rows is what makes this instant; refresh the
+        # moment the list is up so stale states self-correct without a keypress.
+        f"load:reload-sync({self_cmd} rows --refresh)" if from_cache else "",
+    ]
+    cmd = [
+        "fzf",
+        "--ansi",
+        "--no-sort",
+        "--header",
+        _FZF_HEADER,
+        "--preview",
+        "tmux capture-pane -ep -S -200 -t {1} | grep '[^[:space:]]' | tail -60",
+        "--preview-window",
+        "right:55%:wrap:follow",
+        "--prompt",
+        "agent> ",
+    ]
+    for bind in binds:
+        if bind:
+            cmd += ["--bind", bind]
+
+    proc = subprocess.run(
+        cmd, input=render.picker_lines(agents), capture_output=True, text=True
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return 0
+
+    pane = proc.stdout.split()[0]
+    scan.switch_to(pane)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="amux",
+        description="See and jump between coding agents running in tmux panes.",
+    )
+    parser.add_argument(
+        "--max-age",
+        type=float,
+        default=30.0,
+        help="seconds a cached scan stays usable (default: 30)",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    pick = sub.add_parser("pick", help="interactive picker (default)")
+    pick.set_defaults(func=cmd_pick)
+
+    lst = sub.add_parser("list", help="print all live agents")
+    lst.add_argument("--json", action="store_true", help="machine-readable output")
+    lst.add_argument("--cached", action="store_true", help="use the cache if fresh")
+    lst.add_argument("--no-color", action="store_true", help="disable colour")
+    lst.set_defaults(func=cmd_list)
+
+    scan_cmd = sub.add_parser("scan", help="refresh the cache")
+    scan_cmd.set_defaults(func=cmd_scan)
+
+    rows = sub.add_parser("rows", help=argparse.SUPPRESS)
+    rows.add_argument("--refresh", action="store_true")
+    rows.set_defaults(func=cmd_rows)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the ``amux`` console script."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "func", None):
+        args = parser.parse_args([*(argv or []), "pick"])
+    if not scan.tmux_available():
+        print("amux: no tmux server running", file=sys.stderr)
+        return 1
+    return int(args.func(args) or 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude_code_tools/amux/cli.py
+++ b/claude_code_tools/amux/cli.py
@@ -12,6 +12,7 @@ instant even with hundreds of panes.
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import shlex
 import shutil
@@ -128,6 +129,21 @@ def cmd_pick(args: argparse.Namespace) -> int:
     return 0
 
 
+def _finite_seconds(value: str) -> float:
+    """Parse a --max-age value, rejecting nan/inf.
+
+    argparse's ``type=float`` happily accepts "nan", and every comparison
+    against NaN is False -- so ``--max-age nan`` disabled cache expiry
+    entirely and served arbitrarily stale data.
+    """
+    seconds = float(value)
+    if not math.isfinite(seconds) or seconds < 0:
+        raise argparse.ArgumentTypeError(
+            f"must be a non-negative finite number of seconds, got {value!r}"
+        )
+    return seconds
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Construct the argument parser."""
     parser = argparse.ArgumentParser(
@@ -136,7 +152,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--max-age",
-        type=float,
+        type=_finite_seconds,
         default=30.0,
         help="seconds a cached scan stays usable (default: 30)",
     )

--- a/claude_code_tools/amux/cli.py
+++ b/claude_code_tools/amux/cli.py
@@ -116,8 +116,16 @@ def cmd_pick(args: argparse.Namespace) -> int:
         if bind:
             cmd += ["--bind", bind]
 
+    # Capture ONLY stdout. capture_output=True also pipes stderr, which is
+    # where fzf draws its interface -- the UI never reaches the terminal and
+    # the picker looks hung, waiting for keys against an invisible prompt.
+    # (fzf reads keystrokes from /dev/tty, so feeding the list on stdin is
+    # fine.)
     proc = subprocess.run(
-        cmd, input=render.picker_lines(agents), capture_output=True, text=True
+        cmd,
+        input=render.picker_lines(agents),
+        stdout=subprocess.PIPE,
+        text=True,
     )
     if proc.returncode != 0 or not proc.stdout.strip():
         return 0

--- a/claude_code_tools/amux/cli.py
+++ b/claude_code_tools/amux/cli.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -83,7 +84,9 @@ def cmd_pick(args: argparse.Namespace) -> int:
         print("no agents running")
         return 0
 
-    self_cmd = f"{sys.executable} -m claude_code_tools.amux"
+    # fzf runs bind commands through a shell, so the interpreter path must be
+    # quoted: a venv at "/tmp/my venv/bin/python" would otherwise run "/tmp/my".
+    self_cmd = f"{shlex.quote(sys.executable)} -m claude_code_tools.amux"
     binds = [
         f"ctrl-r:reload({self_cmd} rows --refresh)",
         # Opening on cached rows is what makes this instant; refresh the
@@ -94,6 +97,11 @@ def cmd_pick(args: argparse.Namespace) -> int:
         "fzf",
         "--ansi",
         "--no-sort",
+        # Field 1 is the pane target, hidden from view; see picker_lines().
+        "--delimiter",
+        "\t",
+        "--with-nth",
+        "2..",
         "--header",
         _FZF_HEADER,
         "--preview",
@@ -113,7 +121,9 @@ def cmd_pick(args: argparse.Namespace) -> int:
     if proc.returncode != 0 or not proc.stdout.strip():
         return 0
 
-    pane = proc.stdout.split()[0]
+    pane = render.pane_from_selection(proc.stdout)
+    if not pane:
+        return 0
     scan.switch_to(pane)
     return 0
 
@@ -154,9 +164,14 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``amux`` console script."""
     parser = build_parser()
-    args = parser.parse_args(argv)
-    if not getattr(args, "func", None):
-        args = parser.parse_args([*(argv or []), "pick"])
+    raw = list(sys.argv[1:] if argv is None else argv)
+    # Default to the picker, but insert the subcommand rather than reparsing
+    # only ["pick"] -- reparsing dropped global options, so `amux --max-age 0`
+    # silently used the 30s default.
+    known = {"pick", "list", "scan", "rows"}
+    if not any(tok in known for tok in raw):
+        raw.append("pick")
+    args = parser.parse_args(raw)
     if not scan.tmux_available():
         print("amux: no tmux server running", file=sys.stderr)
         return 1

--- a/claude_code_tools/amux/detect.py
+++ b/claude_code_tools/amux/detect.py
@@ -72,8 +72,13 @@ def detect_state(screen: str, kind: Kind) -> State:
         One of ``input`` (waiting on the user), ``busy`` (mid-turn),
         ``bg`` (background monitors running), or ``idle``.
     """
-    tail = "\n".join(screen.splitlines()[-_PROMPT_TAIL_LINES:])
-    if _ASKING.search(tail):
+    tail_lines = screen.splitlines()[-_PROMPT_TAIL_LINES:]
+    tail = "\n".join(tail_lines)
+    # An ANSWERED prompt keeps its choices on screen, with Claude's footer
+    # rendered below them. Only treat a prompt as pending when nothing from
+    # the footer appears after it -- otherwise a just-answered
+    # AskUserQuestion stays flagged as blocking until it scrolls off.
+    if _ASKING.search(tail) and not _footer_below_prompt(tail_lines):
         return "input"
     if kind == "codex" and _codex_awaiting_answer(screen):
         return "input"
@@ -83,6 +88,20 @@ def detect_state(screen: str, kind: Kind) -> State:
         return "bg"
     return "idle"
 
+
+#: Footer chrome Claude renders BELOW a completed exchange.
+_FOOTER = re.compile(r"bypass permissions on|ctx [█░]|new task\?|/clear to save")
+
+
+def _footer_below_prompt(lines: list[str]) -> bool:
+    """Whether harness footer chrome appears after the last prompt line."""
+    last_prompt = -1
+    for index, line in enumerate(lines):
+        if _ASKING.search(line):
+            last_prompt = index
+    if last_prompt < 0:
+        return False
+    return any(_FOOTER.search(line) for line in lines[last_prompt + 1 :])
 
 def _codex_awaiting_answer(screen: str) -> bool:
     """Heuristic: Codex asked a question and stopped.

--- a/claude_code_tools/amux/detect.py
+++ b/claude_code_tools/amux/detect.py
@@ -55,6 +55,12 @@ _CODEX_CHROME = re.compile(
 )
 
 
+#: A pending prompt is at the BOTTOM of the screen. Searching all retained
+#: text made any earlier sentence containing e.g. "Would you like" pin the
+#: pane to `input` until it scrolled off.
+_PROMPT_TAIL_LINES = 12
+
+
 def detect_state(screen: str, kind: Kind) -> State:
     """Classify what the agent is doing from its visible screen.
 
@@ -66,7 +72,8 @@ def detect_state(screen: str, kind: Kind) -> State:
         One of ``input`` (waiting on the user), ``busy`` (mid-turn),
         ``bg`` (background monitors running), or ``idle``.
     """
-    if _ASKING.search(screen):
+    tail = "\n".join(screen.splitlines()[-_PROMPT_TAIL_LINES:])
+    if _ASKING.search(tail):
         return "input"
     if kind == "codex" and _codex_awaiting_answer(screen):
         return "input"

--- a/claude_code_tools/amux/detect.py
+++ b/claude_code_tools/amux/detect.py
@@ -80,10 +80,14 @@ def detect_state(screen: str, kind: Kind) -> State:
     # AskUserQuestion stays flagged as blocking until it scrolls off.
     if _ASKING.search(tail) and not _footer_below_prompt(tail_lines):
         return "input"
-    if kind == "codex" and _codex_awaiting_answer(screen):
-        return "input"
+    # BUSY must be decided before the Codex question heuristic. A visible
+    # spinner is proof the agent is working, whereas the heuristic can only
+    # guess from an older question still on screen: Codex asks, you answer,
+    # it starts working -- and the question is still up there.
     if _BUSY.search(screen):
         return "busy"
+    if kind == "codex" and _codex_awaiting_answer(tail):
+        return "input"
     if _BG.search(screen):
         return "bg"
     return "idle"
@@ -118,6 +122,10 @@ def _codex_awaiting_answer(screen: str) -> bool:
     the last real content line -- ignoring the input box and status chrome --
     ends in a question mark. This has false positives (an answer that merely
     ends in a question) and misses (a question phrased as a statement).
+
+    Only the screen TAIL is considered, and callers must rule out "busy"
+    first: a question further up the scrollback says nothing about whether
+    the agent is still waiting for you.
     """
     for line in reversed(screen.splitlines()):
         if not line.strip() or _CODEX_CHROME.search(line):

--- a/claude_code_tools/amux/detect.py
+++ b/claude_code_tools/amux/detect.py
@@ -74,8 +74,28 @@ _ASKING = re.compile(
     r"Select an option|Choose an option",
     re.MULTILINE,
 )
-_BUSY = re.compile(r"esc to interrupt", re.IGNORECASE)
-_BG = re.compile(r"\b\d+\s+monitors?\b")
+#: The MAIN agent is mid-turn. Two forms seen live:
+#:   "✻ Cooked for 14m 17s · esc to interrupt"
+#:   "· Razzmatazzing… (1m 42s · ↓ 4.8k tokens · thought for 14s)"
+#: The second has no "esc to interrupt" at all, so matching only that phrase
+#: reported an actively working pane as idle. The parenthesised
+#: elapsed-time-plus-token-counter is what distinguishes it from a subagent
+#: row, which carries the same counter WITHOUT parentheses.
+_BUSY = re.compile(
+    r"esc to interrupt|\(\d+[ms][^)]*↓[^)]*tokens",
+    re.IGNORECASE,
+)
+#: Background work. Two forms, both taken from live panes:
+#:   "✻ Baked for 16m 24s · 1 monitor still running"
+#:   "  ◯ cache-incremental-evidence  Grepping ...   1m 16s · ↓ 873.5k tokens"
+#: The second is Claude's subagent tree: ◯ marks a subagent still RUNNING
+#: (✓ marks a finished one, and ⏺ is ordinary assistant output, so neither of
+#: those can be used). Without this a pane with a working subagent but a free
+#: main prompt reported as idle.
+_BG = re.compile(
+    r"\b\d+\s+monitors?\b|^\s*◯\s+\S",
+    re.MULTILINE,
+)
 
 #: Codex chrome to ignore when looking for its last content line.
 _CODEX_CHROME = re.compile(

--- a/claude_code_tools/amux/detect.py
+++ b/claude_code_tools/amux/detect.py
@@ -18,23 +18,51 @@ from .model import Kind, State
 
 # --- harness identification (from the pane's child process argv) -----------
 
-_CODEX_ARGV = re.compile(r"(^|/|\s)codex(\s|$)|@openai/codex")
-_CLAUDE_ARGV = re.compile(r"(^|/|\s)claude(\s|$)")
+#: Interpreters that launch an agent via a script path rather than being the
+#: agent themselves (Codex ships as JS run under node).
+_INTERPRETERS = {"node", "node.exe", "python", "python3", "bun", "deno"}
+
+#: Script-path fragments that identify a harness when run under an interpreter.
+_CODEX_PATH = re.compile(r"@openai/codex|/codex(\.js|-cli)?\b")
+_CLAUDE_PATH = re.compile(r"/claude(\.js|-code)?\b|/\.local/share/claude/")
+
+
+def _basename(token: str) -> str:
+    """Executable name from an argv[0] token."""
+    return token.rsplit("/", 1)[-1]
 
 
 def classify_argv(argv: str) -> Kind | None:
-    """Identify the harness from a pane child process's command line.
+    """Identify the harness from a single process command line.
+
+    Only the EXECUTABLE decides -- argv[0], or the script path when argv[0] is
+    an interpreter. Searching the whole command line matched arguments too, so
+    an ordinary ``rg claude .`` in a pane was listed as an idle Claude agent.
 
     Args:
-        argv: Newline-joined command lines of the pane's child processes.
+        argv: One process's command line.
 
     Returns:
-        ``"codex"``, ``"claude"``, or ``None`` when no agent is running.
+        ``"codex"``, ``"claude"``, or ``None`` when this is not an agent.
     """
-    if _CODEX_ARGV.search(argv):
-        return "codex"
-    if _CLAUDE_ARGV.search(argv):
-        return "claude"
+    for line in argv.splitlines():
+        tokens = line.split()
+        if not tokens:
+            continue
+        exe = _basename(tokens[0])
+        if exe in ("codex", "codex-cli"):
+            return "codex"
+        if exe in ("claude", "claude-code"):
+            return "claude"
+        # Versioned Claude binaries are named after the version (2.1.220).
+        if re.fullmatch(r"\d+\.\d+\.\d+", exe):
+            return "claude"
+        if exe in _INTERPRETERS and len(tokens) > 1:
+            script = tokens[1]
+            if _CODEX_PATH.search(script):
+                return "codex"
+            if _CLAUDE_PATH.search(script):
+                return "claude"
     return None
 
 

--- a/claude_code_tools/amux/detect.py
+++ b/claude_code_tools/amux/detect.py
@@ -1,0 +1,146 @@
+"""Screen-scraping heuristics: what harness is this, and what is it doing.
+
+Everything here is deliberately pure (string in, verdict out) so it can be
+unit-tested against captured fixtures without a live tmux server.
+
+Why screen-scraping at all: ``pane_current_command`` is useless for
+identifying these harnesses -- Claude Code reports a bare version string like
+``2.1.220`` because it runs a versioned binary, and Codex reports ``node``.
+Process *argv* identifies the harness reliably; the *screen* is the only place
+that reveals what it is currently doing.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .model import Kind, State
+
+# --- harness identification (from the pane's child process argv) -----------
+
+_CODEX_ARGV = re.compile(r"(^|/|\s)codex(\s|$)|@openai/codex")
+_CLAUDE_ARGV = re.compile(r"(^|/|\s)claude(\s|$)")
+
+
+def classify_argv(argv: str) -> Kind | None:
+    """Identify the harness from a pane child process's command line.
+
+    Args:
+        argv: Newline-joined command lines of the pane's child processes.
+
+    Returns:
+        ``"codex"``, ``"claude"``, or ``None`` when no agent is running.
+    """
+    if _CODEX_ARGV.search(argv):
+        return "codex"
+    if _CLAUDE_ARGV.search(argv):
+        return "claude"
+    return None
+
+
+# --- state detection (from the pane's visible screen) ----------------------
+
+#: Claude renders AskUserQuestion and permission prompts as numbered choices.
+_ASKING = re.compile(
+    r"❯\s*1\.|Do you want|Would you like|^\s*1\.\s*Yes|\(y/n\)|"
+    r"Select an option|Choose an option",
+    re.MULTILINE,
+)
+_BUSY = re.compile(r"esc to interrupt", re.IGNORECASE)
+_BG = re.compile(r"\b\d+\s+monitors?\b")
+
+#: Codex chrome to ignore when looking for its last content line.
+_CODEX_CHROME = re.compile(
+    r"^\s*[›❯]|·|gpt-[\d.]|^\s*─|esc to|tab to|^\s*$|^\s*[▌│]"
+)
+
+
+def detect_state(screen: str, kind: Kind) -> State:
+    """Classify what the agent is doing from its visible screen.
+
+    Args:
+        screen: The pane's captured text (escape sequences stripped).
+        kind: Which harness is running, from :func:`classify_argv`.
+
+    Returns:
+        One of ``input`` (waiting on the user), ``busy`` (mid-turn),
+        ``bg`` (background monitors running), or ``idle``.
+    """
+    if _ASKING.search(screen):
+        return "input"
+    if kind == "codex" and _codex_awaiting_answer(screen):
+        return "input"
+    if _BUSY.search(screen):
+        return "busy"
+    if _BG.search(screen):
+        return "bg"
+    return "idle"
+
+
+def _codex_awaiting_answer(screen: str) -> bool:
+    """Heuristic: Codex asked a question and stopped.
+
+    Codex has no structured prompt UI, so the only available signal is that
+    the last real content line -- ignoring the input box and status chrome --
+    ends in a question mark. This has false positives (an answer that merely
+    ends in a question) and misses (a question phrased as a statement).
+    """
+    for line in reversed(screen.splitlines()):
+        if not line.strip() or _CODEX_CHROME.search(line):
+            continue
+        return line.rstrip().endswith("?")
+    return False
+
+
+# --- context extraction ----------------------------------------------------
+
+_CODEX_STATUS = re.compile(r"(gpt-[\w.\-]+)\s+(\w+)?\s*·\s*([^·]+)·\s*([^·\n]+)")
+_CLAUDE_MODEL = re.compile(
+    r"\b(opus[\w.\-\[\]]*|sonnet[\w.\-\[\]]*|haiku[\w.\-\[\]]*|fable[\w.\-\[\]]*)"
+)
+_SEPARATOR_NAME = re.compile(r"─\s([A-Za-z0-9][A-Za-z0-9._-]{3,})\s─")
+_ARGV_NAME = re.compile(r"--(?:resume|name)[= ]([^\s]+)")
+_SPINNER = re.compile(r"^[✳*⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏\s]+")
+
+
+def extract_model(screen: str, kind: Kind) -> str:
+    """Pull the model identifier out of the harness footer, if present."""
+    if kind == "codex":
+        match = _CODEX_STATUS.search(screen)
+        return match.group(1) if match else ""
+    match = _CLAUDE_MODEL.search(screen)
+    return match.group(1) if match else ""
+
+
+def extract_name(argv: str, pane_title: str, screen: str) -> str:
+    """Best-effort agent session name, most reliable source first.
+
+    Order: the harness's own argv (``--resume``/``--name``), then the tmux
+    pane title (Claude sets it to ``✳ <name>``), then an on-screen separator
+    line. Codex rarely carries a name in any of these and returns ``""``.
+    """
+    match = _ARGV_NAME.search(argv)
+    if match:
+        return match.group(1)
+
+    title = _SPINNER.sub("", pane_title).strip()
+    # Shell-set titles are paths, ~[dir] forms, or hostnames -- not names.
+    if title and not re.search(r"[/\[\]]|\.lan$|\.local$", title):
+        return title
+
+    names = _SEPARATOR_NAME.findall(screen)
+    return names[-1] if names else ""
+
+
+def extract_info(screen: str, kind: Kind) -> str:
+    """One line of context for the list view (model, repo, branch, …)."""
+    if kind == "codex":
+        match = _CODEX_STATUS.search(screen)
+        if match:
+            parts = [p.strip() for p in match.groups() if p]
+            return " · ".join(parts)
+    lines = [ln.strip() for ln in screen.splitlines() if ln.strip()]
+    for line in reversed(lines):
+        if _CLAUDE_MODEL.search(line):
+            return re.sub(r"\s{2,}", " ", line)[:80]
+    return lines[-1][:80] if lines else ""

--- a/claude_code_tools/amux/detect.py
+++ b/claude_code_tools/amux/detect.py
@@ -89,8 +89,11 @@ def detect_state(screen: str, kind: Kind) -> State:
     return "idle"
 
 
-#: Footer chrome Claude renders BELOW a completed exchange.
-_FOOTER = re.compile(r"bypass permissions on|ctx [█░]|new task\?|/clear to save")
+#: Footer chrome Claude renders BELOW a completed exchange. Anchored to the
+#: start of a line: an option in a PENDING prompt can quote this text
+#: ("2. Explain why the status says bypass permissions on") and must not be
+#: mistaken for the footer itself.
+_FOOTER = re.compile(r"^\s*(⏵⏵|ctx [█░]|new task\?|✻|※)")
 
 
 def _footer_below_prompt(lines: list[str]) -> bool:

--- a/claude_code_tools/amux/detect.py
+++ b/claude_code_tools/amux/detect.py
@@ -93,7 +93,12 @@ def detect_state(screen: str, kind: Kind) -> State:
 #: start of a line: an option in a PENDING prompt can quote this text
 #: ("2. Explain why the status says bypass permissions on") and must not be
 #: mistaken for the footer itself.
-_FOOTER = re.compile(r"^\s*(⏵⏵|ctx [█░]|new task\?|✻|※)")
+_FOOTER = re.compile(
+    r"^\s*("
+    r"⏵⏵|ctx [█░]|new task\?|✻|※"       # Claude chrome
+    r"|gpt-[\w.\-]+\s|›"                # Codex status line and input box
+    r")"
+)
 
 
 def _footer_below_prompt(lines: list[str]) -> bool:

--- a/claude_code_tools/amux/model.py
+++ b/claude_code_tools/amux/model.py
@@ -1,0 +1,68 @@
+"""Data model for amux: one record per tmux pane running a coding agent."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+Kind = Literal["claude", "codex"]
+State = Literal["input", "busy", "bg", "idle"]
+
+#: Sort order for the picker: the agent waiting on YOU comes first.
+STATE_RANK: dict[str, int] = {"input": 0, "busy": 1, "bg": 2, "idle": 3}
+
+#: ANSI colour per state, applied only when rendering to a terminal.
+STATE_COLOR: dict[str, str] = {
+    "input": "1;31",  # bold red   - stopped, asking you something
+    "busy": "1;32",  # bold green - mid-turn
+    "bg": "1;36",  # bold cyan  - monitors/subagents running
+    "idle": "2;37",  # dim        - at prompt, nothing pending
+}
+
+
+@dataclass
+class Agent:
+    """A coding agent running inside a tmux pane.
+
+    Attributes:
+        pane: tmux target, e.g. ``sasy:1.4``.
+        session: tmux session name.
+        kind: Which harness is running (``claude`` or ``codex``).
+        state: What it is doing right now; see :data:`STATE_RANK`.
+        name: Agent session name (from argv ``--resume``/``--name``, the pane
+            title, or an on-screen separator), or ``""`` if undiscoverable.
+        cwd: Pane working directory.
+        repo: Basename of the enclosing git worktree, or ``""``.
+        branch: Current git branch, or ``""``.
+        model: Model string parsed from the harness footer, e.g. ``opus-5``.
+        info: One-line context lifted from the pane's footer.
+        pid: PID of the agent process itself (not the pane's shell).
+    """
+
+    pane: str
+    session: str
+    kind: Kind
+    state: State = "idle"
+    name: str = ""
+    cwd: str = ""
+    repo: str = ""
+    branch: str = ""
+    model: str = ""
+    info: str = ""
+    pid: int = 0
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def rank(self) -> int:
+        """Urgency rank used for sorting (lower sorts first)."""
+        return STATE_RANK.get(self.state, 9)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable dict (used by the cache)."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Agent:
+        """Rebuild an :class:`Agent` from :meth:`to_dict` output."""
+        known = {k: v for k, v in data.items() if k in cls.__dataclass_fields__}
+        return cls(**known)

--- a/claude_code_tools/amux/model.py
+++ b/claude_code_tools/amux/model.py
@@ -62,7 +62,23 @@ class Agent:
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> Agent:
-        """Rebuild an :class:`Agent` from :meth:`to_dict` output."""
+    def from_dict(cls, data: dict[str, Any]) -> Agent | None:
+        """Rebuild an :class:`Agent` from :meth:`to_dict` output.
+
+        Returns ``None`` for a record that is the right shape but the wrong
+        types -- a hand-edited or truncated cache with ``"pane": null`` would
+        otherwise reach the renderer and crash on ``len(None)``.
+        """
         known = {k: v for k, v in data.items() if k in cls.__dataclass_fields__}
+        for field_name in ("pane", "session", "kind", "state"):
+            value = known.get(field_name)
+            if value is not None and not isinstance(value, str):
+                return None
+        for field_name in ("name", "cwd", "repo", "branch", "model", "info"):
+            if not isinstance(known.get(field_name, ""), str):
+                return None
+        if known.get("pane") is None or known.get("session") is None:
+            return None
+        if not isinstance(known.get("pid", 0), int):
+            return None
         return cls(**known)

--- a/claude_code_tools/amux/model.py
+++ b/claude_code_tools/amux/model.py
@@ -81,4 +81,10 @@ class Agent:
             return None
         if not isinstance(known.get("pid", 0), int):
             return None
+        # Literal[...] is a type-checker hint only; a hand-edited cache can
+        # still carry kind="vim" or state="waiting" and render as an agent.
+        if known.get("kind") not in ("claude", "codex"):
+            return None
+        if known.get("state", "idle") not in STATE_RANK:
+            return None
         return cls(**known)

--- a/claude_code_tools/amux/render.py
+++ b/claude_code_tools/amux/render.py
@@ -30,20 +30,32 @@ def _colour(state: str, text: str, colour: bool) -> str:
 
 
 def picker_row(agent: Agent, colour: bool = True) -> str:
-    """One aligned, optionally coloured row for the fzf list."""
+    """The visible part of an fzf row (no key field); see :func:`picker_lines`."""
     state = _colour(agent.state, f"{agent.state:<{_W_STATE}}", colour)
     branch = f"@{agent.branch}" if agent.branch else ""
     where = _clip(f"{agent.repo}{branch}", _W_REPO)
     return (
-        f"{agent.pane:<{_W_PANE}} {state} {agent.kind:<{_W_KIND}} "
+        f"{_clip(agent.pane, _W_PANE):<{_W_PANE}} {state} {agent.kind:<{_W_KIND}} "
         f"{_clip(agent.name or '-', _W_NAME):<{_W_NAME}} "
         f"{where:<{_W_REPO}} {agent.info}"
     )
 
 
 def picker_lines(agents: list[Agent], colour: bool = True) -> str:
-    """All picker rows, newline-joined."""
-    return "\n".join(picker_row(a, colour) for a in agents)
+    """All fzf rows: a tab-separated key field followed by the visible text.
+
+    The leading ``pane<TAB>`` field exists because tmux permits spaces in
+    session names, so ``amux test:1.1`` would make fzf's whitespace-split
+    ``{1}`` resolve to ``amux`` -- pointing the preview and the jump at a pane
+    that does not exist. With ``--delimiter '\\t' --with-nth 2..`` the key stays
+    intact and invisible.
+    """
+    return "\n".join(f"{a.pane}\t{picker_row(a, colour)}" for a in agents)
+
+
+def pane_from_selection(line: str) -> str:
+    """Recover the pane target from a selected fzf line."""
+    return line.split("\t", 1)[0].strip()
 
 
 def table(agents: list[Agent], colour: bool = True) -> str:

--- a/claude_code_tools/amux/render.py
+++ b/claude_code_tools/amux/render.py
@@ -1,0 +1,74 @@
+"""Rendering: aligned rows for the picker, and a table for humans."""
+
+from __future__ import annotations
+
+import json
+
+from .model import STATE_COLOR, Agent
+
+#: Column widths for the picker rows. Pane comes first because fzf's preview
+#: binding uses ``{1}`` to address it.
+_W_PANE = 20
+_W_STATE = 5
+_W_KIND = 6
+_W_NAME = 26
+_W_REPO = 22
+
+
+def _clip(text: str, width: int) -> str:
+    """Truncate *text* to *width*, marking loss with an ellipsis."""
+    if len(text) <= width:
+        return text
+    return text[: width - 1] + "…"
+
+
+def _colour(state: str, text: str, colour: bool) -> str:
+    """Wrap *text* in this state's ANSI colour when *colour* is enabled."""
+    if not colour:
+        return text
+    return f"\033[{STATE_COLOR.get(state, '0')}m{text}\033[0m"
+
+
+def picker_row(agent: Agent, colour: bool = True) -> str:
+    """One aligned, optionally coloured row for the fzf list."""
+    state = _colour(agent.state, f"{agent.state:<{_W_STATE}}", colour)
+    branch = f"@{agent.branch}" if agent.branch else ""
+    where = _clip(f"{agent.repo}{branch}", _W_REPO)
+    return (
+        f"{agent.pane:<{_W_PANE}} {state} {agent.kind:<{_W_KIND}} "
+        f"{_clip(agent.name or '-', _W_NAME):<{_W_NAME}} "
+        f"{where:<{_W_REPO}} {agent.info}"
+    )
+
+
+def picker_lines(agents: list[Agent], colour: bool = True) -> str:
+    """All picker rows, newline-joined."""
+    return "\n".join(picker_row(a, colour) for a in agents)
+
+
+def table(agents: list[Agent], colour: bool = True) -> str:
+    """A bordered summary table, grouped by state with counts in the header."""
+    if not agents:
+        return "no agents found"
+
+    counts: dict[str, int] = {}
+    for agent in agents:
+        counts[agent.state] = counts.get(agent.state, 0) + 1
+    summary = "  ".join(
+        _colour(state, f"{state}={counts[state]}", colour)
+        for state in ("input", "busy", "bg", "idle")
+        if state in counts
+    )
+
+    header = (
+        f"{'PANE':<{_W_PANE}} {'STATE':<{_W_STATE}} {'KIND':<{_W_KIND}} "
+        f"{'NAME':<{_W_NAME}} {'REPO@BRANCH':<{_W_REPO}} CONTEXT"
+    )
+    rule = "─" * min(len(header) + 20, 120)
+    rows = [picker_row(a, colour) for a in agents]
+    return "\n".join([f"{len(agents)} agents   {summary}", rule, header, rule, *rows])
+
+
+def as_json(agents: list[Agent]) -> str:
+    """Machine-readable output for scripts and other tools."""
+    return json.dumps([a.to_dict() for a in agents], indent=2)

--- a/claude_code_tools/amux/scan.py
+++ b/claude_code_tools/amux/scan.py
@@ -79,13 +79,42 @@ def _children_by_ppid() -> dict[int, list[tuple[int, str]]]:
     return children
 
 
+def descendants(
+    tree: dict[int, list[tuple[int, str]]], root: int, limit: int = 200
+) -> list[tuple[int, str]]:
+    """Every process beneath *root*, breadth-first.
+
+    Direct children are not enough: a pane whose shell launches a wrapper
+    (``direnv exec``, a login shell, a `just` recipe) which then launches the
+    agent would otherwise show only the wrapper, and the agent would be
+    invisible. The whole process table is already snapshotted, so walking it
+    costs nothing extra.
+
+    Args:
+        tree: Map of ppid to ``(pid, command)`` pairs.
+        root: PID whose descendants are wanted.
+        limit: Safety bound on nodes visited, in case of a cycle.
+    """
+    out: list[tuple[int, str]] = []
+    queue = list(tree.get(root, []))
+    seen: set[int] = set()
+    while queue and len(out) < limit:
+        pid, cmd = queue.pop(0)
+        if pid in seen:
+            continue
+        seen.add(pid)
+        out.append((pid, cmd))
+        queue.extend(tree.get(pid, []))
+    return out
+
+
 def argv_of(children: list[tuple[int, str]]) -> str:
     """Joined command lines, for harness classification."""
     return "\n".join(cmd for _, cmd in children)
 
 
 def agent_pid(children: list[tuple[int, str]], kind: str) -> int:
-    """PID of the child matching *kind*, else the first child, else 0.
+    """PID of the process matching *kind*, else the first, else 0.
 
     Matching on kind matters: a pane running ``sleep 600 &`` alongside an
     agent would otherwise report the sleep's PID.
@@ -172,7 +201,7 @@ def scan(workers: int = 16) -> list[Agent]:
             ppid = int(pid_s)
         except ValueError:
             continue
-        children = child_map.get(ppid, [])
+        children = descendants(child_map, ppid)
         kind = detect.classify_argv(argv_of(children))
         if kind is None:
             continue
@@ -198,14 +227,14 @@ def scan(workers: int = 16) -> list[Agent]:
                 kind=kind,  # type: ignore[arg-type]
                 state=detect.detect_state(screen, kind),  # type: ignore[arg-type]
                 name=detect.extract_name(
-                    argv_of(child_map.get(ppid, [])), title, screen
+                    argv_of(descendants(child_map, ppid)), title, screen
                 ),
                 cwd=cwd,
                 repo=repo,
                 branch=branch,
                 model=detect.extract_model(screen, kind),  # type: ignore[arg-type]
                 info=detect.extract_info(screen, kind),  # type: ignore[arg-type]
-                pid=agent_pid(child_map.get(ppid, []), kind),
+                pid=agent_pid(descendants(child_map, ppid), kind),
             )
         )
 

--- a/claude_code_tools/amux/scan.py
+++ b/claude_code_tools/amux/scan.py
@@ -47,11 +47,14 @@ def _tmux(*args: str) -> str:
     return out.stdout if out.returncode == 0 else ""
 
 
-def _child_argv_by_ppid() -> dict[int, str]:
-    """Map each PID to the joined command lines of its direct children.
+def _children_by_ppid() -> dict[int, list[tuple[int, str]]]:
+    """Map each PID to its direct children as ``(pid, command_line)`` pairs.
 
-    One ``ps`` call for the whole process table; the alternative is a fork per
-    pane, which dominated the old runtime.
+    One ``ps`` call for the whole process table; a fork per pane dominated the
+    original runtime. Keeping the child PIDs here (rather than a second
+    ``pgrep``) also means agent-PID selection sees full command lines --
+    ``pgrep -l`` reports only the executable name, which is ``node`` for Codex
+    and therefore unidentifiable.
     """
     try:
         out = subprocess.run(
@@ -63,44 +66,34 @@ def _child_argv_by_ppid() -> dict[int, str]:
     except (OSError, subprocess.SubprocessError):
         return {}
 
-    children: dict[int, list[str]] = {}
+    children: dict[int, list[tuple[int, str]]] = {}
     for line in out.splitlines():
         parts = line.strip().split(None, 2)
         if len(parts) < 3:
             continue
         try:
-            ppid = int(parts[0])
+            ppid, pid = int(parts[0]), int(parts[1])
         except ValueError:
             continue
-        children.setdefault(ppid, []).append(parts[2])
-    return {ppid: "\n".join(cmds) for ppid, cmds in children.items()}
+        children.setdefault(ppid, []).append((pid, parts[2]))
+    return children
 
 
-def _child_pid(ppid: int, kind: str) -> int:
-    """PID of the agent process under a pane's shell.
+def argv_of(children: list[tuple[int, str]]) -> str:
+    """Joined command lines, for harness classification."""
+    return "\n".join(cmd for _, cmd in children)
 
-    Matches on *kind* rather than taking the first child: a pane running
-    ``sleep 600 &`` alongside an agent would otherwise report the sleep's PID.
+
+def agent_pid(children: list[tuple[int, str]], kind: str) -> int:
+    """PID of the child matching *kind*, else the first child, else 0.
+
+    Matching on kind matters: a pane running ``sleep 600 &`` alongside an
+    agent would otherwise report the sleep's PID.
     """
-    try:
-        out = subprocess.run(
-            ["pgrep", "-P", str(ppid), "-l"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        ).stdout
-    except (OSError, subprocess.SubprocessError):
-        return 0
-    fallback = 0
-    for line in out.splitlines():
-        parts = line.split(None, 1)
-        if len(parts) != 2 or not parts[0].isdigit():
-            continue
-        pid = int(parts[0])
-        fallback = fallback or pid
-        if detect.classify_argv(parts[1]) == kind:
+    for pid, cmd in children:
+        if detect.classify_argv(cmd) == kind:
             return pid
-    return fallback
+    return children[0][0] if children else 0
 
 
 def capture(pane: str, lines: int = 40) -> str:
@@ -162,10 +155,13 @@ def scan(workers: int = 16) -> list[Agent]:
     if not listing:
         return []
 
-    argv_map = _child_argv_by_ppid()
+    child_map = _children_by_ppid()
     candidates: list[tuple[str, str, int, str, str, str]] = []
     for record in listing.split(_REC):
-        record = record.strip("\n")
+        # tmux terminates each -F line with a newline AFTER our record marker,
+        # so exactly one leading newline is separator; anything else is data
+        # (a path may legitimately end in a newline).
+        record = record[1:] if record.startswith("\n") else record
         if not record:
             continue
         parts = record.split(_SEP)
@@ -176,8 +172,8 @@ def scan(workers: int = 16) -> list[Agent]:
             ppid = int(pid_s)
         except ValueError:
             continue
-        argv = argv_map.get(ppid, "")
-        kind = detect.classify_argv(argv)
+        children = child_map.get(ppid, [])
+        kind = detect.classify_argv(argv_of(children))
         if kind is None:
             continue
         candidates.append((pane, session, ppid, title, cwd, kind))
@@ -201,13 +197,15 @@ def scan(workers: int = 16) -> list[Agent]:
                 session=session,
                 kind=kind,  # type: ignore[arg-type]
                 state=detect.detect_state(screen, kind),  # type: ignore[arg-type]
-                name=detect.extract_name(argv_map.get(ppid, ""), title, screen),
+                name=detect.extract_name(
+                    argv_of(child_map.get(ppid, [])), title, screen
+                ),
                 cwd=cwd,
                 repo=repo,
                 branch=branch,
                 model=detect.extract_model(screen, kind),  # type: ignore[arg-type]
                 info=detect.extract_info(screen, kind),  # type: ignore[arg-type]
-                pid=_child_pid(ppid, kind),
+                pid=agent_pid(child_map.get(ppid, []), kind),
             )
         )
 

--- a/claude_code_tools/amux/scan.py
+++ b/claude_code_tools/amux/scan.py
@@ -69,15 +69,30 @@ def _child_argv_by_ppid() -> dict[int, str]:
 
 
 def _child_pid(ppid: int, kind: str) -> int:
-    """Find the PID of the agent process under a pane's shell."""
+    """PID of the agent process under a pane's shell.
+
+    Matches on *kind* rather than taking the first child: a pane running
+    ``sleep 600 &`` alongside an agent would otherwise report the sleep's PID.
+    """
     try:
         out = subprocess.run(
-            ["pgrep", "-P", str(ppid)], capture_output=True, text=True, timeout=5
+            ["pgrep", "-P", str(ppid), "-l"],
+            capture_output=True,
+            text=True,
+            timeout=5,
         ).stdout
     except (OSError, subprocess.SubprocessError):
         return 0
-    pids = [int(p) for p in out.split() if p.isdigit()]
-    return pids[0] if pids else 0
+    fallback = 0
+    for line in out.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) != 2 or not parts[0].isdigit():
+            continue
+        pid = int(parts[0])
+        fallback = fallback or pid
+        if detect.classify_argv(parts[1]) == kind:
+            return pid
+    return fallback
 
 
 def capture(pane: str, lines: int = 40) -> str:
@@ -101,7 +116,9 @@ def _git_context(cwd: str) -> tuple[str, str]:
         if git.is_file():  # worktree: ".git" is a pointer file
             try:
                 target = git.read_text().strip().removeprefix("gitdir: ")
-                head = Path(target) / "HEAD"
+                # Worktree pointers may be relative, and are relative to the
+                # directory holding .git -- not to amux's cwd.
+                head = (path / target).resolve() / "HEAD"
             except OSError:
                 head = None
         if head and head.exists():
@@ -129,8 +146,11 @@ def scan(workers: int = 16) -> list[Agent]:
             "#{session_name}:#{window_index}.#{pane_index}",
             "#{session_name}",
             "#{pane_pid}",
-            "#{pane_title}",
-            "#{pane_current_path}",
+            # tmux permits newlines in titles and paths, which would split one
+            # -F record across lines and make the pane vanish. Strip them at
+            # the source with tmux's own substitution.
+            "#{s/\n/ /:pane_title}",
+            "#{s/\n/ /:pane_current_path}",
         ]
     )
     listing = _tmux("list-panes", "-a", "-F", fmt)
@@ -162,6 +182,10 @@ def scan(workers: int = 16) -> list[Agent]:
 
     agents: list[Agent] = []
     for (pane, session, ppid, title, cwd, kind), screen in zip(candidates, screens):
+        # A pane that closed between list-panes and capture-pane yields "".
+        # Listing it would offer a jump target that no longer exists.
+        if not screen.strip():
+            continue
         repo, branch = _git_context(cwd)
         agents.append(
             Agent(

--- a/claude_code_tools/amux/scan.py
+++ b/claude_code_tools/amux/scan.py
@@ -1,0 +1,200 @@
+"""Scan live tmux panes for running coding agents.
+
+Performance notes, measured on a 160-pane server where the original shell
+implementation took ~8.5s:
+
+* One ``ps`` snapshot replaces ~160 ``pgrep``+``ps`` forks (was ~5.6s).
+* ``capture-pane`` runs only for panes that actually host an agent, and in a
+  thread pool rather than serially (was ~2.9s for all panes).
+
+Together these turn a multi-second scan into a fraction of a second, which is
+what makes the picker feel instant even before the cache layer.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from . import detect
+from .model import Agent
+
+#: Field separator for tmux -F output; chosen to not occur in paths or titles.
+_SEP = "\x1f"
+
+_ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(\x07|\x1b\\)")
+
+
+def _tmux(*args: str) -> str:
+    """Run a tmux command, returning stdout (empty string on failure)."""
+    try:
+        out = subprocess.run(
+            ["tmux", *args], capture_output=True, text=True, timeout=10
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return out.stdout if out.returncode == 0 else ""
+
+
+def _child_argv_by_ppid() -> dict[int, str]:
+    """Map each PID to the joined command lines of its direct children.
+
+    One ``ps`` call for the whole process table; the alternative is a fork per
+    pane, which dominated the old runtime.
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-eo", "ppid=,pid=,command="],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return {}
+
+    children: dict[int, list[str]] = {}
+    for line in out.splitlines():
+        parts = line.strip().split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            ppid = int(parts[0])
+        except ValueError:
+            continue
+        children.setdefault(ppid, []).append(parts[2])
+    return {ppid: "\n".join(cmds) for ppid, cmds in children.items()}
+
+
+def _child_pid(ppid: int, kind: str) -> int:
+    """Find the PID of the agent process under a pane's shell."""
+    try:
+        out = subprocess.run(
+            ["pgrep", "-P", str(ppid)], capture_output=True, text=True, timeout=5
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return 0
+    pids = [int(p) for p in out.split() if p.isdigit()]
+    return pids[0] if pids else 0
+
+
+def capture(pane: str, lines: int = 40) -> str:
+    """Return a pane's recent screen text with escape sequences stripped."""
+    raw = _tmux("capture-pane", "-p", "-t", pane)
+    text = _ANSI.sub("", raw)
+    kept = [ln for ln in text.splitlines() if ln.strip()]
+    return "\n".join(kept[-lines:])
+
+
+def _git_context(cwd: str) -> tuple[str, str]:
+    """Return ``(repo, branch)`` for a directory, without forking git.
+
+    Reads ``.git/HEAD`` directly by walking up from *cwd*; a subprocess per
+    pane would reintroduce the cost this module exists to avoid.
+    """
+    path = Path(cwd) if cwd else None
+    while path and path != path.parent:
+        git = path / ".git"
+        head = git / "HEAD" if git.is_dir() else None
+        if git.is_file():  # worktree: ".git" is a pointer file
+            try:
+                target = git.read_text().strip().removeprefix("gitdir: ")
+                head = Path(target) / "HEAD"
+            except OSError:
+                head = None
+        if head and head.exists():
+            try:
+                ref = head.read_text().strip()
+            except OSError:
+                return path.name, ""
+            branch = ref.removeprefix("ref: refs/heads/") if "ref:" in ref else ""
+            return path.name, branch
+        path = path.parent
+    return "", ""
+
+
+def scan(workers: int = 16) -> list[Agent]:
+    """Find every tmux pane currently running a Claude or Codex agent.
+
+    Args:
+        workers: Thread-pool size for the ``capture-pane`` calls.
+
+    Returns:
+        Agents sorted by urgency (waiting-on-you first), then by pane.
+    """
+    fmt = _SEP.join(
+        [
+            "#{session_name}:#{window_index}.#{pane_index}",
+            "#{session_name}",
+            "#{pane_pid}",
+            "#{pane_title}",
+            "#{pane_current_path}",
+        ]
+    )
+    listing = _tmux("list-panes", "-a", "-F", fmt)
+    if not listing:
+        return []
+
+    argv_map = _child_argv_by_ppid()
+    candidates: list[tuple[str, str, int, str, str, str]] = []
+    for line in listing.splitlines():
+        parts = line.split(_SEP)
+        if len(parts) != 5:
+            continue
+        pane, session, pid_s, title, cwd = parts
+        try:
+            ppid = int(pid_s)
+        except ValueError:
+            continue
+        argv = argv_map.get(ppid, "")
+        kind = detect.classify_argv(argv)
+        if kind is None:
+            continue
+        candidates.append((pane, session, ppid, title, cwd, kind))
+
+    if not candidates:
+        return []
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        screens = list(pool.map(lambda c: capture(c[0]), candidates))
+
+    agents: list[Agent] = []
+    for (pane, session, ppid, title, cwd, kind), screen in zip(candidates, screens):
+        repo, branch = _git_context(cwd)
+        agents.append(
+            Agent(
+                pane=pane,
+                session=session,
+                kind=kind,  # type: ignore[arg-type]
+                state=detect.detect_state(screen, kind),  # type: ignore[arg-type]
+                name=detect.extract_name(argv_map.get(ppid, ""), title, screen),
+                cwd=cwd,
+                repo=repo,
+                branch=branch,
+                model=detect.extract_model(screen, kind),  # type: ignore[arg-type]
+                info=detect.extract_info(screen, kind),  # type: ignore[arg-type]
+                pid=_child_pid(ppid, kind),
+            )
+        )
+
+    agents.sort(key=lambda a: (a.rank, a.pane))
+    return agents
+
+
+def tmux_available() -> bool:
+    """Whether a tmux server is reachable."""
+    return bool(_tmux("list-sessions"))
+
+
+def switch_to(pane: str) -> None:
+    """Focus *pane*: select its window and pane, then switch/attach the client."""
+    window = pane.rsplit(".", 1)[0]
+    session = pane.split(":", 1)[0]
+    _tmux("select-window", "-t", window)
+    _tmux("select-pane", "-t", pane)
+    if os.environ.get("TMUX"):
+        _tmux("switch-client", "-t", session)
+    else:
+        os.execvp("tmux", ["tmux", "attach", "-t", session])

--- a/claude_code_tools/amux/scan.py
+++ b/claude_code_tools/amux/scan.py
@@ -25,6 +25,14 @@ from .model import Agent
 #: Field separator for tmux -F output; chosen to not occur in paths or titles.
 _SEP = "\x1f"
 
+#: Explicit record terminator. tmux permits newlines in pane titles and in
+#: paths, so line-based parsing drops those panes entirely. Emitting an ASCII
+#: RS and splitting on it keeps records intact WITHOUT altering the data --
+#: tmux's own "#{s/\n/ /:...}" substitution is not the answer here: its
+#: pattern is a literal string, so it rewrites every letter "n"
+#: (/Users/pchalasani/Git/avon -> "/Users/pchalasa i/Git/avo ").
+_REC = "\x1e"
+
 _ANSI = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(\x07|\x1b\\)")
 
 
@@ -146,21 +154,21 @@ def scan(workers: int = 16) -> list[Agent]:
             "#{session_name}:#{window_index}.#{pane_index}",
             "#{session_name}",
             "#{pane_pid}",
-            # tmux permits newlines in titles and paths, which would split one
-            # -F record across lines and make the pane vanish. Strip them at
-            # the source with tmux's own substitution.
-            "#{s/\n/ /:pane_title}",
-            "#{s/\n/ /:pane_current_path}",
+            "#{pane_title}",
+            "#{pane_current_path}",
         ]
     )
-    listing = _tmux("list-panes", "-a", "-F", fmt)
+    listing = _tmux("list-panes", "-a", "-F", fmt + _REC)
     if not listing:
         return []
 
     argv_map = _child_argv_by_ppid()
     candidates: list[tuple[str, str, int, str, str, str]] = []
-    for line in listing.splitlines():
-        parts = line.split(_SEP)
+    for record in listing.split(_REC):
+        record = record.strip("\n")
+        if not record:
+            continue
+        parts = record.split(_SEP)
         if len(parts) != 5:
             continue
         pane, session, pid_s, title, cwd = parts

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -98,6 +98,7 @@ export default defineConfig({
                 },
               ],
             },
+            { label: "amux", slug: "tools/amux" },
             { label: "lmsh", slug: "tools/lmsh" },
             { label: "fix-session", slug: "tools/fix-session" },
             { label: "Status Line", slug: "tools/statusline" },

--- a/docs-site/src/content/docs/tools/amux.mdx
+++ b/docs-site/src/content/docs/tools/amux.mdx
@@ -1,0 +1,127 @@
+---
+title: "amux — Agents Tmux Dashboard"
+---
+
+`amux` finds the coding agents running across your tmux panes and lets you
+jump to one. Its job is to answer the question that gets hard once you have
+more than a handful of sessions: **which agent is waiting on me?**
+
+:::note[Installation]
+Part of the `claude-code-tools` package.
+See [Quick Start](../../getting-started/) for installation.
+Requires [`fzf`](https://github.com/junegunn/fzf) for the picker
+(`brew install fzf`); `amux list` works without it.
+:::
+
+## What It Does
+
+```bash
+amux              # interactive picker: pick an agent, jump to its pane
+amux list         # table of every live agent
+amux list --json  # machine-readable
+amux scan         # refresh the cache
+```
+
+In the picker, rows are sorted by urgency, the right-hand pane shows a live
+preview of whatever is highlighted, `enter` jumps to that pane, and `ctrl-r`
+refreshes.
+
+## Agent states
+
+Every pane running an agent gets one of four states, sorted most urgent first:
+
+| state | colour | meaning |
+|---|---|---|
+| `input` | red | the agent stopped and is **asking you something** |
+| `busy` | green | mid-turn, actively working |
+| `bg` | cyan | background monitors or subagents running |
+| `idle` | dim | at its prompt, nothing pending |
+
+`input` is the reason the tool exists. An agent blocked on a permission
+prompt or an `AskUserQuestion` is invisible among a hundred panes, and it
+will sit there indefinitely until you notice.
+
+## What each row shows
+
+```
+sasy:1.8   input  codex   certify-main    observability@feat/certify-codex   gpt-5.6-sol · …
+└─ pane    state  harness session name    repo@branch                        context
+```
+
+- **pane** — the tmux target; jump to it manually with `tmux switch-client`
+- **name** — the agent's session name, from its own `--resume`/`--name`
+  argument, the tmux pane title, or an on-screen banner
+- **repo@branch** — read directly from `.git/HEAD`, so git worktrees resolve
+  to the branch they are actually on
+- **context** — the model and status line lifted from the harness footer
+
+## How detection works
+
+Two questions, answered from two different places.
+
+**Which harness is this?** From the process, not the screen.
+`pane_current_command` is useless here: Claude Code reports a bare version
+string like `2.1.220` because it runs a versioned binary, and Codex reports
+`node`. `amux` inspects the executable of each process beneath the pane's
+shell — including under wrappers like `direnv exec` — and matches on
+`argv[0]`, or on the script path when `argv[0]` is an interpreter.
+
+**What is it doing?** From the screen, since only the rendered UI knows.
+Claude's prompts are a structured choice list, so they are recognised
+directly; position disambiguates a *pending* prompt from one you already
+answered, because an answered prompt has the harness footer rendered below
+it.
+
+Codex has no structured prompt UI, so "waiting for you" is a heuristic: the
+last content line ends in a question mark, and nothing indicates it is
+working. Expect occasional misses and false alarms there.
+
+## Speed
+
+On a server with 160 panes: **1.1s cold, 0.075s warm.**
+
+The picker opens on cached rows and refreshes in the background, so it feels
+instant regardless of how many panes you have. `--max-age` controls how long
+a cached scan stays usable (default 30s); `amux scan` refreshes it explicitly,
+which is useful from cron or a tmux hook.
+
+## tmux keybinding
+
+Bind the picker to a popup overlay so it is one keystroke from anywhere:
+
+```bash
+# ~/.tmux.conf
+bind-key A display-popup -E -w 85% -h 75% amux
+```
+
+Then `prefix + A` opens the dashboard over whatever you are looking at,
+`enter` jumps to the chosen agent, and `esc` closes without moving anything.
+
+Pair it with a "jump back" binding, since jumping to an agent switches your
+current client to that session:
+
+```bash
+bind-key a switch-client -l   # return to the session you came from
+```
+
+## Scripting
+
+`amux list --json` emits one object per agent with every field — pane,
+session, kind, state, name, cwd, repo, branch, model, info, pid — so you can
+drive alerts or dashboards from it:
+
+```bash
+# how many agents are blocked on me right now?
+amux list --json | jq '[.[] | select(.state == "input")] | length'
+
+# name every waiting agent and its pane
+amux list --json | jq -r '.[] | select(.state=="input") | "\(.name)\t\(.pane)"'
+```
+
+## Limitations
+
+- **Local tmux only.** It reads the tmux server on this machine.
+- **Codex input detection is heuristic** — Codex exposes no prompt state, so
+  the question-mark rule will sometimes miss or over-report.
+- **States are sampled, not streamed.** The list reflects the moment you
+  opened it (`ctrl-r` re-scans); the preview pane is always live.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ aichat = "claude_code_tools.aichat:main"
 # Non-session utilities
 vault = "claude_code_tools.dotenv_vault:main"
 tmux-cli = "claude_code_tools.tmux_cli_controller:main"
+amux = "claude_code_tools.amux.cli:main"
 env-safe = "claude_code_tools.env_safe:main"
 md2gdoc = "claude_code_tools.md2gdoc:main"
 gdoc2md = "claude_code_tools.gdoc2md:main"

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -292,8 +292,11 @@ class TestScanWithStubbedTmux:
 
     SEP = "\x1f"
 
+    REC = "\x1e"
+
     def _listing(self, rows: list[tuple[str, str, str, str, str]]) -> str:
-        return "\n".join(self.SEP.join(r) for r in rows)
+        """Mimic tmux -F output: fields by SEP, records terminated by REC."""
+        return "".join(self.SEP.join(r) + self.REC for r in rows)
 
     def test_only_agent_panes_are_returned(self, monkeypatch) -> None:
         from claude_code_tools.amux import scan as scan_mod
@@ -388,3 +391,52 @@ class TestCli:
         quoted = shlex.quote("/tmp/my venv/bin/python")
         assert quoted != "/tmp/my venv/bin/python"
         assert shlex.split(f"{quoted} -m x")[0] == "/tmp/my venv/bin/python"
+
+
+class TestRecordParsing:
+    """Pane records must survive newlines in titles/paths without mangling.
+
+    Regression: an earlier fix used tmux's "#{s/\\n/ /:...}" substitution,
+    whose pattern is a literal string -- it rewrote every letter 'n', turning
+    /Users/pchalasani/Git/avon into "/Users/pchalasa i/Git/avo ". Paths were
+    silently corrupted and git context came back blank for most panes.
+    """
+
+    def test_field_values_are_never_rewritten(self, monkeypatch) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        cwd = "/Users/pchalasani/Git/avon"
+        rec = scan_mod._SEP.join(["s:1.1", "s", "100", "title", cwd])
+        monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
+            rec + scan_mod._REC if a[0] == "list-panes" else "screen"))
+        monkeypatch.setattr(scan_mod, "_child_argv_by_ppid",
+                            lambda: {100: "claude --resume x"})
+        monkeypatch.setattr(scan_mod, "_child_pid", lambda ppid, kind: 1)
+        agents = scan_mod.scan(workers=1)
+        assert agents[0].cwd == cwd
+
+    def test_newline_in_title_does_not_drop_the_pane(self, monkeypatch) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        rec = scan_mod._SEP.join(["s:1.1", "s", "100", "two\nlines", "/tmp"])
+        monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
+            rec + scan_mod._REC if a[0] == "list-panes" else "screen"))
+        monkeypatch.setattr(scan_mod, "_child_argv_by_ppid",
+                            lambda: {100: "codex --yolo"})
+        monkeypatch.setattr(scan_mod, "_child_pid", lambda ppid, kind: 1)
+        assert [a.pane for a in scan_mod.scan(workers=1)] == ["s:1.1"]
+
+    def test_multiple_records_split_correctly(self, monkeypatch) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        recs = "".join(
+            scan_mod._SEP.join([f"s:1.{i}", "s", str(100 + i), "t", "/tmp"])
+            + scan_mod._REC
+            for i in range(3)
+        )
+        monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
+            recs if a[0] == "list-panes" else "screen"))
+        monkeypatch.setattr(scan_mod, "_child_argv_by_ppid",
+                            lambda: {100 + i: "claude x" for i in range(3)})
+        monkeypatch.setattr(scan_mod, "_child_pid", lambda ppid, kind: 1)
+        assert len(scan_mod.scan(workers=2)) == 3

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -913,3 +913,40 @@ class TestFzfStderrReachesTheTerminal:
         assert seen.get("capture_output") is not True, "must not capture stderr"
         assert seen.get("stderr") is None, "stderr must be inherited"
         assert seen.get("stdout") is _sp.PIPE, "stdout must be captured"
+
+
+class TestWorkingWithoutEscToInterrupt:
+    """Claude signals work in more than one way; only one mentions 'esc'.
+
+    Regression: sasy:1.4 had a subagent actively running and reported 'idle'.
+    All strings here are verbatim from live panes.
+    """
+
+    MAIN_SPINNER = "· Razzmatazzing… (1m 42s · ↓ 4.8k tokens · thought for 14s)"
+    SUBAGENT_ROW = (
+        "  ◯ cache-incremental-evidence  Grepping running.mdx for stale counts"
+        "                  1m 16s · ↓ 873.5k tokens"
+    )
+    FOOTER = "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 1 agent"
+
+    def test_main_spinner_without_esc_is_busy(self) -> None:
+        assert detect.detect_state(f"{self.MAIN_SPINNER}\n{self.FOOTER}", "claude") == "busy"
+
+    def test_running_subagent_is_background_work(self) -> None:
+        screen = f"{self.FOOTER}\n  ⏺ main\n{self.SUBAGENT_ROW}"
+        assert detect.detect_state(screen, "claude") == "bg"
+
+    def test_agent_marker_alone_is_not_background(self) -> None:
+        """'← 1 agent' appears on idle panes too; it must not imply work."""
+        assert detect.detect_state(self.FOOTER, "claude") == "idle"
+
+    def test_finished_output_line_is_not_background(self) -> None:
+        """⏺ prefixes ordinary assistant output, not just tree rows."""
+        screen = "⏺ The keepalive is built and done.\n" + self.FOOTER
+        assert detect.detect_state(screen, "claude") == "idle"
+
+    def test_finished_turn_with_live_monitor_is_background(self) -> None:
+        """'Baked for 16m 24s' is past tense -- the turn ended, but a monitor
+        is still going, which is precisely what bg means."""
+        screen = "✻ Baked for 16m 24s · 1 monitor still running"
+        assert detect.detect_state(screen, "claude") == "bg"

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -795,3 +795,81 @@ class TestCodexBusyBeatsStaleQuestion:
             + "\n›\n  gpt-5.6-sol high · repo · main"
         )
         assert detect.detect_state(screen, "codex") == "idle"
+
+
+class TestExecutableOnlyMatching:
+    """Only the executable identifies a harness, never its arguments.
+
+    Regression (PR review): the patterns searched the whole command line, so
+    `rg claude .` in a pane was listed as an idle Claude agent.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "rg claude .",
+            "grep -r codex /src",
+            "vim claude_notes.md",
+            "less /var/log/codex.log",
+            "git commit -m 'fix codex handling'",
+        ],
+    )
+    def test_agent_name_in_arguments_is_not_an_agent(self, cmd: str) -> None:
+        assert detect.classify_argv(cmd) is None
+
+    @pytest.mark.parametrize(
+        "cmd,kind",
+        [
+            ("claude --resume x", "claude"),
+            ("/usr/local/bin/codex --yolo", "codex"),
+            ("node /p/node_modules/@openai/codex/bin/codex.js --yolo", "codex"),
+            ("/Users/p/.local/share/claude/versions/2.1.220 --resume y", "claude"),
+        ],
+    )
+    def test_real_launchers_still_match(self, cmd: str, kind: str) -> None:
+        assert detect.classify_argv(cmd) == kind
+
+
+class TestDescendantTraversal:
+    """An agent under a wrapper process must still be found.
+
+    Regression (PR review): only direct children were inspected, so a pane
+    shell that launches a wrapper which launches the agent showed only the
+    wrapper and the agent was invisible.
+    """
+
+    TREE = {
+        100: [(101, "direnv exec . zsh")],
+        101: [(102, "claude --resume nested")],
+    }
+
+    def test_finds_agent_two_levels_down(self) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        found = scan_mod.descendants(self.TREE, 100)
+        assert detect.classify_argv(scan_mod.argv_of(found)) == "claude"
+        assert scan_mod.agent_pid(found, "claude") == 102
+
+    def test_direct_child_still_works(self) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        tree = {100: [(101, "codex --yolo")]}
+        found = scan_mod.descendants(tree, 100)
+        assert scan_mod.agent_pid(found, "codex") == 101
+
+    def test_cycle_does_not_hang(self) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        cyclic = {100: [(101, "a")], 101: [(100, "b")]}
+        assert len(scan_mod.descendants(cyclic, 100)) <= 2
+
+    def test_scan_finds_a_nested_agent(self, monkeypatch) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        rec = scan_mod._SEP.join(["s:1.1", "s", "100", "t", "/tmp"])
+        monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
+            rec + scan_mod._REC + "\n" if a[0] == "list-panes" else "screen"))
+        monkeypatch.setattr(scan_mod, "_children_by_ppid", lambda: self.TREE)
+        agents = scan_mod.scan(workers=1)
+        assert [(a.pane, a.kind, a.pid) for a in agents] == [("s:1.1", "claude", 102)]
+        assert agents[0].name == "nested"

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -873,3 +873,43 @@ class TestDescendantTraversal:
         agents = scan_mod.scan(workers=1)
         assert [(a.pane, a.kind, a.pid) for a in agents] == [("s:1.1", "claude", 102)]
         assert agents[0].name == "nested"
+
+
+class TestFzfStderrReachesTheTerminal:
+    """fzf draws its interface on stderr; capturing it hangs the picker.
+
+    Regression: subprocess.run(..., capture_output=True) piped stderr as well
+    as stdout, so the UI never reached the terminal and amux appeared to hang
+    waiting for keys against an invisible prompt. Only stdout may be captured.
+    """
+
+    def test_only_stdout_is_captured(self, monkeypatch) -> None:
+        import argparse as _ap
+        import subprocess as _sp
+
+        from claude_code_tools.amux import cli
+        from claude_code_tools.amux.model import Agent as _A
+
+        seen: dict[str, object] = {}
+
+        class _Proc:
+            returncode = 1
+            stdout = ""
+
+        def fake_run(cmd, **kwargs):
+            seen.update(kwargs)
+            return _Proc()
+
+        monkeypatch.setattr(cli.shutil, "which", lambda _: "/usr/bin/fzf")
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: True)
+        monkeypatch.setattr(
+            cli, "_agents_for_display",
+            lambda _: ([_A(pane="a:1.1", session="a", kind="claude")], False),
+        )
+        monkeypatch.setattr(cli.subprocess, "run", fake_run)
+        cli.cmd_pick(_ap.Namespace(max_age=30.0))
+
+        assert seen.get("capture_output") is not True, "must not capture stderr"
+        assert seen.get("stderr") is None, "stderr must be inherited"
+        assert seen.get("stdout") is _sp.PIPE, "stdout must be captured"

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -295,8 +295,14 @@ class TestScanWithStubbedTmux:
     REC = "\x1e"
 
     def _listing(self, rows: list[tuple[str, str, str, str, str]]) -> str:
-        """Mimic tmux -F output: fields by SEP, records terminated by REC."""
-        return "".join(self.SEP.join(r) + self.REC for r in rows)
+        """Mimic REAL tmux -F output.
+
+        tmux terminates each -F line with a newline AFTER our record marker,
+        so the wire form is ``record + REC + "\n"``. Joining records
+        REC-adjacent (no newline) meant the leading-newline strip in scan()
+        was never exercised, and deleting it left these tests green.
+        """
+        return "".join(self.SEP.join(r) + self.REC + "\n" for r in rows)
 
     def test_only_agent_panes_are_returned(self, monkeypatch) -> None:
         from claude_code_tools.amux import scan as scan_mod
@@ -444,7 +450,7 @@ class TestRecordParsing:
         cwd = "/Users/pchalasani/Git/avon"
         rec = scan_mod._SEP.join(["s:1.1", "s", "100", "title", cwd])
         monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
-            rec + scan_mod._REC if a[0] == "list-panes" else "screen"))
+            rec + scan_mod._REC + "\n" if a[0] == "list-panes" else "screen"))
         monkeypatch.setattr(scan_mod, "_children_by_ppid",
                             lambda: {100: [(101, "claude --resume x")]})
         agents = scan_mod.scan(workers=1)
@@ -455,7 +461,7 @@ class TestRecordParsing:
 
         rec = scan_mod._SEP.join(["s:1.1", "s", "100", "two\nlines", "/tmp"])
         monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
-            rec + scan_mod._REC if a[0] == "list-panes" else "screen"))
+            rec + scan_mod._REC + "\n" if a[0] == "list-panes" else "screen"))
         monkeypatch.setattr(scan_mod, "_children_by_ppid",
                             lambda: {100: [(101, "codex --yolo")]})
         assert [a.pane for a in scan_mod.scan(workers=1)] == ["s:1.1"]
@@ -488,6 +494,7 @@ class TestRecordParsing:
         recs = "".join(
             scan_mod._SEP.join([f"s:1.{i}", "s", str(100 + i), "t", "/tmp"])
             + scan_mod._REC
+            + "\n"
             for i in range(3)
         )
         monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
@@ -495,4 +502,41 @@ class TestRecordParsing:
         monkeypatch.setattr(scan_mod, "_children_by_ppid",
                             lambda: {100 + i: [(200 + i, "claude x")]
                                      for i in range(3)})
-        assert len(scan_mod.scan(workers=2)) == 3
+        # Assert the VALUES, not just the count: without the leading-newline
+        # strip every record after the first yields pane "\ns:1.N", which still
+        # counts as 3 but cannot be captured or selected.
+        assert [a.pane for a in scan_mod.scan(workers=2)] == [
+            "s:1.0", "s:1.1", "s:1.2"
+        ]
+
+
+class TestCacheTypeValidation:
+    """A well-shaped cache record can still hold wrong-typed fields."""
+
+    def test_null_pane_is_dropped_not_rendered(self, tmp_path, monkeypatch) -> None:
+        """Regression: reached render._clip() and crashed on len(None)."""
+        path = tmp_path / "amux.json"
+        path.write_text(
+            '{"time":9999999999,"agents":['
+            '{"pane":null,"session":"s","kind":"claude"}]}'
+        )
+        monkeypatch.setenv("AMUX_CACHE", str(path))
+        agents, _ = cache.read()
+        assert agents == []
+        render.picker_lines(agents, colour=False)  # must not raise
+
+    def test_wrong_typed_optional_field_is_dropped(self, tmp_path, monkeypatch) -> None:
+        path = tmp_path / "amux.json"
+        path.write_text(
+            '{"time":9999999999,"agents":['
+            '{"pane":"a:1.1","session":"s","kind":"claude","name":123}]}'
+        )
+        monkeypatch.setenv("AMUX_CACHE", str(path))
+        assert cache.read()[0] == []
+
+    def test_valid_record_still_loads(self, tmp_path, monkeypatch) -> None:
+        """Validation must not reject legitimate cache entries."""
+        monkeypatch.setenv("AMUX_CACHE", str(tmp_path / "amux.json"))
+        cache.write([Agent(pane="a:1.1", session="a", kind="claude", pid=7)])
+        loaded, _ = cache.read()
+        assert len(loaded) == 1 and loaded[0].pid == 7

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -749,3 +749,37 @@ class TestMaxAgeValidation:
         from claude_code_tools.amux import cli
 
         assert cli.build_parser().parse_args(["--max-age", "0", "list"]).max_age == 0.0
+
+
+class TestCodexBusyBeatsStaleQuestion:
+    """A visible spinner outranks an older question still on screen.
+
+    Regression: Codex asks, you answer, it starts working -- the question is
+    still rendered above, and the heuristic reported 'input' while the agent
+    was plainly busy.
+    """
+
+    ANSWERED_AND_WORKING = """• Would you like me to run the full suite?
+› Yes, please run it.
+• Waiting for background terminal (1m 02s • esc to interrupt)
+  gpt-5.6-sol high · repo · main"""
+
+    STILL_ASKING = """• I found two candidate configs.
+  Should I delete the stale one before continuing?
+›
+  gpt-5.6-sol high · farchat · main"""
+
+    def test_working_after_an_answer_is_busy(self) -> None:
+        assert detect.detect_state(self.ANSWERED_AND_WORKING, "codex") == "busy"
+
+    def test_genuine_pending_question_is_still_input(self) -> None:
+        assert detect.detect_state(self.STILL_ASKING, "codex") == "input"
+
+    def test_question_far_up_the_scrollback_is_ignored(self) -> None:
+        """Only the tail counts; an old question must not pin the state."""
+        screen = (
+            "• Should I continue?\n"
+            + "\n".join(f"• step {i} done." for i in range(20))
+            + "\n›\n  gpt-5.6-sol high · repo · main"
+        )
+        assert detect.detect_state(screen, "codex") == "idle"

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -540,3 +540,62 @@ class TestCacheTypeValidation:
         cache.write([Agent(pane="a:1.1", session="a", kind="claude", pid=7)])
         loaded, _ = cache.read()
         assert len(loaded) == 1 and loaded[0].pid == 7
+
+
+class TestAnsweredPromptIsNotBlocking:
+    """An answered prompt leaves its choices on screen; only footer position
+    distinguishes it from one still waiting."""
+
+    ANSWERED = """
+  Which do you prefer?
+❯ 1. Yes
+  2. No
+  Understood, rebasing now.
+  ctx ████░░░░░░ 44%
+  ⏵⏵ bypass permissions on
+❯
+"""
+    PENDING = """
+  Understood, here are the options.
+  Which do you prefer?
+❯ 1. Yes
+  2. No
+"""
+
+    def test_answered_prompt_is_not_input(self) -> None:
+        assert detect.detect_state(self.ANSWERED, "claude") == "idle"
+
+    def test_pending_prompt_is_input(self) -> None:
+        assert detect.detect_state(self.PENDING, "claude") == "input"
+
+
+class TestCacheEnumAndClock:
+    def _write(self, tmp_path, monkeypatch, body: str):
+        path = tmp_path / "amux.json"
+        path.write_text(body)
+        monkeypatch.setenv("AMUX_CACHE", str(path))
+
+    def test_unknown_kind_is_rejected(self, tmp_path, monkeypatch) -> None:
+        self._write(tmp_path, monkeypatch,
+                    '{"time":0,"agents":[{"pane":"s:1.1","session":"s",'
+                    '"kind":"vim"}]}')
+        assert cache.read(max_age=None)[0] == []
+
+    def test_unknown_state_is_rejected(self, tmp_path, monkeypatch) -> None:
+        self._write(tmp_path, monkeypatch,
+                    '{"time":0,"agents":[{"pane":"s:1.1","session":"s",'
+                    '"kind":"claude","state":"waiting"}]}')
+        assert cache.read(max_age=None)[0] == []
+
+    def test_known_kind_and_state_accepted(self, tmp_path, monkeypatch) -> None:
+        self._write(tmp_path, monkeypatch,
+                    '{"time":0,"agents":[{"pane":"s:1.1","session":"s",'
+                    '"kind":"codex","state":"busy"}]}')
+        assert len(cache.read(max_age=None)[0]) == 1
+
+    def test_future_timestamp_never_counts_as_fresh(self, tmp_path, monkeypatch) -> None:
+        """Regression: negative age passed every max_age check indefinitely."""
+        self._write(tmp_path, monkeypatch,
+                    '{"time":9999999999,"agents":[{"pane":"s:1.1",'
+                    '"session":"s","kind":"claude"}]}')
+        assert cache.read(max_age=30)[0] == []

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -690,3 +690,62 @@ class TestFooterMatchesRealHarnessChrome:
             "  gpt-5.6-sol medium · farchat · main · Context 51% used\n"
         )
         assert detect.detect_state(screen, "codex") != "input"
+
+
+class TestFooterAnchorSpecifically:
+    """The anchor's job: footer chrome quoted INSIDE a content line is content.
+
+    The earlier 'option quoting footer text' test did not actually exercise
+    the anchor -- it relied on word alternatives the regex no longer uses, so
+    un-anchoring left it green. These use the real chrome glyphs mid-line.
+    """
+
+    def test_chrome_glyph_midline_is_not_footer(self) -> None:
+        line = "  I ran it and the status bar showed ⏵⏵ bypass permissions on"
+        assert not detect._FOOTER.search(line)
+
+    def test_ctx_bar_midline_is_not_footer(self) -> None:
+        line = "  The output contained ctx ████ which confused the parser"
+        assert not detect._FOOTER.search(line)
+
+    def test_codex_model_midline_is_not_footer(self) -> None:
+        line = "• Model changed to gpt-5.6-terra medium"
+        assert not detect._FOOTER.search(line)
+
+    def test_same_glyph_at_line_start_is_footer(self) -> None:
+        assert detect._FOOTER.search("  ⏵⏵ bypass permissions on")
+
+    def test_pending_prompt_quoting_chrome_stays_blocking(self) -> None:
+        """End to end: an option quoting chrome must not look answered."""
+        screen = (
+            "Which action should I take?\n"
+            "❯ 1. Continue\n"
+            "  2. Explain the ⏵⏵ bypass permissions on indicator\n"
+        )
+        assert detect.detect_state(screen, "claude") == "input"
+
+
+class TestMaxAgeValidation:
+    def test_nan_is_rejected(self) -> None:
+        """Regression: NaN max_age disabled expiry, serving stale data."""
+        from claude_code_tools.amux import cli
+
+        with pytest.raises(SystemExit):
+            cli.build_parser().parse_args(["--max-age", "nan", "list"])
+
+    def test_inf_is_rejected(self) -> None:
+        from claude_code_tools.amux import cli
+
+        with pytest.raises(SystemExit):
+            cli.build_parser().parse_args(["--max-age", "inf", "list"])
+
+    def test_negative_is_rejected(self) -> None:
+        from claude_code_tools.amux import cli
+
+        with pytest.raises(SystemExit):
+            cli.build_parser().parse_args(["--max-age", "-5", "list"])
+
+    def test_ordinary_value_accepted(self) -> None:
+        from claude_code_tools.amux import cli
+
+        assert cli.build_parser().parse_args(["--max-age", "0", "list"]).max_age == 0.0

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -1,0 +1,212 @@
+"""Tests for amux detection, rendering, and caching.
+
+The detection heuristics are the fragile part -- they read harness UIs that
+change between releases -- so they are tested against captured screen text
+rather than a live tmux server.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from claude_code_tools.amux import cache, detect, render
+from claude_code_tools.amux.model import Agent
+
+CLAUDE_IDLE = """
+  I've committed the change and pushed the branch.
+────────────────────────────────────────────── certify-main ──
+❯
+──────────────────────────────────────────────────────────────
+   fable   observability.feat-certify-codex  feat/certify-codex
+  ctx ████████░░ 86%   5h ░░░░░░░░░░ 3% ↻4h29m
+  ⏵⏵ bypass permissions on · ← 1 agent
+"""
+
+CLAUDE_BG = CLAUDE_IDLE.replace("· ← 1 agent", "· 1 monitor · ← 1 agent")
+
+CLAUDE_BUSY = """
+  Reading the config file now.
+✻ Cooked for 14m 17s · esc to interrupt
+  ctx ████░░░░░░ 44%
+"""
+
+CLAUDE_ASKING = """
+  I can either rebase or merge. Which do you prefer?
+❯ 1. Rebase onto main
+  2. Merge main in
+  3. Skip for now
+"""
+
+CODEX_IDLE = """
+• Explored the repository layout.
+─ Worked for 2m 04s ─────────────────────────────────
+› Write tests for @filename
+  gpt-5.6-sol high · proposalwriter · main · Context 55% used
+"""
+
+CODEX_BUSY = """
+• Waiting for background terminal (1m 02s • esc to interrupt)
+  gpt-5.6-sol xhigh · observability · main
+"""
+
+CODEX_ASKING = """
+• I found two candidate configs.
+  Should I delete the stale one before continuing?
+›
+  gpt-5.6-sol high · farchat · main
+"""
+
+
+class TestClassifyArgv:
+    def test_detects_claude(self) -> None:
+        argv = "claude --dangerously-skip-permissions --resume certify"
+        assert detect.classify_argv(argv) == "claude"
+
+    def test_detects_codex(self) -> None:
+        argv = "node /path/@openai/codex/bin/codex.js --yolo"
+        assert detect.classify_argv(argv) == "codex"
+
+    def test_plain_shell_is_not_an_agent(self) -> None:
+        assert detect.classify_argv("vim README.md") is None
+
+    def test_empty_argv(self) -> None:
+        assert detect.classify_argv("") is None
+
+
+class TestDetectState:
+    @pytest.mark.parametrize(
+        "screen,kind,expected",
+        [
+            (CLAUDE_ASKING, "claude", "input"),
+            (CLAUDE_BUSY, "claude", "busy"),
+            (CLAUDE_BG, "claude", "bg"),
+            (CLAUDE_IDLE, "claude", "idle"),
+            (CODEX_ASKING, "codex", "input"),
+            (CODEX_BUSY, "codex", "busy"),
+            (CODEX_IDLE, "codex", "idle"),
+        ],
+    )
+    def test_states(self, screen: str, kind: str, expected: str) -> None:
+        assert detect.detect_state(screen, kind) == expected  # type: ignore[arg-type]
+
+    def test_input_outranks_busy(self) -> None:
+        """A question on screen wins even if a spinner is also visible."""
+        screen = CLAUDE_ASKING + "\n✻ thinking · esc to interrupt"
+        assert detect.detect_state(screen, "claude") == "input"
+
+    def test_codex_statement_is_not_a_question(self) -> None:
+        assert detect.detect_state(CODEX_IDLE, "codex") == "idle"
+
+
+class TestExtract:
+    def test_name_from_argv_beats_everything(self) -> None:
+        name = detect.extract_name(
+            "claude --resume my-session", "✳ other-name", CLAUDE_IDLE
+        )
+        assert name == "my-session"
+
+    def test_name_from_pane_title(self) -> None:
+        assert detect.extract_name("", "✳ my-title", "") == "my-title"
+
+    def test_name_strips_spinner_glyphs(self) -> None:
+        assert detect.extract_name("", "⠹ farchat", "") == "farchat"
+
+    def test_shell_titles_are_rejected(self) -> None:
+        """Paths and hostnames are shell-set titles, not agent names."""
+        assert detect.extract_name("", "~/Git/foo", "") == ""
+        assert detect.extract_name("", "macbookpro.lan", "") == ""
+
+    def test_name_from_separator_line(self) -> None:
+        assert detect.extract_name("", "~[dir]", CLAUDE_IDLE) == "certify-main"
+
+    def test_name_absent(self) -> None:
+        assert detect.extract_name("", "", "nothing here") == ""
+
+    def test_model_claude(self) -> None:
+        assert detect.extract_model(CLAUDE_IDLE, "claude") == "fable"
+
+    def test_model_codex(self) -> None:
+        assert detect.extract_model(CODEX_IDLE, "codex") == "gpt-5.6-sol"
+
+
+class TestAgentModel:
+    def test_rank_orders_by_urgency(self) -> None:
+        states = ["idle", "input", "bg", "busy"]
+        agents = [Agent(pane=f"s:1.{i}", session="s", kind="claude", state=s)  # type: ignore[arg-type]
+                  for i, s in enumerate(states)]
+        agents.sort(key=lambda a: a.rank)
+        assert [a.state for a in agents] == ["input", "busy", "bg", "idle"]
+
+    def test_roundtrip_through_dict(self) -> None:
+        agent = Agent(
+            pane="sasy:1.4", session="sasy", kind="claude", state="bg", name="certify"
+        )
+        assert Agent.from_dict(agent.to_dict()) == agent
+
+    def test_from_dict_ignores_unknown_keys(self) -> None:
+        data = {"pane": "a:1.1", "session": "a", "kind": "codex", "bogus": 1}
+        assert Agent.from_dict(data).pane == "a:1.1"
+
+
+class TestRender:
+    def _agents(self) -> list[Agent]:
+        return [
+            Agent(pane="sasy:1.4", session="sasy", kind="claude", state="input",
+                  name="certify", repo="observability", branch="main"),
+            Agent(pane="cc:1.1", session="cc", kind="codex", state="idle"),
+        ]
+
+    def test_row_contains_key_fields(self) -> None:
+        row = render.picker_row(self._agents()[0], colour=False)
+        assert "sasy:1.4" in row and "input" in row and "certify" in row
+        assert "observability@main" in row
+
+    def test_pane_is_first_field(self) -> None:
+        """fzf addresses the pane as {1}; it must lead the row."""
+        row = render.picker_row(self._agents()[0], colour=False)
+        assert row.split()[0] == "sasy:1.4"
+
+    def test_colour_can_be_disabled(self) -> None:
+        assert "\033[" not in render.picker_row(self._agents()[0], colour=False)
+
+    def test_colour_present_when_enabled(self) -> None:
+        assert "\033[" in render.picker_row(self._agents()[0], colour=True)
+
+    def test_table_reports_counts(self) -> None:
+        out = render.table(self._agents(), colour=False)
+        assert "2 agents" in out and "input=1" in out
+
+    def test_table_handles_empty(self) -> None:
+        assert "no agents" in render.table([], colour=False)
+
+    def test_json_roundtrips(self) -> None:
+        data = json.loads(render.as_json(self._agents()))
+        assert [d["pane"] for d in data] == ["sasy:1.4", "cc:1.1"]
+
+
+class TestCache:
+    def test_write_then_read(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("AMUX_CACHE", str(tmp_path / "amux.json"))
+        agents = [Agent(pane="a:1.1", session="a", kind="claude", name="x")]
+        cache.write(agents)
+        loaded, age = cache.read()
+        assert [a.pane for a in loaded] == ["a:1.1"]
+        assert 0 <= age < 5
+
+    def test_missing_cache_is_not_an_error(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("AMUX_CACHE", str(tmp_path / "absent.json"))
+        agents, age = cache.read()
+        assert agents == [] and age == -1
+
+    def test_stale_cache_is_rejected(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("AMUX_CACHE", str(tmp_path / "amux.json"))
+        cache.write([Agent(pane="a:1.1", session="a", kind="claude")])
+        assert cache.read(max_age=-1)[0] == []
+
+    def test_corrupt_cache_is_not_an_error(self, tmp_path, monkeypatch) -> None:
+        path = tmp_path / "amux.json"
+        path.write_text("{not json")
+        monkeypatch.setenv("AMUX_CACHE", str(path))
+        assert cache.read()[0] == []

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -91,9 +91,18 @@ class TestDetectState:
     def test_states(self, screen: str, kind: str, expected: str) -> None:
         assert detect.detect_state(screen, kind) == expected  # type: ignore[arg-type]
 
-    def test_input_outranks_busy(self) -> None:
-        """A question on screen wins even if a spinner is also visible."""
+    def test_spinner_below_a_prompt_means_it_was_answered(self) -> None:
+        """Position decides, not mere presence.
+
+        A spinner rendered BELOW the choices means the user already answered
+        and work resumed -- that pane is busy, not blocking.
+        """
         screen = CLAUDE_ASKING + "\n✻ thinking · esc to interrupt"
+        assert detect.detect_state(screen, "claude") == "busy"
+
+    def test_prompt_below_a_spinner_is_still_blocking(self) -> None:
+        """Claude worked, then stopped to ask: the prompt is last, so input."""
+        screen = "✻ Cooked for 2m · esc to interrupt\n" + CLAUDE_ASKING
         assert detect.detect_state(screen, "claude") == "input"
 
     def test_codex_statement_is_not_a_question(self) -> None:
@@ -515,10 +524,14 @@ class TestCacheTypeValidation:
 
     def test_null_pane_is_dropped_not_rendered(self, tmp_path, monkeypatch) -> None:
         """Regression: reached render._clip() and crashed on len(None)."""
+        import time as _t
+
         path = tmp_path / "amux.json"
+        # A CURRENT timestamp: a future one is rejected before agents are
+        # parsed, so this test would not reach Agent.from_dict at all.
         path.write_text(
-            '{"time":9999999999,"agents":['
-            '{"pane":null,"session":"s","kind":"claude"}]}'
+            '{"time":%f,"agents":['
+            '{"pane":null,"session":"s","kind":"claude"}]}' % _t.time()
         )
         monkeypatch.setenv("AMUX_CACHE", str(path))
         agents, _ = cache.read()
@@ -526,10 +539,12 @@ class TestCacheTypeValidation:
         render.picker_lines(agents, colour=False)  # must not raise
 
     def test_wrong_typed_optional_field_is_dropped(self, tmp_path, monkeypatch) -> None:
+        import time as _t
+
         path = tmp_path / "amux.json"
         path.write_text(
-            '{"time":9999999999,"agents":['
-            '{"pane":"a:1.1","session":"s","kind":"claude","name":123}]}'
+            '{"time":%f,"agents":['
+            '{"pane":"a:1.1","session":"s","kind":"claude","name":123}]}' % _t.time()
         )
         monkeypatch.setenv("AMUX_CACHE", str(path))
         assert cache.read()[0] == []
@@ -599,3 +614,36 @@ class TestCacheEnumAndClock:
                     '{"time":9999999999,"agents":[{"pane":"s:1.1",'
                     '"session":"s","kind":"claude"}]}')
         assert cache.read(max_age=30)[0] == []
+
+
+class TestNaNTimestamp:
+    def test_nan_timestamp_is_not_fresh(self, tmp_path, monkeypatch) -> None:
+        """Regression: every comparison against NaN is False, so a NaN age
+        passed both the negative check and max_age -- cached forever."""
+        path = tmp_path / "amux.json"
+        path.write_text(
+            '{"time":NaN,"agents":[{"pane":"s:1.1","session":"s",'
+            '"kind":"claude"}]}'
+        )
+        monkeypatch.setenv("AMUX_CACHE", str(path))
+        assert cache.read(max_age=30)[0] == []
+
+
+class TestOptionTextResemblingFooter:
+    def test_option_quoting_footer_text_stays_blocking(self) -> None:
+        """Regression: an option mentioning footer words made a PENDING
+        prompt look answered, hiding a genuinely blocked agent."""
+        screen = (
+            "Which action should I take?\n"
+            "❯ 1. Continue\n"
+            "  2. Explain why the status says bypass permissions on\n"
+        )
+        assert detect.detect_state(screen, "claude") == "input"
+
+    def test_option_mentioning_ctx_bar_stays_blocking(self) -> None:
+        screen = (
+            "Pick one?\n"
+            "❯ 1. Yes\n"
+            "  2. Show me the ctx ████ meter\n"
+        )
+        assert detect.detect_state(screen, "claude") == "input"

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -307,9 +307,9 @@ class TestScanWithStubbedTmux:
         ]
         monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
             self._listing(rows) if a[0] == "list-panes" else "agent screen text"))
-        monkeypatch.setattr(scan_mod, "_child_argv_by_ppid",
-                            lambda: {100: "claude --resume alpha", 200: "vim x"})
-        monkeypatch.setattr(scan_mod, "_child_pid", lambda ppid, kind: ppid + 1)
+        monkeypatch.setattr(scan_mod, "_children_by_ppid",
+                            lambda: {100: [(101, "claude --resume alpha")],
+                                     200: [(201, "vim x")]})
         agents = scan_mod.scan(workers=2)
         assert [a.pane for a in agents] == ["s:1.1"]
         assert agents[0].name == "alpha" and agents[0].pid == 101
@@ -321,9 +321,8 @@ class TestScanWithStubbedTmux:
         rows = [("s:1.1", "s", "100", "t", "/tmp")]
         monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
             self._listing(rows) if a[0] == "list-panes" else ""))
-        monkeypatch.setattr(scan_mod, "_child_argv_by_ppid",
-                            lambda: {100: "codex --yolo"})
-        monkeypatch.setattr(scan_mod, "_child_pid", lambda ppid, kind: 0)
+        monkeypatch.setattr(scan_mod, "_children_by_ppid",
+                            lambda: {100: [(101, "codex --yolo")]})
         assert scan_mod.scan(workers=1) == []
 
     def test_no_panes_at_all(self, monkeypatch) -> None:
@@ -367,16 +366,22 @@ class TestGitContext:
 
 
 class TestCli:
-    def test_default_command_keeps_global_options(self) -> None:
-        """Regression: `amux --max-age 0` used to fall back to the 30s default."""
+    def test_default_command_keeps_global_options(self, monkeypatch) -> None:
+        """Regression: `amux --max-age 0` fell back to the 30s default.
+
+        Drives main() so that reverting the argv rewrite fails this test.
+        """
         from claude_code_tools.amux import cli
 
-        parser = cli.build_parser()
-        raw = ["--max-age", "0"]
-        if not any(t in {"pick", "list", "scan", "rows"} for t in raw):
-            raw.append("pick")
-        args = parser.parse_args(raw)
-        assert args.max_age == 0.0 and args.func is cli.cmd_pick
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(cli.scan, "tmux_available", lambda: True)
+        # build_parser() resolves cmd_pick when main() calls it, so patching
+        # the module global here is enough to intercept the dispatch.
+        monkeypatch.setattr(
+            cli, "cmd_pick", lambda a: seen.update(max_age=a.max_age) or 0
+        )
+        cli.main(["--max-age", "0"])
+        assert seen["max_age"] == 0.0
 
     def test_explicit_subcommand_still_parses(self) -> None:
         from claude_code_tools.amux import cli
@@ -384,13 +389,44 @@ class TestCli:
         args = cli.build_parser().parse_args(["list", "--json"])
         assert args.json is True and args.func is cli.cmd_list
 
-    def test_interpreter_path_is_shell_quoted(self) -> None:
-        """fzf binds run through a shell; a spaced venv path must survive."""
-        import shlex
+    def test_fzf_bind_quotes_a_spaced_interpreter_path(self, monkeypatch) -> None:
+        """The reload bind is shell-executed; a spaced venv path must survive.
 
-        quoted = shlex.quote("/tmp/my venv/bin/python")
-        assert quoted != "/tmp/my venv/bin/python"
-        assert shlex.split(f"{quoted} -m x")[0] == "/tmp/my venv/bin/python"
+        Asserts on the actual argv handed to fzf, so removing shlex.quote()
+        from cmd_pick() fails this test.
+        """
+        import shlex as _shlex
+
+        from claude_code_tools.amux import cli
+        from claude_code_tools.amux.model import Agent as _A
+
+        captured: dict[str, list[str]] = {}
+
+        class _Proc:
+            returncode = 1
+            stdout = ""
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _Proc()
+
+        monkeypatch.setattr(cli.sys, "executable", "/tmp/my venv/bin/python")
+        monkeypatch.setattr(cli.shutil, "which", lambda _: "/usr/bin/fzf")
+        monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: True)
+        monkeypatch.setattr(
+            cli, "_agents_for_display",
+            lambda _: ([_A(pane="a:1.1", session="a", kind="claude")], False),
+        )
+        monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+        import argparse as _ap
+
+        cli.cmd_pick(_ap.Namespace(max_age=30.0))
+        binds = [c for c in captured["cmd"] if "reload(" in c]
+        assert binds, "no reload bind was built"
+        inner = binds[0].split("reload(", 1)[1].rstrip(")")
+        assert _shlex.split(inner)[0] == "/tmp/my venv/bin/python"
 
 
 class TestRecordParsing:
@@ -409,9 +445,8 @@ class TestRecordParsing:
         rec = scan_mod._SEP.join(["s:1.1", "s", "100", "title", cwd])
         monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
             rec + scan_mod._REC if a[0] == "list-panes" else "screen"))
-        monkeypatch.setattr(scan_mod, "_child_argv_by_ppid",
-                            lambda: {100: "claude --resume x"})
-        monkeypatch.setattr(scan_mod, "_child_pid", lambda ppid, kind: 1)
+        monkeypatch.setattr(scan_mod, "_children_by_ppid",
+                            lambda: {100: [(101, "claude --resume x")]})
         agents = scan_mod.scan(workers=1)
         assert agents[0].cwd == cwd
 
@@ -421,10 +456,31 @@ class TestRecordParsing:
         rec = scan_mod._SEP.join(["s:1.1", "s", "100", "two\nlines", "/tmp"])
         monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
             rec + scan_mod._REC if a[0] == "list-panes" else "screen"))
-        monkeypatch.setattr(scan_mod, "_child_argv_by_ppid",
-                            lambda: {100: "codex --yolo"})
-        monkeypatch.setattr(scan_mod, "_child_pid", lambda ppid, kind: 1)
+        monkeypatch.setattr(scan_mod, "_children_by_ppid",
+                            lambda: {100: [(101, "codex --yolo")]})
         assert [a.pane for a in scan_mod.scan(workers=1)] == ["s:1.1"]
+
+    def test_scan_requests_the_record_terminator(self, monkeypatch) -> None:
+        """The format string itself must carry the marker.
+
+        Regression: proving a synthetic REC-delimited string can be split says
+        nothing about what scan() asks tmux for.
+        """
+        from claude_code_tools.amux import scan as scan_mod
+
+        seen: dict[str, str] = {}
+
+        def fake_tmux(*args):
+            if args[0] == "list-panes":
+                seen["fmt"] = args[-1]
+            return ""
+
+        monkeypatch.setattr(scan_mod, "_tmux", fake_tmux)
+        scan_mod.scan()
+        # Assert the literal, not scan_mod._REC -- comparing against the
+        # module constant passes even if that constant is emptied.
+        assert seen["fmt"].endswith("\x1e")
+        assert "s/" not in seen["fmt"], "must not use tmux format substitution"
 
     def test_multiple_records_split_correctly(self, monkeypatch) -> None:
         from claude_code_tools.amux import scan as scan_mod
@@ -436,7 +492,7 @@ class TestRecordParsing:
         )
         monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
             recs if a[0] == "list-panes" else "screen"))
-        monkeypatch.setattr(scan_mod, "_child_argv_by_ppid",
-                            lambda: {100 + i: "claude x" for i in range(3)})
-        monkeypatch.setattr(scan_mod, "_child_pid", lambda ppid, kind: 1)
+        monkeypatch.setattr(scan_mod, "_children_by_ppid",
+                            lambda: {100 + i: [(200 + i, "claude x")]
+                                     for i in range(3)})
         assert len(scan_mod.scan(workers=2)) == 3

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -647,3 +647,46 @@ class TestOptionTextResemblingFooter:
             "  2. Show me the ctx ████ meter\n"
         )
         assert detect.detect_state(screen, "claude") == "input"
+
+
+class TestFooterMatchesRealHarnessChrome:
+    """Footer patterns are checked against lines captured from live panes.
+
+    The synthetic fixtures elsewhere in this file only covered Claude, so the
+    Codex status line was not recognised as footer chrome -- meaning a Codex
+    pane whose message contained prompt-like text would stay flagged 'input'
+    indefinitely. These strings are verbatim from real panes.
+    """
+
+    REAL_FOOTERS = [
+        "  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents",
+        "  ctx ████████░░ 86%   5h ░░░░░░░░░░ 3% ↻4h29m",
+        "  gpt-5.6-sol medium · farchat · main · Context 51% used",
+        "  gpt-5.6-sol high · claude-code-tools.feat-brief-v2 · feat/brief-v2",
+        "› Write tests for @filename",
+        "                        new task? /clear to save 317.5k tokens",
+    ]
+
+    REAL_CONTENT = [
+        "• Model changed to gpt-5.6-terra medium",
+        "⚠ MCP client for `gpt-codex` failed to start: MCP startup failed",
+        "  I changed the ctx meter copy in the onboarding flow.",
+        "  2. Explain why the status says bypass permissions on",
+    ]
+
+    @pytest.mark.parametrize("line", REAL_FOOTERS)
+    def test_real_footer_lines_are_recognised(self, line: str) -> None:
+        assert detect._FOOTER.search(line), f"footer not matched: {line!r}"
+
+    @pytest.mark.parametrize("line", REAL_CONTENT)
+    def test_content_is_not_mistaken_for_footer(self, line: str) -> None:
+        assert not detect._FOOTER.search(line), f"content matched: {line!r}"
+
+    def test_codex_prompt_followed_by_status_is_not_blocking(self) -> None:
+        """The concrete regression: Codex footer below an answered question."""
+        screen = (
+            "• Should I delete the stale config?\n"
+            "  Deleted it and reran the suite.\n"
+            "  gpt-5.6-sol medium · farchat · main · Context 51% used\n"
+        )
+        assert detect.detect_state(screen, "codex") != "input"

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -163,10 +163,31 @@ class TestRender:
         assert "sasy:1.4" in row and "input" in row and "certify" in row
         assert "observability@main" in row
 
-    def test_pane_is_first_field(self) -> None:
-        """fzf addresses the pane as {1}; it must lead the row."""
+    def test_pane_is_the_tab_key_field(self) -> None:
+        """fzf addresses the pane as {1} with --delimiter '\\t'."""
+        line = render.picker_lines(self._agents()[:1], colour=False)
+        assert line.split("\t", 1)[0] == "sasy:1.4"
+
+    def test_session_name_with_space_survives(self) -> None:
+        """tmux allows spaces in session names.
+
+        Regression: with whitespace-delimited fields, fzf's {1} resolved to
+        'amux' for a pane in session 'amux test', pointing the preview and the
+        jump at a nonexistent pane.
+        """
+        agent = Agent(pane="amux test:1.1", session="amux test", kind="claude")
+        line = render.picker_lines([agent], colour=False)
+        assert render.pane_from_selection(line) == "amux test:1.1"
+
+    def test_pane_recovered_from_selection_with_trailing_newline(self) -> None:
+        agent = self._agents()[0]
+        line = render.picker_lines([agent], colour=False) + "\n"
+        assert render.pane_from_selection(line) == "sasy:1.4"
+
+    def test_visible_row_still_shows_pane(self) -> None:
+        """The key field is hidden via --with-nth, so the row repeats it."""
         row = render.picker_row(self._agents()[0], colour=False)
-        assert row.split()[0] == "sasy:1.4"
+        assert row.startswith("sasy:1.4")
 
     def test_colour_can_be_disabled(self) -> None:
         assert "\033[" not in render.picker_row(self._agents()[0], colour=False)
@@ -210,3 +231,160 @@ class TestCache:
         path.write_text("{not json")
         monkeypatch.setenv("AMUX_CACHE", str(path))
         assert cache.read()[0] == []
+
+
+class TestPromptIsAtTheBottom:
+    """Regression: a pending question lives at the bottom of the screen."""
+
+    def test_old_question_text_in_history_is_not_input(self) -> None:
+        screen = (
+            'I changed the "Would you like" copy in the onboarding flow.\n'
+            + "\n".join(f"  line {i}" for i in range(20))
+            + "\n❯\n  ⏵⏵ bypass permissions on\n"
+        )
+        assert detect.detect_state(screen, "claude") == "idle"
+
+    def test_current_question_is_input(self) -> None:
+        screen = "some earlier output\n" * 20 + "Do you want to proceed?\n❯ 1. Yes\n"
+        assert detect.detect_state(screen, "claude") == "input"
+
+
+class TestCacheRobustness:
+    def _set(self, tmp_path, monkeypatch, text: str):
+        path = tmp_path / "amux.json"
+        path.write_text(text)
+        monkeypatch.setenv("AMUX_CACHE", str(path))
+        return path
+
+    def test_non_numeric_timestamp(self, tmp_path, monkeypatch) -> None:
+        self._set(tmp_path, monkeypatch, '{"time":"not-a-number","agents":[]}')
+        assert cache.read()[0] == []
+
+    def test_null_entry_in_agents(self, tmp_path, monkeypatch) -> None:
+        self._set(tmp_path, monkeypatch, '{"time":0,"agents":[null]}')
+        assert cache.read()[0] == []
+
+    def test_agents_not_a_list(self, tmp_path, monkeypatch) -> None:
+        self._set(tmp_path, monkeypatch, '{"time":0,"agents":"nope"}')
+        assert cache.read()[0] == []
+
+    def test_fresh_cache_within_max_age(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("AMUX_CACHE", str(tmp_path / "amux.json"))
+        cache.write([Agent(pane="a:1.1", session="a", kind="claude")])
+        assert len(cache.read(max_age=300)[0]) == 1
+
+    def test_cache_older_than_max_age_is_rejected(self, tmp_path, monkeypatch) -> None:
+        """A genuinely stale cache (not the trivial max_age=-1 case)."""
+        import json as _json
+        import time as _time
+
+        path = tmp_path / "amux.json"
+        stale = {"time": _time.time() - 600, "agents": [
+            {"pane": "a:1.1", "session": "a", "kind": "claude"}]}
+        path.write_text(_json.dumps(stale))
+        monkeypatch.setenv("AMUX_CACHE", str(path))
+        assert cache.read(max_age=60)[0] == []
+        assert len(cache.read(max_age=3600)[0]) == 1
+
+
+class TestScanWithStubbedTmux:
+    """scan.py is testable without a live server by stubbing its shell calls."""
+
+    SEP = "\x1f"
+
+    def _listing(self, rows: list[tuple[str, str, str, str, str]]) -> str:
+        return "\n".join(self.SEP.join(r) for r in rows)
+
+    def test_only_agent_panes_are_returned(self, monkeypatch) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        rows = [
+            ("s:1.1", "s", "100", "✳ alpha", "/tmp"),
+            ("s:1.2", "s", "200", "~/dir", "/tmp"),
+        ]
+        monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
+            self._listing(rows) if a[0] == "list-panes" else "agent screen text"))
+        monkeypatch.setattr(scan_mod, "_child_argv_by_ppid",
+                            lambda: {100: "claude --resume alpha", 200: "vim x"})
+        monkeypatch.setattr(scan_mod, "_child_pid", lambda ppid, kind: ppid + 1)
+        agents = scan_mod.scan(workers=2)
+        assert [a.pane for a in agents] == ["s:1.1"]
+        assert agents[0].name == "alpha" and agents[0].pid == 101
+
+    def test_pane_that_dies_mid_scan_is_dropped(self, monkeypatch) -> None:
+        """capture-pane returns '' for a pane that closed after listing."""
+        from claude_code_tools.amux import scan as scan_mod
+
+        rows = [("s:1.1", "s", "100", "t", "/tmp")]
+        monkeypatch.setattr(scan_mod, "_tmux", lambda *a: (
+            self._listing(rows) if a[0] == "list-panes" else ""))
+        monkeypatch.setattr(scan_mod, "_child_argv_by_ppid",
+                            lambda: {100: "codex --yolo"})
+        monkeypatch.setattr(scan_mod, "_child_pid", lambda ppid, kind: 0)
+        assert scan_mod.scan(workers=1) == []
+
+    def test_no_panes_at_all(self, monkeypatch) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        monkeypatch.setattr(scan_mod, "_tmux", lambda *a: "")
+        assert scan_mod.scan() == []
+
+
+class TestGitContext:
+    def test_plain_repo(self, tmp_path) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        (tmp_path / "myrepo" / ".git").mkdir(parents=True)
+        (tmp_path / "myrepo" / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+        repo, branch = scan_mod._git_context(str(tmp_path / "myrepo"))
+        assert (repo, branch) == ("myrepo", "main")
+
+    def test_relative_worktree_pointer(self, tmp_path) -> None:
+        """Regression: relative gitdir: pointers resolved against amux's cwd."""
+        from claude_code_tools.amux import scan as scan_mod
+
+        real = tmp_path / "repo.git" / "worktrees" / "feature"
+        real.mkdir(parents=True)
+        (real / "HEAD").write_text("ref: refs/heads/feat/x\n")
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        (wt / ".git").write_text("gitdir: ../repo.git/worktrees/feature\n")
+        repo, branch = scan_mod._git_context(str(wt))
+        assert (repo, branch) == ("wt", "feat/x")
+
+    def test_outside_any_repo(self, tmp_path) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        assert scan_mod._git_context(str(tmp_path)) == ("", "")
+
+    def test_empty_cwd(self) -> None:
+        from claude_code_tools.amux import scan as scan_mod
+
+        assert scan_mod._git_context("") == ("", "")
+
+
+class TestCli:
+    def test_default_command_keeps_global_options(self) -> None:
+        """Regression: `amux --max-age 0` used to fall back to the 30s default."""
+        from claude_code_tools.amux import cli
+
+        parser = cli.build_parser()
+        raw = ["--max-age", "0"]
+        if not any(t in {"pick", "list", "scan", "rows"} for t in raw):
+            raw.append("pick")
+        args = parser.parse_args(raw)
+        assert args.max_age == 0.0 and args.func is cli.cmd_pick
+
+    def test_explicit_subcommand_still_parses(self) -> None:
+        from claude_code_tools.amux import cli
+
+        args = cli.build_parser().parse_args(["list", "--json"])
+        assert args.json is True and args.func is cli.cmd_list
+
+    def test_interpreter_path_is_shell_quoted(self) -> None:
+        """fzf binds run through a shell; a spaced venv path must survive."""
+        import shlex
+
+        quoted = shlex.quote("/tmp/my venv/bin/python")
+        assert quoted != "/tmp/my venv/bin/python"
+        assert shlex.split(f"{quoted} -m x")[0] == "/tmp/my venv/bin/python"

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -682,14 +682,26 @@ class TestFooterMatchesRealHarnessChrome:
     def test_content_is_not_mistaken_for_footer(self, line: str) -> None:
         assert not detect._FOOTER.search(line), f"content matched: {line!r}"
 
-    def test_codex_prompt_followed_by_status_is_not_blocking(self) -> None:
-        """The concrete regression: Codex footer below an answered question."""
+    def test_codex_question_below_content_needs_footer_recognition(self) -> None:
+        """Footer recognition, not the trailing-line accident, must decide.
+
+        The earlier version of this test ended on a statement, so the Codex
+        heuristic returned idle before footer matching mattered -- it passed
+        with footer handling removed. Here the QUESTION is the last content
+        line, so only recognising the Codex status line below it as chrome
+        keeps this from being read as a pending prompt... and because that
+        chrome IS below it, the pane is genuinely idle.
+        """
         screen = (
-            "• Should I delete the stale config?\n"
-            "  Deleted it and reran the suite.\n"
+            "• Ran the suite; all green.\n"
+            "  Should I delete the stale config?\n"
             "  gpt-5.6-sol medium · farchat · main · Context 51% used\n"
+            "›\n"
         )
-        assert detect.detect_state(screen, "codex") != "input"
+        # The question is the last content line and nothing is working, so
+        # this IS a pending prompt: the value of footer recognition here is
+        # that the status line is not mistaken FOR content.
+        assert detect.detect_state(screen, "codex") == "input"
 
 
 class TestFooterAnchorSpecifically:


### PR DESCRIPTION
## What this adds

`amux` — find and jump between the Claude Code / Codex CLI agents running
across your tmux panes.

```
amux              # fzf picker: rows sorted by urgency, live pane preview,
                  # enter jumps to that pane
amux list         # table of every live agent (--json for scripts)
amux scan         # refresh the cache
```

States, most urgent first: **input** (the agent stopped and is asking YOU
something) · **busy** (mid-turn) · **bg** (monitors running) · **idle**.
`input` is the point of the tool — an agent blocked on a question is
otherwise invisible among 150 panes.

Each row carries the agent's session name, model, and `repo@branch`.

### Why screen-scraping

`pane_current_command` cannot identify these harnesses: Claude Code reports a
bare version string (`2.1.220`, a versioned binary) and Codex reports `node`.
Identification comes from child-process argv; state comes from the screen.

Codex has no structured prompt UI, so its "waiting for input" detection is a
heuristic (last content line ends in `?`, only when nothing indicates it is
working). Expect it to need tuning; the detection logic is pure functions
tested against captured screen text, so adjusting it is cheap and safe.

### Performance

On a 160-pane server: **8.5s → 1.1s cold, 0.075s warm.**

- one `ps` snapshot replaces ~160 `pgrep`+`ps` forks (5.6s of the original)
- `capture-pane` only for panes hosting an agent, in a thread pool
- JSON cache; the picker opens on cached rows and reload-syncs fresh ones

## Review

Eight rounds of adversarial cold-diff review (codex, no context), stopping
when the reviewer's own verdict was "no runtime findings, the diff has
converged."

**28 defects found and fixed. 9 of them were in my own earlier fixes or
tests** — that is the honest number, and the reason the loop ran as long as
it did.

The ones worth knowing about:

- A fix for newlines in pane titles used tmux's `#{s/\n/ /:...}` substitution.
  Its pattern is a literal string, so it replaced every letter `n`:
  `/Users/pchalasani/Git/avon` → `/Users/pchalasa i/Git/avo`. Every path
  containing an `n` was corrupted and git context came back blank for nearly
  every pane. **The suite was green throughout** — the stubs fed synthetic
  values and never exercised tmux's real formatter. Found by running the tool
  and reading the output.
- Footer detection knew only Claude's chrome, so a Codex pane could be
  reported as blocked-on-you indefinitely. Found by checking the regexes
  against lines captured from live panes; unmatched went 11 → 0.
- A working Codex pane was reported as blocked because an already-answered
  question was still on screen above the input box.
- `--max-age nan` disabled cache expiry entirely (every comparison against
  NaN is false), as did a NaN or future timestamp inside the cache file.
- Session names may contain spaces, so fzf's whitespace-split `{1}` pointed
  the preview and the jump at a pane that does not exist.

Every fix has a regression test, and each test was **mutation-checked**:
revert the fix, confirm the test fails. Three tests that would have passed
with their fix reverted were rewritten; one defensive branch no mutation
could reach was deleted rather than kept.

**95 tests.** `scan.py` is covered by stubbing its tmux/`ps` calls, so no
live server is needed.

## Notes

- `~/ops` and the tmux `prefix+A` binding still point at the prototype shell
  script; switching them to `amux` is a follow-up.
- `uv.lock` is untouched by this branch.
