### PR TITLE
docs: add v1.25.3 safety-hooks release note

### DIFF
--- a/release-notes/v1.25.3-safety-hooks-autonomous-git.md
+++ b/release-notes/v1.25.3-safety-hooks-autonomous-git.md
@@ -1,0 +1,31 @@
+# v1.25.3: autonomous commits with guarded staging
+
+v1.25.3 updates the `safety-hooks` plugin for autonomous Git workflows. It
+removes a session flag that could disappear from `/tmp` during long-running
+sessions, while keeping broad staging commands protected.
+
+## Commits Can Stay Enabled Across Sessions (PR #174)
+
+Set `CCTOOLS_ALLOW_GIT=1` to allow `git commit` without an approval prompt in
+every session. The previous allow flag lived in `/tmp`; macOS can remove it
+after a few days, causing a long-running unattended session to stop at a
+commit prompt.
+
+`>allow-git off` remains available when one session should prompt before
+commits. It creates a session-specific deny flag that overrides the environment
+setting. `>allow-git` clears that override, and `>allow-git status` explains
+the active policy.
+
+## Explicit Staging No Longer Prompts (PRs #174 and #175)
+
+`git add` now accepts explicitly named files and directories without an
+approval prompt, whether they are new or modified. `git add --pathspec-from-file`
+still prompts because the hook cannot inspect the path list.
+
+Broad staging remains blocked. That includes `git add -A`, `git add .`,
+wildcards, parent directories, and alternate spellings of the repository root:
+`./`, `:/`, `://`, `:(top)`, an empty pathspec, and an absolute path naming the
+work tree. The checks also follow `GIT_WORK_TREE`, `--work-tree`, `git -C`, and
+`env --chdir` so that a routed work tree cannot bypass the block.
+
+See the published Safety Hooks documentation for setup and usage.


### PR DESCRIPTION
Adds the v1.25.3 release note from the PRs merged after v1.25.2:

- #174: durable CCTOOLS_ALLOW_GIT commit allowance and explicit-path staging
- #175: blocks alternate repository-root pathspecs and respects routed work trees

The release is already tagged and published as v1.25.3.