### PR TITLE
safety-hooks: block pathspecs that stage the repository root

### DIFF
--- a/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
+++ b/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
@@ -106,6 +106,10 @@ The `git add` hook blocks bulk staging outright:
 - `git add ../`
 - `git add *`
 - `git add -A` / `git add --all`
+- pathspecs that name the same thing by
+  another route: `./`, `:/`, `:(top)`, an
+  empty pathspec, or an absolute path that
+  contains the working directory
 
 These stay blocked behind command prefixes too,
 so `env -C <dir> git add -A` and

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 2026-08-20
 
+### safety-hooks 1.15.1
+
+- fix: block pathspecs that stage the repository root by another name
+  - `git add ./`, `git add :/`, `git add :(top)`, `git add ""`, and absolute
+    paths containing the working directory all stage what the blocked
+    `git add .` stages, and are now blocked with it
+  - paths below the root (`sub/`, `./sub`, `:/sub`, `:(top)sub`) and
+    exclusions (`:!file`) are unaffected
+  - reported by the Codex reviewer on PR #174
+
+## 2026-08-20
+
 ### safety-hooks 1.15.0
 
 - feat: `CCTOOLS_ALLOW_GIT=1` allows `git commit` in every session

--- a/plugins/safety-hooks/.claude-plugin/plugin.json
+++ b/plugins/safety-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safety-hooks",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Safety hooks to block or require user approval for dangerous commands (rm, git operations, .env access, file size limits)",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/safety-hooks/README.md
+++ b/plugins/safety-hooks/README.md
@@ -37,6 +37,9 @@ decisions to Claude Code.
   - `git add -A`, `git add -a`, `git add --all` - stages everything including
     untracked files across the entire repo
   - `git add .` - stages entire current directory blindly
+  - equivalents of `git add .`: `git add ./`, the repository-root magic
+    `git add :/` and `git add :(top)`, an empty pathspec, and any absolute
+    path containing the working directory
   - `git add ../` (parent directory patterns) - stages outside current scope
   - `git add *` (wildcard patterns) - shell expansion can match unexpected files
   - `git commit -a` without `-m` flag - would open an editor (not interactive)

--- a/plugins/safety-hooks/hooks/git_add_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_add_block_hook.py
@@ -526,6 +526,73 @@ def check_git_add_command(command):
     return False, None
 
 
+# `git add` options that take their value as the following token.
+_ADD_VALUE_OPTS = {'--chmod', '--pathspec-from-file'}
+
+
+def _add_pathspecs(add_arguments: list[str]) -> list[str]:
+    """Return the pathspec operands of a `git add`, dropping its options."""
+    pathspecs: list[str] = []
+    index = 0
+    while index < len(add_arguments):
+        argument = add_arguments[index]
+        if argument == '--':
+            pathspecs.extend(add_arguments[index + 1:])
+            break
+        if argument in _ADD_VALUE_OPTS:
+            index += 2
+            continue
+        if argument.startswith('-'):
+            index += 1
+            continue
+        pathspecs.append(argument)
+        index += 1
+    return pathspecs
+
+
+def _selects_repository_root(pathspec: str, cwd: str | None) -> bool:
+    """Return whether a pathspec stages everything `git add .` would stage.
+
+    `git add .` is blocked outright, so its equivalents have to be blocked too:
+    `./`, the repository-root magic `:/` and `:(top)`, and any absolute path
+    that contains the working directory.
+    """
+    if not pathspec:
+        # An empty pathspec matches every path in the repository.
+        return True
+
+    if pathspec.startswith(':'):
+        if pathspec.startswith(':('):
+            end = pathspec.find(')')
+            if end == -1:
+                return False
+            if 'exclude' in pathspec[2:end]:
+                return False
+            return os.path.normpath(pathspec[end + 1:] or '.') == '.'
+        magic = pathspec[1:]
+        if magic.startswith(('!', '^')):
+            return False
+        if magic.startswith('/'):
+            return os.path.normpath(magic[1:] or '.') == '.'
+        return magic == ''
+
+    normalized = os.path.normpath(os.path.expanduser(pathspec))
+    if normalized == '.' or normalized == '..':
+        return True
+    if normalized.startswith('..' + os.sep):
+        return True
+    if os.path.isabs(normalized):
+        if cwd is None:
+            return False
+        # realpath, because /var and /private/var name the same directory on
+        # macOS and a plain string compare would miss the equivalence.
+        base = os.path.realpath(cwd)
+        target = os.path.realpath(normalized)
+        return base == target or base.startswith(
+            target.rstrip(os.sep) + os.sep)
+    return False
+
+
 def _check_single_git_add_command(command):
     """
     Check a single (non-compound) command for dangerous git add patterns.
@@ -534,8 +601,9 @@ def _check_single_git_add_command(command):
     # Normalize recognized add commands after stripping supported Git prefixes.
     normalized_cmd = ' '.join(command.strip().split())
     resolved_add = _resolve_git_add_argv(command)
+    repo_cwd: str | None = os.getcwd()
     if resolved_add is not None:
-        add_argv, _ = resolved_add
+        add_argv, repo_cwd = resolved_add
         normalized_cmd = shlex.join(add_argv)
 
     # Always allow --dry-run (used internally to detect what would be staged)
@@ -571,12 +639,18 @@ This restriction prevents accidentally staging unwanted files."""
         argument.split('=', 1)[0] in _ADD_ALL_LONG_OPTIONS
         for argument in add_arguments
     )
