### PR TITLE
voxtype: overlay_opacity knob + double-tap right-Option toggle

### DIFF
--- a/docs-site/src/content/docs/tools/voxtype/configuration.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/configuration.mdx
@@ -206,6 +206,12 @@ language = "en"
 
 # Hotkeys (pynput or bracket-less syntax; `voxtype hotkey` records one)
 hotkey = "<ctrl>+;"          # toggle recording
+# A second toggle for the laptop keyboard (macOS): tap a modifier key
+# twice on its own. One of left_alt right_alt left_cmd right_cmd
+# left_ctrl right_ctrl left_shift right_shift ("alt" = Option). The key
+# keeps working as a normal modifier. "" disables.
+double_tap_key = ""
+double_tap_ms = 400          # max gap between the two taps, press to press
 cancel_hotkey = "<esc>"      # cancel recording (only intercepted WHILE recording)
 paste_hotkey = ""            # re-type last transcript, e.g. "<cmd>+<ctrl>+v"
 
@@ -239,6 +245,7 @@ copy_to_clipboard = false
 overlay = true
 overlay_flex = 1.0   # how much the face flexes its shape (higher = more)
 overlay_speed = 1.0  # animation speed (lower = slower/gentler)
+overlay_opacity = 1.0  # 0.1–1.0; lower it if the ghost hides text under it
 
 # Keep the model's memory warm (parakeet-mlx only). After this many
 # minutes without a decode, voxtype quietly decodes a short silent
@@ -295,6 +302,23 @@ Flags mirror the config keys: `--mode`, `--engine`,
 `--language`, `--hotkey`, `--wake-word`,
 `--stop-phrase`, `--no-sounds`, `--no-overlay`,
 `--config PATH`.
+
+### Double-tap toggle
+
+`double_tap_key` adds a second way to start and stop recording, next
+to the `hotkey` chord: tap one modifier key twice, by itself. It exists
+for the laptop keyboard, where a chord like Ctrl+; is awkward without
+an external keyboard; `right_alt` (the right Option key) is a good
+choice because nothing else uses it alone.
+
+- Both triggers stay active at once; use whichever is under your hand.
+- The taps must be *clean*: press, release, press, release, with no
+  other key in between and within `double_tap_ms` of each other
+  (press to press). Holding the key to type an Option-shortcut or an
+  accented character never triggers it.
+- The modifier is never swallowed — voxtype only observes it — so
+  Option, Command, and friends keep working everywhere.
+- macOS only (it rides on the same event tap as the chord).
 
 ## Hotkey notation
 

--- a/packages/voxtype/src/voxtype/app.py
+++ b/packages/voxtype/src/voxtype/app.py
@@ -585,6 +585,7 @@ class VoiceTypeApp:
                 on_ready=self._start_hotkeys_from_loop,
                 flex=self.cfg.overlay_flex,
                 speed=self.cfg.overlay_speed,
+                opacity=self.cfg.overlay_opacity,
             )
             return result["code"]
         while not self._stop.is_set():
@@ -667,16 +668,35 @@ class VoiceTypeApp:
                 )
                 continue
             bindings.append(binding)
-        if not bindings:
+        double_tap = None
+        if self.cfg.double_tap_key:
+            # Second toggle trigger: two taps of a lone modifier key
+            # (validated by Config, so no per-binding try here).
+            double_tap = (
+                self.cfg.double_tap_key,
+                self.cfg.double_tap_ms,
+                self.toggle,
+            )
+        if not bindings and double_tap is None:
             self._status("no valid hotkeys configured; hotkeys disabled")
             return None
         try:
-            return start_hotkeys(bindings)
+            listener = start_hotkeys(bindings, double_tap=double_tap)
         except ValueError as e:
             self._status(
                 f"invalid hotkey config ({e}); hotkeys disabled"
             )
             return None
+        if double_tap is not None and getattr(
+            listener, "double_tap_active", False
+        ):
+            # Only claim it when the listener actually armed it: the
+            # non-tap fallback reports the omission itself.
+            self._status(
+                f"double-tap {self.cfg.double_tap_key} also toggles "
+                "recording"
+            )
+        return listener
 
     @staticmethod
     def _status(msg: str) -> None:

--- a/packages/voxtype/src/voxtype/config.py
+++ b/packages/voxtype/src/voxtype/config.py
@@ -80,6 +80,20 @@ VALID_MODEL_ARCHS = (
     "medium-streaming",
 )
 
+# Modifier keys that may serve as a double-tap toggle trigger. Must stay
+# in sync with hotkey.DOUBLE_TAP_KEYS (a test enforces it); kept here so
+# config validation never imports the (pynput-backed) hotkey module.
+VALID_DOUBLE_TAP_KEYS = (
+    "left_alt",
+    "right_alt",
+    "left_cmd",
+    "right_cmd",
+    "left_ctrl",
+    "right_ctrl",
+    "left_shift",
+    "right_shift",
+)
+
 
 @dataclass
 class Config:
@@ -111,6 +125,8 @@ class Config:
             shape (1.0 = default; higher = more flexible, calmer < 1.0).
         overlay_speed: Overall animation speed multiplier (1.0 =
             default; lower = slower/gentler motion).
+        overlay_opacity: Whole-ghost opacity, 0.1 (barely there) to
+            1.0 (as drawn). Lower it if the ghost hides text under it.
         keepalive_minutes: Re-decode a short silent clip after this
             many minutes without a decode (parakeet-mlx only). Under
             system-wide memory pressure macOS evicts an idle model to
@@ -124,6 +140,14 @@ class Config:
             only).
         language: Language tag understood by Moonshine (e.g. "en").
         hotkey: Global toggle hotkey in pynput syntax, e.g. "<ctrl>+;".
+        double_tap_key: A second way to toggle recording, alongside
+            ``hotkey``: tap this modifier key twice, alone (e.g.
+            "right_alt" — the right Option key — for laptop use where
+            a chord is awkward). One of VALID_DOUBLE_TAP_KEYS; empty
+            disables. The key is never swallowed, so it keeps working
+            as a modifier; macOS only.
+        double_tap_ms: Maximum gap between the two taps, press to
+            press, in milliseconds (50–2000).
         wake_word: Phrase that activates dictation in "wake" mode.
         wake_word_aliases: Alternate spellings the transcriber may
             produce for the wake word (e.g. "claud", "clawed"); any
@@ -165,10 +189,13 @@ class Config:
     overlay: bool = True
     overlay_flex: float = 1.0
     overlay_speed: float = 1.0
+    overlay_opacity: float = 1.0
     keepalive_minutes: float = 0.0
     model_arch: str = "medium-streaming"
     language: str = "en"
     hotkey: str = "<ctrl>+;"
+    double_tap_key: str = ""
+    double_tap_ms: float = 400
     wake_word: str = "claude"
     wake_word_aliases: list[str] = field(default_factory=list)
     stop_phrase: str = "stop listening"
