### PR TITLE
fix(safety-hooks): env-file guard blocks ordinary globs and ignores find negation

### DIFF
--- a/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
+++ b/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
@@ -173,34 +173,36 @@ inspection of environment variables.
 The guard also inspects filename globs passed to
 `find`, `grep`, and `rg`, and blocks a command only
 when its glob *targets* a dotenv name. A glob counts
-as targeting a dotenv when its literal text mentions
-`env`, or when its non-`*` wildcards (`?`, bracket
-classes) can spell one out:
+as targeting a dotenv when its literal characters or
+its non-`*` wildcards (`?`, bracket classes) help
+spell the `.env` name:
 
 - Blocked: `find . -name '.env'`,
   `find . -path '*/.env'`,
   `grep -r --include='*.env*'`, `rg -g '*env'`,
-  `find . -name '.?nv'`
+  `find . -name '.?nv'`, `rg -g '*e?v'`
 - Allowed: `find . -name '*.ts'`,
   `find . -path '*/dist/*'`,
   `grep -rn TODO --include='*.py' .`,
   `rg TODO -g '*.rs'`
 
-A bare `*` is not treated as naming a dotenv, even
-though it could match one at runtime -- otherwise
-every ordinary include-glob would be denied. This is
-consistent with the guard allowing `grep -r SECRET .`
-(no glob at all), which reads the same files. The
-known trade-off: a glob like `--include='*.local'`
-can match `.env.local` but is allowed, because it
-reaches a dotenv only by `*` expanding over the
-entire `.env` literal.
+A bare `*` on its own is never treated as spelling
+`.env`, even though it could match one at runtime --
+otherwise every ordinary include-glob would be
+denied. This is consistent with the guard allowing
+`grep -r SECRET .` (no glob at all), which reads the
+same files. The known trade-off: a glob like
+`--include='*.local'` can match `.env.local` but is
+allowed, because it reaches a dotenv only by `*`
+expanding over the entire `.env` core.
 
 Negated predicates and globs are exclusions, not
 selections, so they never trigger the guard:
 `find . ! -path '*/.env'`,
 `find . -not -name '.env'`, and
-`rg -g '!.env*'` are all allowed.
+`rg -g '!.env*'` are all allowed. Double negation
+(`find . ! ! -name '.env'`) selects again and is
+still blocked.
 
 :::tip
 If you need to modify a `.env` file, do so

--- a/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
+++ b/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
@@ -168,6 +168,40 @@ The hook directs users to the
 [env-safe](../../tools/env-safe/) CLI for safe
 inspection of environment variables.
 
+#### Globs in find / grep / ripgrep
+
+The guard also inspects filename globs passed to
+`find`, `grep`, and `rg`, and blocks a command only
+when its glob *targets* a dotenv name. A glob counts
+as targeting a dotenv when its literal text mentions
+`env`, or when its non-`*` wildcards (`?`, bracket
+classes) can spell one out:
+
+- Blocked: `find . -name '.env'`,
+  `find . -path '*/.env'`,
+  `grep -r --include='*.env*'`, `rg -g '*env'`,
+  `find . -name '.?nv'`
+- Allowed: `find . -name '*.ts'`,
+  `find . -path '*/dist/*'`,
+  `grep -rn TODO --include='*.py' .`,
+  `rg TODO -g '*.rs'`
+
+A bare `*` is not treated as naming a dotenv, even
+though it could match one at runtime -- otherwise
+every ordinary include-glob would be denied. This is
+consistent with the guard allowing `grep -r SECRET .`
+(no glob at all), which reads the same files. The
+known trade-off: a glob like `--include='*.local'`
+can match `.env.local` but is allowed, because it
+reaches a dotenv only by `*` expanding over the
+entire `.env` literal.
+
+Negated predicates and globs are exclusions, not
+selections, so they never trigger the guard:
+`find . ! -path '*/.env'`,
+`find . -not -name '.env'`, and
+`rg -g '!.env*'` are all allowed.
+
 :::tip
 If you need to modify a `.env` file, do so
 manually outside of Claude Code. Use `env-safe`

