### PR TITLE
voxtype: detect a silent hold take and reopen the microphone

### DIFF
--- a/docs-site/src/content/docs/tools/voxtype/configuration.mdx
+++ b/docs-site/src/content/docs/tools/voxtype/configuration.mdx
@@ -359,5 +359,19 @@ Settings → Privacy & Security), once each:
 - Quiet dynamic mic (Shure MV7 class)? Automatic
   gain control is built in; if speech still isn't
   detected, move closer to the mic.
+- `take was silent (...): microphone muted, held by
+  another app, or its stream went stale — reopening
+  the microphone`? voxtype measured no signal at all
+  during that take (a dead mic reads about a
+  millionth of full scale; even a quiet room reads a
+  thousand times more). Two known causes: a meeting
+  app (Zoom) left the mic muted at the system level
+  — unmute there, or tap the mic's own mute button —
+  or the audio stream went stale after the device
+  setup changed (opening the lid, plugging in a
+  mic). voxtype reopens the stream on its own, so
+  the stale case fixes itself: just dictate again.
+  Hold mode only; in wake/vad mode a dead mic simply
+  never hears anything.
 - Dictated into the wrong window? Set `paste_hotkey`
   and re-type the last session anywhere.

--- a/packages/voxtype/src/voxtype/engine_parakeet.py
+++ b/packages/voxtype/src/voxtype/engine_parakeet.py
@@ -58,9 +58,29 @@ SAMPLE_RATE = 16000
 MIN_SILENCE = 0.5
 # Hold-mode recordings are capped at this length to bound memory.
 MAX_HOLD_SECONDS = 600
+# A hold take whose RAW (pre-AGC) peak never reaches this is a dead
+# microphone, not a quiet user: a stream that was muted at the CoreAudio
+# level (Zoom does this) or went stale after a device-topology change
+# (opening the lid) delivers a dither floor around 1.6e-07, while a live
+# dynamic mic's mere room noise measures ~2.8e-03 (Shure MV7+) to 8e-03
+# (Studio Display). 1e-04 sits ~600x above the dead floor and ~30x
+# below live room noise. Judged on raw samples because the AGC would
+# amplify a dead floor by up to 60x and make it look alive.
+SILENT_TAKE_PEAK = 1e-04
 # A VAD segment continuously "in speech" for this long is stuck
 # (amplified noise pinning the detector): force-close and recover.
 MAX_SEGMENT_SECONDS = 30.0
+
+
+class _ReopenMicrophone(Exception):
+    """Raised inside a capture session to end it and open a fresh stream.
+
+    Used when a take came back silent: if the stream went stale after a
+    device change, the reopen fixes it; if the mic is muted by another
+    app, the user has been told and the reopen is harmless. Handled by
+    ``_loop`` as a deliberate restart — no backoff, and it never counts
+    toward the consecutive-failure limit.
+    """
 
 
 class AutoGain:
@@ -516,6 +536,9 @@ class ParakeetEngine:
         self._hold_buf: list = []
         self._hold_len = 0
         self._hold_capped = False
+        # Loudest RAW (pre-AGC) sample seen during the current take;
+        # compared against SILENT_TAKE_PEAK on hold-stop.
+        self._hold_raw_peak = 0.0
         # Per-session VAD staging buffer / open-segment clock; given
         # real values at the top of each capture session.
         self._vad_pending: Any = None
@@ -573,6 +596,7 @@ class ParakeetEngine:
         self._holding = False
         self._hold_buf, self._hold_len = [], 0
         self._hold_capped = False
+        self._hold_raw_peak = 0.0
 
     def start(
         self,
@@ -739,6 +763,15 @@ class ParakeetEngine:
                 try:
                     self._capture_session(on_utterance, on_activity)
                     failures = 0
+                except _ReopenMicrophone:
+                    # Deliberate: reopen immediately. The session DID
+                    # capture audio (a whole take of it), so like any
+                    # productive session it resets the consecutive-
+                    # failure count — a muted mic producing silent
+                    # take after silent take must never walk the
+                    # counter up to the fatal limit.
+                    failures = 0
+                    continue
                 except Exception as e:
                     if self._stop.is_set():
                         break
@@ -853,6 +886,7 @@ class ParakeetEngine:
                             )
                         continue
                     empty_reads = 0
