### PR TITLE
fix(aichat): hide ask-session helper forks from name resolution

### DIFF
--- a/claude_code_tools/helper_sessions.py
+++ b/claude_code_tools/helper_sessions.py
@@ -1,0 +1,124 @@
+"""Discovery and classification of programmatic helper sessions."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeVar
+
+
+ResultT = TypeVar("ResultT")
+
+
+@dataclass(frozen=True)
+class SessionFileSnapshot:
+    """Transcript paths present before a helper fork starts."""
+
+    directory: Path
+    paths: frozenset[Path]
+
+
+def _session_files(directory: Path) -> frozenset[Path]:
+    """Return regular JSONL transcripts directly beneath a directory.
+
+    Args:
+        directory: Claude project transcript directory.
+
+    Returns:
+        Absolute paths to regular, non-symlink JSONL files.
+    """
+    try:
+        return frozenset(
+            path.absolute()
+            for path in directory.glob("*.jsonl")
+            if path.is_file() and not path.is_symlink()
+        )
+    except OSError:
+        return frozenset()
+
+
+def snapshot_session_files(source_session_file: Path) -> SessionFileSnapshot:
+    """Capture sibling transcripts before launching a headless fork.
+
+    Args:
+        source_session_file: Transcript being forked.
+
+    Returns:
+        The source directory and its current regular JSONL files.
+    """
+    directory = source_session_file.expanduser().absolute().parent
+    return SessionFileSnapshot(directory, _session_files(directory))
+
+
+def is_helper_session(session_file: Path) -> bool:
+    """Return whether a transcript carries explicit helper metadata.
+
+    Args:
+        session_file: Claude transcript to inspect.
+
+    Returns:
+        True only when the first JSON record has ``sessionType=helper``.
+    """
+    try:
+        with session_file.open(encoding="utf-8") as handle:
+            record = json.loads(handle.readline())
+    except (OSError, UnicodeError, ValueError, RecursionError):
+        return False
+    return isinstance(record, dict) and record.get("sessionType") == "helper"
+
+
+def mark_new_helper_session(
+    snapshot: SessionFileSnapshot,
+    session_id: str | None = None,
+) -> Path | None:
+    """Mark a newly created fork without guessing across concurrent files.
+
+    Args:
+        snapshot: Transcript paths captured before the fork started.
+        session_id: Session ID reported by the headless client, when available.
+
+    Returns:
+        The marked transcript, or None when no unique safe target exists.
+    """
+    new_paths = _session_files(snapshot.directory) - snapshot.paths
+    candidate: Path | None = None
+    if session_id:
+        if Path(session_id).name != session_id:
+            return None
+        reported = (snapshot.directory / f"{session_id}.jsonl").absolute()
+        if reported in new_paths:
+            candidate = reported
+    elif len(new_paths) == 1:
+        candidate = next(iter(new_paths))
+    if candidate is None:
+        return None
+
+    from claude_code_tools.session_utils import mark_session_as_helper
+
+    return candidate if mark_session_as_helper(candidate) else None
+
+
+def run_and_mark_helper_fork(
+    source_session_file: Path,
+    operation: Callable[[], ResultT],
+) -> ResultT:
+    """Run a headless fork operation and mark its transcript afterward.
+
+    Marking runs for successful results, nonzero client results, and raised
+    exceptions. When concurrent session creation makes the fork ambiguous,
+    :func:`mark_new_helper_session` safely leaves every transcript untouched.
+
+    Args:
+        source_session_file: Transcript passed to the headless fork client.
+        operation: Blocking operation that creates and runs the fork.
+
+    Returns:
+        The operation's original result.
+    """
+    snapshot = snapshot_session_files(source_session_file)
+    try:
+        return operation()
+    finally:
+        mark_new_helper_session(snapshot)

--- a/claude_code_tools/helper_sessions.py
+++ b/claude_code_tools/helper_sessions.py
@@ -73,26 +73,20 @@ def mark_new_helper_session(
     snapshot: SessionFileSnapshot,
     session_id: str | None = None,
 ) -> Path | None:
-    """Mark a newly created fork without guessing across concurrent files.
+    """Mark the exact newly created fork reported by the headless client.
 
     Args:
         snapshot: Transcript paths captured before the fork started.
-        session_id: Session ID reported by the headless client, when available.
+        session_id: Session ID reported by the headless client.
 
     Returns:
-        The marked transcript, or None when no unique safe target exists.
+        The marked transcript, or None when the reported target is unavailable.
     """