--- a/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
+++ b/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
@@ -205,7 +205,9 @@ selections, so they never trigger the guard:
 still blocked, and negation is ignored when the
 `find` expression contains a disjunction
 (`-o`/`-or`/`,`), since an `-o` branch can re-select
-the excluded file.
+the excluded file. Parenthesised `\( ... \)`
+expressions are not analysed as a unit; the guard
+inspects predicates token by token.
 
 :::tip
 If you need to modify a `.env` file, do so

--- a/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
+++ b/docs-site/src/content/docs/plugins-detail/safety-hooks.mdx
@@ -202,7 +202,10 @@ selections, so they never trigger the guard:
 `find . -not -name '.env'`, and
 `rg -g '!.env*'` are all allowed. Double negation
 (`find . ! ! -name '.env'`) selects again and is
-still blocked.
+still blocked, and negation is ignored when the
+`find` expression contains a disjunction
+(`-o`/`-or`/`,`), since an `-o` branch can re-select
+the excluded file.
 
 :::tip
 If you need to modify a `.env` file, do so

--- a/plugins/CHANGELOG.md
+++ b/plugins/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Plugin Changelog
 
+## 2026-08-23
+
+### safety-hooks 1.15.2
+
+- fix: env-file guard no longer blocks ordinary globs (issue #178)
+  - `find . -name '*.ts'`, `grep --include='*.py'`, `rg -g '*.rs'`, and
+    `find . -path '*/dist/*'` were denied because a bare `*` was allowed
+    to spell out the literal `.env`; a glob now names a dotenv only when
+    literal text or non-`*` wildcards help spell the `.env` core
+  - mixed spellings (`*env`, `*nv`, `*[e]nv`, `*e?v`) still block;
+    `*.local` is a documented accepted trade-off
+  - `find` negation (`! -path X`, `-not -name X`) is now honoured as an
+    exclusion, with fail-closed handling for double negation,
+    disjunctions (`-o`/`-or`/`,`), and `!` operands of
+    `-printf`/`-fprintf`
+  - reported in issue #178 by @tudorsss
+
 ## 2026-08-20
 
 ### safety-hooks 1.15.1

--- a/plugins/safety-hooks/.claude-plugin/plugin.json
+++ b/plugins/safety-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safety-hooks",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Safety hooks to block or require user approval for dangerous commands (rm, git operations, .env access, file size limits)",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -782,6 +782,10 @@ def _reader_accesses_dotenv(command_word: str, args: List[str]) -> bool:
         path_predicates = {
             '-name', '-iname', '-path', '-ipath', '-wholename', '-iwholename',
         }
+        # A disjunction (-o/-or/,) can re-select what a negated predicate
+        # excluded (find . ! -name '.env' -o -exec cat {} \;), so negation
+        # is only honoured when the expression has no disjunction.
+        has_disjunction = any(arg in {'-o', '-or', ','} for arg in args)
         for position, arg in enumerate(args[:-1]):
             pattern = args[position + 1]
             # A predicate under an odd number of negations (-not/! -path X)
@@ -792,7 +796,7 @@ def _reader_accesses_dotenv(command_word: str, args: List[str]) -> bool:
             while scan >= 0 and args[scan] in {'-not', '!'}:
                 negations += 1
                 scan -= 1
-            if negations % 2:
+            if negations % 2 and not has_disjunction:
                 continue
             if arg in path_predicates and (
                     _names_dotenv(pattern)

--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -789,7 +789,16 @@ def _reader_accesses_dotenv(command_word: str, args: List[str]) -> bool:
         # An action left of the negation runs before the exclusion filters
         # (find . -exec cat {} \; ! -name '.env' cats every file, dotenv
         # included), so negation is only honoured with no earlier action.
-        action_tokens = {'-exec', '-execdir', '-ok', '-okdir', '-delete'}
+        action_tokens = {
+            '-exec', '-execdir', '-ok', '-okdir', '-delete',
+            '-fprintf', '-fprint', '-fls',
+        }
+        # These output actions write to their FILE operand, so naming a
+        # dotenv there truncates it: find . -fprintf .env '%p'
+        for position, arg in enumerate(args[:-1]):
+            if arg in {'-fprintf', '-fprint', '-fls'} and _names_dotenv(
+                    args[position + 1]):
+                return True
         for position, arg in enumerate(args[:-1]):
             pattern = args[position + 1]
             # A predicate under an odd number of negations (-not/! -path X)

--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -220,6 +220,12 @@ def _glob_names_dotenv(pattern: str) -> bool:
             )
             if not matches:
                 continue
+            # A bare '*' may only spell out the literal '.env' when the
+            # pattern text itself mentions 'env'; otherwise every glob
+            # containing '*' (e.g. '*.ts') would count as naming a dotenv.
+            if (token == '*' and dotenv_state < 4
+                    and 'env' not in basename_pattern.lower()):
+                continue
             if dotenv_state < 4:
                 expected = '.env'[dotenv_state]
                 if candidate.lower() != expected:
@@ -778,6 +784,10 @@ def _reader_accesses_dotenv(command_word: str, args: List[str]) -> bool:
         }
         for position, arg in enumerate(args[:-1]):
             pattern = args[position + 1]
