### PR TITLE
fix(aichat): support session names across commands

### DIFF
--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -7,7 +7,7 @@ Codex sessions, following the pattern of tools like git, docker, etc.
 
 All session-related tools are accessible as subcommands:
     aichat search          - Full-text search across all sessions
-    aichat resume          - Resume a session (latest or by ID)
+    aichat resume          - Resume a session (latest or by name/ID/path)
     aichat menu            - Interactive session menu
     aichat trim            - Trim session content
     ... and more
@@ -18,75 +18,11 @@ etc.) are still available.
 
 import click
 
-
-def _session_homes() -> tuple[str | None, str | None]:
-    """Return agent homes configured on the root Click context."""
-    context = click.get_current_context(silent=True)
-    if context is None:
-        return None, None
-    root_obj = context.find_root().obj or {}
-    return root_obj.get("claude_home"), root_obj.get("codex_home")
-
-
-def _resolve_cli_session(
-    session: str,
-    agent: str | None = None,
-    *,
-    claude_home: str | None = None,
-    codex_home: str | None = None,
-) -> "ResolvedSessionQuery":
-    """Resolve a CLI session query or print its user-facing error."""
-    import sys
-
-    from claude_code_tools.session_resolution import (
-        ResolvedSessionQuery,
-        SessionQueryError,
-        resolve_session_query,
-    )
-
-    root_claude_home, root_codex_home = _session_homes()
-    effective_claude_home = (
-        root_claude_home if claude_home is None else claude_home
-    )
-    effective_codex_home = (
-        root_codex_home if codex_home is None else codex_home
-    )
-    try:
-        return resolve_session_query(
-            session,
-            agent=agent,
-            claude_home=effective_claude_home,
-            codex_home=effective_codex_home,
-        )
-    except SessionQueryError as error:
-        print(f"Error: {error}", file=sys.stderr)
-        sys.exit(1)
-
-
-def _resolve_export_session(
-    session: str,
-    agent: str | None = None,
-) -> "ResolvedSessionQuery":
-    """Resolve export input and surface shared resolver failures."""
-    import sys
-
-    from claude_code_tools.session_resolution import (
-        ResolvedSessionQuery,
-        SessionQueryError,
-        resolve_session_query,
-    )
-
-    claude_home, codex_home = _session_homes()
-    try:
-        return resolve_session_query(
-            session,
-            agent=agent,
-            claude_home=claude_home,
-            codex_home=codex_home,
-        )
-    except SessionQueryError as error:
-        print(f"Error: {error}", file=sys.stderr)
-        sys.exit(1)
+from claude_code_tools.session_cli_resolution import (
+    resolve_cli_session as _resolve_cli_session,
+    resolve_export_session as _resolve_export_session,
+    session_homes as _session_homes,
+)
 
 
 def _consume_export_agent(
@@ -127,14 +63,27 @@ def _consume_export_agent(
     return agent, remaining
 
 
-class SessionIDGroup(click.Group):
-    """Custom group that treats unknown commands as session IDs for menu."""
+class SessionReferenceGroup(click.Group):
+    """Treat an unknown command token as a session reference for ``menu``."""
 
     def parse_args(self, ctx, args):
-        # If the first arg looks like a session ID (not a known command), route to menu
-        if args and args[0] not in self.commands and not args[0].startswith('-'):
-            # Treat as session ID - prepend 'menu' to make it a menu command
-            args = ['menu'] + args
+        from claude_code_tools.cli_passthrough import (
+            MissingPositionalError,
+            positional_index,
+        )
+
+        try:
+            command_index = positional_index(
+                args,
+                value_options=("--claude-home", "--codex-home"),
+            )
+        except MissingPositionalError:
+            command_index = None
+        if (
+            command_index is not None
+            and args[command_index] not in self.commands
+        ):
+            args.insert(command_index, "menu")
         return super().parse_args(ctx, args)
 
 
@@ -158,7 +107,7 @@ class ResolveCommand(click.Command):
             ctx.exit(1)
 
 
-@click.group(cls=SessionIDGroup, invoke_without_command=True)
+@click.group(cls=SessionReferenceGroup, invoke_without_command=True)
 @click.version_option()
 @click.option(
     '--claude-home',
@@ -373,7 +322,7 @@ def _find_and_run_session_ui(
     Otherwise, finds latest sessions for current project/branch and shows UI.
 
     Args:
-        session_id: Optional explicit session ID or path
+        session_id: Optional explicit session name, ID/fragment, or path.
         agent_constraint: 'claude', 'codex', or 'both'
         start_screen: Screen to show when single session found
         select_target: Screen to go to after selection (multiple sessions)
@@ -758,9 +707,16 @@ Examples:
 @main.command("find-original", context_settings={"ignore_unknown_options": True, "allow_extra_args": True, "allow_interspersed_args": False})
 @click.pass_context
 def find_original(ctx):
-    """Find the original session from a trimmed/continued session."""
+    """Find the original session from a named or identified session."""
     import sys
-    sys.argv = [sys.argv[0].replace('aichat', 'find-original-session')] + ctx.args
+    from claude_code_tools.legacy_session_wrappers import (
+        resolved_find_original_args,
+    )
+
+    sys.argv = [
+        sys.argv[0].replace('aichat', 'find-original-session'),
+        *resolved_find_original_args(ctx.args),
+    ]
     from claude_code_tools.find_original_session import (
         main as find_original_main,
     )
@@ -770,9 +726,16 @@ def find_original(ctx):
 @main.command("find-derived", context_settings={"ignore_unknown_options": True, "allow_extra_args": True, "allow_interspersed_args": False})
 @click.pass_context
 def find_derived(ctx):
-    """Find derived sessions (trimmed/continued) from an original."""
+    """Find sessions derived from a named or identified original."""
     import sys
-    sys.argv = [sys.argv[0].replace('aichat', 'find-trimmed-sessions')] + ctx.args
+    from claude_code_tools.legacy_session_wrappers import (
+        resolved_find_derived_args,
+    )
+
+    sys.argv = [
+        sys.argv[0].replace('aichat', 'find-trimmed-sessions'),
+        *resolved_find_derived_args(ctx.args),
+    ]
     from claude_code_tools.find_trimmed_sessions import (
         main as find_derived_main,
     )
@@ -782,9 +745,14 @@ def find_derived(ctx):
 @main.command("menu", context_settings={"ignore_unknown_options": True, "allow_extra_args": True, "allow_interspersed_args": False})
 @click.pass_context
 def menu(ctx):
-    """Interactive menu for a specific session (by ID or path)."""
+    """Open the action menu for a session name, ID/fragment, or path."""
     import sys
-    sys.argv = [sys.argv[0].replace('aichat', 'session-menu')] + ctx.args
+    from claude_code_tools.legacy_session_wrappers import resolved_menu_args
+
+    sys.argv = [
+        sys.argv[0].replace('aichat', 'session-menu'),
+        *resolved_menu_args(ctx.args),
+    ]
     from claude_code_tools.session_menu_cli import main as menu_main
     menu_main()
 
@@ -805,7 +773,7 @@ def menu(ctx):
               help="Force agent type (auto-detected if not specified)")
 @click.option("--claude-home", help="Path to Claude home directory")
 @click.option("--simple-ui", is_flag=True,
-              help="Use simple CLI trim instead of Node UI (requires session ID)")
+              help="Use simple CLI trim instead of Node UI (requires SESSION)")
 def trim(session, tools, threshold, trim_assistant, output_dir, agent, claude_home, simple_ui):
     """Trim session to reduce size by truncating large tool outputs.
 
@@ -813,8 +781,9 @@ def trim(session, tools, threshold, trim_assistant, output_dir, agent, claude_ho
     the length threshold. Creates a new trimmed session file with lineage
     metadata linking back to the original.
 
-    If no session ID provided, finds latest session for current project/branch
-    and opens the interactive trim menu.
+    If no SESSION is provided, finds the latest session for the current
+    project/branch. SESSION accepts a name, ID/fragment, filename fragment,
+    or path. With no direct trim options, opens the interactive trim menu.
 
     \b
     Examples:
@@ -836,7 +805,7 @@ def trim(session, tools, threshold, trim_assistant, output_dir, agent, claude_ho
     if simple_ui or tools or trim_assistant or output_dir:
         # Direct CLI mode - need a session
         if not session:
-            print("Error: Direct trim options require a session ID", file=sys.stderr)
+            print("Error: Direct trim options require SESSION", file=sys.stderr)
             print("Use 'aichat trim' without options for interactive mode", file=sys.stderr)
             sys.exit(1)
 
@@ -929,6 +898,9 @@ def trim_in_place_cmd(session, tools, threshold, trim_assistant, dry_run,
     This powers the `>trim` in-session trigger of the aichat plugin, and
     can also be used directly on any Claude session.
 
+    SESSION may be a Claude session name, ID/fragment, filename fragment,
+    or direct transcript path.
+
     \b
     Examples:
         aichat trim-in-place abc123 --dry-run     # Preview tokens saved
@@ -940,7 +912,6 @@ def trim_in_place_cmd(session, tools, threshold, trim_assistant, dry_run,
     import sys
     from pathlib import Path
 
-    from claude_code_tools.session_utils import resolve_session_path
     from claude_code_tools.trim_in_place import trim_session_in_place
 
     def emit_error(msg: str) -> None:
@@ -950,24 +921,50 @@ def trim_in_place_cmd(session, tools, threshold, trim_assistant, dry_run,
             print(f"Error: {msg}", file=sys.stderr)
         sys.exit(1)
 
+    root_claude_home, _ = _session_homes()
+    effective_claude_home = claude_home or root_claude_home
     try:
-        session_file = resolve_session_path(session, claude_home)
-    except SystemExit:
-        # resolve_session_path() exits directly (SystemExit is NOT an
-        # Exception) for ambiguous partial ids, after listing the
-        # matches on stderr. Under --json, convert that to the
-        # contractual single {"error": ...} stdout line.
-        if not json_output:
-            raise
-        emit_error(
-            f"Multiple sessions match '{session}'. "
-            f"Use a more specific session ID."
+        direct_path = Path(session).expanduser()
+        is_direct_file = direct_path.is_file()
+    except (OSError, RuntimeError, ValueError):
+        direct_path = None
+        is_direct_file = False
+
+    if is_direct_file and direct_path is not None:
+        session_file = direct_path.absolute()
+    elif json_output:
+        from claude_code_tools.session_cli_resolution import (
+            exact_claude_filename,
         )
-    except Exception as e:
-        # SESSION comes from the CLI/hook and may be hostile (e.g. a
-        # path long enough to raise ENAMETOOLONG): keep the --json
-        # single-line contract for any resolution failure.
-        emit_error(str(e) or type(e).__name__)
+        from claude_code_tools.session_resolution import (
+            SessionQueryError,
+            resolve_session_query,
+        )
+
+        try:
+            resolved = resolve_session_query(
+                session,
+                agent="claude",
+                claude_home=effective_claude_home,
+            )
+        except SessionQueryError as error:
+            session_file = exact_claude_filename(
+                session,
+                effective_claude_home,
+            )
+            if session_file is None:
+                emit_error(str(error))
+        else:
+            session_file = resolved.session_file
+    else:
+        resolved = _resolve_cli_session(
+            session,
+            "claude",
+            claude_home=effective_claude_home,
+            allow_legacy_claude_filename=True,
+            selection_prompt="Which Claude session do you want to trim?",
+        )
+        session_file = resolved.session_file
 
     target_tools = None
     if tools:
@@ -1116,7 +1113,10 @@ def smart_trim(
     # If any direct CLI options specified (but not instructions), use smart_trim.py
     if exclude_types or preserve_recent != 10 or content_threshold != 200 or output_dir or dry_run:
         if not session:
-            print("Error: Direct smart-trim options require a session ID", file=sys.stderr)
+            print(
+                "Error: Direct smart-trim options require a session ID",
+                file=sys.stderr,
+            )
             print("Use 'aichat smart-trim' without options for interactive mode", file=sys.stderr)
             sys.exit(1)
 
@@ -1234,16 +1234,21 @@ def export_session(ctx, agent, session):
 def export_claude(ctx):
     """Export Claude Code session to text/markdown format.
 
-    If no session ID provided, finds latest Claude session for current
-    project/branch.
+    SESSION may be a Claude name, ID/fragment, filename fragment, or path.
+    If omitted, finds the latest Claude session for the current project.
     """
     import sys
-    args = ctx.args
-    session_id = args[0] if args and not args[0].startswith('-') else None
+    from claude_code_tools.legacy_session_wrappers import (
+        resolved_agent_export_args,
+    )
 
-    if session_id:
+    delegated = resolved_agent_export_args(ctx.args, "claude")
+    if delegated is not None:
         # Pass to existing export CLI
-        sys.argv = [sys.argv[0].replace('aichat', 'export-claude-session')] + args
+        sys.argv = [
+            sys.argv[0].replace('aichat', 'export-claude-session'),
+            *delegated,
+        ]
         from claude_code_tools.export_claude_session import (
             main as export_claude_main,
         )
@@ -1264,16 +1269,21 @@ def export_claude(ctx):
 def export_codex(ctx):
     """Export Codex session to text/markdown format.
 
-    If no session ID provided, finds latest Codex session for current
-    project/branch.
+    SESSION may be a Codex name, ID/fragment, filename fragment, or path.
+    If omitted, finds the latest Codex session for the current project.
     """
     import sys
-    args = ctx.args
-    session_id = args[0] if args and not args[0].startswith('-') else None
+    from claude_code_tools.legacy_session_wrappers import (
+        resolved_agent_export_args,
+    )
 
-    if session_id:
+    delegated = resolved_agent_export_args(ctx.args, "codex")
+    if delegated is not None:
         # Pass to existing export CLI
-        sys.argv = [sys.argv[0].replace('aichat', 'export-codex-session')] + args
+        sys.argv = [
+            sys.argv[0].replace('aichat', 'export-codex-session'),
+            *delegated,
+        ]
         from claude_code_tools.export_codex_session import (
             main as export_codex_main,
         )
@@ -1289,14 +1299,43 @@ def export_codex(ctx):
         )
 
 
-@main.command("delete", context_settings={"ignore_unknown_options": True, "allow_extra_args": True, "allow_interspersed_args": False})
-@click.pass_context
-def delete(ctx):
-    """Delete a session file with safety confirmation."""
-    import sys
-    sys.argv = [sys.argv[0].replace('aichat', 'delete-session')] + ctx.args
-    from claude_code_tools.delete_session import main as delete_main
-    delete_main()
+@main.command("delete")
+@click.argument("session", required=True)
+@click.option(
+    "--agent",
+    type=click.Choice(["claude", "codex"], case_sensitive=False),
+    help="Restrict the search to this agent's home",
+)
+@click.option("--claude-home", help="Path to Claude home directory")
+@click.option("--codex-home", help="Path to Codex home directory")
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Skip the final deletion confirmation",
+)
+def delete(
+    session: str,
+    agent: str | None,
+    claude_home: str | None,
+    codex_home: str | None,
+    force: bool,
+) -> None:
+    """Delete a Claude or Codex session safely.
+
+    SESSION accepts a name, ID/fragment, filename fragment, or path. Ambiguous
+    interactive matches display a numbered picker before any deletion prompt.
+    """
+    from claude_code_tools.delete_session import delete_resolved_session
+
+    resolved = _resolve_cli_session(
+        session,
+        agent,
+        claude_home=claude_home,
+        codex_home=codex_home,
+        selection_prompt="Which session do you want to delete?",
+    )
+    delete_resolved_session(resolved.session_file, force=force)
 
 
 @main.command("info")
@@ -1336,7 +1375,11 @@ def info(session, agent, json_output):
 
     # Find session file
     if session:
-        resolved = _resolve_cli_session(session, agent)
+        resolved = _resolve_cli_session(
+            session,
+            agent,
+            interactive=not json_output,
+        )
         session_file = resolved.session_file
         detected_agent = resolved.agent
     else:
@@ -1670,8 +1713,9 @@ def move_account(session, to_home, from_home, agent, keep):
     tool-results, workflows); Codex moves relocate the rollout file
     and its thread-name entries in session_index.jsonl.
 
-    SESSION may be a session UUID (full or partial), a Claude session
-    name assigned with /rename, or a Codex thread name.
+    SESSION may be a session UUID (full or partial), a Claude session name
+    assigned with /rename, or a Codex thread name. Ambiguous interactive
+    matches display a numbered picker including each source account.
 
     \b
     Examples:
@@ -2066,7 +2110,7 @@ def rollover(session, quick, prompt, agent):
     # If CLI options provided, use direct handler (backward compatible)
     if quick or prompt:
         if not session:
-            print("Error: --quick or --prompt require a session ID",
+            print("Error: --quick or --prompt require SESSION",
                   file=sys.stderr)
             print("Use 'aichat rollover' without options for interactive mode",
                   file=sys.stderr)
@@ -2138,7 +2182,11 @@ def lineage(session, agent, json_output):
         )
         return
 
-    resolved = _resolve_cli_session(session, agent)
+    resolved = _resolve_cli_session(
+        session,
+        agent,
+        interactive=not json_output,
+    )
     session_file = resolved.session_file
 
     # Get lineage (returns newest-first, ending with original)
@@ -2205,8 +2253,9 @@ def lineage(session, agent, json_output):
 def resume_session(ctx, claude_home, codex_home, agent):
     """Resume a session with various options (resume, clone, trim, continue).
 
-    If no session ID provided, finds latest session for current project/branch.
-    Shows resume menu with options: resume as-is, clone, trim+resume,
+    If no SESSION is provided, finds the latest session for the current
+    project/branch. SESSION accepts a name, ID/fragment, filename fragment,
+    or path. The resume menu offers resume as-is, clone, trim+resume,
     smart-trim, or continue with context.
 
     \b

--- a/claude_code_tools/cli_passthrough.py
+++ b/claude_code_tools/cli_passthrough.py
@@ -1,0 +1,141 @@
+"""Safe positional rewriting for legacy argparse command delegates."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+
+
+class MissingPositionalError(ValueError):
+    """Raised when passthrough arguments omit the required positional."""
+
+
+def positional_index(
+    arguments: Sequence[str],
+    *,
+    value_options: Iterable[str] = (),
+) -> int:
+    """Find the first positional while respecting options with values.
+
+    Args:
+        arguments: Raw passthrough argument tokens.
+        value_options: Long or short options that consume the next token.
+
+    Returns:
+        Index of the first positional token.
+
+    Raises:
+        MissingPositionalError: If no positional token is present.
+    """
+    valued = set(value_options)
+    index = 0
+    after_separator = False
+    while index < len(arguments):
+        argument = arguments[index]
+        if after_separator:
+            return index
+        if argument == "--":
+            after_separator = True
+            index += 1
+            continue
+        if argument in valued:
+            index += 2
+            continue
+        if any(
+            argument.startswith(f"{option}=")
+            for option in valued
+            if option.startswith("--")
+        ):
+            index += 1
+            continue
+        if any(
+            argument.startswith(option) and argument != option
+            for option in valued
+            if option.startswith("-") and not option.startswith("--")
+        ):
+            index += 1
+            continue
+        if argument.startswith("-"):
+            index += 1
+            continue
+        return index
+    raise MissingPositionalError("A session argument is required.")
+
+
+def replace_positional(
+    arguments: Sequence[str],
+    replacement: str,
+    *,
+    value_options: Iterable[str] = (),
+) -> list[str]:
+    """Replace the first positional token without reordering options.
+
+    Args:
+        arguments: Raw passthrough argument tokens.
+        replacement: Resolved session path to substitute.
+        value_options: Long or short options that consume the next token.
+
+    Returns:
+        A copied argument list containing the replacement.
+    """
+    rewritten = list(arguments)
+    rewritten[positional_index(rewritten, value_options=value_options)] = replacement
+    return rewritten
+
+
+def option_value(
+    arguments: Sequence[str],
+    *names: str,
+) -> str | None:
+    """Return the last value supplied for any named option.
+
+    Args:
+        arguments: Raw argument tokens.
+        names: Equivalent option spellings to inspect.
+
+    Returns:
+        The last explicit value, or None when absent.
+    """
+    found: str | None = None
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument in names and index + 1 < len(arguments):
+            found = arguments[index + 1]
+            index += 2
+            continue
+        for name in names:
+            prefix = f"{name}="
+            if name.startswith("--") and argument.startswith(prefix):
+                found = argument[len(prefix) :]
+        index += 1
+    return found
+
+
+def remove_options(
+    arguments: Sequence[str],
+    *names: str,
+) -> list[str]:
+    """Remove named value options while preserving every other token.
+
+    Args:
+        arguments: Raw argument tokens.
+        names: Equivalent option spellings to remove.
+
+    Returns:
+        Filtered argument tokens.
+    """
+    remaining: list[str] = []
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument in names:
+            index += 2
+            continue
+        if any(
+            name.startswith("--") and argument.startswith(f"{name}=") for name in names
+        ):
+            index += 1
+            continue
+        remaining.append(argument)
+        index += 1
+    return remaining

--- a/claude_code_tools/delete_session.py
+++ b/claude_code_tools/delete_session.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional, Tuple
 
-from claude_code_tools.session_utils import resolve_session_path
+from claude_code_tools.session_utils import get_session_uuid, resolve_session_path
 
 
 def get_session_info(session_file: Path) -> dict:
@@ -112,7 +112,7 @@ def confirm_deletion(session_file: Path, info: dict) -> bool:
     print("SESSION DELETION CONFIRMATION")
     print("=" * 70)
     print(f"\nFile: {session_file}")
-    print(f"Session ID: {session_file.stem}")
+    print(f"Session ID: {get_session_uuid(session_file.stem)}")
     print(f"\nTotal lines: {info['total_lines']}")
 
     # Date range
@@ -135,7 +135,32 @@ def confirm_deletion(session_file: Path, info: dict) -> bool:
     return response in ['yes', 'y']
 
 
-def main():
+def delete_resolved_session(session_file: Path, *, force: bool = False) -> None:
+    """Confirm and delete one already-resolved session transcript.
+
+    Args:
+        session_file: Exact transcript selected by the shared resolver.
+        force: Whether to skip the final destructive confirmation.
+    """
+    try:
+        info = get_session_info(session_file)
+    except Exception as error:
+        print(f"Error reading session file: {error}", file=sys.stderr)
+        sys.exit(1)
+
+    if not force and not confirm_deletion(session_file, info):
+        print("\nDeletion cancelled.")
+        return
+
+    try:
+        session_file.unlink()
+        print(f"\n✅ Session deleted: {get_session_uuid(session_file.stem)}")
+    except Exception as error:
+        print(f"\n❌ Error deleting session: {error}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main() -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(
         description="Delete Claude Code or Codex session files with confirmation"
@@ -168,26 +193,7 @@ def main():
         # resolve_session_path calls sys.exit for multiple matches
         sys.exit(1)
 
-    # Get session info
-    try:
-        info = get_session_info(session_file)
-    except Exception as e:
-        print(f"Error reading session file: {e}", file=sys.stderr)
-        sys.exit(1)
-
-    # Confirm deletion
-    if not args.force:
-        if not confirm_deletion(session_file, info):
-            print("\nDeletion cancelled.")
-            sys.exit(0)
-
-    # Delete the file
-    try:
-        session_file.unlink()
-        print(f"\n✅ Session deleted: {session_file.stem}")
-    except Exception as e:
-        print(f"\n❌ Error deleting session: {e}", file=sys.stderr)
-        sys.exit(1)
+    delete_resolved_session(session_file, force=args.force)
 
 
 if __name__ == "__main__":

--- a/claude_code_tools/find_trimmed_sessions.py
+++ b/claude_code_tools/find_trimmed_sessions.py
@@ -13,7 +13,11 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Set, Optional
 
-from claude_code_tools.session_utils import get_claude_home, resolve_session_path
+from claude_code_tools.session_utils import (
+    get_claude_home,
+    get_codex_home,
+    resolve_session_path,
+)
 
 
 def find_direct_children(
@@ -110,13 +114,18 @@ def print_tree(
         print_tree(lineage, child, child_indent)
 
 
-def get_search_dirs(custom_dir: Path = None, claude_home: Optional[str] = None) -> List[Path]:
+def get_search_dirs(
+    custom_dir: Optional[Path] = None,
+    claude_home: Optional[str] = None,
+    codex_home: Optional[str] = None,
+) -> List[Path]:
     """
     Get list of directories to search for sessions.
 
     Args:
         custom_dir: Optional custom directory to search.
         claude_home: Optional custom Claude home directory.
+        codex_home: Optional custom Codex home directory.
 
     Returns:
         List of directories to search.
@@ -125,11 +134,11 @@ def get_search_dirs(custom_dir: Path = None, claude_home: Optional[str] = None) 
         return [custom_dir]
 
     base_dir = get_claude_home(claude_home)
-    codex_home = Path.home() / ".codex"
+    codex_home_path = get_codex_home(codex_home)
 
     return [
         base_dir / "projects",  # Search all Claude projects
-        codex_home / "sessions",
+        codex_home_path / "sessions",
     ]
 
 
@@ -161,6 +170,11 @@ Examples:
         help="Path to Claude home directory (default: ~/.claude or $CLAUDE_CONFIG_DIR)",
     )
     parser.add_argument(
+        "--codex-home",
+        type=str,
+        help="Path to Codex home directory (default: ~/.codex or $CODEX_HOME)",
+    )
+    parser.add_argument(
         "--tree",
         "-t",
         action="store_true",
@@ -189,7 +203,11 @@ Examples:
 
     # Get search directories
     search_dir = Path(args.search_dir) if args.search_dir else None
-    search_dirs = get_search_dirs(search_dir, claude_home=args.claude_home)
+    search_dirs = get_search_dirs(
+        search_dir,
+        claude_home=args.claude_home,
+        codex_home=args.codex_home,
+    )
 
     # Find all descendants
     lineage = find_all_descendants(session_path, search_dirs)

--- a/claude_code_tools/legacy_session_wrappers.py
+++ b/claude_code_tools/legacy_session_wrappers.py
@@ -1,0 +1,140 @@
+"""Shared-resolution adapters for legacy argparse session commands."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from claude_code_tools.cli_passthrough import (
+    MissingPositionalError,
+    option_value,
+    positional_index,
+    replace_positional,
+)
+from claude_code_tools.session_cli_resolution import (
+    resolve_cli_session,
+    session_homes,
+)
+
+
+def resolved_find_original_args(arguments: Sequence[str]) -> list[str]:
+    """Replace ``find-original`` SESSION while preserving its options."""
+    value_options = ("--claude-home",)
+    try:
+        session_index = positional_index(arguments, value_options=value_options)
+    except MissingPositionalError:
+        return list(arguments)
+    query = arguments[session_index]
+    resolved = resolve_cli_session(
+        query,
+        claude_home=option_value(arguments, "--claude-home"),
+        selection_prompt="Which session's original do you want to find?",
+    )
+    return replace_positional(
+        arguments,
+        str(resolved.session_file),
+        value_options=value_options,
+    )
+
+
+def resolved_find_derived_args(arguments: Sequence[str]) -> list[str]:
+    """Replace ``find-derived`` SESSION while preserving its options."""
+    value_options = (
+        "--claude-home",
+        "--codex-home",
+        "--search-dir",
+        "-d",
+    )
+    try:
+        session_index = positional_index(arguments, value_options=value_options)
+    except MissingPositionalError:
+        return list(arguments)
+    query = arguments[session_index]
+    resolved = resolve_cli_session(
+        query,
+        claude_home=option_value(arguments, "--claude-home"),
+        codex_home=option_value(arguments, "--codex-home"),
+        selection_prompt="Which session's descendants do you want to find?",
+    )
+    delegated = replace_positional(
+        arguments,
+        str(resolved.session_file),
+        value_options=value_options,
+    )
+    root_claude_home, root_codex_home = session_homes()
+    if (
+        option_value(delegated, "--claude-home") is None
+        and root_claude_home is not None
+    ):
+        delegated.extend(["--claude-home", root_claude_home])
+    if (
+        option_value(delegated, "--codex-home") is None
+        and root_codex_home is not None
+    ):
+        delegated.extend(["--codex-home", root_codex_home])
+    return delegated
+
+
+def resolved_menu_args(arguments: Sequence[str]) -> list[str]:
+    """Resolve ``menu`` SESSION and supply exact agent/home metadata."""
+    value_options = (
+        "--agent",
+        "--claude-home",
+        "--codex-home",
+        "--start-screen",
+    )
+    try:
+        session_index = positional_index(arguments, value_options=value_options)
+    except MissingPositionalError:
+        return list(arguments)
+    query = arguments[session_index]
+    resolved = resolve_cli_session(
+        query,
+        option_value(arguments, "--agent"),
+        claude_home=option_value(arguments, "--claude-home"),
+        codex_home=option_value(arguments, "--codex-home"),
+        selection_prompt="Which session do you want to open?",
+    )
+    delegated = replace_positional(
+        arguments,
+        str(resolved.session_file),
+        value_options=value_options,
+    )
+    if option_value(delegated, "--agent") is None:
+        delegated.extend(["--agent", resolved.agent])
+    root_claude_home, root_codex_home = session_homes()
+    if (
+        option_value(delegated, "--claude-home") is None
+        and root_claude_home is not None
+    ):
+        delegated.extend(["--claude-home", root_claude_home])
+    if option_value(delegated, "--codex-home") is None and root_codex_home is not None:
+        delegated.extend(["--codex-home", root_codex_home])
+    return delegated
+
+
+def resolved_agent_export_args(
+    arguments: Sequence[str],
+    agent: str,
+) -> list[str] | None:
+    """Resolve an agent-specific export SESSION without moving options."""
+    home_option = "--claude-home" if agent == "claude" else "--codex-home"
+    value_options = ("--output", "-o", home_option)
+    try:
+        session_index = positional_index(
+            arguments,
+            value_options=value_options,
+        )
+    except MissingPositionalError:
+        return None
+    resolved = resolve_cli_session(
+        arguments[session_index],
+        agent,
+        claude_home=option_value(arguments, home_option) if agent == "claude" else None,
+        codex_home=option_value(arguments, home_option) if agent == "codex" else None,
+        selection_prompt=(f"Which {agent.title()} session do you want to export?"),
+    )
+    return replace_positional(
+        arguments,
+        str(resolved.session_file),
+        value_options=value_options,
+    )

--- a/claude_code_tools/move_account.py
+++ b/claude_code_tools/move_account.py
@@ -20,12 +20,19 @@ import os
 import shutil
 import sys
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from claude_code_tools.resolve_session import SessionRecord
 
 from claude_code_tools.find_claude_session import get_custom_title
 from claude_code_tools.resolve_session_names import codex_thread_names
-from claude_code_tools.session_utils import get_session_uuid
+from claude_code_tools.session_utils import (
+    detect_agent_from_content,
+    get_session_uuid,
+)
 
 
 @dataclass
@@ -41,6 +48,16 @@ class SessionCandidate:
     path: Path
     session_id: str
     title: str
+
+
+@dataclass(frozen=True)
+class AccountSessionMatch:
+    """One globally ranked match in a particular source account."""
+
+    home: Path
+    candidate: SessionCandidate
+    matched_by: str
+    tier: int
 
 
 @dataclass
@@ -101,16 +118,33 @@ def _iter_session_files(home: Path) -> List[Path]:
     projects = home / "projects"
     if not projects.is_dir():
         return []
-    return [
-        f
-        for f in projects.glob("*/*.jsonl")
-        if not f.name.startswith("agent-")
-    ]
+    return [f for f in projects.glob("*/*.jsonl") if not f.name.startswith("agent-")]
 
 
 def _session_title(path: Path) -> str:
     """Return the user-assigned name of a transcript, or ''."""
     return get_custom_title(path.stem, "", session_file=path)
+
+
+def _candidate_match(candidate: SessionCandidate, query: str) -> tuple[int, str] | None:
+    """Return the shared resolver tier and match label for a candidate."""
+    query_cf = query.casefold()
+    session_id = candidate.session_id.casefold()
+    title = candidate.title.casefold()
+    filename = candidate.path.name.casefold()
+    if session_id == query_cf:
+        return 0, "id"
+    if title == query_cf:
+        return 1, "name"
+    if session_id.startswith(query_cf):
+        return 2, "partial-id"
+    if query_cf in session_id:
+        return 3, "id-substring"
+    if query_cf in filename:
+        return 4, "filename"
+    if title and query_cf in title:
+        return 5, "name"
+    return None
 
 
 def _tiered_match(
@@ -119,7 +153,8 @@ def _tiered_match(
     """Pick candidates by tiered matching; first non-empty tier wins.
 
     Tiers: exact session id, exact name, id prefix, id substring,
-    name substring. All comparisons are case-insensitive, so a pasted
+    filename substring, name substring. All comparisons are case-insensitive,
+    so a pasted
     uppercase UUID still resolves. An exact name outranks an id prefix
     so a short name can never silently select a session whose UUID
     happens to start with the same characters.
@@ -131,21 +166,11 @@ def _tiered_match(
     Returns:
         Matching candidates; empty if nothing matched.
     """
-    tiers: List[List[SessionCandidate]] = [[], [], [], [], []]
-    query_cf = query.casefold()
+    tiers: List[List[SessionCandidate]] = [[], [], [], [], [], []]
     for cand in candidates:
-        sid = cand.session_id.casefold()
-        title = cand.title.casefold()
-        if sid == query_cf:
-            tiers[0].append(cand)
-        elif title == query_cf:
-            tiers[1].append(cand)
-        elif sid.startswith(query_cf):
-            tiers[2].append(cand)
-        elif query_cf in sid:
-            tiers[3].append(cand)
-        elif title and query_cf in title:
-            tiers[4].append(cand)
+        match = _candidate_match(cand, query)
+        if match is not None:
+            tiers[match[0]].append(cand)
     for tier in tiers:
         if tier:
             return tier
@@ -163,16 +188,18 @@ def find_sessions_in_home(home: Path, query: str) -> List[SessionCandidate]:
     Returns:
         Matching candidates; empty if nothing matched.
     """
-    candidates = [
+    return _tiered_match(_all_sessions_in_home(home), query)
+
+
+def _all_sessions_in_home(home: Path) -> List[SessionCandidate]:
+    """Return every eligible Claude transcript in one account."""
+    return [
         SessionCandidate(path=f, session_id=f.stem, title=_session_title(f))
         for f in _iter_session_files(home)
     ]
-    return _tiered_match(candidates, query)
 
 
-def find_codex_sessions_in_home(
-    home: Path, query: str
-) -> List[SessionCandidate]:
+def find_codex_sessions_in_home(home: Path, query: str) -> List[SessionCandidate]:
     """Resolve a session query against one Codex home.
 
     Codex rollout files live under ``sessions/YYYY/MM/DD/`` and carry
@@ -186,6 +213,11 @@ def find_codex_sessions_in_home(
     Returns:
         Matching candidates; empty if nothing matched.
     """
+    return _tiered_match(_all_codex_sessions_in_home(home), query)
+
+
+def _all_codex_sessions_in_home(home: Path) -> List[SessionCandidate]:
+    """Return every eligible Codex rollout in one account."""
     home = home.expanduser()
     sessions_dir = home / "sessions"
     if not sessions_dir.is_dir():
@@ -201,7 +233,7 @@ def find_codex_sessions_in_home(
                 title=names.get(uuid.casefold(), ""),
             )
         )
-    return _tiered_match(candidates, query)
+    return candidates
 
 
 def _transcript_cwd(session_file: Path) -> str:
@@ -270,9 +302,7 @@ def move_session_between_homes(
 
     dest_file = to_home / rel
     if dest_file.exists():
-        raise ValueError(
-            f"Session already exists in target account: {dest_file}"
-        )
+        raise ValueError(f"Session already exists in target account: {dest_file}")
 
     sidecar_src = session_file.with_suffix("")
     sidecar_dest = dest_file.with_suffix("")
@@ -417,12 +447,12 @@ def move_codex_session_between_homes(
     session_id = get_session_uuid(session_file.stem)
     dest_file = to_home / rel
     if dest_file.exists():
-        raise ValueError(
-            f"Session already exists in target account: {dest_file}"
-        )
-    clash = next(
-        (to_home / "sessions").rglob(f"rollout-*{session_id}.jsonl"), None
-    ) if (to_home / "sessions").is_dir() else None
+        raise ValueError(f"Session already exists in target account: {dest_file}")
+    clash = (
+        next((to_home / "sessions").rglob(f"rollout-*{session_id}.jsonl"), None)
+        if (to_home / "sessions").is_dir()
+        else None
+    )
     if clash is not None:
         raise ValueError(
             f"Session {session_id} already exists in target account: {clash}"
@@ -442,9 +472,7 @@ def move_codex_session_between_homes(
             "source untouched"
         )
 
-    index_moved = _transfer_index_entries(
-        from_home, to_home, session_id, keep
-    )
+    index_moved = _transfer_index_entries(from_home, to_home, session_id, keep)
     cwd = _transcript_cwd(dest_file)
 
     if not keep:
@@ -481,13 +509,9 @@ def resume_command(result: MoveResult, to_home: Path) -> str:
     # home: the pasted command then works regardless of any
     # CLAUDE_CONFIG_DIR / CODEX_HOME lingering in the user's shell.
     if result.agent == "codex":
-        return (
-            f"{cd_part}CODEX_HOME={home_quoted} "
-            f"codex resume {result.session_id}"
-        )
+        return f"{cd_part}CODEX_HOME={home_quoted} codex resume {result.session_id}"
     return (
-        f"{cd_part}CLAUDE_CONFIG_DIR={home_quoted} "
-        f"claude --resume {result.session_id}"
+        f"{cd_part}CLAUDE_CONFIG_DIR={home_quoted} claude --resume {result.session_id}"
     )
 
 
@@ -514,9 +538,7 @@ def _resolve_agent(
     if agent_arg:
         return agent_arg.lower()
     to_kind = detect_home_kind(to_home)
-    from_kind = (
-        detect_home_kind(Path(from_home_arg)) if from_home_arg else None
-    )
+    from_kind = detect_home_kind(Path(from_home_arg)) if from_home_arg else None
     if to_kind and from_kind and to_kind != from_kind:
         print(
             f"Error: source looks like a {from_kind} home but target "
@@ -555,9 +577,7 @@ def candidate_source_homes(agent: str, to_home: Path) -> List[Path]:
     if agent == "codex":
         env_var, prefix, required = "CODEX_HOME", ".codex", "sessions"
     else:
-        env_var, prefix, required = (
-            "CLAUDE_CONFIG_DIR", ".claude", "projects"
-        )
+        env_var, prefix, required = ("CLAUDE_CONFIG_DIR", ".claude", "projects")
 
     raw: List[Path] = []
     env_val = os.environ.get(env_var)
@@ -579,6 +599,177 @@ def candidate_source_homes(agent: str, to_home: Path) -> List[Path]:
         seen.add(resolved)
         out.append(cand)
     return out
+
+
+def _globally_ranked_account_matches(
+    homes: List[Path],
+    query: str,
+    agent: str,
+) -> List[AccountSessionMatch]:
+    """Return winning-tier matches across every candidate source home."""
+    matches: List[AccountSessionMatch] = []
+    for home in homes:
+        candidates = (
+            _all_codex_sessions_in_home(home)
+            if agent == "codex"
+            else _all_sessions_in_home(home)
+        )
+        for candidate in candidates:
+            match = _candidate_match(candidate, query)
+            if match is not None:
+                matches.append(
+                    AccountSessionMatch(
+                        home=home,
+                        candidate=candidate,
+                        tier=match[0],
+                        matched_by=match[1],
+                    )
+                )
+    if not matches:
+        return []
+    winning_tier = min(match.tier for match in matches)
+    return [match for match in matches if match.tier == winning_tier]
+
+
+def _direct_account_match(
+    session: str,
+    homes: List[Path],
+    agent: str,
+) -> AccountSessionMatch | None:
+    """Resolve an existing transcript path within one source account."""
+    try:
+        session_path = Path(session).expanduser().absolute()
+        is_file = session_path.is_file()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not is_file:
+        return None
+
+    detected = detect_agent_from_content(session_path, max_lines=None)
+    if detected != agent:
+        detected_label = detected or "unknown"
+        raise ValueError(
+            f"session file is {detected_label}, but the account move is "
+            f"configured for {agent}: {session_path}"
+        )
+
+    source_homes = []
+    for home in homes:
+        try:
+            session_path.relative_to(home.expanduser().absolute())
+        except ValueError:
+            continue
+        source_homes.append(home)
+    if len(source_homes) != 1:
+        raise ValueError(
+            "session path must be inside exactly one eligible source home: "
+            f"{session_path}"
+        )
+
+    source_home = source_homes[0]
+    candidates = (
+        _all_codex_sessions_in_home(source_home)
+        if agent == "codex"
+        else _all_sessions_in_home(source_home)
+    )
+    candidate = next(
+        (
+            item
+            for item in candidates
+            if item.path.absolute() == session_path
+        ),
+        None,
+    )
+    if candidate is None:
+        raise ValueError(f"session path is not an eligible transcript: {session_path}")
+    return AccountSessionMatch(
+        home=source_home,
+        candidate=candidate,
+        tier=-1,
+        matched_by="filename",
+    )
+
+
+def _account_match_record(
+    match: AccountSessionMatch,
+    agent: str,
+) -> "SessionRecord":
+    """Convert an account match into common selector metadata."""
+    from typing import cast
+
+    from claude_code_tools.resolve_session import (
+        Agent,
+        MatchKind,
+        SessionRecord,
+    )
+
+    timestamp = match.candidate.path.stat().st_mtime
+    return SessionRecord(
+        agent=cast(Agent, agent),
+        session_id=match.candidate.session_id,
+        name=match.candidate.title or None,
+        directory=_transcript_cwd(match.candidate.path) or None,
+        home=str(match.home),
+        session_file=str(match.candidate.path),
+        matched_by=cast(MatchKind, match.matched_by),
+        modified=datetime.fromtimestamp(timestamp).astimezone().isoformat(),
+        archived=False,
+        _modified_timestamp=timestamp,
+    )
+
+
+def _select_account_match(
+    session: str,
+    matches: List[AccountSessionMatch],
+    agent: str,
+) -> AccountSessionMatch:
+    """Select one ambiguous source account without mutating any files."""
+    records_and_matches = sorted(
+        ((_account_match_record(match, agent), match) for match in matches),
+        key=lambda item: item[0]._modified_timestamp,
+        reverse=True,
+    )
+    records = tuple(item[0] for item in records_and_matches)
+
+    from claude_code_tools.session_selection import (
+        choose_session_record,
+        stdin_is_interactive,
+    )
+
+    if not stdin_is_interactive():
+        print(
+            f"Error: multiple sessions match '{session}':",
+            file=sys.stderr,
+        )
+        for record in records:
+            label = f" ({record.name})" if record.name else ""
+            print(
+                f"  {record.home}: {record.session_id}{label}",
+                file=sys.stderr,
+            )
+        print(
+            "Use a more specific ID or name, or disambiguate with --from.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        selected = choose_session_record(
+            session,
+            records,
+            len(records),
+            prompt="Which source session do you want to move?",
+            show_home=True,
+        )
+    except (EOFError, KeyboardInterrupt):
+        selected = None
+    if selected is None:
+        print("Session selection cancelled.", file=sys.stderr)
+        sys.exit(1)
+    for record, match in records_and_matches:
+        if record is selected:
+            return match
+    raise RuntimeError("Selected account session was not found")
 
 
 def run_move_account(
@@ -632,67 +823,69 @@ def run_move_account(
         )
         if from_home.expanduser().resolve() == to_home.resolve():
             print(
-                "Error: source and target account dirs are the same: "
-                f"{from_home}",
+                f"Error: source and target account dirs are the same: {from_home}",
                 file=sys.stderr,
             )
             sys.exit(1)
-        candidates = finder(from_home, session)
-        if not candidates:
-            print(
-                f"Error: no session matching '{session}' in {from_home}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        homes = [from_home]
     else:
         homes = candidate_source_homes(agent, to_home)
         if not homes:
             print(
-                f"Error: no local {agent} config dirs found to search; "
-                "pass --from",
+                f"Error: no local {agent} config dirs found to search; pass --from",
                 file=sys.stderr,
             )
             sys.exit(1)
-        matches = [
-            (home, cands)
-            for home in homes
-            if (cands := finder(home, session))
-        ]
-        if not matches:
-            searched = ", ".join(str(h) for h in homes)
-            print(
-                f"Error: no session matching '{session}' in any of: "
-                f"{searched}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        if len(matches) > 1:
-            print(
-                f"Error: '{session}' matches sessions in multiple "
-                "accounts:",
-                file=sys.stderr,
-            )
-            for home, cands in matches:
-                for cand in cands:
-                    label = f" ({cand.title})" if cand.title else ""
-                    print(
-                        f"  {home}: {cand.session_id}{label}",
-                        file=sys.stderr,
-                    )
-            print("Disambiguate with --from.", file=sys.stderr)
-            sys.exit(1)
-        from_home, candidates = matches[0]
-    if len(candidates) > 1:
-        print(
-            f"Error: multiple sessions match '{session}':", file=sys.stderr
-        )
-        for cand in candidates:
-            label = f" ({cand.title})" if cand.title else ""
-            print(f"  {cand.session_id}{label}", file=sys.stderr)
-        print("Use a more specific ID or name.", file=sys.stderr)
+
+    try:
+        direct_match = _direct_account_match(session, homes, agent)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    cand = candidates[0]
+    if direct_match is not None:
+        account_matches = [direct_match]
+    elif from_home_arg:
+        candidates = finder(homes[0], session)
+        if not candidates:
+            print(
+                f"Error: no session matching '{session}' in {homes[0]}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        account_matches = []
+        for candidate in candidates:
+            match = _candidate_match(candidate, session)
+            if match is not None:
+                account_matches.append(
+                    AccountSessionMatch(
+                        home=homes[0],
+                        candidate=candidate,
+                        tier=match[0],
+                        matched_by=match[1],
+                    )
+                )
+    else:
+        account_matches = _globally_ranked_account_matches(
+            homes,
+            session,
+            agent,
+        )
+        if not account_matches:
+            searched = ", ".join(str(h) for h in homes)
+            print(
+                f"Error: no session matching '{session}' in any of: {searched}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    selected_match = (
+        account_matches[0]
+        if len(account_matches) == 1
+        else _select_account_match(session, account_matches, agent)
+    )
+    from_home = selected_match.home
+    cand = selected_match.candidate
     label = f" ({cand.title})" if cand.title else ""
     verb = "Copying" if keep else "Moving"
     print(f"{verb} {agent} session {cand.session_id}{label}")

--- a/claude_code_tools/port_render.py
+++ b/claude_code_tools/port_render.py
@@ -9,10 +9,9 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from rich import box
 from rich.console import Console
 from rich.panel import Panel
-from rich.prompt import Confirm, Prompt
+from rich.prompt import Confirm
 from rich.status import Status
 from rich.table import Table
 from rich.text import Text
@@ -23,11 +22,7 @@ if TYPE_CHECKING:
         PortResult,
         ResolvedSession,
     )
-    from claude_code_tools.resolve_session import SessionRecord
-
-
 _AGENT_LABELS = {"claude": "Claude", "codex": "Codex"}
-_MAX_CANDIDATE_TITLE_CHARS = 120
 _MACOS_CLIPBOARD_COMMANDS = (("pbcopy",),)
 _LINUX_CLIPBOARD_COMMANDS = (
     ("wl-copy",),
@@ -51,12 +46,7 @@ def _clipboard_commands(
     if platform_name == "win32":
         system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
         system32 = system_root / "System32"
-        powershell = (
-            system32
-            / "WindowsPowerShell"
-            / "v1.0"
-            / "powershell.exe"
-        )
+        powershell = system32 / "WindowsPowerShell" / "v1.0" / "powershell.exe"
         return (
             (str(system32 / "clip.exe"),),
             (
@@ -122,41 +112,6 @@ def _target_label(source_agent: str) -> str:
     return "Claude Code" if target == "claude" else "Codex"
 
 
-def _match_reason(record: "SessionRecord", query: str) -> str:
-    """Explain why one resolver candidate matched the query."""
-    matched_by = record.matched_by
-    if matched_by == "id":
-        return "exact session ID"
-    if matched_by == "partial-id":
-        return "session ID prefix"
-    if matched_by == "id-substring":
-        return "session ID contains query"
-    if matched_by == "filename":
-        return "rollout filename contains query"
-    if matched_by == "name":
-        name = record.name or ""
-        if name.casefold() == query.casefold():
-            return "exact name/title"
-        return "name/title contains query"
-    return "resolver match"
-
-
-def _candidate_details(record: "SessionRecord") -> Text:
-    """Build a readable multi-line summary for one candidate."""
-    details = Text()
-    title = " ".join((record.name or "Untitled session").split())
-    if len(title) > _MAX_CANDIDATE_TITLE_CHARS:
-        title = title[: _MAX_CANDIDATE_TITLE_CHARS - 3] + "..."
-    details.append(title, style="bold")
-    details.append("\nProject  ", style="dim")
-    details.append(record.directory or "Unknown")
-    details.append("\nID       ", style="dim")
-    details.append(record.session_id)
-    details.append("\nModified ", style="dim")
-    details.append(record.modified)
-    return details
-
-
 class PortDisplay:
     """Render progress, ambiguity choices, errors, and final results."""
 
@@ -187,59 +142,20 @@ class PortDisplay:
             spinner="dots",
         )
 
-    def choose_candidate(
-        self, error: "PortAmbiguityError"
-    ) -> "ResolvedSession | None":
+    def choose_candidate(self, error: "PortAmbiguityError") -> "ResolvedSession | None":
         """Present matching sessions and return the user's selection."""
         from claude_code_tools.port_service import ResolvedSession
+        from claude_code_tools.session_selection import choose_session_record
 
-        heading = Text()
-        heading.append(f"{error.match_count} sessions matched ", style="yellow")
-        heading.append(repr(error.query), style="bold yellow")
-        heading.append(". Choose the source session to port.", style="yellow")
-        self.console.print(heading)
-
-        table = Table(
-            box=box.ROUNDED,
-            header_style="bold cyan",
-            show_lines=True,
-            expand=True,
-        )
-        table.add_column("#", justify="right", no_wrap=True)
-        table.add_column("Agent", no_wrap=True)
-        table.add_column("Why it matched")
-        table.add_column("Session")
-        for index, record in enumerate(error.records, start=1):
-            table.add_row(
-                str(index),
-                _agent_label(record.agent),
-                _match_reason(record, error.query),
-                _candidate_details(record),
-            )
-        self.console.print(table)
-
-        if error.match_count > len(error.records):
-            hidden = error.match_count - len(error.records)
-            self.console.print(
-                f"[dim]{hidden} older matches are not shown. "
-                "Rerun with a full session ID to select one of them.[/dim]"
-            )
-
-        if not sys.stdin.isatty():
-            raise EOFError
-
-        choices = [str(index) for index in range(1, len(error.records) + 1)]
-        choices.append("q")
-        choice = Prompt.ask(
-            "[bold]Which source session do you want to port?[/bold] "
-            "[dim](number or q to cancel)[/dim]",
-            choices=choices,
-            show_choices=False,
+        record = choose_session_record(
+            error.query,
+            error.records,
+            error.match_count,
+            prompt="Which source session do you want to port?",
             console=self.console,
         )
-        if choice == "q":
+        if record is None:
             return None
-        record = error.records[int(choice) - 1]
         return ResolvedSession(
             agent=record.agent,
             session_file=Path(record.session_file),
@@ -334,11 +250,7 @@ class PortDisplay:
             self.console.print(
                 "[bold green]✓ Session ID copied to clipboard.[/bold green]"
             )
-            command = (
-                "codex resume"
-                if target_agent == "codex"
-                else "claude --resume"
-            )
+            command = "codex resume" if target_agent == "codex" else "claude --resume"
             self.console.print("[bold]Now you can run:[/bold]")
             self.console.print(
                 Text(
@@ -354,9 +266,7 @@ class PortDisplay:
 
     def error(self, message: str) -> None:
         """Render an expected failure without a traceback."""
-        self.error_console.print(
-            Text.assemble(("Error: ", "bold red"), message)
-        )
+        self.error_console.print(Text.assemble(("Error: ", "bold red"), message))
 
     def cancelled(self) -> None:
         """Render a user-requested cancellation."""

--- a/claude_code_tools/port_service.py
+++ b/claude_code_tools/port_service.py
@@ -25,13 +25,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:
-    from claude_code_tools.resolve_session import ResolveResult, SessionRecord
+    from claude_code_tools.resolve_session import SessionRecord
 
 from claude_code_tools.session_resolution import (
-    _detect_direct_path_agent,
-    _resolve_query_for_agent,
-    ambiguity_candidates,
-    build_ambiguity_message,
+    SessionQueryAmbiguity,
+    SessionQueryError,
+    resolve_session_query,
 )
 
 
@@ -138,47 +137,28 @@ def resolve_port_session(
         PortSessionError: When the session cannot be found or its
             agent cannot be detected.
     """
-    # Arbitrary session names are legitimate queries here, and some
-    # (e.g. "~nonexistent-user" or names with NUL bytes) make path
-    # probing itself raise. Treat any such input as a non-path query
-    # and fall through to resolver lookup instead of crashing.
     try:
-        input_path: Optional[Path] = Path(session).expanduser()
-        is_direct_file = input_path.is_file()
-    except (OSError, RuntimeError, ValueError):
-        input_path = None
-        is_direct_file = False
-    if is_direct_file and input_path is not None:
-        agent = _detect_direct_path_agent(
-            input_path, claude_home, codex_home
+        resolved = resolve_session_query(
+            session,
+            claude_home=claude_home,
+            codex_home=codex_home,
         )
-        if agent not in ("claude", "codex"):
+    except SessionQueryAmbiguity as error:
+        raise PortAmbiguityError(
+            error.query,
+            error.records,
+            error.match_count,
+            str(error),
+        ) from error
+    except SessionQueryError as error:
+        if not session.strip() or str(error).startswith("Session not found:"):
             raise PortSessionError(
-                f"Could not detect agent for session file: {input_path}"
-            )
-        return ResolvedSession(agent=agent, session_file=input_path)
-
-    results: "list[ResolveResult]" = []
-    for agent_name, home in (("claude", claude_home), ("codex", codex_home)):
-        result = _resolve_query_for_agent(session, agent_name, home)
-        if result is not None and result.kind != "not_found":
-            results.append(result)
-
-    if not results:
-        raise PortSessionError(
-            f"Session not found in Claude or Codex homes: {session}"
-        )
-    if len(results) == 1 and results[0].kind == "single":
-        record = results[0].records[0]
-        return ResolvedSession(
-            agent=record.agent, session_file=Path(record.session_file)
-        )
-    records, match_count = ambiguity_candidates(results)
-    raise PortAmbiguityError(
-        session,
-        records,
-        match_count,
-        build_ambiguity_message(session, results),
+                f"Session not found in Claude or Codex homes: {session}"
+            ) from error
+        raise PortSessionError(str(error)) from error
+    return ResolvedSession(
+        agent=resolved.agent,
+        session_file=resolved.session_file,
     )
 
 

--- a/claude_code_tools/session_cli_resolution.py
+++ b/claude_code_tools/session_cli_resolution.py
@@ -1,0 +1,138 @@
+"""Interactive shared session resolution for ``aichat`` commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from claude_code_tools.session_resolution import ResolvedSessionQuery
+
+
+def session_homes() -> tuple[str | None, str | None]:
+    """Return agent homes configured on the root Click context."""
+    context = click.get_current_context(silent=True)
+    if context is None:
+        return None, None
+    root_obj = context.find_root().obj or {}
+    return root_obj.get("claude_home"), root_obj.get("codex_home")
+
+
+def resolve_cli_session(
+    session: str,
+    agent: str | None = None,
+    *,
+    claude_home: str | None = None,
+    codex_home: str | None = None,
+    interactive: bool = True,
+    allow_legacy_claude_filename: bool = False,
+    selection_prompt: str = "Which session do you want to use?",
+) -> "ResolvedSessionQuery":
+    """Resolve one CLI session query and handle user-facing failures.
+
+    Args:
+        session: Name, ID/fragment, filename fragment, or direct path.
+        agent: Optional hard agent constraint.
+        claude_home: Optional Claude home override.
+        codex_home: Optional Codex home override.
+        interactive: Whether a TTY ambiguity may offer selection.
+        allow_legacy_claude_filename: Preserve exact transcript-stem lookup
+            for commands that historically accepted it.
+        selection_prompt: Question shown beneath an ambiguity table.
+
+    Returns:
+        The unique or interactively selected session.
+    """
+    from claude_code_tools.session_resolution import (
+        ResolvedSessionQuery,
+        SessionQueryAmbiguity,
+        SessionQueryError,
+        resolve_session_query,
+        resolved_session_from_record,
+    )
+
+    root_claude_home, root_codex_home = session_homes()
+    effective_claude_home = root_claude_home if claude_home is None else claude_home
+    effective_codex_home = root_codex_home if codex_home is None else codex_home
+    try:
+        return resolve_session_query(
+            session,
+            agent=agent,
+            claude_home=effective_claude_home,
+            codex_home=effective_codex_home,
+        )
+    except SessionQueryAmbiguity as error:
+        if interactive:
+            from claude_code_tools.session_selection import (
+                choose_session_record,
+                stdin_is_interactive,
+            )
+
+            if stdin_is_interactive():
+                try:
+                    selected = choose_session_record(
+                        error.query,
+                        error.records,
+                        error.match_count,
+                        prompt=selection_prompt,
+                    )
+                except (EOFError, KeyboardInterrupt):
+                    selected = None
+                if selected is not None:
+                    return resolved_session_from_record(selected)
+                click.echo("Session selection cancelled.", err=True)
+                raise click.exceptions.Exit(1) from None
+        click.echo(f"Error: {error}", err=True)
+        raise click.exceptions.Exit(1) from None
+    except SessionQueryError as error:
+        if allow_legacy_claude_filename and agent == "claude":
+            legacy_path = exact_claude_filename(
+                session,
+                effective_claude_home,
+            )
+            if legacy_path is not None:
+                return ResolvedSessionQuery(
+                    "claude",
+                    legacy_path,
+                    None,
+                    None,
+                )
+        click.echo(f"Error: {error}", err=True)
+        raise click.exceptions.Exit(1) from None
+
+
+def exact_claude_filename(
+    session: str,
+    claude_home: str | None,
+) -> Path | None:
+    """Resolve one unique exact Claude transcript stem without indexing."""
+    if not session or Path(session).name != session:
+        return None
+
+    from claude_code_tools.session_utils import get_claude_home
+
+    projects = get_claude_home(claude_home) / "projects"
+    try:
+        matches = [
+            candidate
+            for project in projects.iterdir()
+            if project.is_dir()
+            and (candidate := project / f"{session}.jsonl").is_file()
+        ]
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return matches[0].absolute() if len(matches) == 1 else None
+
+
+def resolve_export_session(
+    session: str,
+    agent: str | None = None,
+) -> "ResolvedSessionQuery":
+    """Resolve an export query with the shared interactive behavior."""
+    return resolve_cli_session(
+        session,
+        agent,
+        selection_prompt="Which session do you want to export?",
+    )

--- a/claude_code_tools/session_resolution.py
+++ b/claude_code_tools/session_resolution.py
@@ -56,6 +56,38 @@ class SessionQueryError(Exception):
     """A user-facing failure while resolving a session query."""
 
 
+class SessionQueryAmbiguity(SessionQueryError):
+    """A session query with several eligible matches.
+
+    Attributes:
+        query: Original user-supplied query.
+        records: Newest-first candidates available for selection.
+        match_count: Total matches, including candidates omitted by the cap.
+        display_limit: Maximum candidates carried for interactive display.
+    """
+
+    def __init__(
+        self,
+        query: str,
+        records: "tuple[SessionRecord, ...]",
+        match_count: int,
+        message: str,
+    ) -> None:
+        """Initialize a structured ambiguity.
+
+        Args:
+            query: Original user-supplied query.
+            records: Newest-first selectable candidates.
+            match_count: Total matches before display capping.
+            message: Human-readable ambiguity listing.
+        """
+        super().__init__(message)
+        self.query = query
+        self.records = records
+        self.match_count = match_count
+        self.display_limit = _MAX_AMBIGUITY_LINES
+
+
 @dataclass(frozen=True)
 class ResolvedSessionQuery:
     """A resolved session file and metadata needed by CLI actions.
@@ -188,15 +220,12 @@ def ambiguity_candidates(
     records = [record for result in results for record in result.records]
     records.sort(key=lambda record: record._modified_timestamp, reverse=True)
     total = sum(
-        1 if result.kind == "single" else result.match_count
-        for result in results
+        1 if result.kind == "single" else result.match_count for result in results
     )
     return tuple(records[:_MAX_AMBIGUITY_LINES]), total
 
 
-def build_ambiguity_message(
-    session: str, results: "list[ResolveResult]"
-) -> str:
+def build_ambiguity_message(session: str, results: "list[ResolveResult]") -> str:
     """Build the shared multi-candidate ambiguity message.
 
     Args:
@@ -231,9 +260,7 @@ def build_ambiguity_message(
     )
 
 
-def _metadata_for_path(
-    agent: str, session_file: Path
-) -> tuple[str | None, str | None]:
+def _metadata_for_path(agent: str, session_file: Path) -> tuple[str | None, str | None]:
     """Read the cwd and branch metadata for a selected session file."""
     if agent == "claude":
         return (
@@ -251,14 +278,33 @@ def _metadata_for_path(
     )
 
 
+def resolved_session_from_record(
+    record: "SessionRecord",
+) -> ResolvedSessionQuery:
+    """Build action metadata for a user-selected resolver record.
+
+    Args:
+        record: Candidate selected from a structured ambiguity.
+
+    Returns:
+        The resolved session metadata used by direct ``aichat`` actions.
+    """
+    session_file = Path(record.session_file).absolute()
+    directory, branch = _metadata_for_path(record.agent, session_file)
+    return ResolvedSessionQuery(
+        agent=record.agent,
+        session_file=session_file,
+        directory=record.directory or directory,
+        git_branch=branch,
+    )
+
+
 def _session_id_from_content(agent: str, session_file: Path) -> str | None:
     """Extract a session identity from authoritative transcript content."""
     import json
 
     try:
-        with session_file.open(
-            "r", encoding="utf-8", errors="replace"
-        ) as transcript:
+        with session_file.open("r", encoding="utf-8", errors="replace") as transcript:
             for line in transcript:
                 try:
                     record = json.loads(line)
@@ -271,16 +317,11 @@ def _session_id_from_content(agent: str, session_file: Path) -> str | None:
                 elif record.get("type") == "session_meta":
                     payload = record.get("payload")
                     session_id = (
-                        payload.get("id")
-                        if isinstance(payload, dict)
-                        else None
+                        payload.get("id") if isinstance(payload, dict) else None
                     )
-                elif (
-                    "timestamp" in record
-                    and (
-                        isinstance(record.get("git"), dict)
-                        or isinstance(record.get("instructions"), str)
-                    )
+                elif "timestamp" in record and (
+                    isinstance(record.get("git"), dict)
+                    or isinstance(record.get("instructions"), str)
                 ):
                     session_id = record.get("id")
                 else:
@@ -325,13 +366,11 @@ def _validated_fast_candidates(
             discovered_path = candidate_path.absolute()
             validation_path = candidate_path.resolve()
             if candidate_agent == "claude":
-                if is_malformed_session(
+                if is_malformed_session(validation_path) or is_sidechain_session(
                     validation_path
-                ) or is_sidechain_session(validation_path):
+                ):
                     continue
-                directory, branch = _metadata_for_path(
-                    candidate_agent, validation_path
-                )
+                directory, branch = _metadata_for_path(candidate_agent, validation_path)
                 if not directory:
                     continue
             else:
@@ -350,13 +389,8 @@ def _validated_fast_candidates(
                     if isinstance(branch_value, str) and branch_value
                     else None
                 )
-            content_id = _session_id_from_content(
-                candidate_agent, validation_path
-            )
-            if (
-                content_id is None
-                or lowered_query not in content_id.casefold()
-            ):
+            content_id = _session_id_from_content(candidate_agent, validation_path)
+            if content_id is None or lowered_query not in content_id.casefold():
                 continue
         except (
             OSError,
@@ -425,9 +459,7 @@ def _codex_has_exact_name(query: str, home: str | None) -> bool | None:
     if database is None:
         return False
     try:
-        connection = sqlite3.connect(
-            f"file:{database}?mode=ro", uri=True
-        )
+        connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
         try:
             rows = connection.execute(
                 "SELECT id, title FROM threads WHERE title IS NOT NULL"
@@ -452,9 +484,7 @@ def _has_exact_name(
     codex_home: str | None,
 ) -> bool | None:
     """Check the higher-priority exact-name tier without full resolution."""
-    if agent in (None, "claude") and _claude_has_exact_name(
-        query, claude_home
-    ):
+    if agent in (None, "claude") and _claude_has_exact_name(query, claude_home):
         return True
     if agent in (None, "codex"):
         return _codex_has_exact_name(query, codex_home)
@@ -488,9 +518,7 @@ def _codex_has_outranking_id(
     candidate_id = candidate.session_id.casefold()
     lowered = query.casefold()
     try:
-        connection = sqlite3.connect(
-            f"file:{database}?mode=ro", uri=True
-        )
+        connection = sqlite3.connect(f"file:{database}?mode=ro", uri=True)
         try:
             rows = connection.execute("SELECT id FROM threads")
             for (session_id,) in rows:
@@ -499,10 +527,7 @@ def _codex_has_outranking_id(
                 normalized_id = session_id.casefold()
                 if not normalized_id.startswith(lowered):
                     continue
-                if (
-                    candidate.resolved.agent != "codex"
-                    or normalized_id != candidate_id
-                ):
+                if candidate.resolved.agent != "codex" or normalized_id != candidate_id:
                     return True
             return False
         finally:
@@ -519,9 +544,7 @@ def _has_fast_path_conflict(
     codex_home: str | None,
 ) -> bool | None:
     """Check cheap higher-priority name and database ID tiers."""
-    exact_name = _has_exact_name(
-        query, agent, claude_home, codex_home
-    )
+    exact_name = _has_exact_name(query, agent, claude_home, codex_home)
     if exact_name is not False:
         return exact_name
     if agent in (None, "codex"):
@@ -563,23 +586,36 @@ def _restore_discovered_path(
     if len(matches) == 1:
         return matches[0]
     if len(matches) > 1:
-        candidates = [
-            ResolvedSessionQuery(agent, path, None, None)
+        all_candidates = [
+            _record_for_resolved_candidate(
+                ResolvedSessionQuery(agent, path, None, None),
+                matched_by="filename",
+                claude_home=claude_home,
+                codex_home=codex_home,
+            )
             for path in matches
         ]
-        raise SessionQueryError(
-            _fast_candidate_ambiguity(session, candidates)
+        all_candidates.sort(
+            key=lambda record: record._modified_timestamp,
+            reverse=True,
+        )
+        candidates = tuple(all_candidates[:_MAX_AMBIGUITY_LINES])
+        raise SessionQueryAmbiguity(
+            session,
+            candidates,
+            len(all_candidates),
+            _fast_candidate_ambiguity(session, all_candidates),
         )
     return canonical_path
 
 
 def _fast_candidate_ambiguity(
-    session: str, candidates: list[ResolvedSessionQuery]
+    session: str, candidates: list["SessionRecord"]
 ) -> str:
     """Build a fallback ambiguity message for resolver-invisible files."""
     lines = [
-        f"  [{candidate.agent}] {candidate.session_file}"
-        for candidate in candidates[:_MAX_AMBIGUITY_LINES]
+        f"  [{record.agent}] {record.session_file}"
+        for record in candidates[:_MAX_AMBIGUITY_LINES]
     ]
     remaining = len(candidates) - len(lines)
     if remaining:
@@ -590,6 +626,49 @@ def _fast_candidate_ambiguity(
         f"{listing}\n"
         "Use a longer unique id, the exact session name, or the "
         "full file path."
+    )
+
+
+def _record_for_resolved_candidate(
+    candidate: ResolvedSessionQuery,
+    *,
+    matched_by: str,
+    claude_home: str | None,
+    codex_home: str | None,
+) -> "SessionRecord":
+    """Convert a validated filename candidate into selector metadata.
+
+    Args:
+        candidate: Validated session candidate.
+        matched_by: Resolver match classification for display.
+        claude_home: Optional Claude home override.
+        codex_home: Optional Codex home override.
+
+    Returns:
+        A session record suitable for structured ambiguity selection.
+    """
+    from datetime import datetime
+
+    from claude_code_tools.resolve_session import Agent, MatchKind, SessionRecord
+
+    path = candidate.session_file
+    timestamp = path.stat().st_mtime
+    home = (
+        get_claude_home(claude_home)
+        if candidate.agent == "claude"
+        else get_codex_home(codex_home)
+    )
+    return SessionRecord(
+        agent=cast(Agent, candidate.agent),
+        session_id=get_session_uuid(path.stem),
+        name=None,
+        directory=candidate.directory,
+        home=str(home),
+        session_file=str(path),
+        matched_by=cast("MatchKind", matched_by),
+        modified=datetime.fromtimestamp(timestamp).astimezone().isoformat(),
+        archived="archived_sessions" in path.parts,
+        _modified_timestamp=timestamp,
     )
 
 
@@ -617,11 +696,7 @@ def _retain_winning_tier(
     if not results:
         return results
     winning_tier = min(_result_tier(result, query) for result in results)
-    return [
-        result
-        for result in results
-        if _result_tier(result, query) == winning_tier
-    ]
+    return [result for result in results if _result_tier(result, query) == winning_tier]
 
 
 def _validate_resolver_content_ids(
@@ -644,12 +719,11 @@ def _validate_resolver_content_ids(
         )
         content_id = _session_id_from_content(record.agent, path)
         filename_id = get_session_uuid(discovered_path.stem)
-        if (
-            content_id is not None
-            and content_id.casefold() != filename_id.casefold()
-        ):
+        if content_id is not None and content_id.casefold() != filename_id.casefold():
             continue
-        valid_records.append(record)
+        valid_records.append(
+            replace(record, session_file=str(discovered_path))
+        )
 
     removed_count = len(result.records) - len(valid_records)
     remaining_count = (
@@ -720,9 +794,7 @@ def resolve_session_query(
         input_path = None
         is_direct_file = False
     if is_direct_file and input_path is not None:
-        detected = _detect_direct_path_agent(
-            input_path, claude_home, codex_home
-        )
+        detected = _detect_direct_path_agent(input_path, claude_home, codex_home)
         if detected == "codex":
             from claude_code_tools.resolve_session import (
                 _is_legacy_codex_rollout,
@@ -743,16 +815,12 @@ def resolve_session_query(
             )
         supplied_path = input_path.absolute()
         directory, branch = _metadata_for_path(detected, supplied_path)
-        return ResolvedSessionQuery(
-            detected, supplied_path, directory, branch
-        )
+        return ResolvedSessionQuery(detected, supplied_path, directory, branch)
 
     fast_candidates: list[_ValidatedFastCandidate] = []
     fast_candidates_overflowed = False
     if _ID_FRAGMENT_RE.fullmatch(session):
-        bounded = _validated_fast_candidates(
-            session, agent, claude_home, codex_home
-        )
+        bounded = _validated_fast_candidates(session, agent, claude_home, codex_home)
         fast_candidates_overflowed = bounded is None
         if bounded is not None:
             fast_candidates = bounded
@@ -787,9 +855,7 @@ def resolve_session_query(
         else (("claude", claude_home), ("codex", codex_home))
     )
     for agent_name, home in homes:
-        result = _resolve_query_for_agent(
-            session, agent_name, home, resolver_errors
-        )
+        result = _resolve_query_for_agent(session, agent_name, home, resolver_errors)
         if result is not None and result.kind != "not_found":
             validated_result = _validate_resolver_content_ids(
                 result,
@@ -812,13 +878,33 @@ def resolve_session_query(
             record.agent, discovered_path, record.directory, branch
         )
     if results:
-        raise SessionQueryError(build_ambiguity_message(session, results))
+        records, match_count = ambiguity_candidates(results)
+        raise SessionQueryAmbiguity(
+            session,
+            records,
+            match_count,
+            build_ambiguity_message(session, results),
+        )
     if len(fast_candidates) > 1:
-        raise SessionQueryError(
-            _fast_candidate_ambiguity(
-                session,
-                [candidate.resolved for candidate in fast_candidates],
+        all_records = [
+            _record_for_resolved_candidate(
+                candidate.resolved,
+                matched_by="id-substring",
+                claude_home=claude_home,
+                codex_home=codex_home,
             )
+            for candidate in fast_candidates
+        ]
+        all_records.sort(
+            key=lambda record: record._modified_timestamp,
+            reverse=True,
+        )
+        records = tuple(all_records[:_MAX_AMBIGUITY_LINES])
+        raise SessionQueryAmbiguity(
+            session,
+            records,
+            len(all_records),
+            _fast_candidate_ambiguity(session, all_records),
         )
     if resolver_errors:
         raise SessionQueryError(str(resolver_errors[0]))

--- a/claude_code_tools/session_selection.py
+++ b/claude_code_tools/session_selection.py
@@ -1,0 +1,153 @@
+"""Reusable Rich selection for ambiguous session queries."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from rich import box
+from rich.console import Console
+from rich.prompt import Prompt
+from rich.table import Table
+from rich.text import Text
+
+if TYPE_CHECKING:
+    from claude_code_tools.resolve_session import SessionRecord
+
+_AGENT_LABELS = {"claude": "Claude", "codex": "Codex"}
+_MAX_TITLE_CHARS = 80
+
+
+def stdin_is_interactive() -> bool:
+    """Return whether stdin can safely answer an interactive picker."""
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, OSError):
+        return False
+
+
+def match_reason(record: "SessionRecord", query: str) -> str:
+    """Explain why one resolver candidate matched the query.
+
+    Args:
+        record: Candidate returned by the shared resolver.
+        query: Original user-supplied query.
+
+    Returns:
+        A concise human-readable match explanation.
+    """
+    matched_by = record.matched_by
+    if matched_by == "id":
+        return "exact session ID"
+    if matched_by == "partial-id":
+        return "session ID prefix"
+    if matched_by == "id-substring":
+        return "session ID contains query"
+    if matched_by == "filename":
+        return "filename contains query"
+    if matched_by == "name":
+        name = record.name or ""
+        if name.casefold() == query.casefold():
+            return "exact name/title"
+        return "name/title contains query"
+    return "resolver match"
+
+
+def _clean_title(title: str | None) -> str:
+    """Normalize and bound a candidate title for tabular display."""
+    cleaned = " ".join((title or "Untitled session").split())
+    if len(cleaned) > _MAX_TITLE_CHARS:
+        return cleaned[: _MAX_TITLE_CHARS - 3] + "..."
+    return cleaned
+
+
+def _candidate_details(record: "SessionRecord", *, show_home: bool) -> Text:
+    """Build a readable multi-line candidate summary."""
+    details = Text()
+    details.append(_clean_title(record.name), style="bold")
+    details.append("\nProject / cwd  ", style="dim")
+    details.append(record.directory or "Unknown")
+    details.append("\nSession ID     ", style="dim")
+    details.append(record.session_id)
+    details.append("\nModified       ", style="dim")
+    details.append(record.modified)
+    if show_home:
+        details.append("\nSource home    ", style="dim")
+        details.append(record.home)
+    return details
+
+
+def choose_session_record(
+    query: str,
+    records: Sequence["SessionRecord"],
+    match_count: int,
+    *,
+    prompt: str = "Which session do you want to use?",
+    show_home: bool = False,
+    console: Console | None = None,
+) -> "SessionRecord | None":
+    """Render ambiguous candidates and ask the user to select one.
+
+    Args:
+        query: Original user-supplied query.
+        records: Newest-first selectable resolver records.
+        match_count: Total number of matches before display capping.
+        prompt: Question shown beneath the table.
+        show_home: Whether to include the source account/home column.
+        console: Optional Rich console, primarily for embedding and tests.
+
+    Returns:
+        The selected record, or None when the user chooses ``q``.
+
+    Raises:
+        EOFError: If stdin is not interactive.
+    """
+    if not stdin_is_interactive():
+        raise EOFError
+
+    output = console or Console()
+    heading = Text()
+    heading.append(f"{match_count} sessions matched ", style="yellow")
+    heading.append(repr(query), style="bold yellow")
+    heading.append(". Choose one to continue.", style="yellow")
+    output.print(heading)
+
+    table = Table(
+        box=box.ROUNDED,
+        header_style="bold cyan",
+        show_lines=True,
+        expand=True,
+    )
+    table.add_column("#", justify="right", no_wrap=True)
+    table.add_column("Agent", no_wrap=True)
+    table.add_column("Why it matched")
+    table.add_column("Session")
+
+    for index, record in enumerate(records, start=1):
+        table.add_row(
+            str(index),
+            _AGENT_LABELS.get(record.agent, record.agent.title()),
+            match_reason(record, query),
+            _candidate_details(record, show_home=show_home),
+        )
+    output.print(table)
+
+    hidden_count = match_count - len(records)
+    if hidden_count > 0:
+        output.print(
+            f"[dim]{hidden_count} older matches are not shown. "
+            "Use a more specific name, ID, or full path to select one.[/dim]"
+        )
+
+    choices = [str(index) for index in range(1, len(records) + 1)]
+    choices.append("q")
+    choice = Prompt.ask(
+        f"[bold]{prompt}[/bold] [dim](number or q to cancel)[/dim]",
+        choices=choices,
+        show_choices=False,
+        console=output,
+    )
+    if choice == "q":
+        return None
+    return records[int(choice) - 1]

--- a/docs-site/src/content/docs/tools/aichat/actions.mdx
+++ b/docs-site/src/content/docs/tools/aichat/actions.mdx
@@ -67,18 +67,18 @@ strategy.
     (`aichat search`) and the action menu appears
     automatically.
   </TabItem>
-  <TabItem label="By session ID">
-    Pass a session ID directly to `aichat menu`:
+  <TabItem label="By session reference">
+    Pass a name, ID/fragment, filename fragment, or path to `aichat menu`:
 
     ```bash
-    aichat menu abc123-def456
+    aichat menu session-finder
     ```
 
-    Or use the shortcut (any unknown argument is
-    treated as a session ID):
+    Or use the shortcut (an unknown command token is treated as the session
+    reference):
 
     ```bash
-    aichat abc123-def456
+    aichat session-finder
     ```
   </TabItem>
   <TabItem label="Latest session">
@@ -158,10 +158,9 @@ swapped into place, so a move interrupted partway
 cannot leave you with a truncated transcript.
 
 :::caution
-An ambiguous query aborts the move and lists the
-candidates — nothing is written or deleted. That
-matters more here than elsewhere, because a Claude
-move removes the old transcript once the new one is
-written. (A Codex move never does: the rollout is
-rewritten where it already lives.)
+In a terminal, an ambiguous query opens the shared candidate table before any
+write. Cancelling leaves every candidate untouched. Without interactive input,
+the move exits and lists the candidates. That matters here because a Claude
+move removes the old transcript after the new one is written. A Codex move
+rewrites its rollout in place.
 :::

--- a/docs-site/src/content/docs/tools/aichat/agent-access.mdx
+++ b/docs-site/src/content/docs/tools/aichat/agent-access.mdx
@@ -110,26 +110,45 @@ consume tokens in your main conversation.
 
 The full list of `aichat` subcommands:
 
-Most of them share one lookup. `info`, `export`, `copy`, `move`, `query`,
-`clone`, `rollover`, `lineage`, `smart-trim`, `trim`, and `resume` all accept
-a full session id, a partial id (prefix, middle, or suffix fragment), a
-session name (set with `/rename`), a rollout filename fragment (e.g.
-`2026-03-25T14-50`), or a session file path — across both agents, with the
-agent auto-detected. See [Resolve](../resolve/) for the exact match
-precedence.
+Session-taking commands share one lookup. They accept a full or partial ID, a
+session name, a rollout filename fragment, or a session file path across both
+agents. See [Resolve](../resolve/) for the exact precedence.
 
-An ambiguous query fails with the list of matching sessions rather than
-silently picking one. `--agent` restricts which agent home is searched; a
-session file path searches no home at all, so there `--agent` instead
-requires the file to belong to that agent. `delete` and `menu` keep their
-legacy id-or-path lookup, so the bare `aichat <id>` shortcut (which routes to
-`menu`) does too.
+In a terminal, ambiguous actions show a numbered Rich table. Enter `q`, press
+Ctrl-C, or send end-of-input to cancel without changing anything. Non-terminal
+and machine-readable modes print the ambiguity and exit nonzero without
+prompting. `--agent` restricts the searched agent home. The bare
+`aichat <session>` shortcut routes through the same lookup as `menu`.
 
-[`port`](../port/) accepts the same query forms, but resolves them slightly
-differently: it has no `--agent`, it searches both homes for every non-path
-query (a file path is classified from its content instead), and it calls a
-query ambiguous whenever each agent yields a match, even when one of them
-matched on a stronger tier.
+[`port`](../port/) uses the same resolver and picker. It has no `--agent`, so
+it searches both configured homes. A direct file path is classified from its
+content.
+
+### Session-reference behavior by command
+
+The following commands use the shared Rich picker for ambiguous interactive
+queries:
+
+- `aichat <session>` and `aichat menu <session>`
+- `trim`, `smart-trim`, `export`, `info`, `copy`, `move`, and `query`
+- `clone`, `rollover`, `lineage`, and `resume`
+- `delete`, `find-original`, and `find-derived`
+- the agent-specific `export-claude` and `export-codex` commands
+- [`port`](../port/)
+
+`trim-in-place` uses the picker for human-readable output, but its `--json`
+mode never prompts and always emits one JSON result or error object. The
+`--json` modes for `info` and `lineage` also fail deterministically instead of
+prompting.
+
+[`move-account`](../move-account/) applies the same match tiers across all
+eligible source homes. Its picker includes the source home so equal names in
+different accounts remain distinguishable.
+
+Every picker sorts candidates newest first. Selecting a number continues with
+that session. Entering `q`, pressing Ctrl-C, or sending end-of-input cancels
+before the command changes anything. Piped and other non-terminal input lists
+the candidates and exits nonzero.
 
 <Tabs>
   <TabItem label="Session management">
@@ -137,14 +156,16 @@ matched on a stronger tier.
     | Command | Description |
     |---------|-------------|
     | `aichat` | Action menu for latest session(s) |
-    | `aichat resume [id]` | Resume with strategy options |
-    | `aichat rollover [id]` | Rollover to fresh session |
-    | `aichat trim [id]` | Trim session content |
-    | `aichat smart-trim [id]` | AI-guided trim of session content |
-    | `aichat clone [id]` | Clone a session file |
-    | `aichat menu [id]` | Interactive action menu |
-    | `aichat lineage [id]` | Show parent lineage chain |
-    | `aichat query [id]` | Query a session with AI |
+    | `aichat <session>` | Action-menu shortcut by name, ID, filename, or path |
+    | `aichat resume [session]` | Resume with strategy options |
+    | `aichat rollover [session]` | Rollover to fresh session |
+    | `aichat trim [session]` | Trim session content |
+    | `aichat trim-in-place <session>` | Trim a Claude session in place |
+    | `aichat smart-trim [session]` | AI-guided trim of session content |
+    | `aichat clone [session]` | Clone a session file |
+    | `aichat menu <session>` | Interactive action menu |
+    | `aichat lineage [session]` | Show parent lineage chain |
+    | `aichat query [session]` | Query a session with AI |
     | `aichat port <session>` | Port a session to the other agent |
 
   </TabItem>
@@ -163,11 +184,14 @@ matched on a stronger tier.
 
     | Command | Description |
     |---------|-------------|
-    | `aichat info [id]` | Show session metadata |
-    | `aichat export [id]` | Export session to text |
-    | `aichat copy [id]` | Copy session file |
+    | `aichat info [session]` | Show session metadata |
+    | `aichat export [session]` | Export session to text |
+    | `aichat export-claude [session]` | Export a Claude session to text |
+    | `aichat export-codex [session]` | Export a Codex session to text |
+    | `aichat copy [session]` | Copy session file |
     | `aichat move <session> <new-project>` | Move session to another project |
-    | `aichat delete [id]` | Delete a session |
+    | `aichat delete <session>` | Delete a session |
+    | `aichat move-account <session>` | Move a session between accounts |
 
   </TabItem>
   <TabItem label="Find (legacy)">
@@ -177,8 +201,8 @@ matched on a stronger tier.
     | `aichat find` | Find sessions (all agents) |
     | `aichat find-claude` | Find Claude sessions |
     | `aichat find-codex` | Find Codex sessions |
-    | `aichat find-original` | Find original from derived |
-    | `aichat find-derived` | Find derived from original |
+    | `aichat find-original <session>` | Find original from derived |
+    | `aichat find-derived <session>` | Find derived from original |
 
     :::note
     The `find` commands are legacy. Prefer

--- a/docs-site/src/content/docs/tools/aichat/index.mdx
+++ b/docs-site/src/content/docs/tools/aichat/index.mdx
@@ -134,8 +134,9 @@ are available:
 ## Example Commands
 
 ```bash
-# Resume specific session with trim/rollover options
-aichat resume <session_id>
+# Resume by session name, ID/fragment, filename fragment, or path
+aichat resume <session>
+aichat resume session-finder
 
 # Resume latest session with trim/rollover options
 aichat resume
@@ -161,3 +162,10 @@ directories (`~/.claude` and `~/.codex`). You can also
 set the `CLAUDE_CONFIG_DIR` and `CODEX_HOME` environment
 variables.
 :::
+
+Session-taking commands accept names set with `/rename` as well as IDs,
+filename fragments, and paths. If a name matches several sessions, an
+interactive terminal shows a numbered Rich table. Enter `q`, press Ctrl-C, or
+send end-of-input to cancel without changing anything. Non-terminal and JSON
+modes list the ambiguity and exit nonzero instead of prompting. See
+[Resolve](./resolve/) for the complete command list and match precedence.

--- a/docs-site/src/content/docs/tools/aichat/move-account.mdx
+++ b/docs-site/src/content/docs/tools/aichat/move-account.mdx
@@ -29,12 +29,18 @@ aichat move-account <session> --to <config-dir> [options]
 - a **session UUID** — full or partial (a prefix or substring)
 - a **Claude session name** — the title set with `/rename`
 - a **Codex thread name**
+- an exact **session file path** inside an eligible source home
 
-Resolution is tiered: an exact id wins, then an exact name, then an id
-prefix, then id/name substrings. An exact name outranks an id prefix, so a
-short name can never silently select a session whose UUID happens to start
-with the same characters. Ambiguous matches are listed and refused rather
-than guessed.
+Resolution uses the shared tiers: exact id, exact name, id prefix, id
+substring, filename substring, then name substring. The winning tier is
+chosen across all searched source accounts, so a weaker match in one account
+cannot compete with an exact name in another.
+
+In an interactive terminal, ambiguous matches appear in a numbered Rich table.
+The table includes the source home so equal names in different accounts remain
+distinguishable. Enter `q`, press Ctrl-C, or send end-of-input to cancel before
+anything moves. Without a terminal, the command lists the matches and exits
+nonzero; use `--from` or a more specific query to disambiguate.
 
 ## Options
 

--- a/docs-site/src/content/docs/tools/aichat/port.mdx
+++ b/docs-site/src/content/docs/tools/aichat/port.mdx
@@ -108,7 +108,8 @@ session whose automatic title happens to contain the same text.
 When multiple sessions match, `aichat port` does not guess. It shows an
 interactive chooser with each candidate's agent, match reason, name or title,
 project directory, session ID, and modification time. Select a number to port
-that source session, or enter `q` to cancel.
+that source session. Enter `q`, press Ctrl-C, or send end-of-input to cancel
+before any conversion output is created.
 
 If no interactive input is available, the command exits without porting a
 session and prints the candidates so a later command can use a full session ID.

--- a/docs-site/src/content/docs/tools/aichat/resolve.mdx
+++ b/docs-site/src/content/docs/tools/aichat/resolve.mdx
@@ -124,11 +124,19 @@ and exits `0`:
 
 ## The same lookup in other commands
 
-You rarely need to call `resolve` by hand first. The
-ordinary session commands — `info`, `export`, `copy`,
-`move`, `query`, `clone`, `rollover`, `lineage`,
-`smart-trim`, `trim`, and `resume` — accept the same
-queries directly:
+You rarely need to call `resolve` by hand first. These commands accept the
+same queries directly:
+
+- `aichat <session>` and `menu`
+- `trim`, `smart-trim`, `trim-in-place`, and `resume`
+- `export`, `export-claude`, `export-codex`, `info`, and `copy`
+- `move`, `delete`, `query`, `clone`, `rollover`, and `lineage`
+- `find-original`, `find-derived`, and [`port`](../port/)
+
+`trim-in-place` and the two agent-specific exporters constrain the resolver to
+the agent named by the command. [`move-account`](../move-account/) uses the
+same tiers across several source homes and includes the source home in its
+picker.
 
 ```bash
 # All of these name one session
@@ -137,11 +145,10 @@ aichat info a15f9ced
 aichat lineage 88e9-43d7
 ```
 
-Those commands search **both** agent homes and detect
-the agent themselves, so `--agent` there narrows the
-search rather than selecting a home. It may come
-before or after the session argument, and
-`--agent=codex` works as well as `--agent codex`.
+Except for the constrained variants above, these commands search **both**
+agent homes and detect the agent themselves. Where a command offers
+`--agent`, the option narrows the search. It may come before or after the
+session argument, and `--agent=codex` works as well as `--agent codex`.
 
 Pass a session file path and no home is searched at
 all: the agent comes from the file's own content, and
@@ -150,9 +157,11 @@ A file that sits inside an agent home but does not
 read as a session is rejected, rather than trusted
 because of where it lives.
 
-An ambiguous query fails with the candidate list
-instead of acting on an arbitrary match. `delete` and
-`menu` still use the older id-or-path lookup.
+In an interactive terminal, an ambiguous action query opens a Rich table with
+the candidates newest first. Choose a number to continue with that session, or
+enter `q` to cancel. Ctrl-C and end-of-input also cancel before the command
+changes anything. Non-interactive and JSON callers still fail deterministically
+with the candidate list instead of guessing or prompting.
 
 ### Home overrides
 
@@ -191,13 +200,8 @@ seconds.
 None of this changes which session you get — it only
 changes how much work is done to be sure of it.
 
-[`port`](../port/) takes the same query forms but
-resolves them on its own path: no `--agent` (use
-`--claude-home` / `--codex-home`), and a query that
-matches in **both** agents is ambiguous there even
-when one side matched on a stronger tier — the
-precedence table above is applied per agent, not
-across the two.
+[`port`](../port/) uses the same resolver and picker. It has no `--agent`, so
+use `--claude-home` and `--codex-home` to choose the searched homes.
 
 ## Exit codes
 

--- a/docs-site/src/content/docs/tools/aichat/resume.mdx
+++ b/docs-site/src/content/docs/tools/aichat/resume.mdx
@@ -97,8 +97,8 @@ deep dive on how it works.
     # Resume the latest session for this project
     aichat resume
 
-    # Resume a specific session by ID
-    aichat resume abc123-def456
+    # Resume by name or ID fragment
+    aichat resume session-finder
     ```
   </TabItem>
 </Tabs>
@@ -138,7 +138,7 @@ So run `>trim` **before** you hit the wall. Once Claude Code
 shows `Context limit reached · /compact or /clear to continue`,
 the *live* context is what is full, so `>trim` typed there
 cannot rescue it — quit and resume (optionally
-`aichat trim-in-place <id>` from a shell first) to come back
+`aichat trim-in-place <session>` from a shell first) to come back
 lean.
 
 ### Options (in-session)
@@ -196,13 +196,13 @@ no explanation at all.
 directly on any Claude session (or from scripts):
 
 ```bash
-aichat trim-in-place <id> --dry-run    # preview tokens saved
-aichat trim-in-place <id>              # trim, keep same ID
-aichat trim-in-place <id> -a -20       # keep last 20 asst msgs
-aichat trim-in-place <id> -a 10        # trim first 10 asst msgs
-aichat trim-in-place <id> -l 800       # char threshold 800
-aichat trim-in-place <id> -t bash,read # only Bash/Read results
-aichat trim-in-place <id> --json       # machine-readable result
+aichat trim-in-place <session> --dry-run    # preview tokens saved
+aichat trim-in-place <session>              # trim, keep same ID
+aichat trim-in-place <session> -a -20       # keep last 20 asst msgs
+aichat trim-in-place <session> -a 10        # trim first 10 asst msgs
+aichat trim-in-place <session> -l 800       # char threshold 800
+aichat trim-in-place <session> -t bash,read # only Bash/Read results
+aichat trim-in-place <session> --json       # machine-readable result
 ```
 
 Flags: `-l/--len` threshold (default 500), `-a/--trim-assistant`
@@ -216,6 +216,10 @@ subcommand — install or update it with
 [Plugins](../../../getting-started/plugins/)). Works on Claude
 sessions only (not Codex).
 
+`<session>` accepts a Claude name, ID/fragment, filename fragment, or path.
+Human-readable ambiguity opens the shared picker. `--json` never prompts and
+always emits exactly one result or error object.
+
 ## CLI usage
 
 ```bash
@@ -223,7 +227,7 @@ sessions only (not Codex).
 aichat resume
 
 # Resume a specific session (opens resume menu)
-aichat resume <session_id>
+aichat resume <session>
 
 # A session name, or a partial id, works too
 aichat resume session-finder
@@ -237,8 +241,8 @@ trimming, or rollover automatically.
 The session argument accepts a name (set with
 `/rename`), a full or partial id, a rollout filename
 fragment, or a file path, across both agents — see
-[Resolve](../resolve/). An ambiguous query lists the
-candidates instead of guessing.
+[Resolve](../resolve/). In a terminal, an ambiguous query opens the shared
+numbered picker; non-interactive use lists the candidates and exits.
 
 Cloning follows the transcript you actually named.
 Give `aichat clone` a file path and it copies **that

--- a/tests/test_aichat_legacy_session_names.py
+++ b/tests/test_aichat_legacy_session_names.py
@@ -1,0 +1,295 @@
+"""Session-name coverage for legacy ``aichat`` command wrappers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from claude_code_tools.aichat import main
+from tests.resolve_session_helpers import FakeHome, claude_home, codex_home
+
+__all__ = ["claude_home", "codex_home"]
+
+
+def _root_args(claude: FakeHome, codex: FakeHome) -> list[str]:
+    """Return root options that isolate both agent homes."""
+    return [
+        "--claude-home",
+        str(claude.path),
+        "--codex-home",
+        str(codex.path),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("command", "options"),
+    [
+        ("find-original", ["--verbose"]),
+        ("find-derived", ["--tree"]),
+        ("menu", []),
+    ],
+)
+def test_required_legacy_session_uses_delegate_usage_error(
+    command: str,
+    options: list[str],
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Omitted SESSION reports ordinary CLI usage, not an internal error."""
+    result = CliRunner().invoke(
+        main,
+        [*_root_args(claude_home, codex_home), command, *options],
+    )
+
+    assert result.exit_code == 2
+    assert "usage:" in result.output.casefold()
+    assert "required" in result.output.casefold()
+    assert "MissingPositionalError" not in result.output
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_agent", "expected_index"),
+    [
+        ("Unique Deployment Review", "claude", 2),
+        ("Unique Codex Migration", "codex", 2),
+    ],
+)
+@pytest.mark.parametrize("shortcut", [False, True])
+def test_menu_and_shortcut_resolve_unique_names(
+    query: str,
+    expected_agent: str,
+    expected_index: int,
+    shortcut: bool,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both menu entry forms resolve names before launching the UI."""
+    captured: dict[str, Any] = {}
+
+    def capture_ui(
+        sessions: list[dict[str, Any]],
+        *_args: object,
+        **_kwargs: object,
+    ) -> None:
+        captured.update(sessions[0])
+
+    monkeypatch.setattr(
+        "claude_code_tools.session_menu_cli.run_node_menu_ui",
+        capture_ui,
+    )
+    arguments = [*_root_args(claude_home, codex_home)]
+    if not shortcut:
+        arguments.append("menu")
+    arguments.append(query)
+
+    result = CliRunner().invoke(main, arguments, catch_exceptions=False)
+
+    expected_home = claude_home if expected_agent == "claude" else codex_home
+    assert result.exit_code == 0, result.output
+    assert captured["agent"] == expected_agent
+    assert captured["file_path"] == str(expected_home.files[expected_index])
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_agent"),
+    [
+        ("Unique Deployment Review", "claude"),
+        ("Unique Codex Migration", "codex"),
+    ],
+)
+def test_delete_force_resolves_unique_names_for_both_agents(
+    query: str,
+    expected_agent: str,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Delete resolves either agent's name before unlinking exactly one file."""
+    expected_home = claude_home if expected_agent == "claude" else codex_home
+    selected = expected_home.files[2]
+
+    result = CliRunner().invoke(
+        main,
+        [*_root_args(claude_home, codex_home), "delete", query, "--force"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not selected.exists()
+    assert all(path.exists() for path in expected_home.files[:2])
+    assert "Session deleted" in result.output
+
+
+@pytest.mark.parametrize(
+    ("command", "query", "delegate", "home_option", "expected_file"),
+    [
+        (
+            "export-claude",
+            "Unique Deployment Review",
+            "claude_code_tools.export_claude_session.main",
+            "--claude-home",
+            "claude",
+        ),
+        (
+            "export-codex",
+            "Unique Codex Migration",
+            "claude_code_tools.export_codex_session.main",
+            "--codex-home",
+            "codex",
+        ),
+    ],
+)
+def test_agent_exports_resolve_names_and_preserve_option_order(
+    command: str,
+    query: str,
+    delegate: str,
+    home_option: str,
+    expected_file: str,
+    tmp_path: Path,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agent exports replace only SESSION when options precede it."""
+    captured: list[str] = []
+
+    def capture_main() -> None:
+        captured.extend(sys.argv[1:])
+
+    monkeypatch.setattr(delegate, capture_main)
+    output = tmp_path / f"{command}.md"
+    selected_home = claude_home if expected_file == "claude" else codex_home
+    result = CliRunner().invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            command,
+            "--output",
+            str(output),
+            home_option,
+            str(selected_home.path),
+            query,
+            "--verbose",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured[0:2] == ["--output", str(output)]
+    assert str(selected_home.files[2]) in captured
+    assert "--verbose" in captured
+
+
+@pytest.mark.parametrize(
+    ("command", "query", "delegate", "extra"),
+    [
+        (
+            "find-original",
+            "Unique Deployment Review",
+            "claude_code_tools.find_original_session.main",
+            ["--verbose"],
+        ),
+        (
+            "find-derived",
+            "Unique Codex Migration",
+            "claude_code_tools.find_trimmed_sessions.main",
+            ["--tree", "--stats"],
+        ),
+    ],
+)
+def test_lineage_wrappers_resolve_names_and_preserve_flags(
+    command: str,
+    query: str,
+    delegate: str,
+    extra: list[str],
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lineage passthrough wrappers substitute only the session argument."""
+    captured: list[str] = []
+
+    def capture_main() -> None:
+        captured.extend(sys.argv[1:])
+
+    monkeypatch.setattr(delegate, capture_main)
+    result = CliRunner().invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            command,
+            *extra,
+            query,
+        ],
+        catch_exceptions=False,
+    )
+
+    expected = (
+        claude_home.files[2] if command == "find-original" else (codex_home.files[2])
+    )
+    assert result.exit_code == 0, result.output
+    assert str(expected) in captured
+    if command == "find-derived":
+        assert captured[-4:] == [
+            "--claude-home",
+            str(claude_home.path),
+            "--codex-home",
+            str(codex_home.path),
+        ]
+    assert all(flag in captured for flag in extra)
+
+
+def test_trim_in_place_json_resolves_unique_claude_name(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """The hook-safe JSON path accepts a Claude session name without UI."""
+    result = CliRunner().invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "trim-in-place",
+            "Unique Deployment Review",
+            "--dry-run",
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.count("\n") == 1
+    assert "session_file" in result.output
+    assert str(claude_home.files[2]) in result.output
+
+
+def test_trim_in_place_json_ambiguity_never_prompts(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ambiguous name remains a single JSON error even on a TTY."""
+    monkeypatch.setattr(
+        "click.testing._NamedTextIOWrapper.isatty",
+        lambda _stream: True,
+    )
+    result = CliRunner().invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "trim-in-place",
+            "Shared Plan",
+            "--dry-run",
+            "--json",
+        ],
+        input="1\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert result.output.count("\n") == 1
+    assert "Ambiguous session" in result.output
+    assert "Which session" not in result.output

--- a/tests/test_move_account_selection.py
+++ b/tests/test_move_account_selection.py
@@ -1,0 +1,162 @@
+"""Interactive ambiguity selection for ``aichat move-account``."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from claude_code_tools.aichat import main
+from tests.test_move_account import ENC, UUID_A, UUID_B, _write_session
+
+
+def _reports_stdin_tty(_stream: object) -> bool:
+    """Make Click's isolated stdin behave like an interactive terminal."""
+    return True
+
+
+@pytest.fixture()
+def ambiguous_homes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Path, Path, Path]:
+    """Create two source accounts with the same name and one target."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    older = tmp_path / ".claude-work"
+    newer = tmp_path / ".claude-other"
+    target = tmp_path / ".claude"
+    (target / "projects").mkdir(parents=True)
+    older_file = _write_session(older, UUID_A, title="same-name")
+    newer_file = _write_session(newer, UUID_B, title="same-name")
+    os.utime(older_file, (1_700_000_000, 1_700_000_000))
+    os.utime(newer_file, (1_700_000_001, 1_700_000_001))
+    return older, newer, target
+
+
+def test_move_account_selects_source_home_from_shared_table(
+    ambiguous_homes: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A numbered choice identifies both transcript and source account."""
+    older, newer, target = ambiguous_homes
+    monkeypatch.setattr(
+        "click.testing._NamedTextIOWrapper.isatty",
+        _reports_stdin_tty,
+    )
+    result = CliRunner().invoke(
+        main,
+        [
+            "move-account",
+            "same-name",
+            "--to",
+            str(target),
+            "--agent",
+            "claude",
+            "--keep",
+        ],
+        input="2\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Source home" in result.output
+    assert UUID_A in result.output
+    assert UUID_B in result.output
+    assert (target / "projects" / ENC / f"{UUID_A}.jsonl").exists()
+    assert not (target / "projects" / ENC / f"{UUID_B}.jsonl").exists()
+    assert (older / "projects" / ENC / f"{UUID_A}.jsonl").exists()
+    assert (newer / "projects" / ENC / f"{UUID_B}.jsonl").exists()
+
+
+def test_move_account_cancellation_preserves_all_accounts(
+    ambiguous_homes: tuple[Path, Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancelling the picker leaves both sources and target untouched."""
+    older, newer, target = ambiguous_homes
+    monkeypatch.setattr(
+        "click.testing._NamedTextIOWrapper.isatty",
+        _reports_stdin_tty,
+    )
+    result = CliRunner().invoke(
+        main,
+        [
+            "move-account",
+            "same-name",
+            "--to",
+            str(target),
+            "--agent",
+            "claude",
+        ],
+        input="q\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "selection cancelled" in result.output.lower()
+    assert (older / "projects" / ENC / f"{UUID_A}.jsonl").exists()
+    assert (newer / "projects" / ENC / f"{UUID_B}.jsonl").exists()
+    assert list((target / "projects").rglob("*.jsonl")) == []
+
+
+def test_move_account_accepts_exact_transcript_path(
+    tmp_path: Path,
+) -> None:
+    """A direct path selects exactly that transcript in its source home."""
+    source = tmp_path / "claude-source"
+    target = tmp_path / "claude-target"
+    (target / "projects").mkdir(parents=True)
+    selected = _write_session(source, UUID_A, title="direct-source")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "move-account",
+            str(selected),
+            "--from",
+            str(source),
+            "--to",
+            str(target),
+            "--agent",
+            "claude",
+            "--keep",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert selected.exists()
+    assert (target / "projects" / ENC / f"{UUID_A}.jsonl").exists()
+
+
+def test_move_account_path_rejects_conflicting_agent(
+    tmp_path: Path,
+) -> None:
+    """A path's transcript content must agree with the requested agent."""
+    source = tmp_path / "claude-source"
+    target = tmp_path / "codex-target"
+    (target / "sessions").mkdir(parents=True)
+    selected = _write_session(source, UUID_A)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "move-account",
+            str(selected),
+            "--from",
+            str(source),
+            "--to",
+            str(target),
+            "--agent",
+            "codex",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "session file is claude" in result.output
+    assert selected.exists()

--- a/tests/test_port_resolver_integration.py
+++ b/tests/test_port_resolver_integration.py
@@ -86,9 +86,7 @@ def _write_claude_session(
     title: str | None = None,
 ) -> Path:
     """Write a minimal portable Claude session, optionally named."""
-    proj = claude_home / "projects" / encode_claude_project_path(
-        str(project_dir)
-    )
+    proj = claude_home / "projects" / encode_claude_project_path(str(project_dir))
     proj.mkdir(parents=True, exist_ok=True)
     lines: list[dict[str, object]] = [
         {
@@ -118,9 +116,7 @@ def _write_claude_session(
     return path
 
 
-def _resolve(
-    session: str, claude_home: Path, codex_home: Path
-) -> ResolvedSession:
+def _resolve(session: str, claude_home: Path, codex_home: Path) -> ResolvedSession:
     """Resolve a port query against the two isolated fake homes."""
     return resolve_port_session(
         session,
@@ -188,9 +184,7 @@ class TestLookupForms:
         self, claude_home: Path, codex_home: Path, project_dir: Path
     ) -> None:
         rollout = write_modern_rollout(codex_home, project_dir)
-        resolved = _resolve(
-            "rollout-2026-07-16T20-41-57", claude_home, codex_home
-        )
+        resolved = _resolve("rollout-2026-07-16T20-41-57", claude_home, codex_home)
         assert resolved.agent == "codex"
         assert resolved.session_file == rollout.resolve()
 
@@ -259,9 +253,7 @@ class TestLookupForms:
         of masking the database error as "session not found".
         """
         rollout = write_modern_rollout(codex_home, project_dir)
-        (codex_home / "state_9.sqlite").write_bytes(
-            b"not a sqlite database"
-        )
+        (codex_home / "state_9.sqlite").write_bytes(b"not a sqlite database")
         resolved = _resolve(MODERN_UUID, claude_home, codex_home)
         assert resolved.agent == "codex"
         assert resolved.session_file == rollout.resolve()
@@ -322,9 +314,7 @@ class TestRejections:
         with pytest.raises(PortSessionError, match="not found"):
             _resolve(query, claude_home, codex_home)
 
-    @pytest.mark.parametrize(
-        "query", ["a/b", "a\\b", "*", "??", "has*star", "what?"]
-    )
+    @pytest.mark.parametrize("query", ["a/b", "a\\b", "*", "??", "has*star", "what?"])
     def test_separator_and_glob_queries_reject_matching_names(
         self,
         claude_home: Path,
@@ -360,9 +350,7 @@ class TestRejections:
     ) -> None:
         """One claude and one codex match must be rejected together."""
         sid = str(uuid.uuid4())
-        _write_claude_session(
-            claude_home, sid, project_dir, title="xshared-name"
-        )
+        _write_claude_session(claude_home, sid, project_dir, title="xshared-name")
         rollout = write_modern_rollout(codex_home, project_dir)
         database = codex_home / "state_1.sqlite"
         _create_threads_database(database)
@@ -393,7 +381,7 @@ class TestRejections:
         project_dir: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """An exact name and an incidental title match stay user-chosen."""
+        """Equal-tier exact names across agents stay user-chosen."""
         query = "sasy-blog-21jul2026"
         claude_id = str(uuid.uuid4())
         claude_session = _write_claude_session(
@@ -410,11 +398,7 @@ class TestRejections:
             MODERN_UUID,
             rollout,
             str(project_dir),
-            (
-                f"see how port works; source name {query}; "
-                + ("long automatic title " * 20)
-                + "NEVER_SHOW_THIS_TAIL"
-            ),
+            query,
             1_720_000_000,
         )
         # Candidate order is newest first. Keep Claude first so input
@@ -442,14 +426,9 @@ class TestRejections:
         assert result.exit_code == 0, result.output
         assert "2 sessions matched" in result.output
         assert "exact name/title" in result.output
-        assert "name/title contains query" in result.output
-        assert "see how port works" in result.output
-        assert "NEVER_SHOW_THIS_TAIL" not in result.output
+        assert result.output.count("exact name/title") == 2
         assert "Which source session do you want to port?" in result.output
-        assert (
-            "Detected source agent: claude — porting to Codex"
-            in result.output
-        )
+        assert "Detected source agent: claude — porting to Codex" in result.output
         assert "Port complete" in result.output
         assert len(list((codex_home / "sessions").rglob("*.jsonl"))) == 2
 
@@ -522,9 +501,7 @@ class TestRejections:
     ) -> None:
         """`aichat port <name>` converts the named claude session."""
         sid = str(uuid.uuid4())
-        _write_claude_session(
-            claude_home, sid, project_dir, title="cli-name-port"
-        )
+        _write_claude_session(claude_home, sid, project_dir, title="cli-name-port")
         result = runner.invoke(
             main,
             [
@@ -537,10 +514,7 @@ class TestRejections:
             ],
         )
         assert result.exit_code == 0, result.output
-        assert (
-            "Detected source agent: claude — porting to Codex"
-            in result.output
-        )
+        assert "Detected source agent: claude — porting to Codex" in result.output
         assert "New Codex session id:" in result.output
         assert list((codex_home / "sessions").rglob("rollout-*.jsonl"))
 

--- a/tests/test_session_ambiguity_selection.py
+++ b/tests/test_session_ambiguity_selection.py
@@ -1,0 +1,229 @@
+"""Structured ambiguity and shared Rich selection regressions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from claude_code_tools.aichat import main
+from claude_code_tools.session_resolution import (
+    SessionQueryAmbiguity,
+    resolve_session_query,
+)
+from tests.resolve_session_helpers import FakeHome, claude_home, codex_home
+
+__all__ = ["claude_home", "codex_home"]
+
+
+def _reports_stdin_tty(_stream: object) -> bool:
+    """Make Click's isolated stdin behave like an interactive terminal."""
+    return True
+
+
+def _root_args(claude: FakeHome, codex: FakeHome) -> list[str]:
+    """Return root options that isolate both agent homes."""
+    return [
+        "--claude-home",
+        str(claude.path),
+        "--codex-home",
+        str(codex.path),
+    ]
+
+
+def _snapshot(paths: tuple[Path, ...]) -> dict[Path, bytes]:
+    """Capture exact bytes for a small set of session files."""
+    return {path: path.read_bytes() for path in paths}
+
+
+def test_shared_resolver_exposes_structured_newest_first_ambiguity(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Action callers receive records, total count, and display cap."""
+    with pytest.raises(SessionQueryAmbiguity) as error_info:
+        resolve_session_query(
+            "Shared Plan",
+            claude_home=str(claude_home.path),
+            codex_home=str(codex_home.path),
+        )
+
+    error = error_info.value
+    assert error.query == "Shared Plan"
+    assert error.match_count == 2
+    assert error.display_limit == 25
+    assert [record.session_id for record in error.records] == [
+        claude_home.ids[1],
+        claude_home.ids[0],
+    ]
+    assert "Ambiguous session 'Shared Plan'" in str(error)
+
+
+def test_ambiguity_records_preserve_discovered_symlinks(
+    tmp_path: Path,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """A selected mutation targets an in-home link, not its referent."""
+    links = claude_home.files[:2]
+    for index, link in enumerate(links):
+        external = tmp_path / f"external-{index}.jsonl"
+        external.write_bytes(link.read_bytes())
+        link.unlink()
+        link.symlink_to(external)
+
+    with pytest.raises(SessionQueryAmbiguity) as error_info:
+        resolve_session_query(
+            "Shared Plan",
+            agent="claude",
+            claude_home=str(claude_home.path),
+            codex_home=str(codex_home.path),
+        )
+
+    selected_paths = {
+        Path(record.session_file) for record in error_info.value.records
+    }
+    assert selected_paths == {path.absolute() for path in links}
+    assert all(path.is_symlink() for path in selected_paths)
+
+
+def test_info_ambiguity_renders_shared_table_and_uses_selection(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A human action can choose a numbered candidate and continue."""
+    monkeypatch.setattr(
+        "click.testing._NamedTextIOWrapper.isatty",
+        _reports_stdin_tty,
+    )
+    result = CliRunner().invoke(
+        main,
+        [*_root_args(claude_home, codex_home), "info", "Shared Plan"],
+        input="2\n",
+        env={"COLUMNS": "240"},
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    for heading in (
+        "Agent",
+        "Why it matched",
+        "Project / cwd",
+        "Session ID",
+        "Modified",
+    ):
+        assert heading in result.output
+    assert "Which session do you want to use?" in result.output
+    assert f"Session: {claude_home.ids[0]}" in result.output
+
+
+def test_info_json_never_prompts_even_with_tty(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Machine-readable modes retain deterministic ambiguity failure."""
+    monkeypatch.setattr(
+        "click.testing._NamedTextIOWrapper.isatty",
+        _reports_stdin_tty,
+    )
+    result = CliRunner().invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "info",
+            "Shared Plan",
+            "--json",
+        ],
+        input="1\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "Ambiguous session" in result.output
+    assert "Which session" not in result.output
+    assert "Why it matched" not in result.output
+
+
+def test_delete_selection_then_confirmation_deletes_only_selected(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Selection precedes confirmation and targets only the chosen file."""
+    monkeypatch.setattr(
+        "click.testing._NamedTextIOWrapper.isatty",
+        _reports_stdin_tty,
+    )
+    result = CliRunner().invoke(
+        main,
+        [*_root_args(claude_home, codex_home), "delete", "Shared Plan"],
+        input="2\nyes\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not claude_home.files[0].exists()
+    assert claude_home.files[1].exists()
+    assert claude_home.files[2].exists()
+    assert str(claude_home.files[0]) in result.output
+    assert "SESSION DELETION CONFIRMATION" in result.output
+
+
+@pytest.mark.parametrize(("input_text", "force"), [("q\n", False), ("", True)])
+def test_delete_selection_cancellation_and_eof_do_not_mutate(
+    input_text: str,
+    force: bool,
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation and EOF happen before any destructive action."""
+    monkeypatch.setattr(
+        "click.testing._NamedTextIOWrapper.isatty",
+        _reports_stdin_tty,
+    )
+    before = _snapshot(claude_home.files)
+    arguments = [
+        *_root_args(claude_home, codex_home),
+        "delete",
+        "Shared Plan",
+    ]
+    if force:
+        arguments.append("--force")
+    result = CliRunner().invoke(
+        main,
+        arguments,
+        input=input_text,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "selection cancelled" in result.output.lower()
+    assert _snapshot(claude_home.files) == before
+
+
+def test_delete_non_tty_ambiguity_never_accepts_piped_selection(
+    claude_home: FakeHome,
+    codex_home: FakeHome,
+) -> None:
+    """Piped input cannot select a destructive target."""
+    before = _snapshot(claude_home.files)
+    result = CliRunner().invoke(
+        main,
+        [
+            *_root_args(claude_home, codex_home),
+            "delete",
+            "Shared Plan",
+            "--force",
+        ],
+        input="2\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "Ambiguous session" in result.output
+    assert "Which session" not in result.output
+    assert _snapshot(claude_home.files) == before


### PR DESCRIPTION
## Summary

- route every session-taking `aichat` command through shared name, ID,
  filename-fragment, and path resolution
- show a newest-first Rich picker for ambiguous interactive matches, with
  clean cancellation and deterministic non-interactive behavior
- unify `port` and `move-account`, preserve custom-home and JSON contracts,
  and keep mutation targets tied to the selected discovered path
- document session names and multiple-match behavior across the Starlight
  command reference

## Root cause

Several older command wrappers bypassed the shared resolver and passed raw
arguments to ID/path-only helpers. `port` and `move-account` also maintained
independent ambiguity logic, so lookup precedence, custom-home propagation,
and cancellation behavior varied by command.

## Impact

Users can now pass session names to `delete`, `menu`, the bare `aichat
<session>` shortcut, lineage commands, agent-specific exporters, and all newer
session actions. When a name matches several sessions, interactive commands
show a numbered candidate table before performing any action. Piped and JSON
modes never prompt, and cancellation performs no mutation.

## Validation

- `uv run pytest tests -q` (1,857 passed, 7 skipped)
- `make docs-build` (45 Starlight pages built)
- focused resolver, move, port, legacy-wrapper, and ambiguity suites
- Python compilation, targeted Ruff fatal checks, `git diff --check`, and
  88-column checks for added Python and Markdown lines
- final cold-diff review: no blocking findings