@@ -266,6 +293,40 @@ class Config:
                 raise ValueError(
                     f"{name} must be between 0 and 5, got {value!r}"
                 )
+        if (
+            isinstance(self.overlay_opacity, bool)
+            or not isinstance(self.overlay_opacity, (int, float))
+            or (
+                isinstance(self.overlay_opacity, float)
+                and not math.isfinite(self.overlay_opacity)
+            )
+            or not 0.1 <= self.overlay_opacity <= 1.0
+        ):
+            raise ValueError(
+                "overlay_opacity must be a number between 0.1 and 1.0, "
+                f"got {self.overlay_opacity!r}"
+            )
+        if not isinstance(self.double_tap_key, str) or (
+            self.double_tap_key and
+            self.double_tap_key not in VALID_DOUBLE_TAP_KEYS
+        ):
+            raise ValueError(
+                f"double_tap_key must be empty or one of "
+                f"{VALID_DOUBLE_TAP_KEYS}, got {self.double_tap_key!r}"
+            )
+        if (
+            isinstance(self.double_tap_ms, bool)
+            or not isinstance(self.double_tap_ms, (int, float))
+            or (
+                isinstance(self.double_tap_ms, float)
+                and not math.isfinite(self.double_tap_ms)
+            )
+            or not 50 <= self.double_tap_ms <= 2000
+        ):
+            raise ValueError(
+                "double_tap_ms must be a number of milliseconds between "
+                f"50 and 2000, got {self.double_tap_ms!r}"
+            )
         if isinstance(self.keepalive_minutes, bool) or not isinstance(
             self.keepalive_minutes, (int, float)
         ):
@@ -427,6 +488,9 @@ overlay = true
 overlay_flex = 1.0
 # Overall animation speed (lower = slower, gentler motion).
 overlay_speed = 1.0
+# Whole-ghost opacity, 0.1–1.0. Lower it (e.g. 0.6) if the ghost hides
+# the text underneath it.
+overlay_opacity = 1.0
 
 # Remove standalone filler words (uh, um, ...) from typed text.
 strip_fillers = true
@@ -453,6 +517,15 @@ language = "en"
 # Global toggle hotkey, pynput syntax. Examples: "<ctrl>+;",
 # "<ctrl>+<alt>+d", "<cmd>+<shift>+v"
 hotkey = "<ctrl>+;"
+
+# A second way to toggle recording (macOS): tap a modifier key twice,
+# on its own — handy on the laptop keyboard where a chord is awkward.
+# One of: left_alt right_alt left_cmd right_cmd left_ctrl right_ctrl
+# left_shift right_shift ("alt" is the Option key). The key still works
+# normally as a modifier. Empty disables.
+double_tap_key = ""
+# Max gap between the two taps, press to press, in milliseconds.
+double_tap_ms = 400
 
 # Wake word / stop phrase. The wake word is used in "wake" mode; the
 # stop phrase deactivates dictation wherever utterances are

--- a/packages/voxtype/src/voxtype/hotkey.py
+++ b/packages/voxtype/src/voxtype/hotkey.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import sys
 import threading