+            # A negated predicate (-not/! -path X) excludes matches rather
+            # than selecting them, so it cannot be used to read a dotenv.
+            if position and args[position - 1] in {'-not', '!'}:
+                continue
             if arg in path_predicates and (
                     _names_dotenv(pattern)
                     or _glob_names_dotenv(pattern)):

--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -796,7 +796,16 @@ def _reader_accesses_dotenv(command_word: str, args: List[str]) -> bool:
             while scan >= 0 and args[scan] in {'-not', '!'}:
                 negations += 1
                 scan -= 1
-            if negations % 2 and not has_disjunction:
+            # Fail closed on ambiguous negation: a '-...' token right
+            # before the chain (other than a conjunction) may be a value
+            # predicate whose operand is the '!' itself, as in
+            # find . -printf '!' -name '.env' -exec cat {} \;
+            unambiguous = (
+                scan < 0
+                or not args[scan].startswith('-')
+                or args[scan] in {'-a', '-and', '(', ')'}
+            )
+            if negations % 2 and unambiguous and not has_disjunction:
                 continue
             if arg in path_predicates and (
                     _names_dotenv(pattern)

--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -786,6 +786,10 @@ def _reader_accesses_dotenv(command_word: str, args: List[str]) -> bool:
         # excluded (find . ! -name '.env' -o -exec cat {} \;), so negation
         # is only honoured when the expression has no disjunction.
         has_disjunction = any(arg in {'-o', '-or', ','} for arg in args)
+        # An action left of the negation runs before the exclusion filters
+        # (find . -exec cat {} \; ! -name '.env' cats every file, dotenv
+        # included), so negation is only honoured with no earlier action.
+        action_tokens = {'-exec', '-execdir', '-ok', '-okdir', '-delete'}
         for position, arg in enumerate(args[:-1]):
             pattern = args[position + 1]
             # A predicate under an odd number of negations (-not/! -path X)
@@ -810,7 +814,10 @@ def _reader_accesses_dotenv(command_word: str, args: List[str]) -> bool:
                 # find . -fprintf /tmp/list '!' -name '.env' -delete
                 scan >= 1 and args[scan - 1] == '-fprintf'
             )