+    if not session_id or Path(session_id).name != session_id:
+        return None
     new_paths = _session_files(snapshot.directory) - snapshot.paths
-    candidate: Path | None = None
-    if session_id:
-        if Path(session_id).name != session_id:
-            return None
-        reported = (snapshot.directory / f"{session_id}.jsonl").absolute()
-        if reported in new_paths:
-            candidate = reported
-    elif len(new_paths) == 1:
-        candidate = next(iter(new_paths))
-    if candidate is None:
+    candidate = (snapshot.directory / f"{session_id}.jsonl").absolute()
+    if candidate not in new_paths:
         return None
 
     from claude_code_tools.session_utils import mark_session_as_helper
@@ -102,7 +96,7 @@ def mark_new_helper_session(
 
 def run_and_mark_helper_fork(
     source_session_file: Path,
-    operation: Callable[[], ResultT],
+    operation: Callable[[], tuple[ResultT, str | None]],
 ) -> ResultT:
     """Run a headless fork operation and mark its transcript afterward.
 
@@ -112,13 +106,16 @@ def run_and_mark_helper_fork(
 
     Args:
         source_session_file: Transcript passed to the headless fork client.
-        operation: Blocking operation that creates and runs the fork.
+        operation: Blocking operation returning its result and fork session ID.
 
     Returns:
         The operation's original result.
     """
     snapshot = snapshot_session_files(source_session_file)
+    outcome: tuple[ResultT, str | None] | None = None
     try:
-        return operation()
+        outcome = operation()
+        return outcome[0]
     finally:
-        mark_new_helper_session(snapshot)
+        if outcome is not None:
+            mark_new_helper_session(snapshot, session_id=outcome[1])

--- a/claude_code_tools/helper_sessions.py
+++ b/claude_code_tools/helper_sessions.py
@@ -100,9 +100,9 @@ def run_and_mark_helper_fork(
 ) -> ResultT:
     """Run a headless fork operation and mark its transcript afterward.
 
-    Marking runs for successful results, nonzero client results, and raised
-    exceptions. When concurrent session creation makes the fork ambiguous,
-    :func:`mark_new_helper_session` safely leaves every transcript untouched.
+    Marking runs whenever the operation returns an exact session ID, including
+    nonzero client results. Raised exceptions and missing IDs safely leave every
+    transcript untouched.
 
     Args:
         source_session_file: Transcript passed to the headless fork client.

--- a/claude_code_tools/resolve_session.py
+++ b/claude_code_tools/resolve_session.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal, TextIO
 
+from claude_code_tools.helper_sessions import is_helper_session
 from claude_code_tools.resolve_session_names import codex_thread_names
 from claude_code_tools.session_utils import (
     get_claude_home,
@@ -331,6 +332,7 @@ def enumerate_claude_sessions(home: Path) -> list[SessionRecord]:
             eligible = (
                 eligible
                 and not claude_sessions.is_malformed_session(path)
+                and not is_helper_session(path)
             )
         except (OSError, UnicodeError, TypeError, ValueError):
             eligible = False
@@ -362,6 +364,7 @@ def enumerate_claude_sessions(home: Path) -> list[SessionRecord]:
                 eligible = (
                     eligible
                     and not claude_sessions.is_malformed_session(session_file)
+                    and not is_helper_session(session_file)
                     and directory is not None
                 )
             except (OSError, UnicodeError, TypeError, ValueError):
@@ -992,4 +995,3 @@ def resolve(
         records=tuple(tagged[:25]),
         match_count=len(tagged),
     )
-

--- a/tests/test_helper_sessions.py
+++ b/tests/test_helper_sessions.py
@@ -45,7 +45,7 @@ def test_marks_the_only_new_fork_as_helper(tmp_path: Path) -> None:
     _write_session(fork, "fork")
     original_tail = fork.read_text(encoding="utf-8").splitlines()[1]
 
-    marked = mark_new_helper_session(snapshot)
+    marked = mark_new_helper_session(snapshot, session_id="fork")
 
     assert marked == fork
     assert is_helper_session(fork)
@@ -84,9 +84,23 @@ def test_ambiguous_new_sessions_are_not_guessed(tmp_path: Path) -> None:
     _write_session(first, "first")
     _write_session(second, "second")
 
-    assert mark_new_helper_session(snapshot) is None
+    assert mark_new_helper_session(snapshot, session_id="missing") is None
     assert not is_helper_session(first)
     assert not is_helper_session(second)
+
+
+def test_missing_result_id_does_not_mark_only_new_session(
+    tmp_path: Path,
+) -> None:
+    """A concurrent session cannot be mistaken for a failed helper fork."""
+    source = tmp_path / "source.jsonl"
+    unrelated = tmp_path / "unrelated.jsonl"
+    _write_session(source, "source")
+    snapshot = snapshot_session_files(source)
+    _write_session(unrelated, "unrelated")
+
+    assert mark_new_helper_session(snapshot) is None
+    assert not is_helper_session(unrelated)
 
 
 def test_malformed_first_record_is_not_a_helper(tmp_path: Path) -> None:
@@ -103,9 +117,9 @@ def test_failed_headless_operation_still_marks_its_fork(tmp_path: Path) -> None:
     fork = tmp_path / "failed-fork.jsonl"
     _write_session(source, "source")
 
-    def failed_operation() -> int:
+    def failed_operation() -> tuple[int, str]:
         _write_session(fork, "failed-fork")
-        return 17
+        return 17, "failed-fork"
 
     result = run_and_mark_helper_fork(source, failed_operation)
 

--- a/tests/test_helper_sessions.py
+++ b/tests/test_helper_sessions.py
@@ -1,0 +1,113 @@
+"""Helper-session discovery and marking regressions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_code_tools.helper_sessions import (
+    is_helper_session,
+    mark_new_helper_session,
+    run_and_mark_helper_fork,
+    snapshot_session_files,
+)
+
+
+def _write_session(path: Path, session_id: str) -> None:
+    """Write a minimal resumable Claude transcript."""
+    path.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "sessionId": session_id,
+                "message": {"content": "question"},
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "type": "assistant",
+                "sessionId": session_id,
+                "message": {"content": "answer"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_marks_the_only_new_fork_as_helper(tmp_path: Path) -> None:
+    """A headless fork created after the snapshot receives helper metadata."""
+    source = tmp_path / "source.jsonl"
+    fork = tmp_path / "fork.jsonl"
+    _write_session(source, "source")
+    snapshot = snapshot_session_files(source)
+    _write_session(fork, "fork")
+    original_tail = fork.read_text(encoding="utf-8").splitlines()[1]
+
+    marked = mark_new_helper_session(snapshot)
+
+    assert marked == fork
+    assert is_helper_session(fork)
+    lines = fork.read_text(encoding="utf-8").splitlines()
+    assert json.loads(lines[0])["sessionType"] == "helper"
+    assert lines[1] == original_tail
+    assert not is_helper_session(source)
+
+
+def test_result_id_selects_fork_among_concurrent_new_sessions(
+    tmp_path: Path,
+) -> None:
+    """A returned session ID prevents an unrelated new file being marked."""
+    source = tmp_path / "source.jsonl"
+    expected = tmp_path / "expected.jsonl"
+    unrelated = tmp_path / "unrelated.jsonl"
+    _write_session(source, "source")
+    snapshot = snapshot_session_files(source)
+    _write_session(expected, "expected")
+    _write_session(unrelated, "unrelated")
+
+    marked = mark_new_helper_session(snapshot, session_id="expected")
+
+    assert marked == expected
+    assert is_helper_session(expected)
+    assert not is_helper_session(unrelated)
+
+
+def test_ambiguous_new_sessions_are_not_guessed(tmp_path: Path) -> None:
+    """Without a returned ID, concurrent new transcripts remain untouched."""
+    source = tmp_path / "source.jsonl"
+    first = tmp_path / "first.jsonl"
+    second = tmp_path / "second.jsonl"
+    _write_session(source, "source")
+    snapshot = snapshot_session_files(source)
+    _write_session(first, "first")
+    _write_session(second, "second")
+
+    assert mark_new_helper_session(snapshot) is None
+    assert not is_helper_session(first)
+    assert not is_helper_session(second)
+
+
+def test_malformed_first_record_is_not_a_helper(tmp_path: Path) -> None:
+    """Malformed transcripts are handled without exceptions."""
+    session_file = tmp_path / "broken.jsonl"
+    session_file.write_text("not-json\n", encoding="utf-8")
+
+    assert not is_helper_session(session_file)
+
+
+def test_failed_headless_operation_still_marks_its_fork(tmp_path: Path) -> None:
+    """A nonzero client result cannot leave its newly created fork visible."""
+    source = tmp_path / "source.jsonl"
+    fork = tmp_path / "failed-fork.jsonl"
+    _write_session(source, "source")
+
+    def failed_operation() -> int:
+        _write_session(fork, "failed-fork")
+        return 17
+
+    result = run_and_mark_helper_fork(source, failed_operation)
+
+    assert result == 17
+    assert is_helper_session(fork)

--- a/tests/test_resolve_session_helpers.py
+++ b/tests/test_resolve_session_helpers.py
@@ -1,0 +1,67 @@
+"""Helper transcripts stay out of human-facing name resolution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner, Result
+
+from claude_code_tools.aichat import main
+from claude_code_tools.session_utils import mark_session_as_helper
+from tests.resolve_session_helpers import _write_claude_session
+
+
+def _resolve(runner: CliRunner, home: Path, query: str) -> Result:
+    """Invoke the Claude resolver against an isolated home."""
+    return runner.invoke(
+        main,
+        ["resolve", query, "--agent", "claude", "--home", str(home), "--json"],
+    )
+
+
+def test_name_resolution_ignores_newer_helper_with_same_name(
+    tmp_path: Path,
+) -> None:
+    """A helper fork cannot make its named source ambiguous."""
+    home = tmp_path / "claude"
+    cwd = str(tmp_path / "project")
+    source_id = "11111111-1111-4111-8111-111111111111"
+    helper_id = "22222222-2222-4222-8222-222222222222"
+    _write_claude_session(home, source_id, cwd, "Named Session", 10.0)
+    helper = _write_claude_session(
+        home,
+        helper_id,
+        cwd,
+        "Named Session",
+        20.0,
+    )
+    assert mark_session_as_helper(helper)
+
+    result = _resolve(CliRunner(), home, "Named Session")
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["session_id"] == source_id
+
+
+def test_helper_remains_resolvable_by_exact_id(tmp_path: Path) -> None:
+    """Exact IDs retain a diagnostic escape hatch for helper transcripts."""
+    home = tmp_path / "claude"
+    cwd = str(tmp_path / "project")
+    helper_id = "22222222-2222-4222-8222-222222222222"
+    helper = _write_claude_session(
+        home,
+        helper_id,
+        cwd,
+        "Named Session",
+        20.0,
+    )
+    assert mark_session_as_helper(helper)
+
+    result = _resolve(CliRunner(), home, helper_id)
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["session_id"] == helper_id
+    assert payload["matched_by"] == "id"
+    assert payload["name"] is None


### PR DESCRIPTION
## Summary

- add exact-ID tracking and helper metadata support for headless session forks
- exclude helper-marked Claude transcripts from name resolution while preserving exact UUID lookup
- cover failed operations, concurrent session creation, resolver filtering, and diagnostic ID resolution

## Verification

- `pytest -q tests/test_helper_sessions.py tests/test_resolve_session_helpers.py tests/test_resolve_session_codex.py tests/test_resolve_session_hardening.py tests/test_resolve_session_tiers.py` (102 passed)
- `aichat resolve certify-generation --json` returns the canonical `5123cada-6453-40fd-868e-33d1fa79ac6a` session
- final cold review: clean

## Deployment note

The standalone installed `ask-session.py` caller was updated locally to consume the new exact-ID helper API; that personal skill directory is not Git-backed.