### PR TITLE
fix(exports): expose package modules safely

### DIFF
--- a/claude_code_tools/__init__.py
+++ b/claude_code_tools/__init__.py
@@ -1,3 +1,21 @@
 """Claude Code Tools - Collection of utilities for Claude Code."""
 
+from importlib import import_module
+from types import ModuleType
+
 __version__ = "1.24.0"
+__all__ = ["action_rpc", "env_safe", "config"]
+
+
+def __getattr__(name: str) -> ModuleType:
+    """Load public modules when they are first accessed."""
+    if name in __all__:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Include lazy public modules in directory listings."""
+    return sorted({*globals(), *__all__})

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -1,0 +1,35 @@
+"""Tests for lazy modules exported from the package root."""
+
+import subprocess
+import sys
+from textwrap import dedent
+
+
+def test_public_modules_are_lazy_and_preserve_identity() -> None:
+    """An ordinary import should defer public module imports until access."""
+    script = dedent(
+        """
+        import importlib
+        import sys
+
+        original_path = sys.path.copy()
+        import claude_code_tools
+
+        names = ("action_rpc", "env_safe", "config")
+        assert claude_code_tools.__all__ == list(names)
+        assert all(name in dir(claude_code_tools) for name in claude_code_tools.__all__)
+        assert sys.path == original_path
+        for name in names:
+            qualified_name = f"claude_code_tools.{name}"
+            assert qualified_name not in sys.modules
+            assert name not in claude_code_tools.__dict__
+
+            exported = getattr(claude_code_tools, name)
+
+            assert exported is importlib.import_module(qualified_name)
+            assert exported is sys.modules[qualified_name]
+            assert getattr(claude_code_tools, name) is exported
+        """
+    )
+
+    subprocess.run([sys.executable, "-c", script], check=True)


### PR DESCRIPTION
Supersedes #161 by @nickhac.

This preserves the original goal of exposing the main package modules while avoiding imports of symbols that do not exist.

Changes:
- Export action_rpc, env_safe, and config as lazy package modules.
- Preserve normal module identity and defer imports until first access.
- Add isolated package-export coverage, including __all__ and dir() behavior.

Verification:
- Focused package-export test passed.
- Full suite: 1,652 passed, 7 skipped.

No merge is performed by this PR creation.