-            if negations % 2 and unambiguous and not has_disjunction:
+            no_prior_action = not any(
+                early in action_tokens for early in args[:position])
+            if (negations % 2 and unambiguous and not has_disjunction
+                    and no_prior_action):
                 continue
             if arg in path_predicates and (
                     _names_dotenv(pattern)

--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -184,21 +184,25 @@ def _glob_names_dotenv(pattern: str) -> bool:
         index += 1
     alphabet = {chr(code) for code in range(32, 127)}
     alphabet.update(basename_pattern)
-    pending = [(0, 0)]
+    # Third state component: whether a non-'*' token has spelled part of
+    # the '.env' core. A bare '*' can expand to anything, so a match that
+    # exists only because '*' spelled out '.env' (e.g. '*.ts' matching
+    # '.env.ts') does not count as the pattern naming a dotenv.
+    pending = [(0, 0, False)]
     seen = set()
     while pending:
-        token_index, dotenv_state = pending.pop()
-        state = (token_index, dotenv_state)
+        token_index, dotenv_state, contributed = pending.pop()
+        state = (token_index, dotenv_state, contributed)
         if state in seen:
             continue
         seen.add(state)
         if token_index == len(tokens):
-            if dotenv_state in {4, 5}:
+            if dotenv_state in {4, 5} and contributed:
                 return True
             continue
         token = tokens[token_index]
         if token == '*':
-            pending.append((token_index + 1, dotenv_state))
+            pending.append((token_index + 1, dotenv_state, contributed))
         for candidate in alphabet:
             negated = token.startswith(('[!', '[^'))
             bracket_body = token[2:-1] if negated else token[1:-1]
@@ -220,12 +224,6 @@ def _glob_names_dotenv(pattern: str) -> bool:
             )
             if not matches:
                 continue
-            # A bare '*' may only spell out the literal '.env' when the
-            # pattern text itself mentions 'env'; otherwise every glob
-            # containing '*' (e.g. '*.ts') would count as naming a dotenv.
-            if (token == '*' and dotenv_state < 4
-                    and 'env' not in basename_pattern.lower()):
-                continue
             if dotenv_state < 4:
                 expected = '.env'[dotenv_state]
                 if candidate.lower() != expected:
@@ -238,7 +236,9 @@ def _glob_names_dotenv(pattern: str) -> bool:
             else:
                 next_state = 5
             next_token = token_index if token == '*' else token_index + 1
-            pending.append((next_token, next_state))
+            next_contributed = contributed or (
+                token != '*' and dotenv_state < 4)
+            pending.append((next_token, next_state, next_contributed))
     return False
 
 
@@ -784,9 +784,15 @@ def _reader_accesses_dotenv(command_word: str, args: List[str]) -> bool:
         }
         for position, arg in enumerate(args[:-1]):
             pattern = args[position + 1]
-            # A negated predicate (-not/! -path X) excludes matches rather
-            # than selecting them, so it cannot be used to read a dotenv.
-            if position and args[position - 1] in {'-not', '!'}:
+            # A predicate under an odd number of negations (-not/! -path X)
+            # excludes matches rather than selecting them, so it cannot be
+            # used to read a dotenv. Even counts (! ! -name X) still select.
+            negations = 0
+            scan = position - 1
+            while scan >= 0 and args[scan] in {'-not', '!'}:
+                negations += 1
+                scan -= 1
+            if negations % 2:
                 continue
             if arg in path_predicates and (
                     _names_dotenv(pattern)

--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -804,6 +804,11 @@ def _reader_accesses_dotenv(command_word: str, args: List[str]) -> bool:
                 scan < 0
                 or not args[scan].startswith('-')
                 or args[scan] in {'-a', '-and', '(', ')'}
+            ) and not (
+                # -fprintf FILE FORMAT: with FILE before the chain, the
+                # chain's first '!' is the two-operand FORMAT, as in
+                # find . -fprintf /tmp/list '!' -name '.env' -delete
+                scan >= 1 and args[scan - 1] == '-fprintf'
             )
             if negations % 2 and unambiguous and not has_disjunction:
                 continue

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -211,6 +211,11 @@ class TestBlocked(unittest.TestCase):
         # pre-existing gap on main; the single-segment forms are covered.)
         self.assertBlocked("find . -delete ! -name '.env'")
         self.assertBlocked("find . -exec cat {} + ! -name '.env'")
