### PR TITLE
safety-hooks: allow commits via CCTOOLS_ALLOW_GIT, ungate git add

### DIFF
--- a/docs-site/src/content/docs/getting-started/plugins.mdx
+++ b/docs-site/src/content/docs/getting-started/plugins.mdx
@@ -153,9 +153,9 @@ dangerous operations.
 | Hook | What it blocks / modifies |
 |------|--------------------------|
 | `rm` protection | Blocks `rm -rf` on critical paths; requires approval for others |
-| `git add` protection | Blocks `git add -A`; requires approval for modified files |
+| `git add` protection | Blocks bulk staging (`git add -A`, `git add .`, wildcards) |
 | `git checkout` protection | Warns before discarding uncommitted changes |
-| `git commit` protection | Blocks commits without user review |
+| `git commit` protection | Asks before commits; `CCTOOLS_ALLOW_GIT=1` allows them |
 | `.env` protection | Blocks all read/write/edit of `.env` files; suggests `env-safe` CLI |
 | File length limit | Blocks reading files >500 lines to prevent context bloat |
 

--- a/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
+++ b/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
@@ -43,10 +43,9 @@ claude plugin install safety-hooks@cctools-plugins
   </Card>
 
   <Card title="Git Add Protection">
-    Smart staging control that hard-blocks dangerous
-    patterns like `git add .` and `git add -A`,
-    while allowing new files and prompting for
-    modified files.
+    Hard-blocks bulk staging patterns like
+    `git add .` and `git add -A`, while staging
+    of specific paths goes through untouched.
   </Card>
 
   <Card title="Environment Security">
@@ -91,7 +90,7 @@ Each hook returns one of three results:
 |-----------|-----------------|
 | `bash_hook.py` | Main orchestrator for all bash command checks |
 | `git_commit_block_hook.py` | User permission prompt for `git commit` |
-| `git_add_block_hook.py` | Smart staging: blocks dangerous patterns, prompts for modified files |
+| `git_add_block_hook.py` | Blocks bulk staging patterns (`git add -A`, `git add .`, wildcards) |
 | `env_file_protection_hook.py` | Blocks all `.env` file operations (read/write/edit) |
 | `file_size_conditional_hook.py` | Prevents reading files over 500 lines |
 | `grep_block_hook.py` | Enforces ripgrep (`rg`) over `grep` |
@@ -101,50 +100,56 @@ Each hook returns one of three results:
 
 ### Git Add Protection
 
-The `git add` hook applies layered protection:
+The `git add` hook blocks bulk staging outright:
 
-- **Hard blocks** (always denied):
+- `git add .`
+- `git add ../`
+- `git add *`
+- `git add -A` / `git add --all`
 
-  - `git add .`
-  - `git add ../`
-  - `git add *`
-  - `git add -A` / `git add --all`
+These stay blocked behind command prefixes too,
+so `env -C <dir> git add -A` and
+`GIT_DIR=... git add .` are blocked as well.
 
-- **New files** -- allowed without a prompt,
-  since they pose minimal risk.
+Staging specific paths -- new files, modified
+files, a named directory -- is never gated and
+never prompts. The one exception is
+`--pathspec-from-file`, which stages an
+unreadable list of paths and so still asks.
 
-- **Modified files** -- require user approval
-  via the permission prompt.
+### Allowing Commits
 
-- **Directories** -- the hook performs a dry-run
-  to detect which files would be staged. If any
-  modified files are included, approval is
-  required.
+`git commit` asks for approval by default. Set
+`CCTOOLS_ALLOW_GIT=1` in your environment to allow
+commits everywhere without prompting -- useful for
+unattended workflows, where a prompt stalls the run:
 
-### Temporarily Allowing Staging & Commits
+```json title="~/.claude/settings.json"
+{
+  "env": {
+    "CCTOOLS_ALLOW_GIT": "1"
+  }
+}
+```
 
-When you're in a workflow where you trust the agent
-to stage modified files and commit, you can
-temporarily disable the approval prompts using a
-`>allow-git` trigger. Type it directly at the prompt:
+The `>allow-git` trigger is the per-session
+override. Type it directly at the prompt:
 
 | Trigger | Effect |
 |---------|--------|
-| `>allow-git` | Allow both staging and commits |
-| `>allow-git staging` | Allow only staging modified files |
-| `>allow-git commit` | Allow only commits |
-| `>allow-git off` | Restore approval prompts |
-| `>allow-git status` | Show current state |
+| `>allow-git` | Allow commits in this session |
+| `>allow-git off` | Restore approval prompts in this session |
+| `>allow-git status` | Show current state and why |
 
-This is **session-scoped** — it only affects the
-current Claude Code session. Other concurrent sessions
-are unaffected, and the allowance is automatically
-gone when the session ends.
+`>allow-git off` wins over `CCTOOLS_ALLOW_GIT`, so a
+single session can opt back into prompts. Both
+triggers are **session-scoped**: other concurrent
+sessions are unaffected.
 
 :::caution
 Dangerous operations like `git add -A`, `git add .`,
 and `git checkout --force` remain **always blocked**
-regardless of this setting.
+regardless of these settings.
 :::
 
 ### Environment File Protection

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Plugin Changelog
 
