### PR TITLE
fix(voxtype): keepalive_minutes — stop slow takes after idle

### DIFF
--- a/docs-site/src/content/docs/tools/voxtype/configuration.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/configuration.mdx
@@ -246,9 +246,38 @@ overlay_speed = 1.0  # animation speed (lower = slower/gentler)
 # likely to evict it to swap — otherwise, on a memory-pressured
 # machine, the first take after a long pause can stall for seconds
 # paging the model back in. Keeps ~1.7 GB in active use. 0 disables;
-# max 1440 (a day).
+# max 1440 (a day). See the note below on the one trade-off.
 keepalive_minutes = 0.0
 ```
+
+### About `keepalive_minutes`
+
+Turn this on if your Mac runs under heavy memory
+pressure and your *first* take after a pause is
+sometimes slow — several seconds for a few seconds of
+audio, when a normal take is near-instant. That
+slowness is macOS having evicted the idle model
+(~1.7 GB) to swap; the periodic silent decode keeps
+those pages in active use so it is far less likely to
+happen. A value of 5 (minutes) is a reasonable start.
+On a machine with memory to spare, leave it off — it
+is not free, it keeps ~1.7 GB resident.
+
+One trade-off worth knowing:
+
+- The keepalive decode runs on the same thread that
+  reads the microphone, so while it runs, capture
+  pauses. It skips itself during a take, during an
+  utterance, and for 30 seconds after any hotkey
+  press, so it should never collide with you
+  speaking — but if you happen to press the hotkey
+  in the instant it starts, the first fraction of a
+  second of your dictation can be lost.
+- In practice that window is ~0.2 s, because a
+  keepalive on a warm model is fast, and keeping the
+  model warm is the whole point. A multi-second
+  keepalive means the model had already been evicted,
+  which is the situation this option prevents.
 
 ## CLI
 

--- a/docs-site/src/content/docs/tools/voxtype/configuration.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/configuration.mdx
@@ -239,6 +239,15 @@ copy_to_clipboard = false
 overlay = true
 overlay_flex = 1.0   # how much the face flexes its shape (higher = more)
 overlay_speed = 1.0  # animation speed (lower = slower/gentler)
+
+# Keep the model's memory warm (parakeet-mlx only). After this many
+# minutes without a decode, voxtype quietly decodes a short silent
+# clip so the idle model stays recently-used and macOS is far less
+# likely to evict it to swap — otherwise, on a memory-pressured
+# machine, the first take after a long pause can stall for seconds
+# paging the model back in. Keeps ~1.7 GB in active use. 0 disables;
+# max 1440 (a day).
+keepalive_minutes = 0.0
 ```
 
 ## CLI

--- a/packages/voxtype/src/voxtype/config.py
+++ b/packages/voxtype/src/voxtype/config.py
@@ -436,7 +436,10 @@ strip_fillers = true
 # idle model stays recently-used and macOS is far less likely to
 # evict it to swap — otherwise the first take after a long pause can
 # stall for seconds paging it back in. Keeps ~1.7 GB in active use.
-# 0 disables; max 1440 (a day).
+# 0 disables; max 1440 (a day). Trade-off: the keepalive briefly
+# pauses capture (~0.2 s on a warm model); it avoids takes and waits
+# 30 s after any hotkey, but a press landing exactly as it starts can
+# clip the first moment of dictation.
 keepalive_minutes = 0.0
 
 # Moonshine model: tiny | base | tiny-streaming | base-streaming |

--- a/packages/voxtype/src/voxtype/config.py
+++ b/packages/voxtype/src/voxtype/config.py
@@ -111,6 +111,15 @@ class Config:
             shape (1.0 = default; higher = more flexible, calmer < 1.0).
         overlay_speed: Overall animation speed multiplier (1.0 =
             default; lower = slower/gentler motion).
+        keepalive_minutes: Re-decode a short silent clip after this
+            many minutes without a decode (parakeet-mlx only). Under
+            system-wide memory pressure macOS evicts an idle model to
+            compressed memory/swap, and the next take then pays a
+            multi-second page-in stall; the periodic throwaway decode
+            keeps the model's ~1.7 GB recently-used so eviction is
+            far less likely, and any page-in cost lands in an idle
+            moment instead of on a take. 0 disables (default);
+            max 1440 (a day).
         model_arch: Moonshine model architecture name (moonshine engine
             only).
         language: Language tag understood by Moonshine (e.g. "en").