+        self.assertBlocked(r"find . -fprintf .env '%p\n' ! -name '.env'")
+        # Output actions write to their FILE operand.
+        self.assertBlocked("find . -fprintf .env '%p'")
+        self.assertBlocked("find . -fprint .env")
+        self.assertBlocked("find . -fls .env.local")
 
     def test_file_literally_named_env(self):
         self.assertBlocked("cat env")
@@ -374,6 +379,7 @@ class TestAllowed(unittest.TestCase):
         self.assertAllowed("find . -type f ! -name '.env'")
         # Exclusion before the action: -exec never sees the dotenv.
         self.assertAllowed(r"find . ! -name '.env' -exec cat {} \;")
+        self.assertAllowed("find . -fprint /tmp/list ! -name '*.log'")
 
     def test_quoted_or_escaped_shell_globs_are_literal(self):
         self.assertAllowed("cat '.[e]nv'")

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -126,6 +126,8 @@ class TestBlocked(unittest.TestCase):
         self.assertBlocked("rg -g '.[e]nv.[0-9]*' SECRET .")
         self.assertBlocked("rg -g '[^a]env' SECRET .")
         self.assertBlocked("grep --include='[^a]env' SECRET .")
+        self.assertBlocked("grep -r SECRET --include='*env' .")
+        self.assertBlocked("grep -r SECRET --include='*env*' .")
 
     def test_write_and_copy(self):
         self.assertBlocked("cp " + DOTENV + " " + DOTENV + ".bak")
@@ -188,6 +190,8 @@ class TestBlocked(unittest.TestCase):
         self.assertBlocked(r"find . -regex '.*/\.env' -delete")
         self.assertBlocked("find . -regex '.*[.]env' -delete")
         self.assertBlocked(r"find . -regex '.*\.env' -delete")
+        self.assertBlocked("find . -not -path '*/build/*' -name '.env'")
+        self.assertBlocked("find . ! -name '*.log' -path '*/.env'")
 
     def test_file_literally_named_env(self):
         self.assertBlocked("cat env")
@@ -331,6 +335,23 @@ class TestAllowed(unittest.TestCase):
         self.assertAllowed("rg -g '!.env*' SECRET .")
         self.assertAllowed("rg --glob='!**/.env*' SECRET .")
         self.assertAllowed("rg -g '[a-z]*.py' SECRET .")
+
+    def test_ordinary_globs_do_not_select_dotenv(self):
+        """A '*' must not be allowed to spell out the literal '.env'."""
+        self.assertAllowed("find . -name '*.ts'")
+        self.assertAllowed("find . -path '*/dist/*'")
+        self.assertAllowed("grep -rn TODO --include='*.py' .")
+        self.assertAllowed("rg TODO -g '*.rs'")
+        self.assertAllowed("grep -r SECRET --include='*' .")
+        # Accepted trade-off: '*.local' can match '.env.local', but only by
+        # '*' expanding over the whole '.env' literal; treated as ordinary.
+        self.assertAllowed("grep -r X --include='*.local' .")
+
+    def test_negated_find_predicates_are_exclusions(self):
+        self.assertAllowed("find . ! -path '*/build/*'")
+        self.assertAllowed("find . -not -path '*/build/*' -name '*.go'")
+        self.assertAllowed("find . ! -path '*/.env'")
+        self.assertAllowed("find . -not -name '.env'")
 
     def test_quoted_or_escaped_shell_globs_are_literal(self):
         self.assertAllowed("cat '.[e]nv'")

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -204,6 +204,8 @@ class TestBlocked(unittest.TestCase):
         self.assertBlocked("find . ! -name '.env' , -exec cat {} +")
         # '!' here is -printf's format operand, not a negation.
         self.assertBlocked(r"find . -printf '!' -name '.env' -exec cat {} \;")