+## 2026-08-20
+
+### safety-hooks 1.15.0
+
+- feat: `CCTOOLS_ALLOW_GIT=1` allows `git commit` in every session
+  - the session-scoped `/tmp` allow flag no longer has to survive for commits
+    to work, which it did not: macOS reaps `/tmp` after a few days, so a
+    long-lived session started prompting again partway through its life
+  - `>allow-git off` writes a session-scoped deny flag that overrides the
+    environment variable, so one session can opt back into prompts
+  - `>allow-git status` reports which of the three is in effect
+- change: `git add` of explicitly named paths never asks for approval
+  - blanket staging (`git add -A`, `git add .`, `git add *`) stays blocked,
+    including behind `env -C`, `env -S`, and `GIT_DIR=` prefixes
+  - `git add --pathspec-from-file` still asks, since the hook cannot read the
+    path list it would stage
+  - `>allow-git staging` is gone; staging is no longer gated
+
 ## 2026-07-16
 
 ### dynamic-workflow 0.2.1

--- a/plugins/safety-hooks/.claude-plugin/plugin.json
+++ b/plugins/safety-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safety-hooks",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Safety hooks to block or require user approval for dangerous commands (rm, git operations, .env access, file size limits)",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/safety-hooks/README.md
+++ b/plugins/safety-hooks/README.md
@@ -43,19 +43,12 @@ decisions to Claude Code.
 
 - **Ask (user approval required)**:
 
-  - Staging **modified** files (files already tracked that have changes)
-  - Staging a directory that contains modified files
+  - `--pathspec-from-file` - stages a list of paths the hook cannot read
 
-- **Allow without prompting**:
-
-  - Staging **new/untracked** files (no approval needed)
-  - `--dry-run` or `-n` flag (used internally)
-  - Directories containing only new files
-
-- **How it works**: Uses `git add --dry-run` to detect what would be staged,
-  then checks `git status --porcelain` to distinguish new vs modified files.
-- **Purpose**: Prevent accidental staging while allowing smooth workflow for
-  new files
+- **Allow without prompting**: every other `git add`, whether the paths are
+  new, modified, or a named directory. Explicit selection is the point: if the
+  paths are spelled out, the command is not blanket staging.
+- **Purpose**: Prevent blanket staging, without gating ordinary work
 
 #### 1c. git_checkout_safety_hook.py
 
@@ -86,6 +79,11 @@ decisions to Claude Code.
 - **Purpose**: Ensure user is aware of and approves commits
 - **Note**: Uses `hookSpecificOutput` with `permissionDecision: "ask"` to
   trigger UI prompt
+- **Allowing commits**: set `CCTOOLS_ALLOW_GIT=1` in the environment (e.g. the
+  `env` block of `~/.claude/settings.json`) to allow commits in every session,
+  which is what unattended workflows need. Per session, `>allow-git` allows
+  commits and `>allow-git off` restores the prompt; `off` wins over the
+  environment variable.
 
 #### 1e. env_file_protection_hook.py
 
@@ -132,7 +130,7 @@ decisions to Claude Code.
 |------|---------------|-------------|
 | bash_hook.py | block/ask/allow | Unified hook combining all bash safety checks |
 | rm_block_hook.py | block | Blocks rm, suggests TRASH |
-| git_add_block_hook.py | block/ask/allow | Blocks dangerous patterns; asks for modified files; allows new files |
+| git_add_block_hook.py | block/ask/allow | Blocks blanket staging; allows explicitly named paths |
 | git_checkout_safety_hook.py | block | Protects uncommitted changes |
 | git_commit_block_hook.py | ask | Prompts user for commit approval |
 | env_file_protection_hook.py | block | Protects .env files from Bash commands |

--- a/plugins/safety-hooks/hooks/allow_git_hook.py
+++ b/plugins/safety-hooks/hooks/allow_git_hook.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
 """
-UserPromptSubmit hook to toggle git staging/commit approval.
+UserPromptSubmit hook to toggle git commit approval.
 
 Triggers:
-- '>allow-git': Allow both staging modified files and commits
-- '>allow-git staging': Allow only staging modified files
-- '>allow-git commit': Allow only commits
-- '>allow-git off': Restore approval prompts
+- '>allow-git': Allow commits for this session
+- '>allow-git off': Restore approval prompts for this session
 - '>allow-git status': Show current status
 
-Creates session-scoped flag files so the PreToolUse hooks
-(git_add_block_hook, git_commit_block_hook) can skip the
-"ask" prompt. Dangerous operations (git add -A, git add .,
-git checkout --force) remain always blocked.
+Commits are normally allowed everywhere by setting CCTOOLS_ALLOW_GIT=1 in the
+environment. This hook is the per-session override: '>allow-git off' writes a
+session-scoped deny flag that wins over the environment variable, and
+'>allow-git' removes it (and writes a session-scoped allow flag, which is what
+enables commits when the environment variable is not set).
+
+Staging is no longer gated: 'git add' of specific paths never prompts, while
+bulk staging ('git add -A', 'git add .', wildcards) stays blocked outright.
 """
 import json
 import os
@@ -20,7 +22,10 @@ import sys
 
 TRIGGER = ">allow-git"
 FLAG_DIR = "/tmp/claude"