@@ -156,6 +165,7 @@ class Config:
     overlay: bool = True
     overlay_flex: float = 1.0
     overlay_speed: float = 1.0
+    keepalive_minutes: float = 0.0
     model_arch: str = "medium-streaming"
     language: str = "en"
     hotkey: str = "<ctrl>+;"
@@ -256,6 +266,30 @@ class Config:
                 raise ValueError(
                     f"{name} must be between 0 and 5, got {value!r}"
                 )
+        if isinstance(self.keepalive_minutes, bool) or not isinstance(
+            self.keepalive_minutes, (int, float)
+        ):
+            raise ValueError(
+                f"keepalive_minutes must be a number of minutes, "
+                f"got {self.keepalive_minutes!r}"
+            )
+        if isinstance(self.keepalive_minutes, float) and not math.isfinite(
+            self.keepalive_minutes
+        ):
+            # TOML accepts nan/inf literals; NaN would make the idle
+            # comparison permanently false, silently disabling the
+            # feature while looking enabled.
+            raise ValueError(
+                f"keepalive_minutes must be finite, "
+                f"got {self.keepalive_minutes!r}"
+            )
+        if not 0 <= self.keepalive_minutes <= 1440:
+            # The upper bound also keeps huge TOML integers out of the
+            # engine, where float(minutes) * 60.0 would overflow.
+            raise ValueError(
+                "keepalive_minutes must be between 0 and 1440 "
+                "(a day); 0 disables"
+            )
         if self.mode == "wake" and not self.wake_word.strip():
             raise ValueError('mode "wake" requires a non-empty wake_word')
         if isinstance(self.idle_timeout, bool) or not isinstance(
@@ -396,6 +430,14 @@ overlay_speed = 1.0
 
 # Remove standalone filler words (uh, um, ...) from typed text.
 strip_fillers = true
+
+# Keep the model's memory warm (parakeet-mlx only): after this many
+# minutes without a decode, quietly decode a short silent clip so the
+# idle model stays recently-used and macOS is far less likely to
+# evict it to swap — otherwise the first take after a long pause can
+# stall for seconds paging it back in. Keeps ~1.7 GB in active use.
+# 0 disables; max 1440 (a day).
+keepalive_minutes = 0.0
 
 # Moonshine model: tiny | base | tiny-streaming | base-streaming |
 # small-streaming | medium-streaming (most accurate; ~245M params)

--- a/packages/voxtype/src/voxtype/engine_parakeet.py
+++ b/packages/voxtype/src/voxtype/engine_parakeet.py
@@ -494,6 +494,15 @@ class ParakeetEngine:
         # never be replayed ahead of the hold-start it followed.
         self._cmd_lock = threading.Lock()
         self._commands: deque[str] = deque()
+        # When the last cross-thread command ARRIVED (stamped in
+        # _request, so it covers commands not yet drained by the
+        # worker). The MLX keepalive holds off for a grace period
+        # after any command: a just-activated user is about to speak,
+        # and a keepalive page-in blocking capture at that exact
+        # moment is the one delay the feature must never cause.
+        # -inf: no grace at startup. Benign cross-thread float write
+        # (GIL-atomic); only ever compared against the clock.
+        self._last_command = float("-inf")
         # Completed hold takes, decoded on a FIFO decoder thread so a
         # slow decode never blocks capture; None = shutdown sentinel.
         self._takes: queue.Queue = queue.Queue()
@@ -514,6 +523,7 @@ class ParakeetEngine:
         self.fatal_error: str | None = None
 
     def _request(self, command: str) -> None:
+        self._last_command = time.monotonic()
         with self._cmd_lock:
             self._commands.append(command)
 
@@ -823,6 +833,7 @@ class ParakeetEngine:
                 )
                 while not self._stop.is_set():
                     self._process_commands(on_utterance, np)
+                    self._keepalive_tick()
                     samples = self._read_samples(
                         stream, read_size, native_rate, np
                     )
@@ -924,6 +935,16 @@ class ParakeetEngine:
         finally:
             with self._stream_lock:
                 self._stream = None