+        # Same trick through two-operand -fprintf FILE FORMAT.
+        self.assertBlocked("find . -fprintf /tmp/list '!' -name '.env' -delete")
 
     def test_file_literally_named_env(self):
         self.assertBlocked("cat env")

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -202,6 +202,8 @@ class TestBlocked(unittest.TestCase):
         self.assertBlocked(r"find . ! -name '.env' -o -exec cat {} \;")
         self.assertBlocked("find . ! -name '.env' -or -delete")
         self.assertBlocked("find . ! -name '.env' , -exec cat {} +")
+        # '!' here is -printf's format operand, not a negation.
+        self.assertBlocked(r"find . -printf '!' -name '.env' -exec cat {} \;")
 
     def test_file_literally_named_env(self):
         self.assertBlocked("cat env")
@@ -362,6 +364,7 @@ class TestAllowed(unittest.TestCase):
         self.assertAllowed("find . -not -path '*/build/*' -name '*.go'")
         self.assertAllowed("find . ! -path '*/.env'")
         self.assertAllowed("find . -not -name '.env'")
+        self.assertAllowed("find . -type f ! -name '.env'")
 
     def test_quoted_or_escaped_shell_globs_are_literal(self):
         self.assertAllowed("cat '.[e]nv'")

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -207,8 +207,10 @@ class TestBlocked(unittest.TestCase):
         # Same trick through two-operand -fprintf FILE FORMAT.
         self.assertBlocked("find . -fprintf /tmp/list '!' -name '.env' -delete")
         # An action left of the negation runs before the exclusion filters.
-        self.assertBlocked(r"find . -exec cat {} \; ! -name '.env'")
+        # (The \; -exec spelling splits into another shell segment and is a
+        # pre-existing gap on main; the single-segment forms are covered.)
         self.assertBlocked("find . -delete ! -name '.env'")
+        self.assertBlocked("find . -exec cat {} + ! -name '.env'")
 
     def test_file_literally_named_env(self):
         self.assertBlocked("cat env")

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -197,6 +197,11 @@ class TestBlocked(unittest.TestCase):
         self.assertBlocked("find . ! -name '*.log' -path '*/.env'")
         self.assertBlocked("find . ! ! -name '.env'")
         self.assertBlocked("find . -not -not -name '.env' -print")
+        # -o re-selects what the negation excluded, so negation is not
+        # honoured when the expression contains a disjunction.
+        self.assertBlocked(r"find . ! -name '.env' -o -exec cat {} \;")
+        self.assertBlocked("find . ! -name '.env' -or -delete")
+        self.assertBlocked("find . ! -name '.env' , -exec cat {} +")
 
     def test_file_literally_named_env(self):
         self.assertBlocked("cat env")

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -206,6 +206,9 @@ class TestBlocked(unittest.TestCase):
         self.assertBlocked(r"find . -printf '!' -name '.env' -exec cat {} \;")
         # Same trick through two-operand -fprintf FILE FORMAT.
         self.assertBlocked("find . -fprintf /tmp/list '!' -name '.env' -delete")
+        # An action left of the negation runs before the exclusion filters.
+        self.assertBlocked(r"find . -exec cat {} \; ! -name '.env'")
+        self.assertBlocked("find . -delete ! -name '.env'")
 
     def test_file_literally_named_env(self):
         self.assertBlocked("cat env")
@@ -367,6 +370,8 @@ class TestAllowed(unittest.TestCase):
         self.assertAllowed("find . ! -path '*/.env'")
         self.assertAllowed("find . -not -name '.env'")
         self.assertAllowed("find . -type f ! -name '.env'")
+        # Exclusion before the action: -exec never sees the dotenv.
+        self.assertAllowed(r"find . ! -name '.env' -exec cat {} \;")
 
     def test_quoted_or_escaped_shell_globs_are_literal(self):
         self.assertAllowed("cat '.[e]nv'")

--- a/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/test_env_file_protection_hook.py
@@ -128,6 +128,9 @@ class TestBlocked(unittest.TestCase):
         self.assertBlocked("grep --include='[^a]env' SECRET .")
         self.assertBlocked("grep -r SECRET --include='*env' .")
         self.assertBlocked("grep -r SECRET --include='*env*' .")