-    if dangerous_pattern.search(normalized_cmd) or abbreviated_all:
+    stages_root = any(
+        _selects_repository_root(pathspec, repo_cwd)
+        for pathspec in _add_pathspecs(add_arguments)
+    )
+    if dangerous_pattern.search(normalized_cmd) or abbreviated_all or stages_root:
         reason = """BLOCKED: Dangerous git add pattern detected!
 
 DO NOT use:
 - 'git add -A', 'git add -a', 'git add --all' (adds ALL files)
-- 'git add .' (adds entire current directory)
+- 'git add .' (adds entire current directory), or an equivalent such as
+  'git add ./', 'git add :/', 'git add :(top)', or an absolute path that
+  contains the current directory
 - 'git add ../' or similar parent directory patterns
 - 'git add *' (wildcard patterns)
 

--- a/plugins/safety-hooks/hooks/git_add_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_add_block_hook.py
@@ -270,6 +270,18 @@ def _is_repository_routing_assignment(token: str) -> bool:
     return token.partition('=')[0] in _REPOSITORY_ROUTING_VARS
 
 
+def _routing_assignment_work_tree(token: str) -> str | None:
+    """Return the work tree an assignment names, unresolved.
+
+    `GIT_WORK_TREE` names the tree Git stages from. `GIT_DIR` only relocates
+    the repository metadata, leaving the work tree where it is, so it returns
+    None. The value stays unresolved because a later `git -C` moves the
+    directory a relative value is resolved against.
+    """
+    name, _separator, value = token.partition('=')
+    return value if name == 'GIT_WORK_TREE' and value else None
+
+
 def _resolve_git_add_argv(
     command: str,
 ) -> tuple[list[str], str | None] | None:
@@ -283,10 +295,11 @@ def _resolve_git_add_argv(
         return None
 
     cwd = os.getcwd()
+    work_tree: str | None = None
     i = 0
     while i < len(argv) and _ASSIGNMENT_WORD.match(argv[i]):
         if _is_repository_routing_assignment(argv[i]):
-            cwd = None
+            work_tree = _routing_assignment_work_tree(argv[i]) or work_tree
         i += 1
 
     if i < len(argv) and Path(argv[i]).name == 'env':
@@ -297,14 +310,16 @@ def _resolve_git_add_argv(
             short_value = _env_short_value(token)
             if _ASSIGNMENT_WORD.match(token):
                 if _is_repository_routing_assignment(token):
-                    cwd = None
+                    work_tree = (
+                        _routing_assignment_work_tree(token) or work_tree)
                 i += 1
                 continue
             if token == '--':
                 i += 1
                 while i < len(argv) and _ASSIGNMENT_WORD.match(argv[i]):
                     if _is_repository_routing_assignment(argv[i]):
-                        cwd = None
+                        work_tree = (
+                            _routing_assignment_work_tree(argv[i]) or work_tree)
                     i += 1
                 break
             if name in _ENV_VALUE_OPTS or short_value:
@@ -362,14 +377,18 @@ def _resolve_git_add_argv(
                 value = argv[i]
             if name == '-C' and value:
                 cwd = _resolve_add_chdir(cwd, value)
-            elif name in {'--git-dir', '--work-tree'}:
-                cwd = None
+            elif name == '--work-tree' and value:
+                work_tree = value
             i += 1
             continue
         break
 
     if i >= len(argv) or argv[i] != 'add':
         return None
+    if work_tree is not None:
+        # `git -C` moves the directory a relative work tree resolves against,
+        # so this cannot be done where the value is first seen.
+        cwd = _resolve_add_chdir(cwd, work_tree)
     return ['git', 'add', *argv[i + 1:]], cwd
 
 
@@ -550,6 +569,18 @@ def _add_pathspecs(add_arguments: list[str]) -> list[str]:
     return pathspecs
 
 
+def _is_root_of_its_base(path: str) -> bool:
+    """Return whether a path selects the whole tree it is resolved against.
+
+    Used for repository-root magic, where the remainder is relative to the
+    repository root: `:/` and `://` both name the root, and `git add ://`
+    stages every file in the repository.
+    """
+    if not path:
+        return True
+    return os.path.normpath(path) in {'.', os.sep}
+
+
 def _selects_repository_root(pathspec: str, cwd: str | None) -> bool:
     """Return whether a pathspec stages everything `git add .` would stage.
 
