### PR TITLE
dynamic-workflow: resume --recover for completed semantic halts

### DIFF
--- a/docs-site/src/content/docs/plugins-detail/dynamic-workflow.mdx
+++ b/docs-site/src/content/docs/plugins-detail/dynamic-workflow.mdx
@@ -127,9 +127,10 @@ node bin/workflow.mjs resume <run-id> --recover
 Steps whose prompts and options are unchanged return cached results; changed
 steps rerun. If workers need a write sandbox, pass `--allow-workspace-write`
 (or `--allow-danger-full-access`) again, since a script edit invalidates the
-earlier write approval. `--recover` is refused for runs that completed
-successfully (`approved` is `true` or absent) and while a prior runner
-process is still alive.
+earlier write approval. `--recover` only applies to completed semantic
+halts: it is refused for runs that completed successfully (`approved` is
+`true` or absent), for failed, canceled, or active runs (plain `resume`
+covers those), and while a prior runner process is still alive.
 
 ## Completion callbacks
 

--- a/docs-site/src/content/docs/plugins-detail/dynamic-workflow.mdx
+++ b/docs-site/src/content/docs/plugins-detail/dynamic-workflow.mdx
@@ -113,6 +113,24 @@ Pause is cooperative: active workers finish, while new workers wait. Resume
 replays the JavaScript and returns cached results for compatible completed
 steps. This works across Codex CLI sessions because state lives on disk.
 
+A workflow can also end in a semantic halt: it returns an object with
+`approved: false` (for example, a review gate that found blocking problems),
+and the run records status `completed`. Plain `resume` leaves completed runs
+alone; for a semantic halt it prints a hint instead of replaying. After
+repairing the workflow script, replay the same run — keeping its cached
+steps — with:
+
+```bash
+node bin/workflow.mjs resume <run-id> --recover
+```
+
+Steps whose prompts and options are unchanged return cached results; changed
+steps rerun. If workers need a write sandbox, pass `--allow-workspace-write`
+(or `--allow-danger-full-access`) again, since a script edit invalidates the
+earlier write approval. `--recover` is refused for runs that completed
+successfully (`approved` is `true` or absent) and while a prior runner
+process is still alive.
+
 ## Completion callbacks
 
 A detached `wait` process can observe completion without making model calls,

--- a/plugins/dynamic-workflow/.codex-plugin/plugin.json
+++ b/plugins/dynamic-workflow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-workflow",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Run durable JavaScript workflows with Codex callbacks",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/dynamic-workflow/bin/workflow.mjs
+++ b/plugins/dynamic-workflow/bin/workflow.mjs
@@ -3794,7 +3794,8 @@ var BOOLEAN_OPTIONS = /* @__PURE__ */ new Set([
   "help",
   "json",
   "no-notify-current-thread",
-  "notify-current-thread"
+  "notify-current-thread",
+  "recover"
 ]);
 var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "canceled",
@@ -3834,7 +3835,7 @@ Usage:
   codex-workflow wait <run-id> [--json]
   codex-workflow notify <run-id> [--force] [--json]
   codex-workflow pause <run-id>
-  codex-workflow resume <run-id> [--foreground] [--json]
+  codex-workflow resume <run-id> [--recover] [--foreground] [--json]
                         [--allow-workspace-write]
                         [--allow-danger-full-access]
   codex-workflow cancel <run-id>
@@ -3847,7 +3848,13 @@ Environment:
                             Callback default set by codex-dynamic
 
 Workflow scripts receive agent(), pipeline(), parallel(), checkpoint(), log(),