+import time
 from typing import Callable
 
 _MODIFIERS = {
@@ -50,6 +51,75 @@ _NAMED_VKS = {
     "f11": 103, "f12": 111, "f13": 105, "f14": 107, "f15": 113,
     "f16": 106, "f17": 64, "f18": 79, "f19": 80, "f20": 90,
 }
+
+# Modifier keys usable as a double-tap toggle: name -> (kVK_* virtual
+# keycode, device-specific CGEventFlags bit). Modifier presses arrive as
+# kCGEventFlagsChanged, whose generic flag (kCGEventFlagMaskAlternate…)
+# cannot tell LEFT from RIGHT; the NX_DEVICE*KEYMASK bits can, and are
+# what make "right_alt" mean only the right Option key. Keep in sync
+# with config.VALID_DOUBLE_TAP_KEYS (a test enforces it).
+DOUBLE_TAP_KEYS: dict[str, tuple[int, int]] = {
+    "left_alt": (58, 0x00000020),
+    "right_alt": (61, 0x00000040),
+    "left_cmd": (55, 0x00000008),
+    "right_cmd": (54, 0x00000010),
+    "left_ctrl": (59, 0x00000001),
+    "right_ctrl": (62, 0x00002000),
+    "left_shift": (56, 0x00000002),
+    "right_shift": (60, 0x00000004),
+}
+
+
+class DoubleTapDetector:
+    """Recognize two clean taps of one key within a time window.
+
+    Pure logic, fed one key event at a time with an explicit clock so
+    it is testable without an event tap. A "clean" double tap is
+    press, release, press, release of the target key with NO other
+    key event in between; it fires on the second RELEASE (never on the
+    press) so that holding the key to type a chord — Option+letter —
+    can never trigger it, even right after a first tap. The window is
+    measured press-to-press; a late second press simply becomes a new
+    first tap.
+    """
+
+    _IDLE, _FIRST_DOWN, _FIRST_UP, _SECOND_DOWN = range(4)
+
+    def __init__(self, vk: int, window: float) -> None:
+        self._vk = vk
+        self._window = window
+        self._state = self._IDLE
+        self._first_down = 0.0
+
+    def reset(self) -> None:
+        self._state = self._IDLE
+
+    def feed(self, vk: int, down: bool, now: float) -> bool:
+        """Consume one key event; True exactly when a double tap completes."""
+        if vk != self._vk:
+            # Any other key, pressed OR released, breaks the sequence:
+            # the user is typing or chording, not tapping.
+            self._state = self._IDLE
+            return False
+        if down:
+            if (
+                self._state == self._FIRST_UP
+                and now - self._first_down <= self._window
+            ):
+                self._state = self._SECOND_DOWN
+            else:
+                self._state = self._FIRST_DOWN
+                self._first_down = now
+            return False
+        # release
+        if self._state == self._FIRST_DOWN:
+            self._state = self._FIRST_UP
+        elif self._state == self._SECOND_DOWN:
+            self._state = self._IDLE
+            return True
+        else:
+            self._state = self._IDLE
+        return False
 
 
 def parse_hotkey(hotkey: str) -> tuple[frozenset[str], str]:
@@ -112,11 +182,28 @@ class _SuppressingHotKeys:
     def __init__(
         self,
         bindings: list[tuple],  # (mods, terminal, callback, when|None)
+        double_tap: tuple | None = None,  # (vk, devbit, window, cb, when)
     ) -> None:
         import Quartz
         from pynput import keyboard
 
         self._quartz = Quartz
+        # Optional double-tap modifier trigger. Unlike chords it is
+        # observed, never swallowed (see _intercept). ``double_tap_active``
+        # is the public "did it arm?" flag the app reports on; the
+        # observing fallback listener sets it False.
+        self._dt: DoubleTapDetector | None = None
+        # True when the listener accepted a double-tap binding. Like
+        # the chords, it does not prove the OS granted the tap —
+        # missing Input Monitoring is reported by check_permissions.
+        self.double_tap_active = double_tap is not None
+        if double_tap is not None:
+            vk, devbit, window, cb, when = double_tap
+            self._dt = DoubleTapDetector(vk, window)
+            self._dt_vk = vk
+            self._dt_devbit = devbit
+            self._dt_cb = cb
+            self._dt_when = when
         masks = {
             "ctrl": Quartz.kCGEventFlagMaskControl,
             "alt": Quartz.kCGEventFlagMaskAlternate,
@@ -130,6 +217,17 @@ class _SuppressingHotKeys:
         self._mod_mask = 0
         for m in masks.values():
             self._mod_mask |= m
+        if self._dt is not None:
+            # Anything held during the taps besides the tapped key
+            # itself means a chord is in progress, not a lone double
+            # tap: every other family's generic flag, plus the
+            # opposite-side device bit of the same family (left Option
+            # held while right Option is tapped).
+            family_generic = self._family_mask(Quartz, self._dt_devbit)
+            family_devbits = self._family_devbits(self._dt_devbit)
+            self._dt_foreign_mask = (self._mod_mask & ~family_generic) | (
+                family_devbits & ~self._dt_devbit
+            )
         # vk -> list of (mask, callback, when); ``when`` (nullable)
         # gates matching dynamically: a False-returning ``when`` lets
         # the event pass through untouched, so e.g. Escape can cancel
@@ -160,11 +258,70 @@ class _SuppressingHotKeys:
         self._listener.daemon = True
         self._listener.start()
 
+    @staticmethod
+    def _family_mask(quartz, devbit: int) -> int:  # noqa: ANN001
+        """Generic CGEventFlags bit for the family a device bit belongs to."""
+        if devbit & 0x60:  # NX_DEVICE[LR]ALTKEYMASK
+            return quartz.kCGEventFlagMaskAlternate
+        if devbit & 0x18:  # NX_DEVICE[LR]CMDKEYMASK
+            return quartz.kCGEventFlagMaskCommand
+        if devbit & 0x2001:  # NX_DEVICE[LR]CTLKEYMASK
+            return quartz.kCGEventFlagMaskControl
+        return quartz.kCGEventFlagMaskShift
+
+    @staticmethod
+    def _family_devbits(devbit: int) -> int:
+        """Both sides' NX_DEVICE*KEYMASK bits for a device bit's family."""
+        for family in (0x60, 0x18, 0x2001, 0x06):  # alt, cmd, ctl, shift
+            if devbit & family:
+                return family
+        return devbit
+
+    def _fire(self, callback: Callable[[], None]) -> None:
+        """Run a matched callback on its own thread (tracked for stop)."""
+        thread = threading.Thread(target=callback, daemon=True)
+        self._threads = [t for t in self._threads if t.is_alive()]
+        self._threads.append(thread)
+        thread.start()
+
     def _intercept(self, event_type: int, event):  # noqa: ANN001, ANN202
         q = self._quartz
+        if event_type == q.kCGEventFlagsChanged:
+            # Modifier press/release. Only the double-tap trigger cares,
+            # and it only OBSERVES: swallowing a modifier would break
+            # Option/Cmd for every chord and accented character, so the
+            # event is always returned untouched.
+            if self._dt is not None:
+                vk = q.CGEventGetIntegerValueField(
+                    event, q.kCGKeyboardEventKeycode
+                )
+                flags = q.CGEventGetFlags(event)
+                if flags & self._dt_foreign_mask:
+                    # Another modifier is held (e.g. Shift+Option-Option):
+                    # a chord, not a lone tap. A modifier held from
+                    # BEFORE the first tap produces no event of its own,
+                    # so this check — not the reset-on-other-key path —
+                    # is what enforces "tapped alone".
+                    self._dt.reset()
+                    return event
+                down = bool(flags & self._dt_devbit)
+                if self._dt.feed(vk, down, time.monotonic()):
+                    ok = True
+                    if self._dt_when is not None:
+                        try:
+                            ok = bool(self._dt_when())
+                        except Exception:
+                            ok = False
+                    if ok and not self._stopping:
+                        self._fire(self._dt_cb)
+            return event
         if event_type not in (q.kCGEventKeyDown, q.kCGEventKeyUp):
             return event
         vk = q.CGEventGetIntegerValueField(event, q.kCGKeyboardEventKeycode)
+        if self._dt is not None:
+            # A real key between (or during) the taps means the user is
+            # typing/chording, not double-tapping: break the sequence.
+            self._dt.reset()
         entries = self._by_vk.get(vk)
         if entries is None:
             return event
@@ -191,14 +348,7 @@ class _SuppressingHotKeys:
                 )
                 if not repeat and not self._stopping:
                     self._down.add(vk)
-                    thread = threading.Thread(
-                        target=callback, daemon=True
-                    )
-                    self._threads = [
-                        t for t in self._threads if t.is_alive()
-                    ]
-                    self._threads.append(thread)
-                    thread.start()
+                    self._fire(callback)
                 return None  # swallow the chord (and auto-repeats)
             return event
         if vk in self._down:
@@ -423,7 +573,9 @@ def _check_accessibility() -> list[str]:
     return warnings
 
 
-def start_hotkeys(bindings: list[tuple]):  # noqa: ANN201
+def start_hotkeys(  # noqa: ANN201
+    bindings: list[tuple], double_tap: tuple | None = None
+):
     """Start one global listener for several chords; returns ``stop()``-able.
 
     Each binding is ``(hotkey, callback)`` or ``(hotkey, callback,
@@ -431,13 +583,20 @@ def start_hotkeys(bindings: list[tuple]):  # noqa: ANN201
     returns False the chord passes through to the focused app
     untouched (used for context-dependent keys like Escape-to-cancel).
 
+    ``double_tap`` optionally adds ``(key_name, window_ms, callback)``
+    or ``(key_name, window_ms, callback, when)``: ``key_name`` is one
+    of ``DOUBLE_TAP_KEYS`` and two clean taps of that modifier within
+    ``window_ms`` run ``callback``. macOS only (it needs the event
+    tap); elsewhere it is reported and ignored.
+
     On macOS every matched chord is fully suppressed. Elsewhere -- or
     when suppression isn't possible for a key -- falls back to
     pynput's observing ``GlobalHotKeys`` (apps may also receive the
     keys; ``when`` is then checked inside the callback).
 
     Raises:
-        ValueError: If any hotkey string is malformed.
+        ValueError: If any hotkey string is malformed, or the
+            double-tap key name is unknown.
     """
     parsed = []
     for binding in bindings:
@@ -445,15 +604,32 @@ def start_hotkeys(bindings: list[tuple]):  # noqa: ANN201
         when = binding[2] if len(binding) > 2 else None
         mods, term = parse_hotkey(hk)  # validate on every platform
         parsed.append((mods, term, cb, when))
+    dt = None
+    if double_tap is not None:
+        key_name, window_ms, dt_cb = double_tap[0], double_tap[1], double_tap[2]
+        dt_when = double_tap[3] if len(double_tap) > 3 else None
+        if key_name not in DOUBLE_TAP_KEYS:
+            raise ValueError(
+                f"unknown double_tap key {key_name!r}; must be one of "
+                f"{sorted(DOUBLE_TAP_KEYS)}"
+            )
+        vk, devbit = DOUBLE_TAP_KEYS[key_name]
+        dt = (vk, devbit, float(window_ms) / 1000.0, dt_cb, dt_when)
     if sys.platform == "darwin":
         try:
-            return _SuppressingHotKeys(parsed)
+            return _SuppressingHotKeys(parsed, double_tap=dt)
         except ValueError as e:
             print(
                 f"[voxtype] {e}; falling back to non-suppressing "
                 "hotkeys (chords may leak keystrokes)",
                 file=sys.stderr,
             )
+    if dt is not None:
+        print(
+            "[voxtype] double-tap hotkey needs the macOS event tap; "
+            "ignored here",
+            file=sys.stderr,
+        )
     from pynput import keyboard
 
     # Rebuild canonical pynput syntax (GlobalHotKeys doesn't know our
@@ -471,6 +647,7 @@ def start_hotkeys(bindings: list[tuple]):  # noqa: ANN201
         for mods, term, cb, when in parsed
     }
     hotkeys = keyboard.GlobalHotKeys(canonical)
