### PR TITLE
docs: simplify Visual Brief card subtitle

### DIFF
--- a/assets/card-visual-brief.svg
+++ b/assets/card-visual-brief.svg
@@ -16,7 +16,7 @@
   <text x="100" y="37" font-family="monospace" font-size="22" font-weight="bold"
         fill="#5eead4" text-anchor="middle" filter="url(#glow)">visual brief</text>
   <text x="100" y="62" font-family="monospace" font-size="13" fill="#99f6e4"
-        text-anchor="middle">Structured local</text>
+        text-anchor="middle">Structured</text>
   <text x="100" y="77" font-family="monospace" font-size="13" fill="#99f6e4"
         text-anchor="middle">agent updates</text>
 </svg>

--- a/docs-site/public/assets/card-visual-brief.svg
+++ b/docs-site/public/assets/card-visual-brief.svg
@@ -16,7 +16,7 @@
   <text x="100" y="37" font-family="monospace" font-size="22" font-weight="bold"
         fill="#5eead4" text-anchor="middle" filter="url(#glow)">visual brief</text>
   <text x="100" y="62" font-family="monospace" font-size="13" fill="#99f6e4"
-        text-anchor="middle">Structured local</text>
+        text-anchor="middle">Structured</text>
   <text x="100" y="77" font-family="monospace" font-size="13" fill="#99f6e4"
         text-anchor="middle">agent updates</text>
 </svg>


### PR DESCRIPTION
## Summary

- remove “local” from the Visual Brief card subtitle
- keep the README and Starlight copies synchronized as “Structured agent updates”

## Verification

- `npm --prefix docs-site run build` (47 pages built)
- browser-rendered the edited SVG and confirmed the centered two-line subtitle
- both SVG copies are byte-identical and valid XML
- context-free Codex cold review of exact commit `8567eef`: no findings

Follow-up to #192.