### PR TITLE
fix(safety-hooks): compare tool_name case-insensitively (#186)

### DIFF
--- a/plugins/safety-hooks/README.md
+++ b/plugins/safety-hooks/README.md
@@ -139,3 +139,18 @@ decisions to Claude Code.
 | env_file_protection_hook.py | block | Protects .env files from Bash commands |
 | read_env_protection_hook.py | block | Protects .env files from Read tool |
 | file_length_limit_hook.py | block (speed bump) | Limits source file size |
+
+## Tool name matching
+
+Every hook gates on the incoming `tool_name` before running any check, and
+clients do not agree on how to spell it — Claude Code sends `Bash`, others
+send `bash`. That comparison is therefore case-insensitive at both layers:
+
+- the `hooks.json` matchers accept any case (`^[Bb][Aa][Ss][Hh]$`)
+- each script folds case before comparing (`tool_name.lower() != "bash"`)
+
+Both layers matter. The matcher decides whether the hook runs at all; the
+in-script check is the second line of defence. Comparing exact case there
+would send a mismatched spelling straight to the approve branch, so the
+hook would return "allowed" for a command it exists to block — silently,
+with no log line and no non-zero exit.

--- a/plugins/safety-hooks/hooks/bash_hook.py
+++ b/plugins/safety-hooks/hooks/bash_hook.py
@@ -46,9 +46,12 @@ def main():
 
     session_id = data.get("session_id", "")
 
-    # Check if this is a Bash tool call
-    tool_name = data.get("tool_name")
-    if tool_name != "Bash":
+    # Check if this is a Bash tool call. Clients spell tool names
+    # differently ("Bash" vs "bash"), so fold case before comparing --
+    # an exact-case mismatch would fall through to "approve" and
+    # silently disable every check below.
+    tool_name = (data.get("tool_name") or "").lower()
+    if tool_name != "bash":
         print(json.dumps({"decision": "approve"}))
         sys.exit(0)
 

--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -1014,9 +1014,10 @@ if __name__ == "__main__":
 
     data = json.load(sys.stdin)
 
-    # Check if this is a Bash tool call
-    tool_name = data.get("tool_name")
-    if tool_name != "Bash":
+    # Check if this is a Bash tool call. Fold case first: an exact-case
+    # mismatch would allow the command without checking it.
+    tool_name = (data.get("tool_name") or "").lower()
+    if tool_name != "bash":
         print(json.dumps({
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",

--- a/plugins/safety-hooks/hooks/file_length_limit_hook.py
+++ b/plugins/safety-hooks/hooks/file_length_limit_hook.py
@@ -74,13 +74,18 @@ def get_resulting_line_count(
 
     For Write: count lines in new content
     For Edit: count lines in file after replacement
+
+    ``tool_name`` is matched case-insensitively, since clients differ on
+    how they spell it ("Write" vs "write").
     """
-    if tool_name == "Write":
+    tool_name = tool_name.lower()
+
+    if tool_name == "write":
         # For Write, the new content is in the 'content' field
         content = tool_input.get("content", "")
         return count_lines_in_content(content)
 
-    elif tool_name == "Edit":
+    elif tool_name == "edit":
         # For Edit, we need to calculate the result of the replacement
         old_string = tool_input.get("old_string", "")
         new_string = tool_input.get("new_string", "")
@@ -124,10 +129,12 @@ def check_file_length_limit(data: dict) -> tuple[bool, str | None]:
     Returns:
         (should_block, reason)
     """
-    tool_name = data.get("tool_name")
+    # Fold case first: an exact-case mismatch would skip the limit check
+    # entirely on clients that spell the tool name differently.
+    tool_name = (data.get("tool_name") or "").lower()
 
     # Only check Edit and Write tools
-    if tool_name not in ("Edit", "Write"):
+    if tool_name not in ("edit", "write"):
         return False, None
 
     tool_input = data.get("tool_input", {})

--- a/plugins/safety-hooks/hooks/git_add_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_add_block_hook.py
@@ -732,9 +732,10 @@ if __name__ == "__main__":
 
     data = json.load(sys.stdin)
 
-    # Check if this is a Bash tool call
-    tool_name = data.get("tool_name")
-    if tool_name != "Bash":
+    # Check if this is a Bash tool call. Fold case first: an exact-case
+    # mismatch would approve the command without checking it.
+    tool_name = (data.get("tool_name") or "").lower()
+    if tool_name != "bash":
         print(json.dumps({"decision": "approve"}))
         sys.exit(0)
 

--- a/plugins/safety-hooks/hooks/git_checkout_safety_hook.py
+++ b/plugins/safety-hooks/hooks/git_checkout_safety_hook.py
@@ -595,9 +595,10 @@ if __name__ == "__main__":
 
     data = json.load(sys.stdin)
 
-    # Check if this is a Bash tool call
-    tool_name = data.get("tool_name")
-    if tool_name != "Bash":
+    # Check if this is a Bash tool call. Fold case first: an exact-case
+    # mismatch would approve the command without checking it.
+    tool_name = (data.get("tool_name") or "").lower()
+    if tool_name != "bash":
         print(json.dumps({"decision": "approve"}))
         sys.exit(0)
 

--- a/plugins/safety-hooks/hooks/git_commit_block_hook.py
+++ b/plugins/safety-hooks/hooks/git_commit_block_hook.py
@@ -555,9 +555,10 @@ def check_git_commit_command(
 if __name__ == "__main__":
     data = json.load(sys.stdin)
 
-    # Check if this is a Bash tool call
-    tool_name = data.get("tool_name")
-    if tool_name != "Bash":
+    # Check if this is a Bash tool call. Fold case first: an exact-case
+    # mismatch would approve the command without checking it.
+    tool_name = (data.get("tool_name") or "").lower()
+    if tool_name != "bash":
         print(json.dumps({"decision": "approve"}))
         sys.exit(0)
 

--- a/plugins/safety-hooks/hooks/hooks.json
+++ b/plugins/safety-hooks/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "^[Bb][Aa][Ss][Hh]$",
         "hooks": [
           {
             "type": "command",
@@ -13,7 +13,7 @@
         ]
       },
       {
-        "matcher": "Edit",
+        "matcher": "^[Ee][Dd][Ii][Tt]$",
         "hooks": [
           {
             "type": "command",
@@ -23,7 +23,7 @@
         ]
       },
       {
-        "matcher": "Write",
+        "matcher": "^[Ww][Rr][Ii][Tt][Ee]$",
         "hooks": [
           {
             "type": "command",
@@ -33,7 +33,7 @@
         ]
       },
       {
-        "matcher": "Read",
+        "matcher": "^[Rr][Ee][Aa][Dd]$",
         "hooks": [
           {
             "type": "command",

--- a/plugins/safety-hooks/hooks/read_env_protection_hook.py
+++ b/plugins/safety-hooks/hooks/read_env_protection_hook.py
@@ -38,9 +38,10 @@ def check_env_file_path(file_path):
 def main():
     data = json.load(sys.stdin)
 
-    # Check if this is a Read tool call
-    tool_name = data.get("tool_name")
-    if tool_name != "Read":
+    # Check if this is a Read tool call. Fold case first: an exact-case
+    # mismatch would allow the read without checking it.
+    tool_name = (data.get("tool_name") or "").lower()
+    if tool_name != "read":
         print(json.dumps({
             "hookSpecificOutput": {
                 "hookEventName": "PreToolUse",

--- a/plugins/safety-hooks/hooks/rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/rm_block_hook.py
@@ -89,9 +89,10 @@ if __name__ == "__main__":
 
     data = json.load(sys.stdin)
 
-    # Only intercept Bash tool calls
-    tool_name = data.get("tool_name")
-    if tool_name != "Bash":
+    # Only intercept Bash tool calls. Fold case first: an exact-case
+    # mismatch would approve the command without checking it.
+    tool_name = (data.get("tool_name") or "").lower()
+    if tool_name != "bash":
         print(json.dumps({"decision": "approve"}))
         sys.exit(0)
 

--- a/plugins/safety-hooks/hooks/test_tool_name_case.py
+++ b/plugins/safety-hooks/hooks/test_tool_name_case.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Regression tests for case-insensitive tool_name dispatch (issue #186).
+
+Every safety-hook entrypoint gates on `tool_name` before running any
+check. When that gate compared exact case, a client spelling the tool
+name differently ("bash" instead of "Bash") fell through to the
+approve/allow branch -- the hook failed OPEN and looked healthy from
+the outside.
+
+These tests assert, for each entrypoint, that:
+    - a lowercase/mixed-case spelling still reaches the safety check
+    - the canonical spelling still behaves exactly as before
+    - an unrelated tool name is still passed through untouched
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from file_length_limit_hook import MAX_FILE_LINES, check_file_length_limit
+
+HOOKS_DIR = Path(__file__).resolve().parent
+
+# Spellings a client might send for a single tool.
+BASH_SPELLINGS = ("Bash", "bash", "BASH", "BaSh")
+
+# Standalone Bash entrypoints, each with a command its own check blocks.
+BASH_ENTRYPOINTS = (
+    ("bash_hook.py", "rm secrets.txt"),
+    ("rm_block_hook.py", "rm secrets.txt"),
+    ("env_file_protection_hook.py", "cat .env"),
+    ("git_add_block_hook.py", "git add -A"),
+    ("git_checkout_safety_hook.py", "git checkout -f"),
+    ("git_commit_block_hook.py", "git commit -m wip"),
+)
+
+
+def run_hook(script: str, payload: dict, cwd: str) -> dict:
+    """Run a hook entrypoint on a JSON payload and return its response.
+
+    Args:
+        script: Filename of the entrypoint inside the hooks directory.
+        payload: Hook input, serialized to the script's stdin.
+        cwd: Working directory for the subprocess.
+
+    Returns:
+        The parsed JSON object the entrypoint printed on stdout.
+    """
+    env = {**os.environ, "HOME": cwd}
+    # The commit hook has an escape hatch; keep it out of these tests so
+    # a developer's shell cannot mask a real regression.
+    env.pop("CCTOOLS_ALLOW_GIT", None)
+
+    result = subprocess.run(
+        [sys.executable, str(HOOKS_DIR / script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=cwd,
+        env=env,
+    )
+    return json.loads(result.stdout)
+
+
+def is_pass_through(response: dict) -> bool:
+    """Return whether a hook response lets the tool call proceed unchecked."""
+    if response.get("decision") == "approve":
+        return True
+    hook_output = response.get("hookSpecificOutput", {})
+    return hook_output.get("permissionDecision") == "allow"
+
+
+class TestBashEntrypointsFoldCase(unittest.TestCase):
+    """Bash-gated entrypoints must not fail open on a case mismatch."""
+
+    def test_every_spelling_reaches_the_safety_check(self) -> None:
+        """No spelling of "Bash" lets a blocked command through."""
+        for script, command in BASH_ENTRYPOINTS:
+            for spelling in BASH_SPELLINGS:
+                with self.subTest(script=script, tool_name=spelling):
+                    with tempfile.TemporaryDirectory() as work_dir:
+                        response = run_hook(
+                            script,
+                            {
+                                "tool_name": spelling,
+                                # Unique, so no allow-flag file exists.
+                                "session_id": f"case-test-{os.getpid()}",
+                                "tool_input": {"command": command},
+                            },
+                            work_dir,
+                        )
+                    self.assertFalse(
+                        is_pass_through(response),
+                        f"{script} failed open for tool_name={spelling!r}: "
+                        f"{response}",
+                    )
+
+    def test_unrelated_tool_name_still_passes_through(self) -> None:
+        """Folding case must not widen the gate to other tools."""
+        for script, command in BASH_ENTRYPOINTS:
+            with self.subTest(script=script):
+                with tempfile.TemporaryDirectory() as work_dir:
+                    response = run_hook(
+                        script,
+                        {
+                            "tool_name": "Grep",
+                            "tool_input": {"command": command},
+                        },
+                        work_dir,
+                    )
+                self.assertTrue(
+                    is_pass_through(response),
+                    f"{script} intercepted an unrelated tool: {response}",
+                )
+
+    def test_missing_tool_name_still_passes_through(self) -> None:
+        """A payload with no tool_name must not crash the entrypoint."""
+        for script, command in BASH_ENTRYPOINTS:
+            with self.subTest(script=script):
+                with tempfile.TemporaryDirectory() as work_dir:
+                    response = run_hook(
+                        script,
+                        {"tool_input": {"command": command}},
+                        work_dir,
+                    )
+                self.assertTrue(
+                    is_pass_through(response),
+                    f"{script} intercepted a payload with no tool_name: "
+                    f"{response}",
+                )
+
+
+class TestReadEntrypointFoldsCase(unittest.TestCase):
+    """The Read hook must protect dotenv files regardless of spelling."""
+
+    def test_every_spelling_blocks_dotenv_reads(self) -> None:
+        """"Read", "read" and "READ" all deny a .env read."""
+        for spelling in ("Read", "read", "READ", "ReAd"):
+            with self.subTest(tool_name=spelling):
+                with tempfile.TemporaryDirectory() as work_dir:
+                    response = run_hook(
+                        "read_env_protection_hook.py",
+                        {
+                            "tool_name": spelling,
+                            "tool_input": {"file_path": ".env"},
+                        },
+                        work_dir,
+                    )
+                self.assertEqual(
+                    response["hookSpecificOutput"]["permissionDecision"],
+                    "deny",
+                    f"failed open for tool_name={spelling!r}: {response}",
+                )
+
+    def test_unrelated_tool_name_still_passes_through(self) -> None:
+        """A non-Read tool is still allowed through untouched."""
+        with tempfile.TemporaryDirectory() as work_dir:
+            response = run_hook(
+                "read_env_protection_hook.py",
+                {"tool_name": "Glob", "tool_input": {"file_path": ".env"}},
+                work_dir,
+            )
+        self.assertTrue(is_pass_through(response))
+
+
+class TestFileLengthHookFoldsCase(unittest.TestCase):
+    """The file-length hook must dispatch Write and Edit case-insensitively."""
+
+    def _oversized(self) -> str:
+        """Return file content that exceeds the line limit."""
+        return "x = 1\n" * (MAX_FILE_LINES + 1)
+
+    def _check_in_temp_dir(self, payload: dict) -> bool:
+        """Run check_file_length_limit from a scratch directory.
+
+        The check drops a `.claude_file_length_warning.flag` speed-bump
+        file in the working directory, so each call needs a fresh one.
+        """
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as work_dir:
+            os.chdir(work_dir)
+            try:
+                if payload["tool_name"].lower() == "edit":
+                    Path("oversized.py").write_text(self._oversized())
+                should_block, _ = check_file_length_limit(payload)
+            finally:
+                os.chdir(original_cwd)
+        return should_block
+
+    def test_write_is_checked_for_every_spelling(self) -> None:
+        """Every spelling of "Write" is length-checked."""
+        for spelling in ("Write", "write", "WRITE", "WrItE"):
+            with self.subTest(tool_name=spelling):
+                blocked = self._check_in_temp_dir({
+                    "tool_name": spelling,
+                    "tool_input": {
+                        "file_path": "oversized.py",
+                        "content": self._oversized(),
+                    },
+                })
+                self.assertTrue(blocked, f"failed open for {spelling!r}")
+
+    def test_edit_is_checked_for_every_spelling(self) -> None:
+        """Every spelling of "Edit" is length-checked.
+
+        This also covers `get_resulting_line_count`, which dispatches on
+        the tool name a second time to decide how to compute the result.
+        """
+        for spelling in ("Edit", "edit", "EDIT", "EdIt"):
+            with self.subTest(tool_name=spelling):
+                blocked = self._check_in_temp_dir({
+                    "tool_name": spelling,
+                    "tool_input": {
+                        "file_path": "oversized.py",
+                        "old_string": "x = 1",
+                        "new_string": "y = 2",
+                    },
+                })
+                self.assertTrue(blocked, f"failed open for {spelling!r}")
+
+    def test_unrelated_tool_name_is_not_checked(self) -> None:
+        """Folding case must not widen the gate to other tools."""
+        blocked = self._check_in_temp_dir({
+            "tool_name": "NotebookEdit",
+            "tool_input": {
+                "file_path": "oversized.py",
+                "content": self._oversized(),
+            },
+        })
+        self.assertFalse(blocked)
+
+    def test_entrypoint_denies_lowercase_write(self) -> None:
+        """End to end, the entrypoint denies a lowercase oversized Write."""
+        with tempfile.TemporaryDirectory() as work_dir:
+            response = run_hook(
+                "file_length_limit_hook.py",
+                {
+                    "tool_name": "write",
+                    "tool_input": {
+                        "file_path": "oversized.py",
+                        "content": self._oversized(),
+                    },
+                },
+                work_dir,
+            )
+        self.assertEqual(
+            response["hookSpecificOutput"]["permissionDecision"], "deny"
+        )
+
+
+class TestHooksJsonMatchers(unittest.TestCase):
+    """The registered matchers must accept what the scripts accept."""
+
+    # Matcher index in hooks.json PreToolUse -> tool name it gates.
+    MATCHED_TOOLS = ("Bash", "Edit", "Write", "Read")
+
+    def setUp(self) -> None:
+        config = json.loads((HOOKS_DIR / "hooks.json").read_text())
+        self.matchers = [
+            entry["matcher"] for entry in config["hooks"]["PreToolUse"]
+        ]
+
+    def test_one_matcher_per_gated_tool(self) -> None:
+        """hooks.json still registers exactly the four PreToolUse gates."""
+        self.assertEqual(len(self.matchers), len(self.MATCHED_TOOLS))
+
+    def test_matchers_accept_every_spelling(self) -> None:
+        """Each matcher accepts its tool name in any case."""
+        for matcher, tool in zip(self.matchers, self.MATCHED_TOOLS):
+            for spelling in (tool, tool.lower(), tool.upper()):
+                with self.subTest(matcher=matcher, spelling=spelling):
+                    self.assertIsNotNone(
+                        re.fullmatch(matcher, spelling),
+                        f"{matcher!r} does not accept {spelling!r}",
+                    )
+
+    def test_matchers_reject_other_tools(self) -> None:
+        """A matcher must not capture a different tool's calls."""
+        for matcher, tool in zip(self.matchers, self.MATCHED_TOOLS):
+            for other in ("BashOutput", "NotebookEdit", "WebFetch", "Grep"):
+                with self.subTest(matcher=matcher, other=other):
+                    self.assertIsNone(
+                        re.fullmatch(matcher, other),
+                        f"{matcher!r} for {tool} also matches {other!r}",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/safety-hooks/hooks/test_tool_name_case.py
+++ b/plugins/safety-hooks/hooks/test_tool_name_case.py
@@ -58,6 +58,10 @@ def run_hook(script: str, payload: dict, cwd: str) -> dict:
     # The commit hook has an escape hatch; keep it out of these tests so
     # a developer's shell cannot mask a real regression.
     env.pop("CCTOOLS_ALLOW_GIT", None)
+    # bash_hook.py resolves its sibling modules through CLAUDE_PLUGIN_ROOT
+    # when that is set. Drop it so these tests always exercise the hooks
+    # checked out next to this file, not an installed copy of the plugin.
+    env.pop("CLAUDE_PLUGIN_ROOT", None)
 
     result = subprocess.run(
         [sys.executable, str(HOOKS_DIR / script)],


### PR DESCRIPTION
Fixes #186.

## The bug

Every safety-hooks entrypoint gated on an **exact-case** comparison of
`tool_name` before running any check. When a client spelled the tool name
differently — `bash` rather than `Bash` — the comparison fell through to the
**approve/allow** branch, so the hook returned "allowed" for the very commands
it was installed to block.

It fails silently: no log line, no non-zero exit, and the hook still lists as
installed. The outcome is indistinguishable from "no dangerous command was
attempted".

This matters here because the repo targets "Claude Code, Codex-CLI, and similar
CLI coding agents", and `tool_name` spelling is exactly the surface that varies
between clients.

## What changed

Case is folded at both layers, keeping exact-match semantics otherwise.

**Script entrypoints** (all 10 comparisons across 8 files reported in the
issue thread):

| File | What was skipped on a mismatch |
|---|---|
| `bash_hook.py` | the whole Bash layer — deletion block, git add/commit/checkout guards, dotenv protection |
| `rm_block_hook.py` | `rm` blocking |
| `env_file_protection_hook.py` | dotenv protection for Bash |
| `git_add_block_hook.py` | blanket-staging guard |
| `git_checkout_safety_hook.py` | uncommitted-work guard |
| `git_commit_block_hook.py` | commit approval prompt |
| `read_env_protection_hook.py` | dotenv protection for Read |
| `file_length_limit_hook.py` | the length limit, plus mis-dispatch in `get_resulting_line_count` |

`get_resulting_line_count` folds case itself rather than relying on its caller
to normalize, so it stays correct for any caller.

**`hooks.json` matchers** had the same property — on a lowercase-emitting
client the hook may not fire at all — so they now accept any case:
`"Bash"` → `"^[Bb][Aa][Ss][Hh]$"`, and likewise for Edit, Write and Read.
Character classes rather than an inline `(?i)` flag, since JavaScript regex
engines do not support inline flags. The anchors make the matchers reject
`BashOutput` and `NotebookEdit`, which the bare substring patterns also
rejected under full-match semantics.

## Tests

New `plugins/safety-hooks/hooks/test_tool_name_case.py`. For every entrypoint
it asserts that:

- each of `Bash` / `bash` / `BASH` / `BaSh` reaches the safety check
- the canonical spelling still behaves exactly as before
- an unrelated tool name (`Grep`, `Glob`, `NotebookEdit`) is still passed
  through untouched — folding case must not widen the gate
- a payload with no `tool_name` does not crash the entrypoint
- each `hooks.json` matcher accepts its tool in any case and rejects other tools

The subprocess helper drops `CCTOOLS_ALLOW_GIT` and `CLAUDE_PLUGIN_ROOT` and
runs each hook under a throwaway `HOME`, so the tests always exercise the tree
under review rather than an installed copy of the plugin.

## Verification

- Full plugin suite on this branch: **315 passed, 184 subtests passed**
  (`uv run pytest plugins/safety-hooks/hooks/ -q`).
- Counter-verified against the unfixed tree: the same tests produce
  **36 failures**, covering every entrypoint and every non-canonical spelling.
  The canonical-spelling and unrelated-tool assertions pass there, confirming
  the tests fail for the intended reason and not by construction.

Reported by @rex4539 in #186, including the follow-up AST sweep that widened
the blast radius from 4 files to 8.
