### PR TITLE
fix(aichat): do not auto-index help requests (supersedes #183)

### DIFF
--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -182,7 +182,15 @@ def main(ctx, claude_home, codex_home):
     # time out. Trimming also rewrites the file, so indexing its
     # pre-trim content first is wasted work twice over.
     skip_auto_index_cmds = ['build-index', 'clear-index', 'index-stats']
+    # A help request must not index. Scan argv rather than click's parsed
+    # options, since -h/--help never reaches this callback as a value.
+    # Anchor the scan at the subcommand so a group-level separator
+    # ('aichat -- search --help') does not hide the flag, and stop at the
+    # subcommand's own separator so a literal '--help' *query*
+    # ('aichat search -- --help') still refreshes the index first.
     cli_args = sys.argv[1:]
+    if ctx.invoked_subcommand and ctx.invoked_subcommand in cli_args:
+        cli_args = cli_args[cli_args.index(ctx.invoked_subcommand):]
     if '--' in cli_args:
         cli_args = cli_args[:cli_args.index('--')]
     help_mode = any(arg in cli_args for arg in ('-h', '--help'))

--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -191,15 +191,21 @@ def main(ctx, claude_home, codex_home):
     # Skip the values of the group's own value-taking options while
     # looking for the subcommand, so 'aichat --claude-home resume ...'
     # does not anchor on the directory named 'resume'.
+    # Only truncate once anchored: SessionReferenceGroup synthesizes a
+    # subcommand for bare session references ('aichat -- --help' routes to
+    # 'menu'), so the name is not always present in argv, and there is then
+    # no subcommand-level separator to respect.
     group_value_opts = ('--claude-home', '--codex-home')
     cli_args = sys.argv[1:]
+    anchored = False
     for i, arg in enumerate(cli_args):
         if i and cli_args[i - 1] in group_value_opts:
             continue
         if arg == ctx.invoked_subcommand:
             cli_args = cli_args[i:]
+            anchored = True
             break
-    if '--' in cli_args:
+    if anchored and '--' in cli_args:
         cli_args = cli_args[:cli_args.index('--')]
     help_mode = any(arg in cli_args for arg in ('-h', '--help'))
     should_skip = (

--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -188,9 +188,17 @@ def main(ctx, claude_home, codex_home):
     # ('aichat -- search --help') does not hide the flag, and stop at the
     # subcommand's own separator so a literal '--help' *query*
     # ('aichat search -- --help') still refreshes the index first.
+    # Skip the values of the group's own value-taking options while
+    # looking for the subcommand, so 'aichat --claude-home resume ...'
+    # does not anchor on the directory named 'resume'.
+    group_value_opts = ('--claude-home', '--codex-home')
     cli_args = sys.argv[1:]
-    if ctx.invoked_subcommand and ctx.invoked_subcommand in cli_args:
-        cli_args = cli_args[cli_args.index(ctx.invoked_subcommand):]
+    for i, arg in enumerate(cli_args):
+        if i and cli_args[i - 1] in group_value_opts:
+            continue
+        if arg == ctx.invoked_subcommand:
+            cli_args = cli_args[i:]
+            break
     if '--' in cli_args:
         cli_args = cli_args[:cli_args.index('--')]
     help_mode = any(arg in cli_args for arg in ('-h', '--help'))

--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -182,7 +182,10 @@ def main(ctx, claude_home, codex_home):
     # time out. Trimming also rewrites the file, so indexing its
     # pre-trim content first is wasted work twice over.
     skip_auto_index_cmds = ['build-index', 'clear-index', 'index-stats']
-    help_mode = any(arg in sys.argv for arg in ('-h', '--help'))
+    cli_args = sys.argv[1:]
+    if '--' in cli_args:
+        cli_args = cli_args[:cli_args.index('--')]
+    help_mode = any(arg in cli_args for arg in ('-h', '--help'))
     should_skip = (
         help_mode
         or ctx.invoked_subcommand in ('port', 'resolve', 'trim-in-place')

--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -182,8 +182,10 @@ def main(ctx, claude_home, codex_home):
     # time out. Trimming also rewrites the file, so indexing its
     # pre-trim content first is wasted work twice over.
     skip_auto_index_cmds = ['build-index', 'clear-index', 'index-stats']
+    help_mode = any(arg in sys.argv for arg in ('-h', '--help'))
     should_skip = (
-        ctx.invoked_subcommand in ('port', 'resolve', 'trim-in-place')
+        help_mode
+        or ctx.invoked_subcommand in ('port', 'resolve', 'trim-in-place')
         or ctx.invoked_subcommand in skip_auto_index_cmds
         or any(cmd in sys.argv for cmd in skip_auto_index_cmds)
     )

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -53,6 +53,9 @@ def _invoke(runner, argv):
         # Click treats a group-level ``--`` as ending only the group's
         # options, so this still renders search help.
         ["--", "search", "--help"],
+        # Routed to the synthesized ``menu`` subcommand, whose name never
+        # appears in argv, so there is no anchor to truncate from.
+        ["--", "--help"],
         ["trim-in-place", "--help"],
         ["port", "--help"],
         ["resolve", "--help"],

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -70,6 +70,12 @@ def test_search_still_auto_indexes_for_a_real_query(runner, mock_auto_index):
     mock_auto_index.assert_called_once()
 
 
+def test_search_literal_help_query_still_auto_indexes(runner, mock_auto_index):
+    """A query after ``--`` is data, not a help request."""
+    _invoke(runner, ["search", "--", "--help"])
+    mock_auto_index.assert_called_once()
+
+
 def test_trim_in_place_skips_indexing_on_a_real_run(
     runner, mock_auto_index, tmp_path
 ):

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -67,6 +67,21 @@ def test_index_free_commands_do_not_auto_index(
     mock_auto_index.assert_not_called()
 
 
+def test_help_after_a_home_named_like_a_subcommand_does_not_index(
+    runner, mock_auto_index, tmp_path, monkeypatch
+):
+    """A ``--claude-home`` value that happens to equal the subcommand name
+    must not be mistaken for the subcommand when locating the help flag."""
+    (tmp_path / "resume").mkdir()
+    monkeypatch.chdir(tmp_path)
+    result = _invoke(
+        runner, ["--claude-home", "resume", "--", "resume", "--help"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Usage:" in result.output
+    mock_auto_index.assert_not_called()
+
+
 def test_search_still_auto_indexes_for_a_real_query(runner, mock_auto_index):
     """A real search reads the index, so it still refreshes it first."""
     _invoke(runner, ["search", "query"])

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -50,6 +50,9 @@ def _invoke(runner, argv):
     [
         ["--help"],
         ["search", "--help"],
+        # Click treats a group-level ``--`` as ending only the group's
+        # options, so this still renders search help.
+        ["--", "search", "--help"],
         ["trim-in-place", "--help"],
         ["port", "--help"],
         ["resolve", "--help"],

--- a/tests/test_aichat_autoindex_skip.py
+++ b/tests/test_aichat_autoindex_skip.py
@@ -48,6 +48,8 @@ def _invoke(runner, argv):
 @pytest.mark.parametrize(
     "argv",
     [
+        ["--help"],
+        ["search", "--help"],
         ["trim-in-place", "--help"],
         ["port", "--help"],
         ["resolve", "--help"],
@@ -62,10 +64,9 @@ def test_index_free_commands_do_not_auto_index(
     mock_auto_index.assert_not_called()
 
 
-def test_search_still_auto_indexes(runner, mock_auto_index):
-    """The skip list must stay narrow: search reads the index, so it
-    still has to refresh it first."""
-    _invoke(runner, ["search", "--help"])
+def test_search_still_auto_indexes_for_a_real_query(runner, mock_auto_index):
+    """A real search reads the index, so it still refreshes it first."""
+    _invoke(runner, ["search", "query"])
     mock_auto_index.assert_called_once()
 
 

--- a/tests/test_aichat_claude_home.py
+++ b/tests/test_aichat_claude_home.py
@@ -63,7 +63,7 @@ class TestClaudeHomeResolution:
         alt_home.mkdir()
         argv = [
             "aichat", "search",
-            "--claude-home", str(alt_home), "--help",
+            "--claude-home", str(alt_home), "query",
         ]
         with patch.object(sys, "argv", argv):
             runner.invoke(main, argv[1:])
@@ -80,7 +80,7 @@ class TestClaudeHomeResolution:
         alt_home.mkdir()
         argv = [
             "aichat",
-            "--claude-home", str(alt_home), "search", "--help",
+            "--claude-home", str(alt_home), "search", "query",
         ]
         with patch.object(sys, "argv", argv):
             runner.invoke(main, argv[1:])
@@ -95,7 +95,7 @@ class TestClaudeHomeResolution:
         """CLAUDE_CONFIG_DIR env var used when no CLI arg."""
         alt_home = tmp_path / ".claude-env"
         alt_home.mkdir()
-        argv = ["aichat", "search", "--help"]
+        argv = ["aichat", "search", "query"]
         with (
             patch.object(sys, "argv", argv),
             patch.dict(
@@ -119,7 +119,7 @@ class TestClaudeHomeResolution:
         cli_home.mkdir()
         argv = [
             "aichat", "search",
-            "--claude-home", str(cli_home), "--help",
+            "--claude-home", str(cli_home), "query",
         ]
         with (
             patch.object(sys, "argv", argv),
@@ -143,7 +143,7 @@ class TestClaudeHomeResolution:
         alt_codex.mkdir()
         argv = [
             "aichat", "search",
-            "--codex-home", str(alt_codex), "--help",
+            "--codex-home", str(alt_codex), "query",
         ]
         with patch.object(sys, "argv", argv):
             runner.invoke(main, argv[1:])

--- a/tests/test_resolve_session.py
+++ b/tests/test_resolve_session.py
@@ -404,6 +404,8 @@ def test_resolve_skips_auto_index_without_changing_other_commands(
     assert resolve_result.returncode == 0
     assert not index_path.exists()
 
+    # A real query, not ``--help``: help requests deliberately skip
+    # auto-indexing, so they cannot show that other commands still index.
     search_result = _run_cli(
         [
             "search",
@@ -412,7 +414,7 @@ def test_resolve_skips_auto_index_without_changing_other_commands(
             "--codex-home",
             str(codex_home),
             "--json",
-            "--help",
+            "Selected",
         ],
         env,
     )


### PR DESCRIPTION
Supersedes #183. Closes #98.

Credit to @mikemikimike, whose two commits are carried here unchanged (original
authorship preserved via cherry-pick).

## What this does

`aichat`'s group callback auto-indexed sessions before every command, including
top-level and subcommand help. That made `aichat search --help` scan and
potentially rebuild the user's real session index — slow and side-effectful, and
the cause of the timeout described in #98.

The callback now skips auto-indexing when the invocation requests help, while
respecting `--` so a literal `--help` *search query* still refreshes the index.
Normal search queries continue to refresh the index before reading it.

## Why a superseding PR

#183 as submitted breaks `tests/test_resolve_session.py::
test_resolve_skips_auto_index_without_changing_other_commands`. That test used
`search --claude-home ... --json --help` as its "other commands still index"
case; once help skips indexing, no `index_state.json` is written and the test
dies with `FileNotFoundError`. Verified: the test passes on `main` and fails on
#183's head.

This PR adds a third commit switching that assertion to a real query, which is
what it actually meant to test. (The author validated on Windows against a
subset of the suite, so the failure was not visible to them.)

## Verification

- Full suite on this branch: **1946 passed, 7 skipped, 0 failed**
  (`uv run --frozen pytest tests -q -p no:randomly`).
- Counter-verified the fix is load-bearing: reverting `aichat.py` to `main`
  makes `test_index_free_commands_do_not_auto_index[search --help]` fail
  (`Expected 'auto_index' to not have been called. Called 1 times.`).
- Counter-verified the repaired assertion still has teeth: adding `search` to
  the skip list makes `test_resolve_skips_auto_index_without_changing_other_commands`
  fail again.
- `python -m compileall` on all four changed files: clean.
- Counter-verified the group-separator fix: `["--", "search", "--help"]`
  fails on the previous commit, passes on this head.
- Four rounds of cold-diff review by independent reviewers with no context;
  the final round reports no blocking findings.

## Deferred

One minor note: `aichat search --dir --help query` (searching a directory
literally named `--help`) is misread as a help request and skips indexing. Not
fixed — the invocation is not realistic, and `--` already covers the literal
query case.


## Review rounds

Independent reviewers found three holes in the argv scan, each now fixed with a
regression test that fails on its parent commit:

1. `aichat -- search --help` rendered help yet still indexed (a group-level
   `--` truncated the scan before the flag). Fixed by anchoring the scan at the
   invoked subcommand.
2. `aichat --claude-home resume -- resume --help` anchored on the `--claude-home`
   *value* rather than the subcommand. Fixed by skipping the values of the
   group's value-taking options.
3. `aichat -- --help` routes to the `menu` subcommand that
   `SessionReferenceGroup` synthesizes, whose name never appears in argv, so
   there was no anchor and the leading `--` truncated the scan to nothing.
   Fixed by truncating at `--` only when the subcommand was actually located.

Note on why this is scanned from `sys.argv` at all: Click 8.2 does not expose
the split subcommand args in a group callback (`ctx.args` is empty and
`protected_args` is gone), so there is no parser-provided alternative short of
restructuring where auto-indexing happens. The surrounding code already scans
`sys.argv` the same way for `--claude-home` / `--codex-home`.

## Deferred (not fixed)

- `aichat search --branch --help query` — searching for a branch literally
  named `--help` is read as a help request and skips indexing, so the query
  could use a stale index. The reviewer that raised it labelled it contrived;
  no user types this.
- `aichat search --dir --help query` — same shape, a directory named `--help`.