+    hotkeys.double_tap_active = False  # observing listener: no tap
     hotkeys.daemon = True
     hotkeys.start()
     return hotkeys

--- a/packages/voxtype/src/voxtype/hotkey.py
+++ b/packages/voxtype/src/voxtype/hotkey.py
@@ -624,7 +624,7 @@ def start_hotkeys(  # noqa: ANN201
                 "hotkeys (chords may leak keystrokes)",
                 file=sys.stderr,
             )
-    if dt is not None:
+    if dt is not None and sys.platform != "darwin":
         print(
             "[voxtype] double-tap hotkey needs the macOS event tap; "
             "ignored here",
@@ -646,11 +646,48 @@ def start_hotkeys(  # noqa: ANN201
         ): _gated(cb, when)
         for mods, term, cb, when in parsed
     }
+    tap = None
+    if dt is not None and sys.platform == "darwin":
+        # One unresolvable CHORD sent the chords to the observing
+        # fallback; that must not take the layout-independent double
+        # tap down with it. A tap with no chords cannot raise (nothing
+        # to resolve), so keep one just for the double tap — built
+        # BEFORE the chord listener starts, so a failure here leaks no
+        # running listener without a handle.
+        tap = _SuppressingHotKeys([], double_tap=dt)
     hotkeys = keyboard.GlobalHotKeys(canonical)
     hotkeys.double_tap_active = False  # observing listener: no tap
     hotkeys.daemon = True
-    hotkeys.start()
+    try:
+        hotkeys.start()
+    except Exception:
+        if tap is not None:
+            tap.stop()
+        raise
+    if tap is not None:
+        return _ChordsPlusTap(hotkeys, tap)
     return hotkeys
+
+
+class _ChordsPlusTap:
+    """Observing chord listener plus a tap that serves only the double tap.
+
+    Used when a chord could not be resolved on this layout (see
+    ``start_hotkeys``). ``stop()`` stops both; ``double_tap_active`` is
+    True because the tap half really did arm it.
+    """
+
+    double_tap_active = True
+
+    def __init__(self, chords, tap) -> None:  # noqa: ANN001
+        self._chords = chords
+        self._tap = tap
+
+    def stop(self) -> None:
+        try:
+            self._tap.stop()
+        finally:
+            self._chords.stop()
 
 
 def start_hotkey(hotkey: str, callback: Callable[[], None]):  # noqa: ANN201