+                    raw = samples  # pre-AGC view, for the silent-take check
                     samples = self._agc.process(samples)
                     self.level = float(
                         min(1.0, float(np.abs(samples).max()))
@@ -873,13 +907,21 @@ class ParakeetEngine:
                         # remaining budget is kept, so even a huge
                         # single read cannot blow past the cap.
                         budget = (
-                            MAX_HOLD_SECONDS * SAMPLE_RATE
+                            int(MAX_HOLD_SECONDS * SAMPLE_RATE)
                             - self._hold_len
                         )
                         if budget > 0:
                             chunk = samples[:budget]
                             self._hold_buf.append(chunk)
                             self._hold_len += len(chunk)
+                            # Raw level BEFORE the AGC, and only over
+                            # the slice actually kept: audio past the
+                            # cap is not in the take and must not
+                            # vouch for it (see SILENT_TAKE_PEAK).
+                            self._hold_raw_peak = max(
+                                self._hold_raw_peak,
+                                float(np.abs(raw[:budget]).max()),
+                            )
                         if (
                             budget <= len(samples)
                             and not self._hold_capped
@@ -993,10 +1035,23 @@ class ParakeetEngine:
                 self._holding = True
                 self._hold_buf, self._hold_len = [], 0
                 self._hold_capped = False
+                self._hold_raw_peak = 0.0
             elif command == "hold_stop":
                 if self._holding and self._hold_len:
                     take = np.concatenate(self._hold_buf)
                     self._hold_buf, self._hold_len = [], 0
+                    self._holding = False
+                    if self._hold_raw_peak < SILENT_TAKE_PEAK:
+                        # Dead microphone: say so (the bland "decoded
+                        # to empty text" hid two real incidents), skip
+                        # the pointless decode, and reopen the stream.
+                        self._report(
+                            f"take was silent ({len(take) / SAMPLE_RATE:.1f}s"
+                            f", peak {self._hold_raw_peak:.1e}): microphone"
+                            " muted, held by another app, or its stream"
+                            " went stale — reopening the microphone"
+                        )
+                        raise _ReopenMicrophone()
                     self._enqueue_take(take, on_utterance)
                 self._holding = False
 

--- a/packages/voxtype/tests/test_voxtype_silent_take.py
+++ b/packages/voxtype/tests/test_voxtype_silent_take.py
@@ -1,0 +1,258 @@
+"""A hold take with no signal is a dead microphone, not a quiet user.
+
+Two real incidents motivated this: Zoom leaving the Shure MV7+ muted at
+the CoreAudio level (voxtype read a 1.6e-07 dither floor and decoded
+43 s of "speech" to nothing), and a PortAudio stream that went stale
+after a lid-open changed the device topology (eight days old; reading
+zeros while a fresh stream on the same device read fine). Both showed
+up only as "decoded to empty text". These tests pin the fix: measure
+the RAW (pre-AGC) peak of every hold take, and when it is below the
+dead-mic floor, say so plainly, skip the pointless decode, and reopen
+the microphone stream so the stale case self-heals.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from test_voxtype_engines import ScriptedStream, _make_parakeet
+from voxtype.config import Config
+
+
+def _hold_engine(monkeypatch):  # noqa: ANN001, ANN202
+    eng, statuses, holder = _make_parakeet(monkeypatch, texts=())
+    eng.cfg = Config(mode="toggle", engine="parakeet", segmentation="hold")
+    decoded: list[int] = []
+
+    def transcribe(samples, sr):  # noqa: ANN001, ANN202
+        decoded.append(len(samples))
+        return f"len={len(samples)}"
+
+    eng.transcribe = transcribe  # type: ignore[method-assign]
+    return eng, statuses, holder, decoded
+
+
+def _final_read(eng, np):  # noqa: ANN001, ANN202
+    def read():  # noqa: ANN202
+        eng._stop.set()
+        return np.zeros((0, 1), dtype=np.float32)
+
+    return read
+
+
+def test_silent_take_floor_is_between_dead_and_live_levels() -> None:
+    """The floor must sit well above a muted/stale stream's dither
+    (measured 1.6e-07) and well below a live dynamic mic's room noise
+    (measured 2.8e-03 on a Shure MV7+, 8e-03 on a Studio Display)."""
+    from voxtype.engine_parakeet import SILENT_TAKE_PEAK
+
+    assert 1.6e-07 * 50 < SILENT_TAKE_PEAK < 2.8e-03 / 10
+
+
+def test_silent_hold_take_is_reported_skipped_and_stream_reopened(
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    np = pytest.importorskip("numpy")
+    eng, statuses, holder, decoded = _hold_engine(monkeypatch)
+    dead = np.full((160, 1), 1.6e-07, dtype=np.float32)  # muted MV7+
+    sessions = {"n": 0}
+
+    def stop_take():  # noqa: ANN202
+        eng.request_hold_stop()
+        return np.zeros((0, 1), dtype=np.float32)
+
+    def factory(**kwargs):  # noqa: ANN003, ANN202
+        sessions["n"] += 1
+        if sessions["n"] == 1:
+            # Silent take; the hold-stop must end this session.
+            return ScriptedStream([dead, dead, stop_take])
+        return ScriptedStream([_final_read(eng, np)])
+
+    holder["factory"] = factory
+    eng.request_hold_start()
+    utterances: list[str] = []
+    eng._loop(utterances.append, lambda: None)
+    assert decoded == []  # nothing to decode
+    assert utterances == []
+    assert sessions["n"] == 2  # the microphone stream was reopened
+    silent = [s for s in statuses if "silent" in s]
+    assert len(silent) == 1
+    assert "0.0s" in silent[0] or "0.02s" in silent[0]
+    assert "reopen" in silent[0]
+    assert "1.6e-07" in silent[0]  # the measured peak, for diagnosis
+    # It is a deliberate reopen, not a capture failure: no retry
+    # countdown, no backoff message.
+    assert not any("retrying" in s for s in statuses)
+
+
+def test_silent_take_uses_raw_peak_not_agc_output(monkeypatch) -> None:  # noqa: ANN001
+    """The AGC amplifies up to 60x, so a dead stream's 1e-06 becomes
+    6e-05 in the hold buffer — still dead. The judgment must be made
+    on the raw samples, before gain, so a dead mic can never be
+    'rescued' into looking live."""
+    np = pytest.importorskip("numpy")
+    eng, statuses, holder, decoded = _hold_engine(monkeypatch)
+    from voxtype.engine_parakeet import SILENT_TAKE_PEAK
+
+    # Raw level just under the floor; after 60x it would be well over.
+    raw = SILENT_TAKE_PEAK * 0.5
+    assert raw * 60 > SILENT_TAKE_PEAK
+    dead = np.full((160, 1), raw, dtype=np.float32)
+
+    def stop_take():  # noqa: ANN202
+        eng.request_hold_stop()
+        return np.zeros((0, 1), dtype=np.float32)
+
+    sessions = {"n": 0}
+
+    def factory(**kwargs):  # noqa: ANN003, ANN202
+        sessions["n"] += 1
+        if sessions["n"] == 1:
+            return ScriptedStream([dead] * 30 + [stop_take])  # ~3 s
+        return ScriptedStream([_final_read(eng, np)])
+
+    holder["factory"] = factory
+    eng.request_hold_start()
+    eng._loop(lambda t: None, lambda: None)
+    assert decoded == []
+    assert any("silent" in s for s in statuses)
+
+
+def test_live_take_still_decodes_and_peak_resets_per_take(
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """A normal take is untouched, and the raw-peak tracking starts
+    fresh on every hold-start: a loud take followed by a dead one
+    must flag the dead one (not inherit the loud peak)."""
+    np = pytest.importorskip("numpy")
+    eng, statuses, holder, decoded = _hold_engine(monkeypatch)
+    live = np.full((160, 1), 0.02, dtype=np.float32)  # quiet speech
+    dead = np.full((160, 1), 1e-07, dtype=np.float32)
+
+    def stop_then_start():  # noqa: ANN202
+        eng.request_hold_stop()
+        eng.request_hold_start()
+        return np.zeros((0, 1), dtype=np.float32)
+
+    def stop_take():  # noqa: ANN202
+        eng.request_hold_stop()
+        return np.zeros((0, 1), dtype=np.float32)
+
+    sessions = {"n": 0}
+
+    def factory(**kwargs):  # noqa: ANN003, ANN202
+        sessions["n"] += 1
+        if sessions["n"] == 1:
+            return ScriptedStream(
+                [live, live, stop_then_start, dead, dead, stop_take]
+            )
+        return ScriptedStream([_final_read(eng, np)])
+
+    holder["factory"] = factory
+    eng.request_hold_start()
+    utterances: list[str] = []
+    eng._loop(utterances.append, lambda: None)
+    assert utterances == ["len=320"]  # the live take was delivered
+    assert decoded == [320]  # ...and only that one was decoded
+    assert sum("silent" in s for s in statuses) == 1
+    assert sessions["n"] == 2
+
+
+def test_silent_reopen_does_not_count_toward_fatal_limit(
+    monkeypatch,  # noqa: ANN001
+) -> None:
+    """A muted mic produces a silent take every time the user tries;
+    each reopen is deliberate and must never accumulate into the
+    'giving up' fatal error that real capture failures trigger."""
+    np = pytest.importorskip("numpy")
+    eng, statuses, holder, decoded = _hold_engine(monkeypatch)
+    eng.MAX_CONSECUTIVE_FAILURES = 3
+    dead = np.full((160, 1), 1e-07, dtype=np.float32)
+
+    def stop_take():  # noqa: ANN202
+        eng.request_hold_stop()
+        return np.zeros((0, 1), dtype=np.float32)
+
+    def start_take():  # noqa: ANN202
+        eng.request_hold_start()
+        return np.zeros((0, 1), dtype=np.float32)
+
+    sessions = {"n": 0}
+
+    def factory(**kwargs):  # noqa: ANN003, ANN202
+        sessions["n"] += 1
+        if sessions["n"] <= 4:  # four silent takes in a row
+            return ScriptedStream([start_take, dead, stop_take])
+        return ScriptedStream([_final_read(eng, np)])
+
+    holder["factory"] = factory
+    eng._loop(lambda t: None, lambda: None)
+    assert eng.fatal_error is None
+    assert sessions["n"] == 5
+    assert sum("silent" in s for s in statuses) == 4
+
+
+def test_silent_take_resets_consecutive_failure_count(monkeypatch) -> None:  # noqa: ANN001
+    """Two real failures, then a silent take (audio WAS captured), then
+    one more failure: the failures were not consecutive, so with a
+    limit of three the engine must not go fatal."""
+    np = pytest.importorskip("numpy")
+    eng, statuses, holder, _ = _hold_engine(monkeypatch)
+    eng.MAX_CONSECUTIVE_FAILURES = 3
+    dead = np.full((160, 1), 1e-07, dtype=np.float32)
+
+    def start_take():  # noqa: ANN202
+        eng.request_hold_start()
+        return np.zeros((0, 1), dtype=np.float32)
+
+    def stop_take():  # noqa: ANN202
+        eng.request_hold_stop()
+        return np.zeros((0, 1), dtype=np.float32)
+
+    sessions = {"n": 0}
+
+    def factory(**kwargs):  # noqa: ANN003, ANN202
+        sessions["n"] += 1
+        if sessions["n"] in (1, 2, 4):
+            raise RuntimeError("mic gone")  # opens fail: real failures
+        if sessions["n"] == 3:
+            return ScriptedStream([start_take, dead, stop_take])
+        return ScriptedStream([_final_read(eng, np)])
+
+    holder["factory"] = factory
+    eng._loop(lambda t: None, lambda: None)
+    assert eng.fatal_error is None
+    assert sessions["n"] == 5
+
+
+def test_silent_take_ignores_audio_beyond_the_hold_cap(monkeypatch) -> None:  # noqa: ANN001
+    """A capped take holds only its first MAX_HOLD_SECONDS; a loud
+    sample arriving after the cap is not in the take and must not make
+    a silent take look live."""
+    np = pytest.importorskip("numpy")
+    import voxtype.engine_parakeet as ep
+
+    monkeypatch.setattr(ep, "MAX_HOLD_SECONDS", 0.02)  # 320 samples
+    eng, statuses, holder, decoded = _hold_engine(monkeypatch)
+    dead = np.full((160, 1), 1e-07, dtype=np.float32)
+    loud = np.full((160, 1), 0.5, dtype=np.float32)
+
+    def stop_take():  # noqa: ANN202
+        eng.request_hold_stop()
+        return np.zeros((0, 1), dtype=np.float32)
+
+    sessions = {"n": 0}
+
+    def factory(**kwargs):  # noqa: ANN003, ANN202
+        sessions["n"] += 1
+        if sessions["n"] == 1:
+            # 320 silent samples fill the cap; the loud chunk is dropped.
+            return ScriptedStream([dead, dead, loud, stop_take])
+        return ScriptedStream([_final_read(eng, np)])
+
+    holder["factory"] = factory
+    eng.request_hold_start()
+    eng._loop(lambda t: None, lambda: None)
+    assert decoded == []
+    assert any("silent" in s for s in statuses)
+    assert any("capped" in s for s in statuses)

--- a/release-notes/pr-196-voxtype-silent-take.md
+++ b/release-notes/pr-196-voxtype-silent-take.md
@@ -1,0 +1,46 @@
+# PR #196 — voxtype: detect a silent hold take and reopen the microphone
+
+## Problem
+
+A hold take with no signal is a dead microphone, not a quiet user — but
+voxtype reported it as `decoded to empty text`, indistinguishable from a
+genuinely empty decode. Two real incidents in one week:
+
+- Zoom left the Shure MV7+ muted at the CoreAudio level; voxtype recorded
+  a 1.6e-07 dither floor and decoded a 43 s take to nothing.
+- A PortAudio stream went stale after opening the lid changed the device
+  topology; eight days old, it read zeros while a fresh stream on the
+  same device read fine.
+
+Silence is valid audio, so nothing tripped the stream-restart logic.
+
+## Fix
+
+- Track each take's raw, pre-AGC peak over the retained slice (the AGC
+  amplifies a dead floor up to 60x; audio past the hold cap is not in
+  the take and must not vouch for it).
+- Below `SILENT_TAKE_PEAK` (1e-04: ~600x above the measured dead floor,
+  ~30x below a live mic's room noise) voxtype prints
+
+  ```
+  take was silent (Ns, peak X): microphone muted, held by another
+  app, or its stream went stale — reopening the microphone
+  ```
+
+  skips the pointless decode, and ends the capture session with
+  `_ReopenMicrophone`, which `_loop` treats as a deliberate reopen: no
+  retry backoff, and the consecutive-failure count resets (audio was
+  captured), so a muted mic can never walk it to the fatal limit.
+- Hold mode only. In wake/vad mode a dead mic never triggers the VAD,
+  and a continuous silence check would false-positive on noise-gated
+  mics.
+
+## Verification
+
+- `tests/test_voxtype_silent_take.py` (7 tests): floor placement,
+  report/skip/reopen, raw-not-AGC judgment, per-take reset with a live
+  take untouched, no fatal accumulation, failure-count reset, cap-slice
+  judgment.
+- Real hardware through the real capture loop: the dead (lid-closed)
+  built-in mic reports silent and reopens; the live Studio Display mic
+  decodes normally.


### PR DESCRIPTION
## Problem

A hold take with no signal is a dead microphone, not a quiet user — but voxtype reported it as `decoded to empty text`, indistinguishable from a real empty decode. Two real incidents in one week:

- Zoom left the Shure MV7+ **muted at the CoreAudio level**; voxtype recorded a 1.6e-07 dither floor and decoded a 43 s take to nothing.
- A PortAudio stream **went stale** after opening the lid changed the device topology; eight days old, it read zeros while a fresh stream on the same device read fine.

Silence is valid audio, so nothing tripped the stream-restart logic and the user found out by losing takes.

## Fix

- Track each take's **raw, pre-AGC** peak over the retained slice (the AGC would amplify a dead floor 60x; audio past the hold cap isn't in the take).
- Below `SILENT_TAKE_PEAK` (1e-04 — ~600x above the measured dead floor, ~30x below a live mic's room noise): print `take was silent (Ns, peak X): microphone muted, held by another app, or its stream went stale — reopening the microphone`, skip the decode, and end the session with `_ReopenMicrophone` so `_loop` reopens the stream.
- The reopen is deliberate: no retry backoff, and it resets the consecutive-failure count (audio *was* captured), so a muted mic can never walk the counter to the fatal limit.
- Hold mode only (documented): in wake/vad mode a dead mic never triggers the VAD, and a continuous silence check would false-positive on noise-gated mics.

## Testing

- 7 tests in `tests/test_voxtype_silent_take.py`: floor placement, report/skip/reopen, raw-not-AGC judgment, per-take reset with a live take untouched, no fatal accumulation, failure-count reset, cap-slice judgment. voxtype suite: 282 passed.
- **Real hardware**: through the real capture loop, the (dead, lid-closed) built-in mic → `take was silent (1.5s, peak 0.0e+00) … reopening`, nothing decoded; the (live) Studio Display mic → normal decode.
- Codex cold-diff review to convergence (2 rounds; final: NO FINDINGS).

Related: #169 (decoupling capture from decoding) is a different defect and stays open.


Details: [release-notes/pr-196-voxtype-silent-take.md](https://github.com/pchalasani/claude-code-tools/blob/fix/voxtype-silent-take/release-notes/pr-196-voxtype-silent-take.md)