@@ -568,12 +599,12 @@ def _selects_repository_root(pathspec: str, cwd: str | None) -> bool:
                 return False
             if 'exclude' in pathspec[2:end]:
                 return False
-            return os.path.normpath(pathspec[end + 1:] or '.') == '.'
+            return _is_root_of_its_base(pathspec[end + 1:])
         magic = pathspec[1:]
         if magic.startswith(('!', '^')):
             return False
         if magic.startswith('/'):
-            return os.path.normpath(magic[1:] or '.') == '.'
+            return _is_root_of_its_base(magic[1:])
         return magic == ''
 
     normalized = os.path.normpath(os.path.expanduser(pathspec))
@@ -583,7 +614,10 @@ def _selects_repository_root(pathspec: str, cwd: str | None) -> bool:
         return True
     if os.path.isabs(normalized):
         if cwd is None:
-            return False
+            # The work tree could not be resolved (a shell expansion, say), so
+            # whether this path contains it is unknowable. Treat it as bulk
+            # staging rather than approving a possible `git add <work-tree>`.
+            return True
         # realpath, because /var and /private/var name the same directory on
         # macOS and a plain string compare would miss the equivalence.
         base = os.path.realpath(cwd)

--- a/plugins/safety-hooks/hooks/test_git_add_staging_ungated.py
+++ b/plugins/safety-hooks/hooks/test_git_add_staging_ungated.py
@@ -112,6 +112,50 @@ class TestStagingIsUngated(unittest.TestCase):
             with self.subTest(command=command):
                 self.assertAllowed(command)
 
+    def test_repository_root_magic_variants_are_blocked(self) -> None:
+        """`git add ://` stages the whole repository, same as `git add :/`."""
+        for command in ("git add ://", "git add :////", "git add :(top)/"):
+            with self.subTest(command=command):
+                self.assertBlocked(command)
+
+    def test_routed_work_tree_is_the_base_for_absolute_paths(self) -> None:
+        """A routed work tree is resolved, not treated as unknown."""
+        for command in (
+            f"GIT_DIR={self.repo}/.git GIT_WORK_TREE={self.repo} "
+            f"git add {self.repo}",
+            f"git --git-dir={self.repo}/.git --work-tree={self.repo} "
+            f"add {self.repo}",
+            f"env GIT_WORK_TREE={self.repo} git add {self.repo}",
+        ):
+            with self.subTest(command=command):
+                self.assertBlocked(command)
+
+        for command in (
+            f"GIT_DIR={self.repo}/.git GIT_WORK_TREE={self.repo} "
+            f"git add {self.repo}/sub",
+            f"git --work-tree={self.repo} add {self.repo}/sub",
+        ):
+            with self.subTest(command=command):
+                self.assertAllowed(command)
+
+    def test_relative_work_tree_resolves_against_the_final_directory(
+        self,
+    ) -> None:
+        """`git -C` moves what a relative GIT_WORK_TREE resolves against."""
+        parent = os.path.dirname(self.repo)
+        name = os.path.basename(self.repo)
+        self.assertBlocked(
+            f"GIT_DIR={self.repo}/.git GIT_WORK_TREE={name} "
+            f"git -C {parent} add {self.repo}")
+        self.assertBlocked(
+            f"git -C {parent} --work-tree={name} add {self.repo}")
+        self.assertAllowed(
+            f"GIT_WORK_TREE={name} git -C {parent} add {self.repo}/sub")
+
+    def test_unresolvable_work_tree_blocks_absolute_paths(self) -> None:
+        """With the base unknown, an absolute path may well be the whole tree."""
+        self.assertBlocked('GIT_WORK_TREE="$TREE" git add /some/absolute/path')
+
     def test_pathspec_file_still_asks(self) -> None:
         decision, _ = check_git_add_command(
             "git add --pathspec-from-file=list.txt")

--- a/plugins/safety-hooks/hooks/test_git_add_staging_ungated.py
+++ b/plugins/safety-hooks/hooks/test_git_add_staging_ungated.py
@@ -3,7 +3,8 @@
 Unit tests for staging decisions in git_add_block_hook.py
 
 Staging specific paths is not gated: `git add <path>` is allowed even when the