--- a/packages/voxtype/src/voxtype/overlay.py
+++ b/packages/voxtype/src/voxtype/overlay.py
@@ -49,6 +49,7 @@ def run_overlay(  # noqa: PLR0913
     on_ready: Callable[[], None] | None = None,
     flex: float = 1.0,
     speed: float = 1.0,
+    opacity: float = 1.0,
 ) -> None:
     """Show the ghost and block until ``stopped()`` returns True.
 
@@ -63,6 +64,10 @@ def run_overlay(  # noqa: PLR0913
             after AppKit is fully up, so the loop can't race and kill it.
         flex: Face shape-flex multiplier (config overlay_flex).
         speed: Animation speed multiplier (config overlay_speed).
+        opacity: Whole-panel alpha, 0.1–1.0 (config overlay_opacity).
+            Applied at the window level so every element — halo,
+            body, face — scales together and the drawing code keeps
+            its own per-element alphas.
 
     SIGINT is redirected to a flag-friendly handler while the loop
     runs (AppKit's run loop would otherwise swallow Ctrl+C), and
@@ -372,6 +377,7 @@ def run_overlay(  # noqa: PLR0913
     panel.setLevel_(AppKit.NSStatusWindowLevel)
     panel.setOpaque_(False)
     panel.setBackgroundColor_(NSColor.clearColor())
+    panel.setAlphaValue_(float(opacity))
     panel.setIgnoresMouseEvents_(True)
     panel.setHasShadow_(True)
     panel.setCollectionBehavior_(

--- a/packages/voxtype/tests/test_voxtype.py
+++ b/packages/voxtype/tests/test_voxtype.py
@@ -834,7 +834,7 @@ def test_overlay_path_starts_hotkeys_from_inside_run_loop(monkeypatch) -> None:
     monkeypatch.setattr(overlay_mod, "overlay_available", lambda: True)
 
     def fake_run_overlay(  # noqa: ANN001, ANN202
-        sample, tick, stopped, on_ready=None, flex=1.0, speed=1.0
+        sample, tick, stopped, on_ready=None, flex=1.0, speed=1.0, opacity=1.0
     ):
         order.append("overlay_loop")
         on_ready()  # the one-shot timer firing inside the live loop
@@ -1744,7 +1744,7 @@ def test_invalid_optional_hotkey_keeps_toggle(monkeypatch) -> None:
     monkeypatch.setattr(app_mod, "Typist", RecordingTypist)
     started: dict = {}
 
-    def fake_start_hotkeys(bindings):  # noqa: ANN001, ANN202
+    def fake_start_hotkeys(bindings, double_tap=None):  # noqa: ANN001, ANN202
         started["bindings"] = bindings
         return SimpleNamespace(stop=lambda: None)
 
@@ -1897,7 +1897,7 @@ def test_startup_emits_permission_warnings_before_hotkeys(
         lambda: ["no input monitoring", "no accessibility"],
     )
 
-    def fake_start_hotkeys(bindings):  # noqa: ANN001, ANN202
+    def fake_start_hotkeys(bindings, double_tap=None):  # noqa: ANN001, ANN202
         events.append("start_hotkeys")
         return SimpleNamespace(stop=lambda: None)
 

--- a/packages/voxtype/tests/test_voxtype_doubletap.py
+++ b/packages/voxtype/tests/test_voxtype_doubletap.py
@@ -365,6 +365,47 @@ def test_start_hotkeys_rejects_unknown_double_tap_key(monkeypatch) -> None:  # n
         )
 
 
+class _FakeGlobalHotKeys:
+    def __init__(self, mapping) -> None:  # noqa: ANN001
+        self.mapping = mapping
+        self.daemon = False
+        self.stopped = False
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+def test_chord_fallback_keeps_double_tap_armed(monkeypatch) -> None:  # noqa: ANN001
+    """A chord that cannot be resolved on this layout sends the chords to
+    the observing fallback — that must not take the layout-independent
+    double tap down with it (GitHub Codex finding on PR #195)."""
+    _install_fakes(monkeypatch)
+    sys.modules["pynput.keyboard"].GlobalHotKeys = _FakeGlobalHotKeys
+    import voxtype.hotkey as hotkey_mod
+
+    monkeypatch.setattr(hotkey_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(hotkey_mod, "_resolve_vk", lambda q, term: None)
+    fired = threading.Event()
+    listener = hotkey_mod.start_hotkeys(
+        [("<ctrl>+;", lambda: None)],
+        double_tap=("right_alt", 400, fired.set),
+    )
+    assert listener.double_tap_active is True
+    vk, devbit = hotkey_mod.DOUBLE_TAP_KEYS["right_alt"]
+    q = _FakeQuartz
+    alt = q.kCGEventFlagMaskAlternate
+    for e in (
+        _ev(vk, alt | devbit), _ev(vk, 0), _ev(vk, alt | devbit), _ev(vk, 0)
+    ):
+        listener._tap._intercept(q.kCGEventFlagsChanged, e)
+    assert fired.wait(2.0), "double tap lost to the chord fallback"
+    listener.stop()
+    assert listener._chords.stopped
+
+
 # -- app wiring ---------------------------------------------------------------
 
 

--- a/packages/voxtype/tests/test_voxtype_doubletap.py
+++ b/packages/voxtype/tests/test_voxtype_doubletap.py
@@ -1,0 +1,506 @@
+"""Tests for the ghost opacity knob and the double-tap modifier hotkey.
+
+Covers config validation for the three new keys, the pure double-tap
+state machine, the macOS event-tap integration (with stubbed Quartz and
+pynput so no real tap is ever installed), and the app-level wiring that
+passes opacity to the overlay and the double-tap binding to the listener.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import threading
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from voxtype.config import (
+    VALID_DOUBLE_TAP_KEYS,
+    Config,
+    load_config,
+    sample_config,
+)
+
+# -- config ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [0.1, 0.6, 1.0, 1])
+def test_overlay_opacity_accepts_range(value: float) -> None:
+    Config(overlay_opacity=value).validate()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [0.0, 0.05, 1.5, -1.0, float("nan"), float("inf"), "0.5", True, None],
+)
+def test_overlay_opacity_rejects_bad_values(value: object) -> None:
+    with pytest.raises(ValueError, match="overlay_opacity"):
+        Config(overlay_opacity=value).validate()
+
+
+@pytest.mark.parametrize("key", ["", *VALID_DOUBLE_TAP_KEYS])
+def test_double_tap_key_accepts_valid_names(key: str) -> None:
+    Config(double_tap_key=key).validate()
+
+
+@pytest.mark.parametrize(
+    "value", ["middle_alt", "alt", "<alt>", "RIGHT_ALT", 3, None]
+)
+def test_double_tap_key_rejects_bad_values(value: object) -> None:
+    with pytest.raises(ValueError, match="double_tap_key"):
+        Config(double_tap_key=value).validate()
+
+
+@pytest.mark.parametrize("value", [50, 400, 2000, 400.0])
+def test_double_tap_ms_accepts_range(value: float) -> None:
+    Config(double_tap_ms=value).validate()
+
+
+@pytest.mark.parametrize(
+    "value", [49, 2001, -1, float("nan"), float("inf"), "400", True, None]
+)
+def test_double_tap_ms_rejects_bad_values(value: object) -> None:
+    with pytest.raises(ValueError, match="double_tap_ms"):
+        Config(double_tap_ms=value).validate()
+
+
+def test_double_tap_key_names_match_hotkey_table() -> None:
+    """Config's allowlist and the hotkey module's keycode table must
+    name exactly the same keys, or a validated config could still fail
+    at listener start."""
+    from voxtype.hotkey import DOUBLE_TAP_KEYS
+
+    assert set(VALID_DOUBLE_TAP_KEYS) == set(DOUBLE_TAP_KEYS)
+    assert "right_alt" in DOUBLE_TAP_KEYS
+    # Left and right must map to DIFFERENT keycodes and flag bits.
+    assert DOUBLE_TAP_KEYS["right_alt"] != DOUBLE_TAP_KEYS["left_alt"]
+
+
+def test_sample_config_documents_new_keys(tmp_path) -> None:  # noqa: ANN001
+    text = sample_config()
+    for key in ("overlay_opacity", "double_tap_key", "double_tap_ms"):
+        assert key in text
+    path = tmp_path / "config.toml"
+    path.write_text(text)
+    assert load_config(path) == Config()  # sample states the defaults
+
+
+def test_load_config_reads_new_keys(tmp_path) -> None:  # noqa: ANN001
+    path = tmp_path / "config.toml"
+    path.write_text(
+        'overlay_opacity = 0.6\ndouble_tap_key = "right_alt"\n'
+        "double_tap_ms = 300\n"
+    )
+    cfg = load_config(path)
+    assert cfg.overlay_opacity == 0.6
+    assert cfg.double_tap_key == "right_alt"
+    assert cfg.double_tap_ms == 300
+
+
+# -- double-tap state machine -----------------------------------------------
+
+
+def _detector(window: float = 0.4):  # noqa: ANN202
+    from voxtype.hotkey import DoubleTapDetector
+
+    return DoubleTapDetector(vk=61, window=window)
+
+
+def test_double_tap_fires_once_on_second_release() -> None:
+    d = _detector()
+    assert d.feed(61, True, 0.00) is False
+    assert d.feed(61, False, 0.05) is False
+    assert d.feed(61, True, 0.20) is False  # second press: not yet
+    assert d.feed(61, False, 0.25) is True  # second release: fire
+    # Fully reset: a lone third tap does not fire again.
+    assert d.feed(61, True, 0.30) is False
+    assert d.feed(61, False, 0.35) is False
+
+
+def test_double_tap_too_slow_does_not_fire_but_rearms() -> None:
+    d = _detector(window=0.4)
+    d.feed(61, True, 0.0)
+    d.feed(61, False, 0.1)
+    # Second press 0.5 s after the first: outside the window.
+    assert d.feed(61, True, 0.5) is False
+    assert d.feed(61, False, 0.55) is False
+    # ...but that late tap counts as a NEW first tap.
+    assert d.feed(61, True, 0.7) is False
+    assert d.feed(61, False, 0.75) is True
+
+
+def test_double_tap_window_measured_press_to_press() -> None:
+    d = _detector(window=0.4)
+    d.feed(61, True, 0.0)
+    d.feed(61, False, 0.35)  # long-ish first tap
+    assert d.feed(61, True, 0.39) is False
+    assert d.feed(61, False, 0.45) is True  # 2nd press was within 0.4 s
+
+
+def test_other_key_between_taps_resets() -> None:
+    d = _detector()
+    d.feed(61, True, 0.0)
+    d.feed(61, False, 0.05)
+    d.feed(0x00, True, 0.10)  # some letter key
+    d.feed(0x00, False, 0.12)
+    assert d.feed(61, True, 0.20) is False
+    assert d.feed(61, False, 0.25) is False  # the sequence was broken
+
+
+def test_chord_during_second_hold_does_not_fire() -> None:
+    """Option-Option-then-a-letter is the user typing an Option chord,
+    not a double tap: the second release must NOT toggle recording."""
+    d = _detector()
+    d.feed(61, True, 0.0)
+    d.feed(61, False, 0.05)
+    d.feed(61, True, 0.15)
+    d.feed(0x00, True, 0.20)  # a key pressed while Option is held
+    d.feed(0x00, False, 0.22)
+    assert d.feed(61, False, 0.30) is False
+
+
+def test_other_modifier_never_fires() -> None:
+    d = _detector()
+    for t in (0.0, 0.05, 0.1, 0.15):
+        assert d.feed(58, t % 0.1 == 0, t) is False  # left option
+
+
+# -- macOS event-tap integration (stubbed Quartz + pynput) ------------------
+
+
+class _FakeQuartz:
+    kCGEventKeyDown = 10
+    kCGEventKeyUp = 11
+    kCGEventFlagsChanged = 12
+    kCGKeyboardEventKeycode = 9
+    kCGKeyboardEventAutorepeat = 8
+    kCGEventFlagMaskShift = 1 << 17
+    kCGEventFlagMaskControl = 1 << 18
+    kCGEventFlagMaskAlternate = 1 << 19
+    kCGEventFlagMaskCommand = 1 << 20
+
+    @staticmethod
+    def CGEventGetIntegerValueField(event, field):  # noqa: ANN001, ANN205
+        return event.vk if field == 9 else event.repeat
+
+    @staticmethod
+    def CGEventGetFlags(event):  # noqa: ANN001, ANN205
+        return event.flags
+
+
+class _FakeListener:
+    def __init__(self, darwin_intercept=None) -> None:  # noqa: ANN001
+        self.intercept = darwin_intercept
+        self.daemon = False
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def join(self, *a) -> None:  # noqa: ANN002
+        pass
+
+
+def _install_fakes(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setitem(sys.modules, "Quartz", _FakeQuartz)
+    pynput = types.ModuleType("pynput")
+    keyboard = types.ModuleType("pynput.keyboard")
+    keyboard.Listener = _FakeListener
+    pynput.keyboard = keyboard
+    monkeypatch.setitem(sys.modules, "pynput", pynput)
+    monkeypatch.setitem(sys.modules, "pynput.keyboard", keyboard)
+
+
+def _ev(vk: int, flags: int = 0, repeat: int = 0):  # noqa: ANN202
+    return SimpleNamespace(vk=vk, flags=flags, repeat=repeat)
+
+
+def test_event_tap_fires_on_right_alt_double_tap(monkeypatch) -> None:  # noqa: ANN001
+    _install_fakes(monkeypatch)
+    from voxtype.hotkey import DOUBLE_TAP_KEYS, _SuppressingHotKeys
+
+    fired = threading.Event()
+    vk, devbit = DOUBLE_TAP_KEYS["right_alt"]
+    hk = _SuppressingHotKeys(
+        [], double_tap=(vk, devbit, 0.4, fired.set, None)
+    )
+    q = _FakeQuartz
+    alt = q.kCGEventFlagMaskAlternate
+    seq = [
+        _ev(vk, alt | devbit),  # down
+        _ev(vk, 0),  # up
+        _ev(vk, alt | devbit),  # down
+        _ev(vk, 0),  # up -> fire
+    ]
+    for e in seq:
+        # Modifier events are NEVER swallowed: Option must keep working.
+        assert hk._intercept(q.kCGEventFlagsChanged, e) is e
+    assert fired.wait(2.0), "double tap did not fire the callback"
+    hk.stop()
+
+
+def test_event_tap_left_alt_does_not_fire_right_alt_binding(
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    _install_fakes(monkeypatch)
+    from voxtype.hotkey import DOUBLE_TAP_KEYS, _SuppressingHotKeys
+
+    fired = threading.Event()
+    vk, devbit = DOUBLE_TAP_KEYS["right_alt"]
+    lvk, ldevbit = DOUBLE_TAP_KEYS["left_alt"]
+    hk = _SuppressingHotKeys(
+        [], double_tap=(vk, devbit, 0.4, fired.set, None)
+    )
+    q = _FakeQuartz
+    alt = q.kCGEventFlagMaskAlternate
+    for e in (
+        _ev(lvk, alt | ldevbit),
+        _ev(lvk, 0),
+        _ev(lvk, alt | ldevbit),
+        _ev(lvk, 0),
+    ):
+        assert hk._intercept(q.kCGEventFlagsChanged, e) is e
+    assert not fired.wait(0.2)
+    hk.stop()
+
+
+def test_event_tap_held_shift_throughout_does_not_fire(monkeypatch) -> None:  # noqa: ANN001
+    """Shift held from before the first tap never produces an event of
+    its own, so the modifier check on each tap must catch the chord."""
+    _install_fakes(monkeypatch)
+    from voxtype.hotkey import DOUBLE_TAP_KEYS, _SuppressingHotKeys
+
+    fired = threading.Event()
+    vk, devbit = DOUBLE_TAP_KEYS["right_alt"]
+    hk = _SuppressingHotKeys(
+        [], double_tap=(vk, devbit, 0.4, fired.set, None)
+    )
+    q = _FakeQuartz
+    alt, shift = q.kCGEventFlagMaskAlternate, q.kCGEventFlagMaskShift
+    for e in (
+        _ev(vk, shift | alt | devbit),
+        _ev(vk, shift),
+        _ev(vk, shift | alt | devbit),
+        _ev(vk, shift),
+    ):
+        assert hk._intercept(q.kCGEventFlagsChanged, e) is e
+    assert not fired.wait(0.2)
+    # Same with the OPPOSITE-side key of the same family held: left
+    # Option down throughout while right Option is tapped is a chord.
+    lvk, ldevbit = DOUBLE_TAP_KEYS["left_alt"]
+    for e in (
+        _ev(vk, alt | ldevbit | devbit),
+        _ev(vk, alt | ldevbit),
+        _ev(vk, alt | ldevbit | devbit),
+        _ev(vk, alt | ldevbit),
+    ):
+        hk._intercept(q.kCGEventFlagsChanged, e)
+    assert not fired.wait(0.2)
+    # ...and a clean double tap right after still works.
+    for e in (
+        _ev(vk, alt | devbit), _ev(vk, 0), _ev(vk, alt | devbit), _ev(vk, 0)
+    ):
+        hk._intercept(q.kCGEventFlagsChanged, e)
+    assert fired.wait(2.0)
+    hk.stop()
+
+
+def test_event_tap_keydown_between_taps_resets(monkeypatch) -> None:  # noqa: ANN001
+    _install_fakes(monkeypatch)
+    from voxtype.hotkey import DOUBLE_TAP_KEYS, _SuppressingHotKeys
+
+    fired = threading.Event()
+    vk, devbit = DOUBLE_TAP_KEYS["right_alt"]
+    hk = _SuppressingHotKeys(
+        [], double_tap=(vk, devbit, 0.4, fired.set, None)
+    )
+    q = _FakeQuartz
+    alt = q.kCGEventFlagMaskAlternate
+    hk._intercept(q.kCGEventFlagsChanged, _ev(vk, alt | devbit))
+    hk._intercept(q.kCGEventFlagsChanged, _ev(vk, 0))
+    letter = _ev(0x00)
+    # An unrelated key press passes through and breaks the sequence.
+    assert hk._intercept(q.kCGEventKeyDown, letter) is letter
+    assert hk._intercept(q.kCGEventKeyUp, letter) is letter
+    hk._intercept(q.kCGEventFlagsChanged, _ev(vk, alt | devbit))
+    hk._intercept(q.kCGEventFlagsChanged, _ev(vk, 0))
+    assert not fired.wait(0.2)
+    hk.stop()
+
+
+def test_event_tap_double_tap_respects_when_predicate(monkeypatch) -> None:  # noqa: ANN001
+    _install_fakes(monkeypatch)
+    from voxtype.hotkey import DOUBLE_TAP_KEYS, _SuppressingHotKeys
+
+    fired = threading.Event()
+    vk, devbit = DOUBLE_TAP_KEYS["right_alt"]
+    hk = _SuppressingHotKeys(
+        [], double_tap=(vk, devbit, 0.4, fired.set, lambda: False)
+    )
+    q = _FakeQuartz
+    alt = q.kCGEventFlagMaskAlternate
+    for e in (
+        _ev(vk, alt | devbit),
+        _ev(vk, 0),
+        _ev(vk, alt | devbit),
+        _ev(vk, 0),
+    ):
+        hk._intercept(q.kCGEventFlagsChanged, e)
+    assert not fired.wait(0.2)
+    hk.stop()
+
+
+def test_start_hotkeys_rejects_unknown_double_tap_key(monkeypatch) -> None:  # noqa: ANN001
+    _install_fakes(monkeypatch)
+    from voxtype.hotkey import start_hotkeys
+
+    with pytest.raises(ValueError, match="double_tap"):
+        start_hotkeys(
+            [("<ctrl>+;", lambda: None)],
+            double_tap=("middle_alt", 400, lambda: None),
+        )
+
+
+# -- app wiring ---------------------------------------------------------------
+
+
+def test_app_passes_double_tap_binding_to_listener(monkeypatch) -> None:  # noqa: ANN001
+    import voxtype.app as app_mod
+    import voxtype.hotkey as hotkey_mod
+
+    captured: dict = {}
+
+    def fake_start_hotkeys(bindings, double_tap=None):  # noqa: ANN001, ANN202
+        captured["bindings"] = bindings
+        captured["double_tap"] = double_tap
+        return SimpleNamespace(stop=lambda: None)
+
+    monkeypatch.setattr(hotkey_mod, "start_hotkeys", fake_start_hotkeys)
+    monkeypatch.setattr(hotkey_mod, "check_permissions", lambda: [])
+    monkeypatch.setattr(app_mod, "Typist", lambda: SimpleNamespace())
+    app = app_mod.VoiceTypeApp(
+        Config(
+            mode="toggle",
+            sounds=False,
+            overlay=False,
+            double_tap_key="right_alt",
+            double_tap_ms=300,
+        )
+    )
+    assert app._start_hotkey_listener() is not None
+    # The Ctrl+; chord is still registered alongside the double tap.
+    assert [b[0] for b in captured["bindings"]][0] == "<ctrl>+;"
+    key, ms, cb = captured["double_tap"][:3]
+    assert (key, ms) == ("right_alt", 300)
+    assert cb == app.toggle
+
+
+def test_app_omits_double_tap_when_unset(monkeypatch) -> None:  # noqa: ANN001
+    import voxtype.app as app_mod
+    import voxtype.hotkey as hotkey_mod
+
+    captured: dict = {}
+
+    def fake_start_hotkeys(bindings, double_tap=None):  # noqa: ANN001, ANN202
+        captured["double_tap"] = double_tap
+        return SimpleNamespace(stop=lambda: None)
+
+    monkeypatch.setattr(hotkey_mod, "start_hotkeys", fake_start_hotkeys)
+    monkeypatch.setattr(hotkey_mod, "check_permissions", lambda: [])
+    monkeypatch.setattr(app_mod, "Typist", lambda: SimpleNamespace())
+    app = app_mod.VoiceTypeApp(
+        Config(mode="toggle", sounds=False, overlay=False)
+    )
+    app._start_hotkey_listener()
+    assert captured["double_tap"] is None
+
+
+@pytest.mark.parametrize("armed", [True, False])
+def test_app_reports_double_tap_only_when_armed(monkeypatch, armed) -> None:  # noqa: ANN001
+    """The startup line claiming the double tap works must track the
+    listener's own verdict, not the config: a fallback listener that
+    ignored the binding must not be reported as active."""
+    import voxtype.app as app_mod
+    import voxtype.hotkey as hotkey_mod
+
+    monkeypatch.setattr(
+        hotkey_mod,
+        "start_hotkeys",
+        lambda bindings, double_tap=None: SimpleNamespace(
+            stop=lambda: None, double_tap_active=armed
+        ),
+    )
+    monkeypatch.setattr(hotkey_mod, "check_permissions", lambda: [])
+    monkeypatch.setattr(app_mod, "Typist", lambda: SimpleNamespace())
+    lines: list[str] = []
+    monkeypatch.setattr(app_mod.VoiceTypeApp, "_status", staticmethod(lines.append))
+    app = app_mod.VoiceTypeApp(
+        Config(mode="toggle", sounds=False, overlay=False, double_tap_key="right_alt")
+    )
+    app._start_hotkey_listener()
+    claimed = any("also toggles recording" in ln for ln in lines)
+    assert claimed is armed
+
+
+def test_suppressing_listener_exposes_double_tap_active(monkeypatch) -> None:  # noqa: ANN001
+    _install_fakes(monkeypatch)
+    from voxtype.hotkey import DOUBLE_TAP_KEYS, _SuppressingHotKeys
+
+    vk, devbit = DOUBLE_TAP_KEYS["right_alt"]
+    armed = _SuppressingHotKeys([], double_tap=(vk, devbit, 0.4, lambda: None, None))
+    assert armed.double_tap_active is True
+    bare = _SuppressingHotKeys([])
+    assert bare.double_tap_active is False
+    armed.stop()
+    bare.stop()
+
+
+def test_run_overlay_accepts_opacity() -> None:
+    from voxtype.overlay import run_overlay
+
+    params = inspect.signature(run_overlay).parameters
+    assert "opacity" in params
+    assert params["opacity"].default == 1.0
+
+
+def test_app_passes_opacity_to_overlay(monkeypatch) -> None:  # noqa: ANN001
+    import voxtype.app as app_mod
+    import voxtype.engines as engines_mod
+    import voxtype.overlay as overlay_mod
+
+    captured: dict = {}
+
+    class _Engine:
+        fatal_error = None
+
+        def start(self, *a, **k) -> None:  # noqa: ANN002, ANN003
+            pass
+
+        def stop(self) -> None:
+            pass
+
+    def fake_run_overlay(sample, tick, stopped, **kw):  # noqa: ANN001, ANN202
+        captured.update(kw)
+        if kw.get("on_ready"):
+            kw["on_ready"]()
+
+    monkeypatch.setattr(app_mod, "Typist", lambda: SimpleNamespace())
+    monkeypatch.setattr(
+        engines_mod, "create_engine", lambda cfg, status: _Engine()
+    )
+    monkeypatch.setattr(
+        app_mod.VoiceTypeApp,
+        "_start_hotkey_listener",
+        lambda self: SimpleNamespace(stop=lambda: None),
+    )
+    monkeypatch.setattr(overlay_mod, "overlay_available", lambda: True)
+    monkeypatch.setattr(overlay_mod, "run_overlay", fake_run_overlay)
+    app = app_mod.VoiceTypeApp(
+        Config(sounds=False, overlay=True, overlay_opacity=0.6)
+    )
+    app.run()
+    assert captured["opacity"] == 0.6

--- a/release-notes/pr-195-voxtype-opacity-doubletap.md
+++ b/release-notes/pr-195-voxtype-opacity-doubletap.md
@@ -1,0 +1,62 @@
+# PR #195 — voxtype: ghost opacity knob, double-tap modifier toggle
+
+## `overlay_opacity`
+
+```toml
+overlay_opacity = 0.6   # 0.1–1.0, default 1.0
+```
+
+Whole-ghost transparency, for when the recording ghost sits on top of
+text you need to read. Applied as the NSPanel's alpha, so every element
+(halo, body, face) scales together and the drawing code keeps its own
+per-element alphas untouched.
+
+## `double_tap_key` / `double_tap_ms`
+
+```toml
+double_tap_key = "right_alt"   # "" disables (default)
+double_tap_ms = 400            # press-to-press window, 50–2000
+```
+
+A second way to toggle recording, alongside the `hotkey` chord: tap one
+modifier key twice, on its own. Meant for the laptop keyboard, where a
+chord like Ctrl+; is awkward; the right Option key is a good choice
+because nothing else uses it alone. Both triggers stay active.
+
+Keys: `left_alt right_alt left_cmd right_cmd left_ctrl right_ctrl
+left_shift right_shift` ("alt" is the Option key).
+
+### How it works
+
+- Rides on voxtype's existing macOS event tap, observing
+  `kCGEventFlagsChanged`. The modifier is **never swallowed** — Option,
+  Cmd and friends keep working everywhere.
+- Left and right are distinguished by keycode plus the
+  `NX_DEVICE*KEYMASK` flag bit (the generic Option flag cannot tell the
+  sides apart). Constants checked against the SDK headers; verified live
+  on the built-in keyboard.
+- Clean-tap rules: press, release, press, release within
+  `double_tap_ms` (press to press); no other key and no other held
+  modifier during the taps (Shift+Option-Option or left-Option-held are
+  chords, not taps); fires on the second *release*, so holding Option
+  for an Option-shortcut can never trigger it.
+- macOS only; elsewhere the binding is reported and ignored. The
+  startup line "double-tap … also toggles recording" is printed only
+  when the listener actually armed it.
+
+### Note for programmable keyboards
+
+A UHK 60 v2's right-Alt position is typically a layer key in the UHK
+config and sends no Option keycode to macOS at all — so the double tap
+does nothing from that keyboard. That is the keyboard's mapping, not a
+voxtype limitation; the built-in keyboard reports it correctly.
+
+## Tests
+
+`tests/test_voxtype_doubletap.py`: config bounds and types for all three
+keys, the detector state machine (timing, reset, chord-during-hold,
+wrong key), stubbed event-tap integration (fires on right Option; not on
+left; not with Shift or left Option held; keydown between taps resets;
+`when` predicate honored; never swallowed), and app wiring (binding
+passed through; opacity passed to the overlay; startup line only when
+armed).


### PR DESCRIPTION
## What

Two small voxtype UX additions:

- **`overlay_opacity`** (0.1–1.0, default 1.0): whole-ghost transparency, for when the ghost hides text under it. Applied as the panel's alpha so the drawing keeps its per-element look.
- **`double_tap_key` / `double_tap_ms`**: a second way to toggle recording alongside the `hotkey` chord — tap one modifier key twice on its own (e.g. `right_alt`, the right Option key, for laptop use where Ctrl+; is awkward). Both triggers stay active.

## How the double tap works

- Rides on the existing macOS event tap, observing `kCGEventFlagsChanged`; the modifier is **never swallowed**, so Option/Cmd keep working everywhere.
- Left vs right told apart by keycode + `NX_DEVICE*KEYMASK` bit (checked against the SDK headers; verified live on the built-in keyboard — fires on right Option, not on left, not on ⌥+e).
- Clean-tap rules: press-release-press-release within `double_tap_ms` (press to press), no other key *or held modifier* during the taps, fires on the second **release** so Option-chords can't trigger it.
- Non-macOS: reported and ignored.

## Testing

- 50+ new tests in `tests/test_voxtype_doubletap.py`: config bounds, the detector state machine, stubbed event-tap integration (incl. held-Shift and held-left-Option chords), app wiring. voxtype suite: 274 passed.
- Codex cold-diff review loop to convergence (4 rounds; final: NO FINDINGS).


Details: [release-notes/pr-195-voxtype-opacity-doubletap.md](https://github.com/pchalasani/claude-code-tools/blob/feat/voxtype-opacity-doubletap/release-notes/pr-195-voxtype-opacity-doubletap.md)