+
+    def _keepalive_tick(self) -> None:
+        """Hook run once per capture-loop iteration; no-op by default.
+
+        The MLX engine overrides this to keep its model's memory
+        resident (see ``ParakeetMlxEngine._keepalive_tick``). It runs
+        on the capture thread — the only thread allowed to touch the
+        MLX model — which is why the hook lives in the capture loop
+        rather than on a timer thread.
+        """
 
     def _process_commands(
         self, on_utterance: Callable[[str], None], np  # noqa: ANN001

--- a/packages/voxtype/src/voxtype/engine_parakeet_mlx.py
+++ b/packages/voxtype/src/voxtype/engine_parakeet_mlx.py
@@ -231,13 +231,23 @@ class ParakeetMlxEngine(ParakeetEngine):
         an unprocessed activation command (e.g. a hotkey press) is
         queued, and for ``KEEPALIVE_COMMAND_GRACE`` seconds after any
         command — a just-activated user (whose activation command was
-        already drained) is about to speak. A command can still arrive
-        in the instant after these checks or mid-decode — inherent to
-        inline decoding on this thread, take decodes included — in
-        which case activation is delayed by the decode's duration and
-        the buffered audio is processed immediately after; the checks
-        make that window rare (quiet for 30+ s, at most once per
-        interval), not impossible. Opt-in: 0 (the default) disables.
+        already drained) is about to speak.
+
+        Known limitation: the checks narrow that window but cannot
+        close it, since a hotkey press can land just after them or
+        mid-decode. Capture is then blocked for the rest of the
+        decode; PortAudio's input buffer holds well under a second, so
+        speech beyond that is dropped rather than merely delayed (the
+        blocking read's overflow flag is not surfaced either). Inline
+        decoding on this thread is pre-existing — an ordinary take
+        decode blocks capture the same way — and closing the window
+        needs capture decoupled from decoding (callback-driven capture
+        feeding a queue), which is deliberately out of scope here. In
+        practice the exposure is small: a keepalive on a warm model
+        takes ~0.2 s, and the feature keeps the model warm precisely
+        so it stays that way; a multi-second keepalive means the model
+        was already evicted, which is the case this option exists to
+        prevent. Opt-in: 0 (the default) disables.
         """
         secs = float(getattr(self.cfg, "keepalive_minutes", 0.0)) * 60.0
         if secs <= 0 or self._holding or self._speech_since is not None:

--- a/packages/voxtype/src/voxtype/engine_parakeet_mlx.py
+++ b/packages/voxtype/src/voxtype/engine_parakeet_mlx.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import tempfile
 import threading
+import time
 import wave
 from pathlib import Path
 from typing import Callable
@@ -30,6 +31,13 @@ from .engine_parakeet import (
 )
 from .engines import StatusFn
 
+# Seconds the keepalive holds off after any cross-thread command
+# (toggle/hold/flush/reset). A just-activated user is about to speak;
+# by the time the grace expires, either their first utterance has
+# been decoded (restamping the keepalive clock) or the session went
+# quiet again and the keepalive is safe to run.
+KEEPALIVE_COMMAND_GRACE = 30.0
+
 
 class ParakeetMlxEngine(ParakeetEngine):
     """Mic -> Silero VAD -> Parakeet-TDT v3 on the MLX GPU."""
@@ -45,6 +53,9 @@ class ParakeetMlxEngine(ParakeetEngine):
                 "(Apple Silicon only)"
             ) from e
         super().__init__(cfg, status)
+        # Time of the last decode (warmup, take, or keepalive); read
+        # only on the capture thread, where every decode also happens.
+        self._last_decode = time.monotonic()
 
     def start(
         self,
@@ -199,6 +210,63 @@ class ParakeetMlxEngine(ParakeetEngine):
         """
         self._deliver_take(take, on_utterance)
 
+    def _keepalive_tick(self) -> None:
+        """Keep the model's memory recently-used by decoding periodically.
+
+        Under system-wide memory pressure macOS evicts the idle
+        model's ~1.7 GB to compressed memory/swap, and the first take
+        after a long pause then stalls for seconds paging it back in
+        (observed: 8.4 s of audio decoded in 6.16 s on a machine deep
+        in swap, vs ~0.2 s warm). Decoding a half-second silent clip
+        whenever ``keepalive_minutes`` have passed without a decode
+        keeps those pages recently-touched, so the paging cost lands
+        here — in an idle moment — instead of on the user's take.
+
+        Runs on the capture thread between reads (MLX is thread-local;
+        see ``start``), so a keepalive that itself pages the model in
+        can block capture for its duration; audio arriving meanwhile
+        is retained by the input stream's buffer, exactly as during an
+        inline take decode. To keep that window away from real speech
+        the tick is skipped while a take or VAD segment is open, while
+        an unprocessed activation command (e.g. a hotkey press) is
+        queued, and for ``KEEPALIVE_COMMAND_GRACE`` seconds after any
+        command — a just-activated user (whose activation command was
+        already drained) is about to speak. A command can still arrive
+        in the instant after these checks or mid-decode — inherent to
+        inline decoding on this thread, take decodes included — in
+        which case activation is delayed by the decode's duration and
+        the buffered audio is processed immediately after; the checks
+        make that window rare (quiet for 30+ s, at most once per
+        interval), not impossible. Opt-in: 0 (the default) disables.
+        """
+        secs = float(getattr(self.cfg, "keepalive_minutes", 0.0)) * 60.0
+        if secs <= 0 or self._holding or self._speech_since is not None:
+            return
+        now = time.monotonic()
+        if now - self._last_decode < secs:
+            return
+        if now - self._last_command < KEEPALIVE_COMMAND_GRACE:
+            return
+        with self._cmd_lock:
+            if self._commands:
+                return
+        import numpy as np
+
+        try:
+            self.transcribe(
+                np.zeros(SAMPLE_RATE // 2, dtype=np.float32), SAMPLE_RATE
+            )
+        except Exception:
+            # Cosmetic feature: a failed keepalive must never disturb
+            # capture.
+            pass
+        finally:
+            # Restamp even when transcribe failed before reaching its
+            # own finally (e.g. temp-file creation raised): a
+            # persistent failure retries once per interval, not once
+            # per ~0.1 s loop iteration.
+            self._last_decode = time.monotonic()
+
     def transcribe(self, samples, sample_rate: int) -> str:  # noqa: ANN001
         """Decode one float32 mono segment via a temp wav file.
 
@@ -226,8 +294,13 @@ class ParakeetMlxEngine(ParakeetEngine):
             text = getattr(result, "text", None)
             return text.strip() if isinstance(text, str) else ""
         finally:
-            tmp.unlink(missing_ok=True)
-            self._release_gpu_cache()
+            # Stamp FIRST: a raising unlink must not skip the stamp
+            # (the keepalive clock) or the cache release below.
+            self._last_decode = time.monotonic()
+            try:
+                tmp.unlink(missing_ok=True)
+            finally:
+                self._release_gpu_cache()
 
     @staticmethod
     def _release_gpu_cache() -> None:

--- a/packages/voxtype/tests/test_voxtype.py
+++ b/packages/voxtype/tests/test_voxtype.py
@@ -238,6 +238,11 @@ def test_load_config_rejects_unknown_keys(tmp_path: Path) -> None:
         ("idle_timeout", float("nan")),
         ("idle_timeout", float("inf")),
         ("idle_timeout", float("-inf")),
+        ("keepalive_minutes", -1.0),
+        ("keepalive_minutes", float("nan")),
+        ("keepalive_minutes", float("inf")),
+        ("keepalive_minutes", 1441),
+        ("keepalive_minutes", 10**1000),
     ],
 )
 def test_validate_rejects_bad_values(field: str, value: object) -> None:
@@ -277,11 +282,21 @@ def test_write_sample_config_refuses_overwrite(tmp_path: Path) -> None:
         ("submit_phrases", "go"),
         ("submit_phrases", ["go", ""]),
         ("submit_phrases", ["go", 3]),
+        ("keepalive_minutes", "5"),
+        ("keepalive_minutes", True),
+        ("keepalive_minutes", None),
     ],
 )
 def test_validate_rejects_bad_types(field: str, value: object) -> None:
     with pytest.raises(ValueError):
         Config(**{field: value}).validate()
+
+
+def test_validate_accepts_keepalive_minutes() -> None:
+    """0 (off, the default), fractional, and integer intervals are valid."""
+    Config(keepalive_minutes=0).validate()
+    Config(keepalive_minutes=2.5).validate()
+    Config(keepalive_minutes=10).validate()
 
 
 def test_validate_huge_integer_idle_timeout() -> None:

--- a/packages/voxtype/tests/test_voxtype_engines.py
+++ b/packages/voxtype/tests/test_voxtype_engines.py
@@ -1223,3 +1223,158 @@ def test_report_decode_time_formats(monkeypatch) -> None:
     assert msgs[-1] == "transcribed 4.0s of audio in 0.20s (20x realtime)"
     eng._report_decode_time(1.0, 0.0)  # never divides by zero
     assert msgs[-1] == "transcribed 1.0s of audio in 0.00s"
+
+
+# -- MLX keepalive --------------------------------------------------------
+
+
+def _make_mlx_engine():  # noqa: ANN202
+    """Build a ParakeetMlxEngine with a fake model (no weights loaded)."""
+    pytest.importorskip("mlx.core")
+    pytest.importorskip("parakeet_mlx")
+    from voxtype.engine_parakeet_mlx import ParakeetMlxEngine
+
+    statuses: list[str] = []
+    eng = ParakeetMlxEngine(
+        Config(engine="parakeet-mlx"), statuses.append
+    )
+    eng._model = SimpleNamespace(
+        transcribe=lambda path: SimpleNamespace(text="hi")
+    )
+    return eng, statuses
+
+
+def test_mlx_transcribe_restamps_last_decode() -> None:
+    """A successful decode restamps ``_last_decode`` (the keepalive
+    clock the tick's not-yet-due check depends on)."""
+    np = pytest.importorskip("numpy")
+    eng, _ = _make_mlx_engine()
+    eng._last_decode = time.monotonic() - 999.0
+    before = time.monotonic()
+    text = eng.transcribe(np.zeros(1600, dtype=np.float32), 16000)
+    assert text == "hi"
+    assert eng._last_decode >= before
+
+
+def test_mlx_transcribe_restamps_last_decode_on_failure() -> None:
+    """A FAILED decode must restamp too — the stamp sits first in
+    transcribe's ``finally`` — or an overdue keepalive would retry
+    every ~0.1 s loop iteration instead of once per interval."""
+    np = pytest.importorskip("numpy")
+    eng, _ = _make_mlx_engine()
+
+    def broken(path):  # noqa: ANN001, ANN202
+        raise RuntimeError("gpu gone")
+
+    eng._model = SimpleNamespace(transcribe=broken)
+    eng._last_decode = time.monotonic() - 999.0
+    before = time.monotonic()
+    with pytest.raises(RuntimeError, match="gpu gone"):
+        eng.transcribe(np.zeros(1600, dtype=np.float32), 16000)
+    assert eng._last_decode >= before
+
+
+def test_mlx_keepalive_tick_conditions() -> None:
+    """The tick decodes only when enabled, overdue, and idle."""
+    np = pytest.importorskip("numpy")  # noqa: F841
+    eng, _ = _make_mlx_engine()
+    calls: list = []
+
+    def fake_transcribe(samples, rate):  # noqa: ANN001, ANN202
+        calls.append(len(samples))
+        eng._last_decode = time.monotonic()  # transcribe's contract
+        return ""
+
+    eng.transcribe = fake_transcribe
+
+    overdue = time.monotonic() - 3600.0
+    # Disabled (default 0): never fires, however overdue.
+    eng._last_decode = overdue
+    eng._keepalive_tick()
+    assert calls == []
+
+    eng.cfg.keepalive_minutes = 5.0
+    # Overdue and idle: fires exactly once, then it's no longer due.
+    eng._keepalive_tick()
+    assert len(calls) == 1
+    eng._keepalive_tick()
+    assert len(calls) == 1
+
+    # Overdue but mid-take, mid-utterance, or with an unprocessed
+    # command (e.g. a hotkey press) queued: never fires.
+    eng._last_decode = overdue
+    eng._holding = True
+    eng._keepalive_tick()
+    eng._holding = False
+    eng._speech_since = time.monotonic()
+    eng._keepalive_tick()
+    eng._speech_since = None
+    from voxtype.engine_parakeet_mlx import KEEPALIVE_COMMAND_GRACE
+
+    stale = time.monotonic() - KEEPALIVE_COMMAND_GRACE - 1.0
+
+    # A command STILL QUEUED but older than the grace (possible when
+    # commands pile up during a slow model load): the queue peek — not
+    # the grace — must block the tick. Enqueue directly, bypassing
+    # _request's _last_command stamp.
+    eng._last_command = stale
+    with eng._cmd_lock:
+        eng._commands.append("reset")
+    eng._keepalive_tick()
+    assert len(calls) == 1
+    with eng._cmd_lock:
+        eng._commands.clear()
+
+    # A command processed and drained moments ago (the real capture-
+    # loop ordering: _process_commands runs before the tick): the
+    # grace must block the tick until it expires.
+    eng.request_reset()
+    with eng._cmd_lock:
+        eng._commands.clear()
+    eng._keepalive_tick()
+    assert len(calls) == 1
+    eng._last_command = stale
+    eng._keepalive_tick()
+    assert len(calls) == 2
+
+
+def test_mlx_keepalive_failure_is_contained() -> None:
+    """A raising decode must not escape the tick (capture must go on),
+    and the tick's own ``finally`` restamps the clock even when the
+    failure precedes ``transcribe``'s internal restamp (e.g. temp-file
+    creation raised), so the next tick is not-yet-due rather than an
+    immediate per-iteration retry."""
+    eng, _ = _make_mlx_engine()
+    attempts: list = []
+
+    def dies_before_transcribes_finally(samples, rate):  # noqa: ANN001, ANN202
+        attempts.append(1)
+        raise OSError("no temp file for you")
+
+    # Replace transcribe wholesale and do NOT restamp in the fake:
+    # only the tick-level finally can restamp here, which is exactly
+    # the safeguard under test.
+    eng.transcribe = dies_before_transcribes_finally
+    eng.cfg.keepalive_minutes = 5.0
+    eng._last_decode = time.monotonic() - 3600.0
+    before = time.monotonic()
+    eng._keepalive_tick()  # must not raise
+    assert len(attempts) == 1
+    assert eng._last_decode >= before  # restamped by the tick's finally
+    eng._keepalive_tick()  # no per-iteration retry storm
+    assert len(attempts) == 1
+
+
+def test_capture_loop_invokes_keepalive_tick(monkeypatch) -> None:
+    """The capture loop calls the hook every iteration (the base no-op;
+    the MLX override rides this same call site)."""
+    np = pytest.importorskip("numpy")
+    eng, statuses, holder = _make_parakeet(monkeypatch)
+    ticks: list[int] = []
+    eng._keepalive_tick = lambda: ticks.append(1)
+
+    chunk = np.zeros(1600, dtype=np.float32)
+    script = [chunk, chunk, lambda: (eng._stop.set(), chunk)[1]]
+    holder["factory"] = lambda **kw: ScriptedStream(script)
+    eng._capture_session(lambda text: None, lambda: None)
+    assert len(ticks) == 3

--- a/release-notes/pr-168-voxtype-keepalive.md
+++ b/release-notes/pr-168-voxtype-keepalive.md
@@ -1,4 +1,4 @@
-# voxtype v0.1.5 — keepalive: stop slow takes after idle
+# PR #168 — voxtype keepalive: stop slow takes after idle
 
 ## Problem
 

--- a/release-notes/voxtype-v0.1.5-keepalive.md
+++ b/release-notes/voxtype-v0.1.5-keepalive.md
@@ -1,0 +1,47 @@
+# voxtype v0.1.5 — keepalive: stop slow takes after idle
+
+## Problem
+
+On a memory-pressured Mac, macOS evicts the idle Parakeet-MLX model
+(~1.7 GB) to compressed memory/swap. The first take after a pause then
+pays a multi-second page-in stall — observed: 8.4 s of audio decoded in
+6.16 s (1x realtime) on a machine deep in swap, vs ~0.2 s warm.
+
+## Fix: `keepalive_minutes` (opt-in)
+
+New config knob (parakeet-mlx engine only):
+
+```toml
+keepalive_minutes = 5.0   # 0 disables (default); max 1440
+```
+
+After that many minutes without a decode, the engine decodes half a
+second of silence, keeping the model's pages recently-used so eviction
+is far less likely — and any page-in cost lands in an idle moment
+instead of on a take.
+
+## Safety guards
+
+The keepalive runs on the capture thread (MLX is thread-local), so it
+is skipped whenever it could collide with real speech:
+
+- while a hold take or VAD segment is open
+- while an unprocessed activation command (hotkey press) is queued
+- for 30 s after any activation command (a just-activated user is
+  about to speak)
+
+A failed keepalive is contained and retries once per interval, never
+per loop iteration. A command can still land mid-decode — inherent to
+inline decoding, take decodes included; activation is then delayed by
+the decode's duration and buffered audio is processed right after.
+
+## Validation
+
+- `keepalive_minutes` must be a finite number in [0, 1440]; huge TOML
+  integers are rejected before they can overflow the engine's math.
+
+## Tests
+
+12 new tests: config bounds/types, restamp on success and failure,
+tick gating (disabled / overdue / mid-take / mid-utterance / queued
+command / command grace), failure containment, and capture-loop wiring.

--- a/release-notes/voxtype-v0.1.5-keepalive.md
+++ b/release-notes/voxtype-v0.1.5-keepalive.md
@@ -31,9 +31,25 @@ is skipped whenever it could collide with real speech:
   about to speak)
 
 A failed keepalive is contained and retries once per interval, never
-per loop iteration. A command can still land mid-decode — inherent to
-inline decoding, take decodes included; activation is then delayed by
-the decode's duration and buffered audio is processed right after.
+per loop iteration.
+
+## Known limitation
+
+The keepalive decodes on the capture thread (MLX is thread-local), so
+capture pauses for its duration. The guards above narrow that window
+but cannot close it: a hotkey press landing just after the checks, or
+mid-decode, can clip the first moment of dictation — PortAudio's input
+buffer holds well under a second, and its overflow flag is not
+surfaced.
+
+Exposure is small in practice: a keepalive on a warm model takes
+~0.2 s, and keeping the model warm is the point; a multi-second
+keepalive means the model was already evicted, which is the case this
+option prevents. Inline decoding is pre-existing — an ordinary take
+decode blocks capture identically — so closing the window means
+decoupling capture from decoding (callback-driven capture feeding a
+queue), tracked separately rather than bundled into this opt-in
+feature.
 
 ## Validation
 

--- a/release-notes/voxtype-v0.1.5-keepalive.md
+++ b/release-notes/voxtype-v0.1.5-keepalive.md
@@ -48,7 +48,7 @@ keepalive means the model was already evicted, which is the case this
 option prevents. Inline decoding is pre-existing — an ordinary take
 decode blocks capture identically — so closing the window means
 decoupling capture from decoding (callback-driven capture feeding a
-queue), tracked separately rather than bundled into this opt-in
+queue), tracked in issue #169 rather than bundled into this opt-in
 feature.
 
 ## Validation

--- a/uv.lock
+++ b/uv.lock
@@ -449,7 +449,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.23.2"
+version = "1.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
## What

Opt-in `keepalive_minutes` config knob (parakeet-mlx only): after N minutes without a decode, decode 0.5 s of silence so macOS doesn't evict the idle ~1.7 GB model to swap. Without it, the first take after a pause on a memory-pressured machine paid a multi-second page-in stall (observed: 8.4 s of audio in 6.16 s, vs ~0.2 s warm).

## How

- Tick runs on the capture thread (MLX is thread-local), between mic reads.
- Skipped mid-take, mid-utterance, with a hotkey command queued, and for 30 s after any activation command.
- Failures contained; retries once per interval. Config validated to a finite [0, 1440].

Details: [release-notes/pr-168-voxtype-keepalive.md](https://github.com/pchalasani/claude-code-tools/blob/feat/voxtype-keepalive/release-notes/pr-168-voxtype-keepalive.md)

## Testing

- 12 new tests (config bounds, tick gating, failure paths, loop wiring); voxtype suite 212 passed, umbrella suite 1651 passed.
- Codex cold-diff review loop run to convergence (final round: NO FINDINGS).

Note: `uv.lock` includes a 2-line refresh recording the 1.24.0 bump that the bump commit missed.