-args, and workflow.runId. Workers default to the read-only Codex sandbox.`);
+args, and workflow.runId. Workers default to the read-only Codex sandbox.
+
+resume --recover replays a completed run whose result is a semantic halt (a
+result object with "approved": false). Steps whose fingerprints still match
+return cached results; changed steps rerun. Other completed runs stay
+non-resumable. Write sandboxes need the --allow-* flag again after a script
+edit.`);
 }
 function parseArguments(args) {
   const parsed = {
@@ -3926,6 +3933,9 @@ function authorizationFromFlags(parsed, workflowHash, current) {
     workflowHash,
     workspaceWrite: dangerFullAccess || parsed.flags.has("allow-workspace-write")
   };
+}
+function isSemanticHalt(result) {
+  return typeof result === "object" && result !== null && !Array.isArray(result) && result.approved === false;
 }
 function summary(state) {
   const completed = Object.values(state.steps).filter(
@@ -4864,12 +4874,19 @@ async function resumeCommand(parsed) {
     "allow-danger-full-access",
     "allow-workspace-write",
     "foreground",
-    "json"
+    "json",
+    "recover"
   ]);
   const runId = requirePositional(parsed, 0, "run ID");
   let store = await StateStore.load(runId);
   let state = store.snapshot();
-  if (state.status === "completed") {
+  const recovering = state.status === "completed" && parsed.flags.has("recover");
+  if (state.status === "completed" && !recovering) {
+    if (isSemanticHalt(state.result)) {
+      console.error(
+        `codex-workflow: run ${runId} completed as a semantic halt (result.approved is false); pass --recover to replay it`
+      );
+    }
     outputState(
       state,
       parsed.flags.has("json"),
@@ -4877,10 +4894,26 @@ async function resumeCommand(parsed) {
     );
     return 0;
   }
+  if (recovering && !isSemanticHalt(state.result)) {
+    throw new Error(
+      `Run ${runId} completed without a semantic halt (result.approved is not false); refusing --recover`
+    );
+  }
   const runnerAlive = processIdentityMatches(
     state.pid,
     state.pidStartedAt
   );
+  if (recovering) {
+    if (runnerAlive) {
+      throw new Error(
+        `Run ${runId} still has an active runner (PID ${state.pid}); wait for it to exit before --recover`
+      );
+    }
+    await store.appendEvent("resume.recover", {
+      completedAt: state.completedAt ?? null,
+      result: state.result ?? null
+    });
+  }
   if (!runnerAlive) {
     const cleaned = await terminateOrphanedExecution(
       store,

--- a/plugins/dynamic-workflow/bin/workflow.mjs
+++ b/plugins/dynamic-workflow/bin/workflow.mjs
@@ -4045,6 +4045,9 @@ async function executeClaimedRun(store, json, requestedToken) {
       state2.runnerStartedAt = nowIso();
       if (TERMINAL_STATUSES.has(state2.status)) {
         state2.status = "starting";
+        delete state2.completedAt;
+        delete state2.error;
+        delete state2.result;
       }
     });
     const state = await superviseEngine(store);
@@ -4930,6 +4933,11 @@ async function resumeCommand(parsed) {
     store = cleaned;
     state = cleaned.snapshot();
     await stopCompletionNotifierForResume(store);
+    if (recovering && (state.status !== "completed" || !isSemanticHalt(state.result))) {
+      throw new Error(
+        `Run ${runId} changed state during recovery (now ${state.status}); check status and retry`
+      );
+    }
   }
   const changingAuthorization = parsed.flags.has("allow-danger-full-access") || parsed.flags.has("allow-workspace-write");
   const workflowHash = changingAuthorization && !runnerAlive ? sha256(await readFile4(state.workflowPath, "utf8")) : state.workflowHash;

--- a/plugins/dynamic-workflow/bin/workflow.mjs
+++ b/plugins/dynamic-workflow/bin/workflow.mjs
@@ -4357,6 +4357,11 @@ async function spawnDetached(store) {
       await store.update((state) => {
         state.pid = pid;
         state.pidStartedAt = pidStartedAt;
+        if (TERMINAL_STATUSES.has(state.status)) {
+          delete state.completedAt;
+          delete state.error;
+          delete state.result;
+        }
         state.status = "starting";
       });
       await store.transferRunner(runnerToken, pid);

--- a/plugins/dynamic-workflow/bin/workflow.mjs
+++ b/plugins/dynamic-workflow/bin/workflow.mjs
@@ -4333,6 +4333,14 @@ async function spawnDetached(store) {
   const runnerToken = await store.claimRunner(process.pid);
   let handedOff = false;
   try {
+    await store.update((state) => {
+      if (TERMINAL_STATUSES.has(state.status)) {
+        state.status = "starting";
+        delete state.completedAt;
+        delete state.error;
+        delete state.result;
+      }
+    });
     const runnerLog = await open(path6.join(store.directory, "runner.log"), "a");
     try {
       const child = spawn2(
@@ -4357,11 +4365,6 @@ async function spawnDetached(store) {
       await store.update((state) => {
         state.pid = pid;
         state.pidStartedAt = pidStartedAt;
-        if (TERMINAL_STATUSES.has(state.status)) {
-          delete state.completedAt;
-          delete state.error;
-          delete state.result;
-        }
         state.status = "starting";
       });
       await store.transferRunner(runnerToken, pid);

--- a/plugins/dynamic-workflow/bin/workflow.mjs
+++ b/plugins/dynamic-workflow/bin/workflow.mjs
@@ -4944,6 +4944,9 @@ async function resumeCommand(parsed) {
     current.authorization = authorization;
   });
   if (parsed.flags.has("foreground")) {
+    await store.update((current) => {
+      current.status = "starting";
+    });
     const finalState = await executeRun(runId, parsed.flags.has("json"));
     if (!parsed.flags.has("json")) {
       outputState(finalState, false);

--- a/plugins/dynamic-workflow/bin/workflow.mjs
+++ b/plugins/dynamic-workflow/bin/workflow.mjs
@@ -4043,6 +4043,9 @@ async function executeClaimedRun(store, json, requestedToken) {
       state2.pid = process.pid;
       state2.pidStartedAt = pidStartedAt;
       state2.runnerStartedAt = nowIso();
+      if (TERMINAL_STATUSES.has(state2.status)) {
+        state2.status = "starting";
+      }
     });
     const state = await superviseEngine(store);
     finalState = state;
@@ -4880,6 +4883,11 @@ async function resumeCommand(parsed) {
   const runId = requirePositional(parsed, 0, "run ID");
   let store = await StateStore.load(runId);
   let state = store.snapshot();
+  if (parsed.flags.has("recover") && state.status !== "completed") {
+    throw new Error(
+      `--recover only applies to completed semantic halts (run ${runId} is ${state.status}); use plain resume`
+    );
+  }
   const recovering = state.status === "completed" && parsed.flags.has("recover");
   if (state.status === "completed" && !recovering) {
     if (isSemanticHalt(state.result)) {
@@ -4944,9 +4952,6 @@ async function resumeCommand(parsed) {
     current.authorization = authorization;
   });
   if (parsed.flags.has("foreground")) {
-    await store.update((current) => {
-      current.status = "starting";
-    });
     const finalState = await executeRun(runId, parsed.flags.has("json"));
     if (!parsed.flags.has("json")) {
       outputState(finalState, false);

--- a/plugins/dynamic-workflow/package-lock.json
+++ b/plugins/dynamic-workflow/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cctools/dynamic-workflow",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cctools/dynamic-workflow",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "bin": {
         "codex-workflow": "bin/workflow.mjs"
       },

--- a/plugins/dynamic-workflow/package.json
+++ b/plugins/dynamic-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cctools/dynamic-workflow",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Durable JavaScript workflows with Codex thread callbacks",
   "private": true,
   "type": "module",

--- a/plugins/dynamic-workflow/skills/dynamic-workflow/SKILL.md
+++ b/plugins/dynamic-workflow/skills/dynamic-workflow/SKILL.md
@@ -393,7 +393,9 @@ repairing the script, replay the same run with
 renew `--allow-workspace-write` or `--allow-danger-full-access` when the
 script changed and workers need a write sandbox. `--recover` is refused when
 the stored result is not a semantic halt or a prior runner process is still
-alive. Runs whose result has `approved` `true` or absent stay non-resumable.
+alive, and it only applies to completed runs; failed, canceled, or active
+runs use plain `resume`. Runs whose result has `approved` `true` or absent
+stay non-resumable.
 
 Treat a context-capacity error as non-retryable. Reduce or chunk the failing
 prompt, replace large fan-in with a tree reduction, validate the edit, and then

--- a/plugins/dynamic-workflow/skills/dynamic-workflow/SKILL.md
+++ b/plugins/dynamic-workflow/skills/dynamic-workflow/SKILL.md
@@ -384,6 +384,17 @@ On failure, inspect the failed step and logs. Fix the script or environment,
 then use `resume`; completed compatible steps remain cached. Do not delete the
 run directory merely to retry.
 
+A workflow can finish deliberately with a semantic halt: it returns an object
+whose `approved` property is `false`, and the run still records status
+`completed`. Plain `resume` leaves any completed run untouched and, for a
+semantic halt, prints a hint instead of replaying. After reviewing and
+repairing the script, replay the same run with
+`resume <run-id> --recover`; it follows the script-edit checklist above, so
+renew `--allow-workspace-write` or `--allow-danger-full-access` when the
+script changed and workers need a write sandbox. `--recover` is refused when
+the stored result is not a semantic halt or a prior runner process is still
+alive. Runs whose result has `approved` `true` or absent stay non-resumable.
+
 Treat a context-capacity error as non-retryable. Reduce or chunk the failing
 prompt, replace large fan-in with a tree reduction, validate the edit, and then
 resume so compatible completed siblings stay cached.

--- a/plugins/dynamic-workflow/skills/dynamic-workflow/references/workflow-api.md
+++ b/plugins/dynamic-workflow/skills/dynamic-workflow/references/workflow-api.md
@@ -184,7 +184,8 @@ logs <run-id>
 wait <run-id> [--json]
 notify <run-id> [--force] [--json]
 pause <run-id>
-resume <run-id> [--foreground] [--json] [--allow-workspace-write]
+resume <run-id> [--recover] [--foreground] [--json]
+                [--allow-workspace-write]
                 [--allow-danger-full-access]
 cancel <run-id>
 ```

--- a/plugins/dynamic-workflow/src/cli.ts
+++ b/plugins/dynamic-workflow/src/cli.ts
@@ -1397,6 +1397,11 @@ async function resumeCommand(parsed: ParsedArguments): Promise<number> {
     current.authorization = authorization;
   });
   if (parsed.flags.has("foreground")) {
+    // Leave the terminal status behind before execution so a bootstrap
+    // failure is recorded instead of skipped by its terminal-status guard.
+    await store.update((current) => {
+      current.status = "starting";
+    });
     const finalState = await executeRun(runId, parsed.flags.has("json"));
     if (!parsed.flags.has("json")) {
       outputState(finalState, false);

--- a/plugins/dynamic-workflow/src/cli.ts
+++ b/plugins/dynamic-workflow/src/cli.ts
@@ -57,6 +57,7 @@ const BOOLEAN_OPTIONS = new Set([
   "json",
   "no-notify-current-thread",
   "notify-current-thread",
+  "recover",
 ]);
 const TERMINAL_STATUSES = new Set<RunStatus>([
   "canceled",
@@ -99,7 +100,7 @@ Usage:
   codex-workflow wait <run-id> [--json]
   codex-workflow notify <run-id> [--force] [--json]
   codex-workflow pause <run-id>
-  codex-workflow resume <run-id> [--foreground] [--json]
+  codex-workflow resume <run-id> [--recover] [--foreground] [--json]
                         [--allow-workspace-write]
                         [--allow-danger-full-access]
   codex-workflow cancel <run-id>
@@ -112,7 +113,13 @@ Environment:
                             Callback default set by codex-dynamic
 
 Workflow scripts receive agent(), pipeline(), parallel(), checkpoint(), log(),
-args, and workflow.runId. Workers default to the read-only Codex sandbox.`);
+args, and workflow.runId. Workers default to the read-only Codex sandbox.
+
+resume --recover replays a completed run whose result is a semantic halt (a
+result object with "approved": false). Steps whose fingerprints still match
+return cached results; changed steps rerun. Other completed runs stay
+non-resumable. Write sandboxes need the --allow-* flag again after a script
+edit.`);
 }
 
 function parseArguments(args: string[]): ParsedArguments {
@@ -220,6 +227,15 @@ function authorizationFromFlags(
     workspaceWrite:
       dangerFullAccess || parsed.flags.has("allow-workspace-write"),
   };
+}
+
+function isSemanticHalt(result: JsonValue | undefined): boolean {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    !Array.isArray(result) &&
+    result.approved === false
+  );
 }
 
 function summary(state: RunState): string {
@@ -1304,11 +1320,19 @@ async function resumeCommand(parsed: ParsedArguments): Promise<number> {
     "allow-workspace-write",
     "foreground",
     "json",
+    "recover",
   ]);
   const runId = requirePositional(parsed, 0, "run ID");
   let store = await StateStore.load(runId);
   let state = store.snapshot();
-  if (state.status === "completed") {
+  const recovering = state.status === "completed" && parsed.flags.has("recover");
+  if (state.status === "completed" && !recovering) {
+    if (isSemanticHalt(state.result)) {
+      console.error(
+        `codex-workflow: run ${runId} completed as a semantic halt ` +
+          "(result.approved is false); pass --recover to replay it",
+      );
+    }
     outputState(
       state,
       parsed.flags.has("json"),
@@ -1316,10 +1340,28 @@ async function resumeCommand(parsed: ParsedArguments): Promise<number> {
     );
     return 0;
   }
+  if (recovering && !isSemanticHalt(state.result)) {
+    throw new Error(
+      `Run ${runId} completed without a semantic halt ` +
+        "(result.approved is not false); refusing --recover",
+    );
+  }
   const runnerAlive = processIdentityMatches(
     state.pid,
     state.pidStartedAt,
   );
+  if (recovering) {
+    if (runnerAlive) {
+      throw new Error(
+        `Run ${runId} still has an active runner (PID ${state.pid}); ` +
+          "wait for it to exit before --recover",
+      );
+    }
+    await store.appendEvent("resume.recover", {
+      completedAt: state.completedAt ?? null,
+      result: state.result ?? null,
+    });
+  }
   if (!runnerAlive) {
     const cleaned = await terminateOrphanedExecution(
       store,

--- a/plugins/dynamic-workflow/src/cli.ts
+++ b/plugins/dynamic-workflow/src/cli.ts
@@ -371,9 +371,14 @@ async function executeClaimedRun(
       state.runnerStartedAt = nowIso();
       // Leave any terminal status behind only after the runner claim
       // succeeded, so a bootstrap failure is recorded instead of skipped
-      // by recordBootstrapFailure's terminal-status guard.
+      // by recordBootstrapFailure's terminal-status guard. Clear the old
+      // terminal fields so a pre-engine failure cannot keep a stale
+      // result; the engine performs the same reset when it starts.
       if (TERMINAL_STATUSES.has(state.status)) {
         state.status = "starting";
+        delete state.completedAt;
+        delete state.error;
+        delete state.result;
       }
     });
     const state = await superviseEngine(store);
@@ -1382,6 +1387,15 @@ async function resumeCommand(parsed: ParsedArguments): Promise<number> {
     store = cleaned;
     state = cleaned.snapshot();
     await stopCompletionNotifierForResume(store);
+    if (
+      recovering &&
+      (state.status !== "completed" || !isSemanticHalt(state.result))
+    ) {
+      throw new Error(
+        `Run ${runId} changed state during recovery (now ${state.status}); ` +
+          "check status and retry",
+      );
+    }
   }
   const changingAuthorization =
     parsed.flags.has("allow-danger-full-access") ||

--- a/plugins/dynamic-workflow/src/cli.ts
+++ b/plugins/dynamic-workflow/src/cli.ts
@@ -369,6 +369,12 @@ async function executeClaimedRun(
       state.pid = process.pid;
       state.pidStartedAt = pidStartedAt;
       state.runnerStartedAt = nowIso();
+      // Leave any terminal status behind only after the runner claim
+      // succeeded, so a bootstrap failure is recorded instead of skipped
+      // by recordBootstrapFailure's terminal-status guard.
+      if (TERMINAL_STATUSES.has(state.status)) {
+        state.status = "starting";
+      }
     });
     const state = await superviseEngine(store);
     finalState = state;
@@ -1325,6 +1331,12 @@ async function resumeCommand(parsed: ParsedArguments): Promise<number> {
   const runId = requirePositional(parsed, 0, "run ID");
   let store = await StateStore.load(runId);
   let state = store.snapshot();
+  if (parsed.flags.has("recover") && state.status !== "completed") {
+    throw new Error(
+      `--recover only applies to completed semantic halts ` +
+        `(run ${runId} is ${state.status}); use plain resume`,
+    );
+  }
   const recovering = state.status === "completed" && parsed.flags.has("recover");
   if (state.status === "completed" && !recovering) {
     if (isSemanticHalt(state.result)) {
@@ -1397,11 +1409,6 @@ async function resumeCommand(parsed: ParsedArguments): Promise<number> {
     current.authorization = authorization;
   });
   if (parsed.flags.has("foreground")) {
-    // Leave the terminal status behind before execution so a bootstrap
-    // failure is recorded instead of skipped by its terminal-status guard.
-    await store.update((current) => {
-      current.status = "starting";
-    });
     const finalState = await executeRun(runId, parsed.flags.has("json"));
     if (!parsed.flags.has("json")) {
       outputState(finalState, false);

--- a/plugins/dynamic-workflow/src/cli.ts
+++ b/plugins/dynamic-workflow/src/cli.ts
@@ -717,6 +717,19 @@ async function spawnDetached(store: StateStore): Promise<number> {
   const runnerToken = await store.claimRunner(process.pid);
   let handedOff = false;
   try {
+    // Leave any terminal status behind right after the claim succeeds and
+    // before the fallible detached setup, so a setup failure is recorded
+    // instead of skipped by recordBootstrapFailure's terminal-status
+    // guard. Clear the old terminal fields so no stale result survives;
+    // the engine performs the same reset when it starts.
+    await store.update((state) => {
+      if (TERMINAL_STATUSES.has(state.status)) {
+        state.status = "starting";
+        delete state.completedAt;
+        delete state.error;
+        delete state.result;
+      }
+    });
     const runnerLog = await open(path.join(store.directory, "runner.log"), "a");
     try {
       const child = spawn(
@@ -741,14 +754,6 @@ async function spawnDetached(store: StateStore): Promise<number> {
       await store.update((state) => {
         state.pid = pid;
         state.pidStartedAt = pidStartedAt;
-        // Clear old terminal fields when leaving a terminal status, so a
-        // detached bootstrap failure cannot keep a stale result; the
-        // engine performs the same reset when it starts.
-        if (TERMINAL_STATUSES.has(state.status)) {
-          delete state.completedAt;
-          delete state.error;
-          delete state.result;
-        }
         state.status = "starting";
       });
       await store.transferRunner(runnerToken, pid);

--- a/plugins/dynamic-workflow/src/cli.ts
+++ b/plugins/dynamic-workflow/src/cli.ts
@@ -741,6 +741,14 @@ async function spawnDetached(store: StateStore): Promise<number> {
       await store.update((state) => {
         state.pid = pid;
         state.pidStartedAt = pidStartedAt;
+        // Clear old terminal fields when leaving a terminal status, so a
+        // detached bootstrap failure cannot keep a stale result; the
+        // engine performs the same reset when it starts.
+        if (TERMINAL_STATUSES.has(state.status)) {
+          delete state.completedAt;
+          delete state.error;
+          delete state.result;
+        }
         state.status = "starting";
       });
       await store.transferRunner(runnerToken, pid);

--- a/plugins/dynamic-workflow/tests/cli.test.ts
+++ b/plugins/dynamic-workflow/tests/cli.test.ts
@@ -419,6 +419,102 @@ test("resume refuses to signal a reused process ID", async () => {
   }
 });
 
+test("resume keeps a successful completion terminal and refuses --recover", async () => {
+  const workflowPath = path.join(temporaryDirectory, "success.js");
+  await writeFile(
+    workflowPath,
+    'return { approved: true, value: await agent("ok", { id: "ok" }) }\n',
+    "utf8",
+  );
+  const run = await invoke(["run", workflowPath, "--json"]);
+  const state = JSON.parse(run.stdout) as RunState;
+  expect(state.status).toBe("completed");
+
+  const resumed = await invoke(["resume", state.runId, "--json"]);
+  expect((JSON.parse(resumed.stdout) as RunState).status).toBe("completed");
+
+  await expect(invoke(["resume", state.runId, "--recover", "--json"]))
+    .rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringMatching(/refusing --recover/),
+    });
+  const codexLog = await readFile(
+    environment.FAKE_CODEX_LOG as string,
+    "utf8",
+  );
+  expect(codexLog.trim().split("\n")).toHaveLength(1);
+});
+
+test("resume without --recover reports a semantic halt without replaying", async () => {
+  const workflowPath = path.join(temporaryDirectory, "halt.js");
+  await writeFile(
+    workflowPath,
+    'const finding = await agent("inspect", { id: "inspect" });\n' +
+      "return { approved: false, finding }\n",
+    "utf8",
+  );
+  const run = await invoke(["run", workflowPath, "--json"]);
+  const state = JSON.parse(run.stdout) as RunState;
+  expect(state.status).toBe("completed");
+  expect(state.result).toMatchObject({ approved: false });
+
+  const resumed = await invoke(["resume", state.runId, "--json"]);
+  expect((JSON.parse(resumed.stdout) as RunState).status).toBe("completed");
+  expect(resumed.stderr).toMatch(/pass --recover to replay/);
+  const codexLog = await readFile(
+    environment.FAKE_CODEX_LOG as string,
+    "utf8",
+  );
+  expect(codexLog.trim().split("\n")).toHaveLength(1);
+});
+
+test("resume --recover replays a semantic halt and reuses cached steps", async () => {
+  const workflowPath = path.join(temporaryDirectory, "recover.js");
+  await writeFile(
+    workflowPath,
+    'const first = await agent("one", { id: "one" });\n' +
+      'const second = await agent("two", { id: "two" });\n' +
+      "return { approved: false, first, second }\n",
+    "utf8",
+  );
+  const run = await invoke(["run", workflowPath, "--json"]);
+  const halted = JSON.parse(run.stdout) as RunState;
+  expect(halted.status).toBe("completed");
+  expect(halted.result).toMatchObject({ approved: false });
+
+  await writeFile(
+    workflowPath,
+    'const first = await agent("one", { id: "one" });\n' +
+      'const second = await agent("two-changed", { id: "two" });\n' +
+      "return { approved: true, first, second }\n",
+    "utf8",
+  );
+  const recovered = await invoke([
+    "resume",
+    halted.runId,
+    "--recover",
+    "--foreground",
+    "--json",
+  ]);
+  const state = JSON.parse(recovered.stdout) as RunState;
+  expect(state.status).toBe("completed");
+  expect(state.result).toEqual({
+    approved: true,
+    first: "result:one",
+    second: "result:two-changed",
+  });
+
+  const codexLog = await readFile(
+    environment.FAKE_CODEX_LOG as string,
+    "utf8",
+  );
+  const prompts = codexLog
+    .trim()
+    .split("\n")
+    .map((line) => (JSON.parse(line) as { prompt: string }).prompt);
+  expect(prompts).toEqual(["one", "two", "two-changed"]);
+});
+
 async function invoke(args: string[]): Promise<{ stderr: string; stdout: string }> {
   return await execFileAsync(process.execPath, [cliPath, ...args], {
     cwd: temporaryDirectory,

--- a/plugins/dynamic-workflow/tests/cli.test.ts
+++ b/plugins/dynamic-workflow/tests/cli.test.ts
@@ -535,6 +535,7 @@ test("resume --recover --foreground records a bootstrap failure", async () => {
   const state = JSON.parse(status.stdout) as RunState;
   expect(state.status).toBe("failed");
   expect(state.error).toMatch(/Runner bootstrap failed/);
+  expect(state.result).toBeUndefined();
 });
 
 test("resume --recover is refused for non-completed runs", async () => {

--- a/plugins/dynamic-workflow/tests/cli.test.ts
+++ b/plugins/dynamic-workflow/tests/cli.test.ts
@@ -537,6 +537,27 @@ test("resume --recover --foreground records a bootstrap failure", async () => {
   expect(state.error).toMatch(/Runner bootstrap failed/);
 });
 
+test("resume --recover is refused for non-completed runs", async () => {
+  const workflowPath = path.join(temporaryDirectory, "recover-failed.js");
+  await writeFile(
+    workflowPath,
+    'return await agent("[fail] boom", { id: "boom" })\n',
+    "utf8",
+  );
+  const error = (await invoke(["run", workflowPath, "--json"]).catch(
+    (rejection: unknown) => rejection,
+  )) as { code: number; stdout: string };
+  expect(error.code).toBe(1);
+  const failed = JSON.parse(error.stdout) as RunState;
+  expect(failed.status).toBe("failed");
+
+  await expect(invoke(["resume", failed.runId, "--recover", "--json"]))
+    .rejects.toMatchObject({
+      code: 1,
+      stderr: expect.stringMatching(/only applies to completed semantic halts/),
+    });
+});
+
 async function invoke(args: string[]): Promise<{ stderr: string; stdout: string }> {
   return await execFileAsync(process.execPath, [cliPath, ...args], {
     cwd: temporaryDirectory,

--- a/plugins/dynamic-workflow/tests/cli.test.ts
+++ b/plugins/dynamic-workflow/tests/cli.test.ts
@@ -1,5 +1,5 @@
 import { execFile, spawn } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -558,6 +558,37 @@ test("detached resume --recover records a bootstrap failure", async () => {
   );
   expect(failed.error).toMatch(/Runner bootstrap failed/);
   expect(failed.result).toBeUndefined();
+});
+
+test("detached recovery records a failure when runner setup fails", async () => {
+  const workflowPath = path.join(temporaryDirectory, "recover-setup.js");
+  await writeFile(
+    workflowPath,
+    'const finding = await agent("inspect", { id: "inspect" });\n' +
+      "return { approved: false, finding }\n",
+    "utf8",
+  );
+  const run = await invoke(["run", workflowPath, "--json"]);
+  const halted = JSON.parse(run.stdout) as RunState;
+  expect(halted.status).toBe("completed");
+
+  // Occupy the runner.log path with a directory so the detached setup
+  // fails after the runner claim succeeds.
+  await mkdir(
+    path.join(
+      environment.CODEX_WORKFLOW_HOME as string,
+      "runs",
+      halted.runId,
+      "runner.log",
+    ),
+  );
+  await expect(invoke(["resume", halted.runId, "--recover", "--json"]))
+    .rejects.toMatchObject({ code: 1 });
+  const status = await invoke(["status", halted.runId, "--json"]);
+  const state = JSON.parse(status.stdout) as RunState;
+  expect(state.status).toBe("failed");
+  expect(state.error).toMatch(/Runner bootstrap failed/);
+  expect(state.result).toBeUndefined();
 });
 
 test("resume --recover is refused for non-completed runs", async () => {

--- a/plugins/dynamic-workflow/tests/cli.test.ts
+++ b/plugins/dynamic-workflow/tests/cli.test.ts
@@ -515,6 +515,28 @@ test("resume --recover replays a semantic halt and reuses cached steps", async (
   expect(prompts).toEqual(["one", "two", "two-changed"]);
 });
 
+test("resume --recover --foreground records a bootstrap failure", async () => {
+  const workflowPath = path.join(temporaryDirectory, "recover-broken.js");
+  await writeFile(
+    workflowPath,
+    'const finding = await agent("inspect", { id: "inspect" });\n' +
+      "return { approved: false, finding }\n",
+    "utf8",
+  );
+  const run = await invoke(["run", workflowPath, "--json"]);
+  const halted = JSON.parse(run.stdout) as RunState;
+  expect(halted.status).toBe("completed");
+
+  await writeFile(workflowPath, "this is not JavaScript {\n", "utf8");
+  await expect(
+    invoke(["resume", halted.runId, "--recover", "--foreground", "--json"]),
+  ).rejects.toMatchObject({ code: 1 });
+  const status = await invoke(["status", halted.runId, "--json"]);
+  const state = JSON.parse(status.stdout) as RunState;
+  expect(state.status).toBe("failed");
+  expect(state.error).toMatch(/Runner bootstrap failed/);
+});
+
 async function invoke(args: string[]): Promise<{ stderr: string; stdout: string }> {
   return await execFileAsync(process.execPath, [cliPath, ...args], {
     cwd: temporaryDirectory,

--- a/plugins/dynamic-workflow/tests/cli.test.ts
+++ b/plugins/dynamic-workflow/tests/cli.test.ts
@@ -538,6 +538,28 @@ test("resume --recover --foreground records a bootstrap failure", async () => {
   expect(state.result).toBeUndefined();
 });
 
+test("detached resume --recover records a bootstrap failure", async () => {
+  const workflowPath = path.join(temporaryDirectory, "recover-detached.js");
+  await writeFile(
+    workflowPath,
+    'const finding = await agent("inspect", { id: "inspect" });\n' +
+      "return { approved: false, finding }\n",
+    "utf8",
+  );
+  const run = await invoke(["run", workflowPath, "--json"]);
+  const halted = JSON.parse(run.stdout) as RunState;
+  expect(halted.status).toBe("completed");
+
+  await writeFile(workflowPath, "this is not JavaScript {\n", "utf8");
+  await invoke(["resume", halted.runId, "--recover", "--json"]);
+  const failed = await waitForRun(
+    halted.runId,
+    (state) => state.status === "failed",
+  );
+  expect(failed.error).toMatch(/Runner bootstrap failed/);
+  expect(failed.result).toBeUndefined();
+});
+
 test("resume --recover is refused for non-completed runs", async () => {
   const workflowPath = path.join(temporaryDirectory, "recover-failed.js");
   await writeFile(


### PR DESCRIPTION
Fixes #180.

## Problem

A workflow that deliberately halts by returning an object with `approved: false` records status `completed`, and `resume` returned immediately for every completed run. After repairing a workflow-script defect exposed by such a halt, the only option was a brand-new run, which discards the durable per-step cache.

## Change

`codex-workflow resume <run-id> --recover` replays a completed run whose stored result is a semantic halt, through the existing resume machinery:

- orphaned engine/worker processes are cleaned up (recovery aborts with an error while a prior runner is still alive, or if the run changes state during cleanup);
- the current (repaired) script is re-read, re-hashed, and snapshotted;
- steps with unchanged fingerprints return cached results; changed steps rerun;
- an edited script still invalidates prior write authorization, so `--allow-workspace-write` / `--allow-danger-full-access` must be renewed for write sandboxes;
- original input, cwd, concurrency, and limits stay bound from durable state.

Safeguards kept: plain `resume` leaves all completed runs untouched (it prints a hint when it meets a semantic halt); `--recover` is refused for successful completions (`approved` `true` or absent) and for non-completed runs.

Hardening found during review: runners now leave a terminal status only after the runner claim succeeds and clear stale `result`/`error`/`completedAt` when doing so, so a bootstrap failure (e.g. broken script) is recorded as `failed` instead of being swallowed or carrying the old halt result — in both foreground and detached paths.

Deferred (pre-existing, unchanged by this PR): two concurrent `resume` invocations of the same run can race in orphan cleanup; this exists identically on main for failed runs.

## Tests

Six new CLI tests: successful completion stays terminal and refuses `--recover`; plain resume hints on a halt without replaying; recovery replays with cache reuse (changed step reruns, sibling cached); foreground and detached bootstrap failures are recorded without stale results; `--recover` refused on non-completed runs. Full plugin suite: 145 passed.

Docs: skill (`SKILL.md`, API reference synopsis) and the Starlight `dynamic-workflow` page. Plugin bumped to 0.2.2.