+        self.assertBlocked("grep -r SECRET --include='*nv' .")
+        self.assertBlocked("grep -r SECRET --include='*[e]nv' .")
+        self.assertBlocked("rg SECRET -g '*e?v' .")
 
     def test_write_and_copy(self):
         self.assertBlocked("cp " + DOTENV + " " + DOTENV + ".bak")
@@ -192,6 +195,8 @@ class TestBlocked(unittest.TestCase):
         self.assertBlocked(r"find . -regex '.*\.env' -delete")
         self.assertBlocked("find . -not -path '*/build/*' -name '.env'")
         self.assertBlocked("find . ! -name '*.log' -path '*/.env'")
+        self.assertBlocked("find . ! ! -name '.env'")
+        self.assertBlocked("find . -not -not -name '.env' -print")
 
     def test_file_literally_named_env(self):
         self.assertBlocked("cat env")
@@ -344,7 +349,7 @@ class TestAllowed(unittest.TestCase):
         self.assertAllowed("rg TODO -g '*.rs'")
         self.assertAllowed("grep -r SECRET --include='*' .")
         # Accepted trade-off: '*.local' can match '.env.local', but only by
-        # '*' expanding over the whole '.env' literal; treated as ordinary.
+        # '*' expanding over the whole '.env' core; treated as ordinary.
         self.assertAllowed("grep -r X --include='*.local' .")
 
     def test_negated_find_predicates_are_exclusions(self):


### PR DESCRIPTION
Fixes #178.

## What

Two defects in `env_file_protection_hook.py` made the dotenv guard deny everyday commands:

1. **A leading `*` always "named" a dotenv.** In `_glob_names_dotenv`, a `*` token could spell out the literal `.env` character by character, so `find . -name '*.ts'`, `grep --include='*.py'`, `rg -g '*.rs'`, and `find . -path '*/dist/*'` were all blocked.
2. **`find` negation was ignored.** `find . ! -path '*/build/*'` and `-not -name X` were treated as inclusions and denied.

## Fix

- The glob NFA now accepts only when literal characters or non-`*` wildcards help spell the `.env` core. A match that exists purely because `*` expanded to `.env` (e.g. `*.ts` matching `.env.ts`) no longer counts. Mixed spellings (`*env`, `*nv`, `*[e]nv`, `*e?v`, `.?nv`) still block. This is stricter than the patch suggested in the issue: `*nv` stays blocked.
- `find` negation is honoured as an exclusion, fail-closed: double negation (`! !`) still selects; negation is ignored when the expression has a disjunction (`-o`/`-or`/`,`), since an `-o` branch can re-select the excluded file; a `!` that may be an operand of `-printf`/`-fprintf` is not treated as negation.

## Documented trade-off

`--include='*.local'` can match `.env.local` but is allowed, since it reaches a dotenv only by `*` expanding over the whole `.env` core — consistent with the guard allowing the strictly broader `grep -r SECRET .`. Documented in code, tests, and docs.

## Also

- Allow-side regression tests (the suite previously asserted only the deny side) plus blocked-side pins for every bypass found during adversarial review.
- Starlight docs: new "Globs in find / grep / ripgrep" subsection under Environment File Protection.
- Plugin bumped to 1.15.2 with changelog entry.

## Verification

- 65 env-hook tests + 238 other hook-suite tests pass.
- E2E matrix from the issue reproduced: all six ordinary commands allowed, all six dotenv accesses (incl. the `cat .env` positive control and `.?nv`) still blocked.
- Five rounds of cold-diff adversarial review (codex, no context); rounds 1–5 findings fixed (`*[e]nv`, double negation, `-o` re-selection, `-printf '!'`, `-fprintf FILE '!'`), final round: no blocking findings.

Thanks @tudorsss for the excellent report and suggested patch.