### PR TITLE
docs: open the Codex workflows guide by naming its Claude Code analog

### DIFF
--- a/docs-site/src/content/docs/guides/claude-to-codex/index.mdx
+++ b/docs-site/src/content/docs/guides/claude-to-codex/index.mdx
@@ -11,15 +11,15 @@ import {
   Steps,
 } from "@astrojs/starlight/components";
 
+This is the Codex analog of Claude Code's
+[dynamic workflows](https://code.claude.com/docs/en/workflows), which Codex
+does not have natively. The `dynamic-workflow` plugin in this repository
+supplies that capability through an installable skill and a durable JavaScript
+runtime.
+
 A dynamic workflow is a small JavaScript program that coordinates agents at
 runtime. JavaScript owns predictable control flow—fan-out, fan-in, loops,
 branches, and aggregation—while agents own reasoning and tool use.
-
-The `dynamic-workflow` plugin in this repository brings that pattern to Codex
-through an installable skill and a durable JavaScript runtime. Claude Code
-offers the same pattern natively as its
-[dynamic workflows](https://code.claude.com/docs/en/workflows), so the model
-here will look familiar if you already write those.
 
 <CardGrid>
   <Card title="What you get">
@@ -27,7 +27,7 @@ here will look familiar if you already write those.
     and adapt as the work progresses.
   </Card>
   <Card title="What differs from Claude Code">
-    Codex has no equivalent of Claude Code's interactive `/workflows` command.
+    Even with the plugin, Codex has no interactive `/workflows` command.
   </Card>
 </CardGrid>
 


### PR DESCRIPTION
Follow-up to #170. This commit was pushed a few minutes after that PR merged,
so it never landed on `main` — this re-lands it.

## Why

The guide dove straight into defining what a dynamic workflow is, which reads
as though it is something newly invented here for Codex. It isn't: it's the
Codex counterpart of a Claude Code feature. A reader who already knows Claude
Code's dynamic workflows should recognize that from the first sentence, and a
reader who doesn't should get the upstream link.

## What changed

The page now opens with the analogy and the link, and says plainly that Codex
has no native equivalent:

> This is the Codex analog of Claude Code's
> [dynamic workflows](https://code.claude.com/docs/en/workflows), which Codex
> does not have natively. The `dynamic-workflow` plugin in this repository
> supplies that capability through an installable skill and a durable
> JavaScript runtime.

The "what a dynamic workflow is" definition moves to second.

One knock-on fix: the comparison card read "Codex has no equivalent of Claude
Code's interactive `/workflows` command," which sits oddly beside an opening
saying the plugin closes the gap. It now reads "Even with the plugin, Codex
has no interactive `/workflows` command," so it lands as a remaining
limitation rather than a contradiction.

Docs site builds clean (45 pages).