-paths are already-tracked modified files. Bulk staging stays blocked outright.
+paths are already-tracked modified files. Bulk staging stays blocked outright,
+including pathspecs that select the whole repository by another name.
 """
 import os
 import subprocess
@@ -76,6 +77,40 @@ class TestStagingIsUngated(unittest.TestCase):
         for command in ("git add -A", "git add .", "git add --all",
                         "git add *"):
             self.assertBlocked(command)
+
+    def test_root_equivalent_pathspecs_are_blocked(self) -> None:
+        """Anything that stages what `git add .` stages is blocked too."""
+        for command in (
+            "git add ./",
+            "git add .//",
+            "git add :/",
+            "git add :",
+            "git add :(top)",
+            'git add ""',
+            "git add /",
+            "git add ../",
+            f"git add {self.repo}",
+            f"git add {self.repo}/",
+            f"git add {os.path.realpath(self.repo)}/",
+            f"git -C {self.repo} add ./",
+            "git add tracked.txt ./",
+            "git add -- ./",
+        ):
+            with self.subTest(command=command):
+                self.assertBlocked(command)
+
+    def test_paths_below_the_root_are_still_allowed(self) -> None:
+        for command in (
+            "git add sub/",
+            "git add ./sub",
+            "git add :/sub",
+            "git add :(top)sub",
+            "git add :!tracked.txt",
+            f"git add {self.repo}/sub",
+            "git add --chmod=+x tracked.txt",
+        ):
+            with self.subTest(command=command):
+                self.assertAllowed(command)
 
     def test_pathspec_file_still_asks(self) -> None:
         decision, _ = check_git_add_command(

--- a/release-notes/pr-175-git-add-root-pathspec.md
+++ b/release-notes/pr-175-git-add-root-pathspec.md
@@ -1,0 +1,16 @@
+# PR #175 — `git add` root equivalents are blocked
+
+The hard block on `git add .` was bypassable by naming the same thing another
+way. `git add ./`, the repository-root magic `git add :/` and `git add :(top)`,
+an empty pathspec, and any absolute path containing the working directory all
+stage exactly what `git add .` stages, and are now blocked with it.
+
+Before PR #174 those forms did not reach the block either: they asked for
+approval, and only when a tracked file happened to be modified. PR #174 removed
+that prompt, so they were allowed outright until this fix.
+
+Paths below the root are unaffected — `sub/`, `./sub`, `:/sub`, `:(top)sub`,
+and an absolute path pointing inside the working directory all stage normally,
+as do exclusions such as `:!file`.
+
+Reported by the Codex reviewer on PR #174.

--- a/release-notes/v1.25.2-safety-hooks-session-id.md
+++ b/release-notes/v1.25.2-safety-hooks-session-id.md
@@ -1,0 +1,13 @@
+# v1.25.2 — reliable session-scoped safety-hook permissions
+
+## Fix: standalone safety hooks forward the active session ID (PR #150)
+
+The standalone `git_add_block_hook.py` and `git_commit_block_hook.py`
+entrypoints now read `session_id` from the hook payload and pass it to their
+existing checks.
+
+This makes the documented session-scoped `>allow-git` flags work when those
+entrypoints are wired directly, matching the existing unified `bash_hook.py`
+path. The safety rules themselves are unchanged.
+
+Thanks to [@mikemikimike](https://github.com/mikemikimike) for the fix.


### PR DESCRIPTION
Addresses the Codex P1 on #174: https://github.com/pchalasani/claude-code-tools/pull/174#discussion_r3825728462

## The hole

`git add .` is hard-blocked, but several pathspecs stage exactly the same thing and were allowed:

| command | before #174 | after #174 | now |
|---|---|---|---|
| `git add .` | blocked | blocked | blocked |
| `git add ./` | ask, and only if a tracked file was modified | allowed | blocked |
| `git add :/` | same | allowed | blocked |
| `git add :(top)` | same | allowed | blocked |
| `git add ""` | same | allowed | blocked |
| `git add /abs/path/to/cwd/` | same | allowed | blocked |
| `git add /` | same | allowed | blocked |

So the equivalents were never *blocked* — that predates #174. What #174 changed is that the approval prompt which used to catch some of them is gone, so they now sail through.

## The fix

`_add_pathspecs()` separates pathspec operands from options (`--`, `--chmod`, `--pathspec-from-file` and their values). `_selects_repository_root()` then decides whether a spec stages everything:

- magic prefixes: `:/`, `:(top)` with an empty path, bare `:`; `:!`/`:(exclude)` are exclusions and are ignored
- plain paths: `normpath` of `.`, `..`, or anything climbing out of the working directory
- absolute paths: blocked when the working directory is that path or below it, compared through `realpath` (on macOS `/var` and `/private/var` are the same directory)

Paths below the root — `sub/`, `./sub`, `:/sub`, `:(top)sub`, `/abs/path/to/cwd/sub` — and `--chmod=+x file` stay allowed.

## Tests

`python3 -m unittest discover` in `plugins/safety-hooks/hooks`: 297 tests, all passing. Two new subtests cover 14 blocked forms and 7 that must stay allowed, driven against a real temp repo.