-FLAG_NAMES = ("staging", "commit")
+ALLOW_FLAG = "allow-git-commit"
+DENY_FLAG = "deny-git-commit"
+ALLOW_ENV_VAR = "CCTOOLS_ALLOW_GIT"
+_TRUTHY = {"1", "true", "yes", "on"}
 
 # ANSI colors
 BLUE = "\033[94m"
@@ -30,50 +35,62 @@ RESET = "\033[0m"
 
 
 def _flag_path(name: str, session_id: str) -> str:
-    return os.path.join(FLAG_DIR, f"allow-git-{name}.{session_id}")
+    return os.path.join(FLAG_DIR, f"{name}.{session_id}")
 
 
-def _set_flags(
-    names: tuple[str, ...],
-    session_id: str,
-) -> str:
-    """Create session-scoped flag files. Returns status message."""
+def _remove(name: str, session_id: str) -> None:
+    try:
+        os.remove(_flag_path(name, session_id))
+    except FileNotFoundError:
+        pass
+
+
+def _env_allows() -> bool:
+    return os.environ.get(ALLOW_ENV_VAR, "").strip().lower() in _TRUTHY
+
+
+def _allow(session_id: str) -> str:
+    """Clear any deny flag and record the session-scoped allowance."""
     os.makedirs(FLAG_DIR, exist_ok=True)
-    for name in names:
-        with open(_flag_path(name, session_id), "w") as f:
-            f.write(session_id)
+    _remove(DENY_FLAG, session_id)
+    with open(_flag_path(ALLOW_FLAG, session_id), "w") as f:
+        f.write(session_id)
 
-    label = " and ".join(names)
     return (
-        f"{GREEN}Git {label} allowed for this session.{RESET}\n"
+        f"{GREEN}Git commits allowed for this session.{RESET}\n"
         f"{BLUE}Use >allow-git off to restore approval prompts.{RESET}"
     )
 
 
-def _clear_flags(session_id: str) -> str:
-    """Remove all session-scoped flag files."""
-    for name in FLAG_NAMES:
-        try:
-            os.remove(_flag_path(name, session_id))
-        except FileNotFoundError:
-            pass
-    return f"{YELLOW}Git approval prompts restored.{RESET}"
+def _deny(session_id: str) -> str:
+    """Write the deny flag, which also overrides the environment variable."""
+    os.makedirs(FLAG_DIR, exist_ok=True)
+    _remove(ALLOW_FLAG, session_id)
+    with open(_flag_path(DENY_FLAG, session_id), "w") as f:
+        f.write(session_id)
+
+    return f"{YELLOW}Git commit approval prompts restored.{RESET}"
 
 
 def _status(session_id: str) -> str:
-    """Report which flags are active."""
-    active = []
-    for name in FLAG_NAMES:
-        if os.path.exists(_flag_path(name, session_id)):
-            active.append(name)
-
-    if active:
-        label = ", ".join(active)
+    """Report whether commits currently need approval, and why."""
+    if os.path.exists(_flag_path(DENY_FLAG, session_id)):
         return (
-            f"{GREEN}Active: {label}{RESET}\n"
+            f"{YELLOW}Commits require approval "
+            f"(>allow-git off is set for this session).{RESET}\n"
+            f"{BLUE}Use >allow-git to allow them again.{RESET}"
+        )
+    if _env_allows():
+        return (
+            f"{GREEN}Commits allowed ({ALLOW_ENV_VAR} is set).{RESET}\n"
+            f"{BLUE}Use >allow-git off to restore prompts here.{RESET}"
+        )
+    if os.path.exists(_flag_path(ALLOW_FLAG, session_id)):
+        return (
+            f"{GREEN}Commits allowed for this session.{RESET}\n"
             f"{BLUE}Use >allow-git off to restore prompts.{RESET}"
         )
-    return f"{BLUE}All git operations require approval.{RESET}"
+    return f"{BLUE}Commits require approval.{RESET}"
 
 
 def main():
@@ -102,16 +119,12 @@ def main():
         arg = prompt[len(TRIGGER):].strip()
 
         if arg == "off":
-            message = _clear_flags(session_id)
-        elif arg == "staging":
-            message = _set_flags(("staging",), session_id)
-        elif arg == "commit":
-            message = _set_flags(("commit",), session_id)
+            message = _deny(session_id)
         elif arg == "status":
             message = _status(session_id)
         else:
