### PR TITLE
fix(aichat): do not auto-index help requests

### DIFF
--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -184,7 +184,11 @@ def main(ctx, claude_home, codex_home):
     skip_auto_index_cmds = ['build-index', 'clear-index', 'index-stats']
     cli_args = sys.argv[1:]
     if '--' in cli_args:
-        cli_args = cli_args[:cli_args.index('--')]
+        separator_index = cli_args.index('--')
+        after_separator = cli_args[separator_index + 1:]
+        cli_args = cli_args[:separator_index]
+        if after_separator and after_separator[0] in ctx.command.commands:
+            cli_args.extend(after_separator)
     help_mode = any(arg in cli_args for arg in ('-h', '--help'))
     should_skip = (
         help_mode

--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -182,7 +182,10 @@ def main(ctx, claude_home, codex_home):
     # time out. Trimming also rewrites the file, so indexing its
     # pre-trim content first is wasted work twice over.
     skip_auto_index_cmds = ['build-index', 'clear-index', 'index-stats']
-    help_mode = any(arg in sys.argv for arg in ('-h', '--help'))
+    cli_args = sys.argv[1:]
+    if '--' in cli_args:
+        cli_args = cli_args[:cli_args.index('--')]
+    help_mode = any(arg in cli_args for arg in ('-h', '--help'))
     should_skip = (
         help_mode
         or ctx.invoked_subcommand in ('port', 'resolve', 'trim-in-place')

--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -182,8 +182,10 @@ def main(ctx, claude_home, codex_home):
     # time out. Trimming also rewrites the file, so indexing its
     # pre-trim content first is wasted work twice over.
     skip_auto_index_cmds = ['build-index', 'clear-index', 'index-stats']
+    help_mode = any(arg in sys.argv for arg in ('-h', '--help'))
     should_skip = (
-        ctx.invoked_subcommand in ('port', 'resolve', 'trim-in-place')
+        help_mode
+        or ctx.invoked_subcommand in ('port', 'resolve', 'trim-in-place')
         or ctx.invoked_subcommand in skip_auto_index_cmds
         or any(cmd in sys.argv for cmd in skip_auto_index_cmds)
     )

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -86,14 +86,15 @@ def test_search_help_after_group_separator_skips_auto_indexing(
 
 
 def test_search_help_after_separator_with_colliding_option_value_skips_indexing(
-    runner, mock_auto_index, tmp_path
+    runner, mock_auto_index, tmp_path, monkeypatch
 ):
     """A group option value matching the command must not hide its help."""
     claude_home = tmp_path / "search"
     claude_home.mkdir()
+    monkeypatch.chdir(tmp_path)
     _invoke(
         runner,
-        ["--claude-home", str(claude_home), "--", "search", "--help"],
+        ["--claude-home", "search", "--", "search", "--help"],
     )
     mock_auto_index.assert_not_called()
 

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -70,6 +70,12 @@ def test_search_still_auto_indexes_for_a_real_query(runner, mock_auto_index):
     mock_auto_index.assert_called_once()
 
 
+def test_search_literal_help_query_still_auto_indexes(runner, mock_auto_index):
+    """A query after ``--`` is data, not a help request."""
+    _invoke(runner, ["search", "--", "--help"])
+    mock_auto_index.assert_called_once()
+
+
 def test_trim_in_place_skips_indexing_on_a_real_run(
     runner, mock_auto_index, tmp_path
 ):

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -84,6 +84,19 @@ def test_search_help_after_group_separator_skips_auto_indexing(
     _invoke(runner, ["--", "search", "--help"])
     mock_auto_index.assert_not_called()
 
+
+def test_search_help_after_separator_with_colliding_option_value_skips_indexing(
+    runner, mock_auto_index, tmp_path
+):
+    """A group option value matching the command must not hide its help."""
+    claude_home = tmp_path / "search"
+    claude_home.mkdir()
+    _invoke(
+        runner,
+        ["--claude-home", str(claude_home), "--", "search", "--help"],
+    )
+    mock_auto_index.assert_not_called()
+
 def test_trim_in_place_skips_indexing_on_a_real_run(
     runner, mock_auto_index, tmp_path
 ):

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -76,6 +76,14 @@ def test_search_literal_help_query_still_auto_indexes(runner, mock_auto_index):
     mock_auto_index.assert_called_once()
 
 
+
+def test_search_help_after_group_separator_skips_auto_indexing(
+    runner, mock_auto_index
+):
+    """A separator before the subcommand does not hide its help request."""
+    _invoke(runner, ["--", "search", "--help"])
+    mock_auto_index.assert_not_called()
+
 def test_trim_in_place_skips_indexing_on_a_real_run(
     runner, mock_auto_index, tmp_path
 ):

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -48,6 +48,8 @@ def _invoke(runner, argv):
 @pytest.mark.parametrize(
     "argv",
     [
+        ["--help"],
+        ["search", "--help"],
         ["trim-in-place", "--help"],
         ["port", "--help"],
         ["resolve", "--help"],
@@ -62,10 +64,9 @@ def test_index_free_commands_do_not_auto_index(
     mock_auto_index.assert_not_called()
 
 
-def test_search_still_auto_indexes(runner, mock_auto_index):
-    """The skip list must stay narrow: search reads the index, so it
-    still has to refresh it first."""
-    _invoke(runner, ["search", "--help"])
+def test_search_still_auto_indexes_for_a_real_query(runner, mock_auto_index):
+    """A real search reads the index, so it still refreshes it first."""
+    _invoke(runner, ["search", "query"])
     mock_auto_index.assert_called_once()
 
 

--- a/tests/test_aichat_claude_home.py
+++ b/tests/test_aichat_claude_home.py
@@ -63,7 +63,7 @@ class TestClaudeHomeResolution:
         alt_home.mkdir()
         argv = [
             "aichat", "search",
-            "--claude-home", str(alt_home), "--help",
+            "--claude-home", str(alt_home), "query",
         ]
         with patch.object(sys, "argv", argv):
             runner.invoke(main, argv[1:])
@@ -80,7 +80,7 @@ class TestClaudeHomeResolution:
         alt_home.mkdir()
         argv = [
             "aichat",
-            "--claude-home", str(alt_home), "search", "--help",
+            "--claude-home", str(alt_home), "search", "query",
         ]
         with patch.object(sys, "argv", argv):
             runner.invoke(main, argv[1:])
@@ -95,7 +95,7 @@ class TestClaudeHomeResolution:
         """CLAUDE_CONFIG_DIR env var used when no CLI arg."""
         alt_home = tmp_path / ".claude-env"
         alt_home.mkdir()
-        argv = ["aichat", "search", "--help"]
+        argv = ["aichat", "search", "query"]
         with (
             patch.object(sys, "argv", argv),
             patch.dict(
@@ -119,7 +119,7 @@ class TestClaudeHomeResolution:
         cli_home.mkdir()
         argv = [
             "aichat", "search",
-            "--claude-home", str(cli_home), "--help",
+            "--claude-home", str(cli_home), "query",
         ]
         with (
             patch.object(sys, "argv", argv),
@@ -143,7 +143,7 @@ class TestClaudeHomeResolution:
         alt_codex.mkdir()
         argv = [
             "aichat", "search",
-            "--codex-home", str(alt_codex), "--help",
+            "--codex-home", str(alt_codex), "query",
         ]
         with patch.object(sys, "argv", argv):
             runner.invoke(main, argv[1:])


### PR DESCRIPTION
Closes #98.

The `aichat` group callback auto-indexed sessions before every command, including top-level and subcommand help. This made help requests scan and potentially rebuild the user's real session index, causing slow, side-effectful help output.

Skip auto-indexing whenever the invocation requests help, while respecting `--` so a literal `--help` search query still refreshes the index. Normal search queries continue to refresh the index before reading it. Existing home-resolution tests now use real search invocations because help requests intentionally skip indexing.

Validation:
- `uv run --python D:\Software\Anaconda\python.exe --frozen pytest tests/test_aichat_autoindex_skip.py tests/test_aichat_claude_home.py -q -k "index_free_commands or search_still_auto_indexes_for_a_real_query or search_literal_help_query_still_auto_indexes or claude_home or codex_home"` (13 passed)
- `uv run --python D:\Software\Anaconda\python.exe --frozen pytest tests/test_aichat_claude_home.py -q` (5 passed)
- `uv run --python D:\Software\Anaconda\python.exe --frozen pytest tests/test_search_import.py -q` (3 passed)
- `uv run --python D:\Software\Anaconda\python.exe --frozen python -m compileall -q claude_code_tools tests` (passed)
- `git diff --check` (passed)

The full auto-index test module retains one pre-existing Windows assertion failure caused by comparing a JSON-escaped path with an unescaped path; it is outside this change.