-            # No arg or unrecognized -> allow both
-            message = _set_flags(FLAG_NAMES, session_id)
+            # No arg, or a legacy 'staging'/'commit' arg -> allow commits
+            message = _allow(session_id)
 
         print(json.dumps({
             "decision": "block",

--- a/plugins/safety-hooks/hooks/bash_hook.py
+++ b/plugins/safety-hooks/hooks/bash_hook.py
@@ -72,8 +72,8 @@ def main():
     ask_reasons = []
 
     for check_func in checks:
-        # Pass session_id to git checks that support it
-        if check_func in (check_git_add_command, check_git_commit_command):
+        # Only the commit check is session-scoped.
+        if check_func is check_git_commit_command:
             result = check_func(command, session_id=session_id)
         else:
             result = check_func(command)

--- a/plugins/safety-hooks/hooks/git_add_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_add_block_hook.py
@@ -534,9 +534,8 @@ def _check_single_git_add_command(command):
     # Normalize recognized add commands after stripping supported Git prefixes.
     normalized_cmd = ' '.join(command.strip().split())
     resolved_add = _resolve_git_add_argv(command)
-    repo_cwd: str | None = os.getcwd()
     if resolved_add is not None:
-        add_argv, repo_cwd = resolved_add
+        add_argv, _ = resolved_add
         normalized_cmd = shlex.join(add_argv)
 
     # Always allow --dry-run (used internally to detect what would be staged)

--- a/plugins/safety-hooks/hooks/git_add_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_add_block_hook.py
@@ -2,7 +2,6 @@
 import os
 import re
 import shlex
-import subprocess
 import sys
 from pathlib import Path
 
@@ -76,10 +75,6 @@ _ENV_VALUE_OPTS: set[str] = {'-u', '--unset', '-C', '--chdir', '-P'}
 _ENV_SHORT_VALUE_OPTS = frozenset('uCPS')
 _UNRESOLVABLE_CHDIR_CHARS = frozenset('$`*?[')
 _REPOSITORY_ROUTING_VARS = {'GIT_DIR', 'GIT_WORK_TREE'}
-_UNVERIFIED_STAGING_REASON = (
-    'Could not safely resolve the target repository or inspect its status. '
-    'Approval is required before staging files.'
-)
 _ADD_ALL_LONG_OPTIONS = {'--a', '--al', '--all'}
 
 
@@ -501,16 +496,7 @@ def _commit_avoids_editor(
     return bool(message_sources or fixup_value)
 
 
-def _is_allowed(flag_name: str, session_id: str = "") -> bool:
-    """Check if a session-scoped allow flag is set."""
-    if not session_id:
-        return False
-    return os.path.exists(
-        f'/tmp/claude/allow-git-{flag_name}.{session_id}'
-    )
-
-
-def check_git_add_command(command, session_id: str = ""):
+def check_git_add_command(command):
     """
     Check if a git add command contains dangerous patterns.
     Handles compound commands (e.g., "cd /path && git add .").
@@ -522,7 +508,7 @@ def check_git_add_command(command, session_id: str = ""):
     first_ask_result = None
 
     for subcmd in _split_compound_command(command):
-        result = _check_single_git_add_command(subcmd, session_id)
+        result = _check_single_git_add_command(subcmd)
         decision, reason = result
 
         # Hard blocks return immediately
@@ -540,7 +526,7 @@ def check_git_add_command(command, session_id: str = ""):
     return False, None
 
 
-def _check_single_git_add_command(command, session_id: str = ""):
+def _check_single_git_add_command(command):
     """
     Check a single (non-compound) command for dangerous git add patterns.
     Returns tuple: (decision, reason) where decision is bool or "ask"/"block"/"allow"
@@ -597,96 +583,17 @@ DO NOT use:
 
 Instead, use:
 - 'git add <specific-files>' to stage specific files
-- 'git add <specific-directory>/' to stage a specific directory (with confirmation)
+- 'git add <specific-directory>/' to stage a specific directory
 - 'git add -u' to stage all modified/deleted files (but not untracked)
 
 This restriction prevents accidentally staging unwanted files."""
         return True, reason
 
-    if resolved_add is not None and repo_cwd is None:
-        return 'ask', _UNVERIFIED_STAGING_REASON
-
     if any(
         argument.startswith('--pathspec-')
         for argument in add_arguments
     ):
-        if _is_allowed('staging', session_id):
-            return False, None
         return 'ask', 'Staging paths supplied through a pathspec file.'
-
-    # Check for git add with a directory
-    # Match: git add <dirname>/ or git add <path/to/dir>/
-    directory_pattern = re.compile(r'^git\s+add\s+(?!-)[^\s]+/$')
-    match = directory_pattern.search(normalized_cmd)
-
-    if match:
-        # Extract the directory path from the command
-        parts = normalized_cmd.split()
-        dir_path = None
-        for i, part in enumerate(parts):
-            if i > 0 and parts[i-1] == 'add' and part.endswith('/'):
-                dir_path = part.rstrip('/')
-                break
-
-        if dir_path:
-            # Use dry-run to get files that would be staged
-            try:
-                result = subprocess.run(
-                    ['git', 'add', '--dry-run', dir_path + '/'],
-                    capture_output=True, text=True, cwd=repo_cwd
-                )
-                if result.returncode != 0:
-                    return 'ask', _UNVERIFIED_STAGING_REASON
-                # Parse dry-run output: "add 'filename'" lines
-                files = []
-                for line in result.stdout.strip().split('\n'):
-                    if line.startswith('add '):
-                        # Extract filename from "add 'filename'"
-                        fname = line[4:].strip().strip("'")
-                        files.append(fname)
-
-                if not files:
-                    # No files to stage
-                    return False, None
-
-                # Check which files are modified vs new
-                modified_files = []
-                new_files = []
-                for f in files:
-                    status_result = subprocess.run(
-                        ['git', 'status', '--porcelain', f],
-                        capture_output=True, text=True, cwd=repo_cwd
-                    )
-                    if status_result.returncode != 0:
-                        return 'ask', _UNVERIFIED_STAGING_REASON
-                    status = status_result.stdout.strip()
-                    if status:
-                        status_code = status[:2]
-                        if '?' in status_code:
-                            new_files.append(f)
-                        else:
-                            modified_files.append(f)
-
-                # If only new files, allow without permission
-                if not modified_files:
-                    return False, None
-
-                # Modified files present - ask for permission
-                # Check if staging is allowed via flag file
-                if _is_allowed('staging', session_id):
-                    return False, None
-                file_list = ", ".join(modified_files[:5])
-                if len(modified_files) > 5:
-                    file_list += f" (+{len(modified_files) - 5} more)"
-                reason = (
-                    f"Staging directory {dir_path}/ with modified files: {file_list}"
-                )
-                return "ask", reason
-
-            except Exception:
-                # If dry-run fails, fall back to asking permission
-                reason = f"Staging directory {dir_path}/ (couldn't verify file status)"
-                return "ask", reason
 
     # Also check for git commit -a without a message flag (which would open an
     # editor).
@@ -708,68 +615,7 @@ This restriction prevents accidentally staging unwanted files."""
             )
             return True, reason
 
-    # Check if staging modified files (not new/untracked) - requires permission
-    # This check runs after all blocking patterns pass
-    if normalized_cmd.startswith('git add'):
-        modified_files = get_modified_files_being_staged(
-            normalized_cmd, cwd=repo_cwd)
-        if modified_files is None:
-            return 'ask', _UNVERIFIED_STAGING_REASON
-        if modified_files:
-            # Check if staging is allowed via flag file
-            if _is_allowed('staging', session_id):
-                return False, None
-            file_list = ", ".join(modified_files[:5])
-            if len(modified_files) > 5:
-                file_list += f" (+{len(modified_files) - 5} more)"
-            reason = f"Staging modified files: {file_list}"
-            return "ask", reason
-
     return False, None
-
-
-def get_modified_files_being_staged(command, cwd=None):
-    """
-    Extract files from git add command and return those that are modified
-    (not new/untracked). Returns empty list if only staging new files.
-    """
-    try:
-        parts = shlex.split(command)
-    except ValueError:
-        return None
-    if len(parts) < 3 or parts[0] != 'git' or parts[1] != 'add':
-        return []
-
-    # Extract file arguments (skip 'git add' and any flags)
-    files = []
-    for part in parts[2:]:
-        if not part.startswith('-'):
-            files.append(part)
-
-    if not files:
-        return []
-
-    modified_files = []
-    for f in files:
-        try:
-            # Check git status for this file
-            result = subprocess.run(
-                ['git', 'status', '--porcelain', f],
-                capture_output=True, text=True, cwd=cwd or os.getcwd()
-            )
-            if result.returncode != 0:
-                return None
-            status = result.stdout.strip()
-            if status:
-                # Status codes: ?? = untracked, M = modified, A = staged
-                # We want to flag modified files (not untracked)
-                status_code = status[:2]
-                if '?' not in status_code:  # Not untracked = modified/staged
-                    modified_files.append(f)
-        except Exception:
-            return None
-
-    return modified_files
 
 
 # If run as a standalone script
@@ -787,9 +633,7 @@ if __name__ == "__main__":
 
     # Get the command being executed
     command = data.get("tool_input", {}).get("command", "")
-    session_id = data.get("session_id", "")
-
-    should_block, reason = check_git_add_command(command, session_id=session_id)
+    should_block, reason = check_git_add_command(command)
 
     if should_block:
         print(json.dumps({

--- a/plugins/safety-hooks/hooks/git_commit_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_commit_block_hook.py
@@ -490,6 +490,42 @@ def git_subcommand(command: str) -> str | None:
     return tokens[i] if i < len(tokens) else None
 
 
+# Setting this environment variable allows commits in every session, without
+# depending on a session-scoped flag file. Flag files live in /tmp, which macOS
+# reaps after a few days, so a long-lived session used to start prompting again
+# partway through its life.
+ALLOW_ENV_VAR = "CCTOOLS_ALLOW_GIT"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+FLAG_DIR = "/tmp/claude"
+ALLOW_FLAG = "allow-git-commit"
+DENY_FLAG = "deny-git-commit"
+
+
+def _flag_path(name: str, session_id: str) -> str:
+    return os.path.join(FLAG_DIR, f"{name}.{session_id}")
+
+
+def env_allows_commit() -> bool:
+    """Return whether the environment opts every session into commits."""
+    return os.environ.get(ALLOW_ENV_VAR, "").strip().lower() in _TRUTHY
+
+
+def commit_allowed(session_id: str = "") -> bool:
+    """Return whether a commit may proceed without asking the user.
+
+    A session-scoped deny flag (written by ``>allow-git off``) wins over the
+    environment variable, so a single session can still opt back into prompts.
+    """
+    if session_id and os.path.exists(_flag_path(DENY_FLAG, session_id)):
+        return False
+    if env_allows_commit():
+        return True
+    return bool(session_id) and os.path.exists(
+        _flag_path(ALLOW_FLAG, session_id)
+    )
+
+
 def check_git_commit_command(
     command: str,
     session_id: str = "",
@@ -507,10 +543,7 @@ def check_git_commit_command(
     # Check each subcommand in compound commands
     for subcmd in _split_shell_commands(command):
         if git_subcommand(subcmd) in COMMIT_SUBCOMMANDS:
-            # Check if commits are allowed via session-scoped flag
-            if session_id and os.path.exists(
-                f'/tmp/claude/allow-git-commit.{session_id}'
-            ):
+            if commit_allowed(session_id):
                 return "allow", None
             reason = "Git commit requires your approval."
             return "ask", reason

--- a/plugins/safety-hooks/hooks/test_git_add_commit_all_flag.py
+++ b/plugins/safety-hooks/hooks/test_git_add_commit_all_flag.py
@@ -8,11 +8,10 @@ Tests cover:
     - Long options with attached and separate values
     - Options that do and do not supply a commit message
     - The `--` pathspec separator
+    - Bulk `git add` forms staying blocked behind supported command prefixes
 """
 import os
-import subprocess
 import sys
-import tempfile
 import unittest
 
 # Add the hooks directory to path for imports
@@ -220,80 +219,20 @@ class TestBlockedGitAdd(unittest.TestCase):
 
     def test_env_separator_assignments_do_not_hide_add(self) -> None:
         self.assertTrue(_blocks("env -- X=1 git add -A"))
-        decision, _ = check_git_add_command(
-            "env -- GIT_DIR=/other/.git git add tracked.txt"
-        )
-        self.assertEqual(decision, "ask")
+        self.assertTrue(_blocks("env -- GIT_DIR=/other/.git git add -A"))
 
-    def test_env_split_checks_modified_file_in_chdir(self) -> None:
-        with tempfile.TemporaryDirectory() as repo:
-            subprocess.run(
-                ["git", "init"], cwd=repo, check=True,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            )
-            path = os.path.join(repo, "tracked.txt")
-            with open(path, "w", encoding="utf-8") as handle:
-                handle.write("staged\n")
-            subprocess.run(
-                ["git", "add", "tracked.txt"], cwd=repo, check=True,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            )
-            with open(path, "w", encoding="utf-8") as handle:
-                handle.write("modified\n")
+    def test_dynamic_chdir_does_not_hide_a_bulk_add(self) -> None:
+        self.assertTrue(_blocks('git -C "$REPO" add -A'))
 
-            decision, _ = check_git_add_command(
-                f"env --chdir={repo} -S 'git add tracked.txt'"
-            )
-            self.assertEqual(decision, "ask")
-
-    def test_attached_env_chdir_checks_target_repository(self) -> None:
-        with tempfile.TemporaryDirectory() as repo:
-            subprocess.run(
-                ["git", "init"], cwd=repo, check=True,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            )
-            path = os.path.join(repo, "tracked.txt")
-            with open(path, "w", encoding="utf-8") as handle:
-                handle.write("staged\n")
-            subprocess.run(
-                ["git", "add", "tracked.txt"], cwd=repo, check=True,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            )
-            with open(path, "w", encoding="utf-8") as handle:
-                handle.write("modified\n")
-
-            commands = (
-                f"env -C{repo} git add tracked.txt",
-                f"env -iC {repo} git add tracked.txt",
-            )
-            for command in commands:
-                with self.subTest(command=command):
-                    decision, _ = check_git_add_command(command)
-                    self.assertEqual(decision, "ask")
-
-    def test_dynamic_chdir_requires_approval(self) -> None:
-        decision, _ = check_git_add_command(
-            'git -C "$REPO" add tracked.txt'
-        )
-        self.assertEqual(decision, "ask")
-
-    def test_repository_routing_requires_approval(self) -> None:
+    def test_repository_routing_does_not_hide_a_bulk_add(self) -> None:
         commands = (
-            "GIT_DIR=/other/.git GIT_WORK_TREE=/other git add tracked.txt",
-            "env GIT_DIR=/other/.git git add tracked.txt",
-            "git --git-dir=/other/.git --work-tree=/other add tracked.txt",
+            "GIT_DIR=/other/.git GIT_WORK_TREE=/other git add -A",
+            "env GIT_DIR=/other/.git git add .",
+            "git --git-dir=/other/.git --work-tree=/other add --all",
         )
         for command in commands:
             with self.subTest(command=command):
-                decision, _ = check_git_add_command(command)
-                self.assertEqual(decision, "ask")
-
-    def test_uninspectable_repository_requires_approval(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            decision, _ = check_git_add_command(
-                f"git -C {directory} add tracked.txt"
-            )
-        self.assertEqual(decision, "ask")
+                self.assertTrue(_blocks(command))
 
     def test_pathspec_file_requires_approval(self) -> None:
         for command in (
@@ -304,28 +243,6 @@ class TestBlockedGitAdd(unittest.TestCase):
             with self.subTest(command=command):
                 decision, _ = check_git_add_command(command)
                 self.assertEqual(decision, "ask")
-
-    def test_quoted_modified_filename_requires_approval(self) -> None:
-        with tempfile.TemporaryDirectory() as repo:
-            subprocess.run(
-                ["git", "init"], cwd=repo, check=True,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            )
-            path = os.path.join(repo, "tracked file.txt")
-            with open(path, "w", encoding="utf-8") as handle:
-                handle.write("staged\n")
-            subprocess.run(
-                ["git", "add", "tracked file.txt"], cwd=repo, check=True,
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-            )
-            with open(path, "w", encoding="utf-8") as handle:
-                handle.write("modified\n")
-
-            decision, _ = check_git_add_command(
-                f"git -C {repo} add 'tracked file.txt'"
-            )
-            self.assertEqual(decision, "ask")
-
 
 class TestAllowedCommits(unittest.TestCase):
     """Commands that supply a message must not be blocked."""

--- a/plugins/safety-hooks/hooks/test_git_add_staging_ungated.py
+++ b/plugins/safety-hooks/hooks/test_git_add_staging_ungated.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Unit tests for staging decisions in git_add_block_hook.py
+
+Staging specific paths is not gated: `git add <path>` is allowed even when the
+paths are already-tracked modified files. Bulk staging stays blocked outright.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from git_add_block_hook import check_git_add_command
+
+
+def _run(*args: str, cwd: str) -> None:
+    subprocess.run(args, cwd=cwd, check=True, capture_output=True)
+
+
+class TestStagingIsUngated(unittest.TestCase):
+    """A repository with one modified file and one untracked file."""
+
+    def setUp(self) -> None:
+        self.repo = tempfile.mkdtemp(prefix="git-add-hook-")
+        self.addCleanup(
+            subprocess.run, ["rm", "-rf", self.repo], check=False)
+
+        _run("git", "init", "-q", "-b", "main", ".", cwd=self.repo)
+        _run("git", "config", "user.email", "test@example.com", cwd=self.repo)
+        _run("git", "config", "user.name", "Test", cwd=self.repo)
+        os.makedirs(os.path.join(self.repo, "sub"), exist_ok=True)
+        for name in ("tracked.txt", "sub/tracked.txt"):
+            with open(os.path.join(self.repo, name), "w") as handle:
+                handle.write("original\n")
+        _run("git", "add", "tracked.txt", "sub/tracked.txt", cwd=self.repo)
+        _run("git", "commit", "-q", "-m", "initial", cwd=self.repo)
+
+        for name in ("tracked.txt", "sub/tracked.txt"):
+            with open(os.path.join(self.repo, name), "w") as handle:
+                handle.write("modified\n")
+        with open(os.path.join(self.repo, "sub/new.txt"), "w") as handle:
+            handle.write("new\n")
+
+        cwd = os.getcwd()
+        os.chdir(self.repo)
+        self.addCleanup(os.chdir, cwd)
+
+    def assertAllowed(self, command: str) -> None:
+        decision, reason = check_git_add_command(command)
+        self.assertEqual((decision, reason), (False, None), command)
+
+    def assertBlocked(self, command: str) -> None:
+        decision, _ = check_git_add_command(command)
+        self.assertIs(decision, True, command)
+
+    def test_modified_file_is_allowed(self) -> None:
+        self.assertAllowed("git add tracked.txt")
+
+    def test_several_modified_files_are_allowed(self) -> None:
+        self.assertAllowed("git add tracked.txt sub/tracked.txt")
+
+    def test_directory_with_modified_files_is_allowed(self) -> None:
+        self.assertAllowed("git add sub/")
+
+    def test_update_flag_is_allowed(self) -> None:
+        self.assertAllowed("git add -u")
+
+    def test_add_in_another_repo_is_allowed(self) -> None:
+        self.assertAllowed(f"git -C {self.repo} add tracked.txt")
+
+    def test_bulk_staging_is_still_blocked(self) -> None:
+        for command in ("git add -A", "git add .", "git add --all",
+                        "git add *"):
+            self.assertBlocked(command)
+
+    def test_pathspec_file_still_asks(self) -> None:
+        decision, _ = check_git_add_command(
+            "git add --pathspec-from-file=list.txt")
+        self.assertEqual(decision, "ask")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/safety-hooks/hooks/test_git_commit_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_git_commit_block_hook.py
@@ -5,7 +5,7 @@ Unit tests for git_commit_block_hook.py
 Tests cover:
     - `git -C <dir> commit` and other global-option forms reaching the gate
     - Compound commands
-    - The session-scoped allow flag
+    - The session-scoped allow flag, the deny flag, and CCTOOLS_ALLOW_GIT
     - Commands that merely mention "git commit" staying allowed
 """
 import os
@@ -17,7 +17,26 @@ import unittest
 # Add the hooks directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from git_commit_block_hook import check_git_commit_command, git_subcommand
+from git_commit_block_hook import (
+    ALLOW_ENV_VAR,
+    check_git_commit_command,
+    git_subcommand,
+)
+
+_SAVED_ENV: str | None = None
+
+
+def setUpModule() -> None:
+    """Run the gate tests with the ambient allow-everywhere setting cleared."""
+    global _SAVED_ENV
+    _SAVED_ENV = os.environ.pop(ALLOW_ENV_VAR, None)
+
+
+def tearDownModule() -> None:
+    if _SAVED_ENV is None:
+        os.environ.pop(ALLOW_ENV_VAR, None)
+    else:
+        os.environ[ALLOW_ENV_VAR] = _SAVED_ENV
 
 
 class TestGitSubcommand(unittest.TestCase):
@@ -283,6 +302,54 @@ class TestSessionAllowFlag(unittest.TestCase):
         )
 
         self.assertEqual(json.loads(result.stdout), {"decision": "approve"})
+
+
+class TestAllowEnvVar(unittest.TestCase):
+    """CCTOOLS_ALLOW_GIT allows commits without a session-scoped flag file."""
+
+    def setUp(self) -> None:
+        self.session_id = "env-session-" + str(os.getpid())
+        self.deny = f"/tmp/claude/deny-git-commit.{self.session_id}"
+        os.makedirs("/tmp/claude", exist_ok=True)
+        self.addCleanup(
+            lambda: os.path.exists(self.deny) and os.remove(self.deny))
+        self.addCleanup(os.environ.pop, ALLOW_ENV_VAR, None)
+
+    def test_env_var_allows_commit_without_any_flag(self) -> None:
+        os.environ[ALLOW_ENV_VAR] = "1"
+        decision, _ = check_git_commit_command(
+            "git commit -m 'x'", session_id=self.session_id)
+        self.assertEqual(decision, "allow")
+
+    def test_env_var_allows_commit_with_no_session_id(self) -> None:
+        os.environ[ALLOW_ENV_VAR] = "true"
+        decision, _ = check_git_commit_command("git commit -m 'x'")
+        self.assertEqual(decision, "allow")
+
+    def test_falsy_env_var_still_asks(self) -> None:
+        os.environ[ALLOW_ENV_VAR] = "0"
+        decision, _ = check_git_commit_command(
+            "git commit -m 'x'", session_id=self.session_id)
+        self.assertEqual(decision, "ask")
+
+    def test_session_deny_flag_overrides_env_var(self) -> None:
+        os.environ[ALLOW_ENV_VAR] = "1"
+        with open(self.deny, "w", encoding="utf-8") as handle:
+            handle.write(self.session_id)
+        decision, _ = check_git_commit_command(
+            "git commit -m 'x'", session_id=self.session_id)
+        self.assertEqual(decision, "ask")
+
+    def test_deny_flag_overrides_allow_flag(self) -> None:
+        allow = f"/tmp/claude/allow-git-commit.{self.session_id}"
+        for path in (allow, self.deny):
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(self.session_id)
+        self.addCleanup(lambda: os.path.exists(allow) and os.remove(allow))
+
+        decision, _ = check_git_commit_command(
+            "git commit -m 'x'", session_id=self.session_id)
+        self.assertEqual(decision, "ask")
 
 
 if __name__ == "__main__":

--- a/release-notes/pr-174-safety-hooks-git-gate.md
+++ b/release-notes/pr-174-safety-hooks-git-gate.md
@@ -1,0 +1,27 @@
+# PR #174 — commit allowance that does not decay
+
+## Fix: `CCTOOLS_ALLOW_GIT` replaces a flag file that `/tmp` deletes
+
+The `git commit` gate allowed a commit only while
+`/tmp/claude/allow-git-commit.<session_id>` existed. macOS reaps `/tmp` after a
+few days, so a session that outlived the reaper started asking for approval
+again partway through its life — stalling unattended runs on a prompt nobody is
+there to answer.
+
+Set `CCTOOLS_ALLOW_GIT=1` in the environment (for example in the `env` block of
+`~/.claude/settings.json`) to allow commits in every session. Nothing has to
+survive in `/tmp`, and the setting reaches every process the hook runs in.
+
+Per session, `>allow-git off` writes a deny flag that overrides the environment
+variable, and `>allow-git` clears it. `>allow-git status` says which of the
+three is in effect.
+
+## Change: staging specific paths is no longer gated
+
+`git add <paths>` never asks for approval, whether the paths are new, modified,
+or a named directory. Blanket staging — `git add -A`, `git add .`,
+`git add *` — stays blocked, including behind `env -C`, `env -S`, and `GIT_DIR=`
+prefixes. `git add --pathspec-from-file` still asks, since the hook cannot read
+the path list it would stage.
+
+`>allow-git staging` is gone along with the gate it controlled.


### PR DESCRIPTION
## Why

The commit gate allowed a commit only when `/tmp/claude/allow-git-commit.<session_id>` existed. macOS reaps `/tmp` after a few days, so a session that outlived the reaper started asking for approval again partway through its life — which stalls unattended workflows on a permission prompt nobody is there to answer.

Verified directly against the hook: same command, `"allow"` with the flag present, `"ask"` with it gone.

## What changed

- `CCTOOLS_ALLOW_GIT=1` in the environment allows `git commit` in every session. Nothing has to survive in `/tmp`, and it reaches every process the hook runs in. The old session-scoped allow flag still works.
- `>allow-git off` now writes a session-scoped *deny* flag that overrides the environment variable, so a single session can opt back into prompts. `>allow-git` clears it. `>allow-git status` reports which of the three is in effect.
- `git add` of explicitly named paths no longer asks for approval. Blanket staging (`git add -A`, `git add .`, `git add *`) stays blocked, including behind `env -C`, `env -S`, and `GIT_DIR=` prefixes. `git add --pathspec-from-file` still asks, since the hook cannot read the path list it would stage.
- `>allow-git staging` is gone along with the staging gate.

`git add_block_hook.py` loses the dry-run plus per-file `git status` analysis that only served the staging prompt: 802 → 646 lines.

## Tests

`python3 -m unittest discover` in `plugins/safety-hooks/hooks`: 295 tests, all passing.

New coverage: `CCTOOLS_ALLOW_GIT` allows with no flag and with no session id, a falsy value still asks, the deny flag overrides both the environment variable and the allow flag, and (new file `test_git_add_staging_ungated.py`, against a real temp repo) staging modified files, several paths, a directory, and `-u` are all allowed while bulk forms stay blocked.

The tests that asserted the old staging prompt now assert that the same command prefixes cannot hide a bulk add.