### PR TITLE
fix(safety-hooks): treat heredoc bodies as data, so documenting the guarded verbs is not blocked (#187)

### DIFF
--- a/plugins/safety-hooks/README.md
+++ b/plugins/safety-hooks/README.md
@@ -31,8 +31,13 @@ decisions to Claude Code.
   mention `rm` freely. Bodies are only treated as data when the heredoc is
   *simple*: the `<<` line has no substitution, backticks, brackets, braces
   or backslashes (plain `$VAR` is fine) and the delimiter is a plain word,
-  optionally quoted. Anything more exotic is scanned in full, which can
-  over-block but never lets a hidden command through.
+  optionally quoted. With an unquoted delimiter the body's expansions run
+  (`$(...)`, backticks, even `${x@P}`), so an unquoted body containing `$`
+  or a backtick is scanned in full too. Anything more exotic is scanned in
+  full, which can over-block but never blanks a line bash would run. Quote
+  the delimiter when documenting commands. (Commands built at run time, e.g.
+  `eval "$x"` or `${x@P}`, are outside what any of these guards inspect,
+  heredoc or not.)
 
 #### 1b. git_add_block_hook.py
 

--- a/plugins/safety-hooks/README.md
+++ b/plugins/safety-hooks/README.md
@@ -27,6 +27,12 @@ decisions to Claude Code.
 - **Behavior**: Blocks deletion and suggests moving files to a TRASH/ directory
   instead, with logging in TRASH-FILES.md
 - **Purpose**: Prevent accidental/permanent file deletion
+- **Heredocs**: a heredoc body is data, so `cat > notes.md <<'EOF'` may
+  mention `rm` freely. Bodies are only treated as data when the heredoc is
+  *simple*: the `<<` line has no substitution, backticks, brackets, braces
+  or backslashes (plain `$VAR` is fine) and the delimiter is a plain word,
+  optionally quoted. Anything more exotic is scanned in full, which can
+  over-block but never lets a hidden command through.
 
 #### 1b. git_add_block_hook.py
 

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -580,13 +580,15 @@ def _heredoc_bodies(
 # function blank less, i.e. hand MORE text to the guards.
 _COMMENT_PRECEDERS = ' \t\n;&|(<>)'
 
-# A word only counts as a keyword when it stands alone.
-_WORD_PRECEDERS = ' \t\n;&|('
+# A reserved word is only reserved in command position: at the start of
+# the command, or right after an operator that begins a new one. Spaces
+# may sit in between, but not another word -- 'echo case' is an argument.
+_COMMAND_STARTERS = '\n;&|({'
 
 
 def _keyword_at(command: str, index: int, keyword: str) -> bool:
     """
-    Report whether a standalone keyword starts at the given index.
+    Report whether a reserved word in command position starts at index.
 
     Args:
         command: The full command string.
@@ -594,11 +596,15 @@ def _keyword_at(command: str, index: int, keyword: str) -> bool:
         keyword: The word to look for, e.g. 'case'.
 
     Returns:
-        True when the keyword is there as a whole word.
+        True when the keyword is there as a whole word and bash would
+        read it as the reserved word rather than an ordinary argument.
     """
     if not command.startswith(keyword, index):
         return False
-    if index and command[index - 1] not in _WORD_PRECEDERS:
+    before = index
+    while before and command[before - 1] in ' \t':
+        before -= 1
+    if before and command[before - 1] not in _COMMAND_STARTERS:
         return False
     after = index + len(keyword)
     return after == len(command) or command[after] in ' \t\n;&|)'
@@ -647,6 +653,63 @@ def _end_of_balanced(command: str, start: int, opener: str) -> int | None:
                     return index + 1
         index += 1
     return None
+
+
+# The delimiter word as written: a plain name, optionally quoted one of
+# the three ways bash allows. Anything else ($'..', $"..", escapes inside
+# quotes, substitutions) is left to the shell.
+_SIMPLE_DELIMITER = re.compile(
+    r"""^(?:\\?[A-Za-z0-9_]+|'[A-Za-z0-9_]+'|"[A-Za-z0-9_]+")$""")
+
+# Header-line text that makes bash's tokenization non-trivial. Every
+# known way to blank a real command (a body boundary the scanner places
+# differently from bash) has needed one of these on the heredoc's own
+# line; refusing to blank when any is present makes the failure direction
+# over-blocking, which the guards tolerate. The list is deliberately
+# blunt: a '(' is enough, whether or not it opens a substitution.
+_COMPLEX_HEADER_MARKS = ('`', '$', '(', ')', '{', '}', '[', ']', '\\')
+_PLAIN_VARIABLE = re.compile(r'\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[A-Za-z_][A-Za-z0-9_]*\})')
+
+
+def _simple_heredoc_header(command: str, operator: int, end: int) -> bool:
+    """
+    Report whether a heredoc's header line is simple enough to trust.
+
+    The scanner approximates bash's tokenizer, and every divergence found
+    so far (parameter expansions, ANSI-C quoting, substitutions closing
+    before a newline, 'case' patterns, subscripts, escaped delimiters)
+    lets an attacker place a body boundary where bash does not, so that
+    a real command is blanked as data. Rather than chase each one, blank
+    bodies only when the header line -- the physical line holding the
+    '<<' -- carries none of the constructs those divergences need, and
+    the delimiter is a plain word with at most simple quoting.
+
+    Args:
+        command: The full command string.
+        operator: Index of the '<<' operator.
+        end: Index just past its delimiter word.
+
+    The same principle covers the spans the scanner steps over as
+    non-command text ($((...)), ${...}, $[...], name[...]=): a '<<' inside
+    one of those is a place where bash and this scanner could disagree
+    about whether a heredoc opened, so the caller blanks nothing then too.
+
+    Returns:
+        True when the header line has no complex construct and the
+        delimiter is plain, so the body boundaries are unambiguous.
+    """
+    line_start = command.rfind('\n', 0, operator) + 1
+    line_end = command.find('\n', operator)
+    if line_end == -1:
+        line_end = len(command)
+    raw = command[operator + 2:end].lstrip('-').strip(' \t')
+    if not _SIMPLE_DELIMITER.match(raw):
+        return False
+    header = command[line_start:operator + 2] + command[end:line_end]
+    # A plain variable reference ("$HOME", "${name}") cannot move a token
+    # boundary, and "cat > $HOME/notes.md <<'EOF'" is the common case.
+    header = _PLAIN_VARIABLE.sub('', header)
+    return not any(mark in header for mark in _COMPLEX_HEADER_MARKS)
 
 
 def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
@@ -802,18 +865,24 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             # '<<' inside $((1 << 2)) is a left shift, not a heredoc.
             arithmetic_end = _end_of_balanced(command, index, '(')
             if arithmetic_end is not None:
+                if '<<' in command[index:arithmetic_end]:
+                    return command, []   # see _simple_heredoc_header
                 index = arithmetic_end
                 continue
         if quote is None and command.startswith('${', index):
             # '<<' inside ${x:-<<EOF} is expansion text, not a heredoc.
             expansion_end = _end_of_balanced(command, index + 1, '{')
             if expansion_end is not None:
+                if '<<' in command[index:expansion_end]:
+                    return command, []   # see _simple_heredoc_header
                 index = expansion_end
                 continue
         if quote is None and command.startswith('$[', index):
             # $[1 << 2] is the deprecated arithmetic form, still a shift.
             legacy_end = _end_of_balanced(command, index + 1, '[')
             if legacy_end is not None:
+                if '<<' in command[index:legacy_end]:
+                    return command, []   # see _simple_heredoc_header
                 index = legacy_end
                 continue
         if quote is None and character == '(':
@@ -828,10 +897,17 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
                 and (command[index - 1].isalnum()
                      or command[index - 1] == '_')):
             # An array subscript is an arithmetic context, so the '<<' in
-            # "a[1<<2]=foo" is a shift. A '[' that does not follow a name
-            # is the test command or a glob, and is left alone.
+            # "a[1<<2]=foo" is a shift. But only an assignment word gets
+            # that reading: in "echo a[<<EOF]" bash sees the argument "a["
+            # followed by a heredoc delimited by "EOF]". So the bracket is
+            # skipped only when the balanced span is followed by '=' or
+            # '+=', i.e. it really is "name[subscript]=value".
             subscript_end = _end_of_balanced(command, index, '[')
-            if subscript_end is not None:
+            if subscript_end is not None and (
+                    command.startswith('=', subscript_end)
+                    or command.startswith('+=', subscript_end)):
+                if '<<' in command[index:subscript_end]:
+                    return command, []   # see _simple_heredoc_header
                 index = subscript_end
                 continue
         if quote is None and command.startswith('<<<', index):
@@ -849,6 +925,11 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
                 break
             if isinstance(delimiter, tuple):
                 word, quoted, strip_tabs, end = delimiter
+                if depth or in_backtick or not _simple_heredoc_header(
+                        command, index, end):
+                    # Not provably simple: blank NOTHING in this command.
+                    # See _simple_heredoc_header for why.
+                    return command, []
                 pending.append((word, quoted, strip_tabs, depth))
                 index = end
                 continue

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -575,18 +575,19 @@ def _end_of_balanced(command: str, start: int, opener: str) -> int | None:
     Return the index just past the bracket balancing the one at start.
 
     Used to step over a span whose contents are not commands: an arithmetic
-    expansion $((...)) or a parameter expansion ${...}. A '<<' inside either
-    is text, not a heredoc operator.
+    expansion $((...)), a parameter expansion ${...} or an array subscript
+    a[...]. A '<<' inside any of them is text or a shift, not a heredoc
+    operator.
 
     Args:
         command: The full command string.
         start: Index of the opening bracket.
-        opener: The opening bracket character, '(' or '{'.
+        opener: The opening bracket character, '(', '{' or '['.
 
     Returns:
         Index just past the matching close, or None when unbalanced.
     """
-    closer = ')' if opener == '(' else '}'
+    closer = {'(': ')', '{': '}', '[': ']'}[opener]
     depth = 0
     index = start
     quote = None
@@ -760,6 +761,16 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             open_parens.append('(')
             index += 1
             continue
+        if (quote is None and character == '[' and index > 0
+                and (command[index - 1].isalnum()
+                     or command[index - 1] == '_')):
+            # An array subscript is an arithmetic context, so the '<<' in
+            # "a[1<<2]=foo" is a shift. A '[' that does not follow a name
+            # is the test command or a glob, and is left alone.
+            subscript_end = _end_of_balanced(command, index, '[')
+            if subscript_end is not None:
+                index = subscript_end
+                continue
         if (quote is None and command.startswith('<<', index)
                 and not command.startswith('<<<', index)):
             delimiter = _heredoc_delimiter(command, index)

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -419,6 +419,23 @@ def _heredoc_delimiter(
             quoted = True
             delimiter_parts.append(content)
             index = end + 1
+        elif (command.startswith('$(', index)
+                or command.startswith('${', index)):
+            # No expansion happens on a delimiter word, so "$(echo EOF)" is
+            # the delimiter, literally, parentheses and all.
+            opener = '(' if command[index + 1] == '(' else '{'
+            end = _end_of_balanced(command, index + 1, opener)
+            if end is None:
+                return None
+            delimiter_parts.append(command[index:end])
+            index = end
+        elif character == '`':
+            # A backtick span is part of the word, and just as literal.
+            end = command.find('`', index + 1)
+            if end == -1:
+                return None
+            delimiter_parts.append(command[index:end + 1])
+            index = end + 1
         elif character in "'\"":
             quoted = True
             end = _end_of_single_quote(command, index, escapes=False)

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -257,7 +257,9 @@ def _extract_balanced_paren_content(command: str, start_idx: int) -> str | None:
     Extract content from balanced parentheses starting at given index.
 
     Given a string and the index of an opening '(', finds the matching
-    closing ')' accounting for nested parentheses.
+    closing ')' accounting for nested parentheses. A ')' inside quotes is
+    text, not the closing one: stopping at it would cut the substitution
+    short and hide the commands after it, as in "$(printf ')'; rm foo)".
 
     Args:
         command: The full command string.
@@ -274,18 +276,10 @@ def _extract_balanced_paren_content(command: str, start_idx: int) -> str | None:
     if start_idx >= len(command) or command[start_idx] != '(':
         return None
 
-    depth = 0
-    for i in range(start_idx, len(command)):
-        if command[i] == '(':
-            depth += 1
-        elif command[i] == ')':
-            depth -= 1
-            if depth == 0:
-                # Found the matching closing paren
-                return command[start_idx + 1:i]
-
-    # No matching closing paren found
-    return None
+    end = _end_of_balanced(command, start_idx, '(')
+    if end is None:
+        return None
+    return command[start_idx + 1:end - 1]
 
 
 def extract_subshell_commands(command: str) -> list[str]:

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -734,6 +734,12 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             # Backticks cannot nest, so one toggles the substitution.
             depth += -1 if in_backtick else 1
             in_backtick = not in_backtick
+            if not in_backtick:
+                # Closing: a heredoc opened inside that never reached a
+                # newline gets no body, exactly as with ')' below. Left
+                # pending, it would swallow the first lines of a later
+                # substitution at the same depth as data.
+                pending = [item for item in pending if item[3] <= depth]
             index += 1
             continue
         if quote is None and (_keyword_at(command, index, 'case')

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -368,22 +368,28 @@ def _heredoc_bounds(
 _COMMENT_PRECEDERS = ' \t\n;&|(<>)'
 
 
-def _end_of_arithmetic(command: str, start: int) -> int | None:
+def _end_of_balanced(command: str, start: int, opener: str) -> int | None:
     """
-    Return the index just past the '))' closing an arithmetic expansion.
+    Return the index just past the bracket balancing the one at start.
+
+    Used to step over a span whose contents are not commands: an arithmetic
+    expansion $((...)) or a parameter expansion ${...}. A '<<' inside either
+    is text, not a heredoc operator.
 
     Args:
         command: The full command string.
-        start: Index of the first '(' of the opening '((' .
+        start: Index of the opening bracket.
+        opener: The opening bracket character, '(' or '{'.
 
     Returns:
         Index just past the matching close, or None when unbalanced.
     """
+    closer = ')' if opener == '(' else '}'
     depth = 0
     for index in range(start, len(command)):
-        if command[index] == '(':
+        if command[index] == opener:
             depth += 1
-        elif command[index] == ')':
+        elif command[index] == closer:
             depth -= 1
             if depth == 0:
                 return index + 1
@@ -442,9 +448,15 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             continue
         if quote is None and command.startswith('((', index):
             # '<<' inside $((1 << 2)) is a left shift, not a heredoc.
-            arithmetic_end = _end_of_arithmetic(command, index)
+            arithmetic_end = _end_of_balanced(command, index, '(')
             if arithmetic_end is not None:
                 index = arithmetic_end
+                continue
+        if quote is None and command.startswith('${', index):
+            # '<<' inside ${x:-<<EOF} is expansion text, not a heredoc.
+            expansion_end = _end_of_balanced(command, index + 1, '{')
+            if expansion_end is not None:
+                index = expansion_end
                 continue
         if (quote is None and command.startswith('<<', index)
                 and not command.startswith('<<<', index)):

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -637,6 +637,16 @@ def _end_of_balanced(command: str, start: int, opener: str) -> int | None:
             # An escaped brace is expansion text, not the closing one.
             index += 2
             continue
+        if quote is None and command.startswith("$'", index):
+            # ANSI-C quoting: unlike '...', a backslash escapes the closing
+            # quote, so "$'don\\'t'" is one word. Reading it as plain
+            # single quoting would end the span early and lose the real
+            # closing bracket after it.
+            end = _end_of_single_quote(command, index + 1, escapes=True)
+            if end is None:
+                return None
+            index = end + 1
+            continue
         if character in "'\"":
             if quote == character:
                 quote = None

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -360,6 +360,33 @@ def _heredoc_bounds(
     return None
 
 
+# A '#' only opens a comment at the start of a word, so it must follow
+# whitespace or an operator (or start the command).
+_COMMENT_PRECEDERS = ' \t\n;&|(<>'
+
+
+def _end_of_arithmetic(command: str, start: int) -> int | None:
+    """
+    Return the index just past the '))' closing an arithmetic expansion.
+
+    Args:
+        command: The full command string.
+        start: Index of the first '(' of the opening '((' .
+
+    Returns:
+        Index just past the matching close, or None when unbalanced.
+    """
+    depth = 0
+    for index in range(start, len(command)):
+        if command[index] == '(':
+            depth += 1
+        elif command[index] == ')':
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    return None
+
+
 def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
     """
     Blank heredoc bodies and return the bodies the shell still expands.
@@ -402,6 +429,20 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
                 quote = character
             index += 1
             continue
+        if quote is None and character == '#' and (
+                index == 0 or command[index - 1] in _COMMENT_PRECEDERS):
+            # A comment runs to end of line, so any '<<' in it is text.
+            newline = command.find('\n', index)
+            if newline == -1:
+                break
+            index = newline + 1
+            continue
+        if quote is None and command.startswith('((', index):
+            # '<<' inside $((1 << 2)) is a left shift, not a heredoc.
+            arithmetic_end = _end_of_arithmetic(command, index)
+            if arithmetic_end is not None:
+                index = arithmetic_end
+                continue
         if (quote is None and command.startswith('<<', index)
                 and not command.startswith('<<<', index)):
             heredoc = _heredoc_bounds(command, index)

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -406,9 +406,11 @@ def _heredoc_delimiter(
             if end is None:
                 return None
             content = command[index + 2:end]
-            if ansi_c and '\\' in content:
-                # Decoding ANSI-C escapes is not worth it here: report no
-                # heredoc, which hands the body to the guards as commands.
+            if '\\' in content:
+                # Both forms unescape: $'...' decodes ANSI-C escapes and
+                # $"..." removes double-quote ones. Rather than replicate
+                # that, report no heredoc, which hands the body to the
+                # guards as commands.
                 return None
             quoted = True
             delimiter_parts.append(content)
@@ -680,8 +682,14 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
                 quote = character
             index += 1
             continue
-        if (quote is None and command.startswith('$(', index)
-                and not command.startswith('$((', index)):
+        if quote is None and (
+                (command.startswith('$(', index)
+                 and not command.startswith('$((', index))
+                or command.startswith('<(', index)
+                or command.startswith('>(', index)):
+            # A command substitution $( ), or a process substitution <( )
+            # or >( ): each is parsed as its own unit, so a newline inside
+            # one does not end the command line that contains it.
             open_parens.append('$(')
             depth += 1
             index += 2

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -361,8 +361,11 @@ def _heredoc_bounds(
 
 
 # A '#' only opens a comment at the start of a word, so it must follow
-# whitespace or an operator (or start the command).
-_COMMENT_PRECEDERS = ' \t\n;&|(<>'
+# whitespace or an operator (or start the command). ')' is included because
+# '(echo x)# comment' is a comment; the cost is that the rarer '$(date)#tag',
+# where '#' is mid-word, is misread as one -- which only ever makes this
+# function blank less, i.e. hand MORE text to the guards.
+_COMMENT_PRECEDERS = ' \t\n;&|(<>)'
 
 
 def _end_of_arithmetic(command: str, start: int) -> int | None:

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -294,6 +294,135 @@ def extract_subshell_commands(command: str) -> list[str]:
     return subshell_commands
 
 
+def _heredoc_bounds(
+        command: str, start: int) -> tuple[int, int, int, bool] | None:
+    """
+    Locate one heredoc introduced by the '<<' at the given index.
+
+    Args:
+        command: The full command string.
+        start: Index of the '<' that starts the '<<' operator.
+
+    Returns:
+        Tuple (body_start, delimiter_start, body_end, quoted) where
+        body_start/delimiter_start bound the heredoc body, body_end is just
+        past the closing delimiter line, and quoted says whether the
+        delimiter was quoted (so the shell performs no expansion in the
+        body). Returns None when this is not a complete, simple heredoc.
+    """
+    index = start + 2
+    strip_tabs = index < len(command) and command[index] == '-'
+    if strip_tabs:
+        index += 1
+    while index < len(command) and command[index] in ' \t':
+        index += 1
+    delimiter_parts = []
+    quoted = False
+    while index < len(command) and command[index] not in ' \t\r\n;&|<>()':
+        character = command[index]
+        if character in "'\"":
+            quoted = True
+            end = command.find(character, index + 1)
+            if end == -1:
+                return None
+            delimiter_parts.append(command[index + 1:end])
+            index = end + 1
+        elif character == '\\':
+            if index + 1 >= len(command):
+                return None
+            quoted = True
+            delimiter_parts.append(command[index + 1])
+            index += 2
+        else:
+            delimiter_parts.append(character)
+            index += 1
+    delimiter = ''.join(delimiter_parts)
+    if not delimiter:
+        return None
+    body_start = command.find('\n', index)
+    if body_start == -1:
+        return None
+    body_start += 1
+    line_start = body_start
+    while line_start <= len(command):
+        line_end = command.find('\n', line_start)
+        if line_end == -1:
+            line_end = len(command)
+        line = command[line_start:line_end].removesuffix('\r')
+        if strip_tabs:
+            line = line.lstrip('\t')
+        if line == delimiter:
+            body_end = min(line_end + 1, len(command))
+            return body_start, line_start, body_end, quoted
+        if line_end == len(command):
+            return None
+        line_start = line_end + 1
+    return None
+
+
+def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
+    """
+    Blank heredoc bodies and return the bodies the shell still expands.
+
+    A heredoc body is data, not code: the shell never runs its lines as
+    commands. When the delimiter is quoted (<<'EOF', <<"EOF", <<\\EOF) the
+    shell performs no expansion at all, so nothing in the body executes.
+    With an unquoted delimiter (<<EOF) only the body's expansions -- $(...)
+    and backticks -- execute.
+
+    Args:
+        command: A bash command string, possibly containing heredocs.
+
+    Returns:
+        Tuple (command_without_bodies, expanded_bodies). The first element
+        is the command with every heredoc body (and its closing delimiter
+        line) replaced by whitespace, preserving offsets and line breaks.
+        The second is the list of bodies whose expansions do execute.
+
+    Example:
+        >>> strip_heredoc_bodies("cat <<'EOF'\\n`rm x`\\nEOF")[1]
+        []
+        >>> strip_heredoc_bodies("cat <<EOF\\n`rm x`\\nEOF")[1]
+        ['`rm x`\\n']
+    """
+    expanded_bodies = []
+    pieces = []
+    copied_to = 0
+    index = 0
+    quote = None
+    while index < len(command):
+        character = command[index]
+        if character == '\\' and quote != "'":
+            index += 2
+            continue
+        if character in "'\"":
+            if quote == character:
+                quote = None
+            elif quote is None:
+                quote = character
+            index += 1
+            continue
+        if (quote is None and command.startswith('<<', index)
+                and not command.startswith('<<<', index)):
+            heredoc = _heredoc_bounds(command, index)
+            if heredoc is not None:
+                body_start, delimiter_start, body_end, quoted = heredoc
+                pieces.append(command[copied_to:body_start])
+                pieces.append(''.join(
+                    '\n' if char == '\n' else ' '
+                    for char in command[body_start:body_end]
+                ))
+                if not quoted:
+                    expanded_bodies.append(
+                        command[body_start:delimiter_start])
+                copied_to = body_end
+                index = body_end
+                continue
+        index += 1
+    pieces.append(command[copied_to:])
+    return ''.join(pieces), expanded_bodies
+
+
 def extract_all_commands(command: str) -> list[str]:
     """
     Recursively extract all commands from a bash command string.
@@ -304,6 +433,10 @@ def extract_all_commands(command: str) -> list[str]:
 
     This is the recommended function for security hooks that need to
     inspect all commands, including those hidden in subshells.
+
+    Heredoc bodies are treated as the data they are: a quoted delimiter
+    (<<'EOF') means nothing in the body executes, and an unquoted one
+    (<<EOF) means only the body's $() and backtick expansions execute.
 
     Args:
         command: A bash command string, possibly compound with subshells.
@@ -316,18 +449,30 @@ def extract_all_commands(command: str) -> list[str]:
         ['echo $(rm foo)', 'ls', 'rm foo']
         >>> extract_all_commands("cat `echo secret` | grep pass")
         ['cat `echo secret`', 'grep pass', 'echo secret']
+        >>> extract_all_commands("cat > f <<'EOF'\\n`rm x` is blocked\\nEOF")
+        ["cat > f <<'EOF'"]
     """
     if not command:
         return []
 
+    # Heredoc bodies are data, so their lines are not commands. Blank them
+    # out first; expanded_bodies holds the bodies (unquoted delimiters only)
+    # whose substitutions the shell does run.
+    stripped, expanded_bodies = strip_heredoc_bodies(command)
+
     all_commands = []
 
     # First, extract top-level subcommands (split on operators)
-    subcommands = extract_subcommands(command)
+    subcommands = extract_subcommands(stripped)
     all_commands.extend(subcommands)
 
     # Then, extract commands from subshells within the original command
-    subshell_cmds = extract_subshell_commands(command)
+    subshell_cmds = extract_subshell_commands(stripped)
+
+    # Only the substitutions inside an unquoted heredoc body execute; the
+    # surrounding text is literal, so it is not split into subcommands.
+    for body in expanded_bodies:
+        subshell_cmds.extend(extract_subshell_commands(body))
 
     # Recursively process subshell commands (they may contain nested subshells
     # or chained operators)

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -453,6 +453,12 @@ def _heredoc_delimiter(command: str, start: int):
         elif character == '\\':
             if index + 1 >= len(command):
                 return None
+            if command[index + 1] == '\n':
+                # A continuation inside the word: the shell removes both
+                # characters before reading the delimiter, so "E\" + "OF"
+                # is the delimiter EOF, and is not quoted by it.
+                index += 2
+                continue
             quoted = True
             delimiter_parts.append(command[index + 1])
             index += 2
@@ -754,14 +760,15 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             index += 1
             continue
         if quote is None and character == '\n' and pending:
-            if pending[0][3] != depth:
-                # This newline is inside a deeper command substitution, so
-                # it does not end the line that opened these heredocs.
+            # Only the heredocs opened at this depth end here; ones opened
+            # further out belong to a command line this newline is nested
+            # inside, and wait for their own.
+            ready = [item for item in pending if item[3] == depth]
+            if not ready:
                 index += 1
                 continue
-            # The command line ended: its heredoc bodies start here.
-            bodies = _heredoc_bodies(command, index + 1, pending)
-            pending = []
+            bodies = _heredoc_bodies(command, index + 1, ready)
+            pending = [item for item in pending if item[3] != depth]
             if bodies is None:
                 index += 1
                 continue

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -160,6 +160,59 @@ def expand_command_aliases(command: str) -> str:
     return ''.join(result)
 
 
+def _split_command_lines(command: str) -> list[str]:
+    """
+    Split on the newlines the shell treats as command separators.
+
+    A newline ends a command like ';' does, but only outside quotes and
+    when it is not escaped: a backslash-newline continues the line, and a
+    newline inside a quoted word is part of that word.
+
+    Args:
+        command: A bash command string, possibly spanning several lines.
+
+    Returns:
+        The command lines, without the separating newlines. A continued
+        line is returned joined, with the backslash-newline removed the
+        way the shell removes it, so the command it continues into is
+        recognisable ("cat <<EOF ; \\\\\\n rm x" ends up as one line).
+    """
+    lines = []
+    pieces = []
+    line_start = 0
+    index = 0
+    quote = None
+    while index < len(command):
+        character = command[index]
+        if character == '\\' and quote != "'":
+            if index + 1 < len(command) and command[index + 1] == '\n':
+                # A backslash-newline continues the line; the shell removes
+                # both characters, so neither is part of any command.
+                pieces.append(command[line_start:index])
+                line_start = index + 2
+            index += 2
+            continue
+        if quote is None and command.startswith("$'", index):
+            # ANSI-C quoting: a backslash escapes the closing quote.
+            end = _end_of_single_quote(command, index + 1, escapes=True)
+            index = len(command) if end is None else end + 1
+            continue
+        if character in "'\"":
+            if quote == character:
+                quote = None
+            elif quote is None:
+                quote = character
+        elif quote is None and character == '\n':
+            pieces.append(command[line_start:index])
+            lines.append(''.join(pieces))
+            pieces = []
+            line_start = index + 1
+        index += 1
+    pieces.append(command[line_start:])
+    lines.append(''.join(pieces))
+    return lines
+
+
 def extract_subcommands(command: str) -> list[str]:
     """
     Split compound bash command into individual subcommands.
@@ -170,6 +223,7 @@ def extract_subcommands(command: str) -> list[str]:
         - ; (sequential)
         - | (pipe)
         - & (background)
+        - a newline outside quotes, which ends a command just as ';' does
 
     Multi-character operators (&&, ||) are matched before single-character
     variants to prevent partial matching (e.g., '&&' won't be split as '&' + '&').
@@ -187,10 +241,14 @@ def extract_subcommands(command: str) -> list[str]:
         ['echo ok', 'rm foo']
         >>> extract_subcommands("sleep 1 & rm bar")
         ['sleep 1', 'rm bar']
+        >>> extract_subcommands("echo ok\\nrm foo")
+        ['echo ok', 'rm foo']
     """
     if not command:
         return []
-    subcommands = re.split(r'\s*(?:&&|\|\||[;&|])\s*', command)
+    subcommands = []
+    for line in _split_command_lines(command):
+        subcommands.extend(re.split(r'\s*(?:&&|\|\||[;&|])\s*', line))
     return [cmd.strip() for cmd in subcommands if cmd.strip()]
 
 
@@ -294,21 +352,46 @@ def extract_subshell_commands(command: str) -> list[str]:
     return subshell_commands
 
 
-def _heredoc_bounds(
-        command: str, start: int) -> tuple[int, int, int, bool] | None:
+def _end_of_single_quote(command: str, start: int, escapes: bool) -> int | None:
     """
-    Locate one heredoc introduced by the '<<' at the given index.
+    Return the index of the quote closing the one at start.
+
+    Args:
+        command: The full command string.
+        start: Index of the opening quote character.
+        escapes: Whether backslash escapes the quote inside this span, as
+            it does in ANSI-C quoting ($'...') but not in plain '...'.
+
+    Returns:
+        Index of the closing quote, or None when it is unterminated.
+    """
+    quote_character = command[start]
+    index = start + 1
+    while index < len(command):
+        if escapes and command[index] == '\\':
+            index += 2
+            continue
+        if command[index] == quote_character:
+            return index
+        index += 1
+    return None
+
+
+def _heredoc_delimiter(
+        command: str, start: int) -> tuple[str, bool, bool, int] | None:
+    """
+    Parse the delimiter word of the '<<' operator at the given index.
 
     Args:
         command: The full command string.
         start: Index of the '<' that starts the '<<' operator.
 
     Returns:
-        Tuple (body_start, delimiter_start, body_end, quoted) where
-        body_start/delimiter_start bound the heredoc body, body_end is just
-        past the closing delimiter line, and quoted says whether the
-        delimiter was quoted (so the shell performs no expansion in the
-        body). Returns None when this is not a complete, simple heredoc.
+        Tuple (delimiter, quoted, strip_tabs, end) where delimiter is the
+        word after quote removal, quoted says whether any part of it was
+        quoted (so the shell performs no expansion in the body),
+        strip_tabs reflects the '<<-' form, and end is the index just past
+        the delimiter word. Returns None when no delimiter word is there.
     """
     index = start + 2
     strip_tabs = index < len(command) and command[index] == '-'
@@ -320,10 +403,26 @@ def _heredoc_bounds(
     quoted = False
     while index < len(command) and command[index] not in ' \t\r\n;&|<>()':
         character = command[index]
-        if character in "'\"":
+        if (character == '$' and index + 1 < len(command)
+                and command[index + 1] in "'\""):
+            # $'EOF' and $"EOF" quote the delimiter; the '$' is not part
+            # of it, so bash ends the body at EOF, not at $EOF.
+            ansi_c = command[index + 1] == "'"
+            end = _end_of_single_quote(command, index + 1, escapes=ansi_c)
+            if end is None:
+                return None
+            content = command[index + 2:end]
+            if ansi_c and '\\' in content:
+                # Decoding ANSI-C escapes is not worth it here: report no
+                # heredoc, which hands the body to the guards as commands.
+                return None
             quoted = True
-            end = command.find(character, index + 1)
-            if end == -1:
+            delimiter_parts.append(content)
+            index = end + 1
+        elif character in "'\"":
+            quoted = True
+            end = _end_of_single_quote(command, index, escapes=False)
+            if end is None:
                 return None
             delimiter_parts.append(command[index + 1:end])
             index = end + 1
@@ -339,11 +438,27 @@ def _heredoc_bounds(
     delimiter = ''.join(delimiter_parts)
     if not delimiter:
         return None
-    body_start = command.find('\n', index)
-    if body_start == -1:
-        return None
-    body_start += 1
-    line_start = body_start
+    return delimiter, quoted, strip_tabs, index
+
+
+def _end_of_heredoc_body(
+        command: str, start: int, delimiter: str,
+        strip_tabs: bool) -> tuple[int, int] | None:
+    """
+    Find the closing delimiter line of one heredoc body.
+
+    Args:
+        command: The full command string.
+        start: Index where the body begins (just past a newline).
+        delimiter: The delimiter word that ends the body.
+        strip_tabs: Whether the '<<-' form allows leading tabs on it.
+
+    Returns:
+        Tuple (delimiter_start, body_end): the index where the delimiter
+        line begins and the index just past it. None when the body is
+        never closed.
+    """
+    line_start = start
     while line_start <= len(command):
         line_end = command.find('\n', line_start)
         if line_end == -1:
@@ -352,12 +467,47 @@ def _heredoc_bounds(
         if strip_tabs:
             line = line.lstrip('\t')
         if line == delimiter:
-            body_end = min(line_end + 1, len(command))
-            return body_start, line_start, body_end, quoted
+            return line_start, min(line_end + 1, len(command))
         if line_end == len(command):
             return None
         line_start = line_end + 1
     return None
+
+
+def _heredoc_bodies(
+        command: str, start: int,
+        pending: list[tuple[str, bool, bool]]) -> tuple[int, list[str]] | None:
+    """
+    Consume the bodies of every heredoc declared on one command line.
+
+    A command line may open several heredocs ("cat <<A <<'B'"); their
+    bodies follow the line in declaration order, one after another. Taking
+    them one at a time would read the second body as shell syntax.
+
+    Args:
+        command: The full command string.
+        start: Index where the first body begins (just past the newline
+            that ends the command line).
+        pending: The (delimiter, quoted, strip_tabs) triples in the order
+            the heredocs were declared.
+
+    Returns:
+        Tuple (end, expanded_bodies): the index just past the last body's
+        delimiter line, and the bodies whose expansions the shell runs
+        (those with an unquoted delimiter). None when any body is
+        unterminated, in which case no body is treated as data.
+    """
+    cursor = start
+    expanded_bodies = []
+    for delimiter, quoted, strip_tabs in pending:
+        bounds = _end_of_heredoc_body(command, cursor, delimiter, strip_tabs)
+        if bounds is None:
+            return None
+        delimiter_start, body_end = bounds
+        if not quoted:
+            expanded_bodies.append(command[cursor:delimiter_start])
+        cursor = body_end
+    return cursor, expanded_bodies
 
 
 # A '#' only opens a comment at the start of a word, so it must follow
@@ -386,13 +536,29 @@ def _end_of_balanced(command: str, start: int, opener: str) -> int | None:
     """
     closer = ')' if opener == '(' else '}'
     depth = 0
-    for index in range(start, len(command)):
-        if command[index] == opener:
-            depth += 1
-        elif command[index] == closer:
-            depth -= 1
-            if depth == 0:
-                return index + 1
+    index = start
+    quote = None
+    while index < len(command):
+        character = command[index]
+        if character == '\\' and quote != "'":
+            # An escaped brace is expansion text, not the closing one.
+            index += 2
+            continue
+        if character in "'\"":
+            if quote == character:
+                quote = None
+            elif quote is None:
+                quote = character
+            index += 1
+            continue
+        if quote is None:
+            if character == opener:
+                depth += 1
+            elif character == closer:
+                depth -= 1
+                if depth == 0:
+                    return index + 1
+        index += 1
     return None
 
 
@@ -426,10 +592,21 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
     copied_to = 0
     index = 0
     quote = None
+    # Heredocs opened on the command line now being scanned. Their bodies
+    # all follow that line, in the order the operators appeared.
+    pending: list[tuple[str, bool, bool]] = []
     while index < len(command):
         character = command[index]
         if character == '\\' and quote != "'":
+            # A backslash-newline continues the command line, so the body
+            # does not start here; skipping the pair keeps that newline
+            # out of the body-start decision below.
             index += 2
+            continue
+        if quote is None and command.startswith("$'", index):
+            # ANSI-C quoting: a backslash escapes the closing quote.
+            end = _end_of_single_quote(command, index + 1, escapes=True)
+            index = len(command) if end is None else end + 1
             continue
         if character in "'\"":
             if quote == character:
@@ -438,13 +615,32 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
                 quote = character
             index += 1
             continue
+        if quote is None and character == '\n' and pending:
+            # The command line ended: its heredoc bodies start here.
+            bodies = _heredoc_bodies(command, index + 1, pending)
+            pending = []
+            if bodies is None:
+                index += 1
+                continue
+            body_end, expanded = bodies
+            pieces.append(command[copied_to:index + 1])
+            pieces.append(''.join(
+                '\n' if char == '\n' else ' '
+                for char in command[index + 1:body_end]
+            ))
+            expanded_bodies.extend(expanded)
+            copied_to = body_end
+            index = body_end
+            continue
         if quote is None and character == '#' and (
                 index == 0 or command[index - 1] in _COMMENT_PRECEDERS):
             # A comment runs to end of line, so any '<<' in it is text.
             newline = command.find('\n', index)
             if newline == -1:
                 break
-            index = newline + 1
+            # Stop on the newline itself: it may still end a command line
+            # whose heredoc bodies start right after the comment.
+            index = newline
             continue
         if quote is None and command.startswith('((', index):
             # '<<' inside $((1 << 2)) is a left shift, not a heredoc.
@@ -460,19 +656,11 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
                 continue
         if (quote is None and command.startswith('<<', index)
                 and not command.startswith('<<<', index)):
-            heredoc = _heredoc_bounds(command, index)
-            if heredoc is not None:
-                body_start, delimiter_start, body_end, quoted = heredoc
-                pieces.append(command[copied_to:body_start])
-                pieces.append(''.join(
-                    '\n' if char == '\n' else ' '
-                    for char in command[body_start:body_end]
-                ))
-                if not quoted:
-                    expanded_bodies.append(
-                        command[body_start:delimiter_start])
-                copied_to = body_end
-                index = body_end
+            delimiter = _heredoc_delimiter(command, index)
+            if delimiter is not None:
+                word, quoted, strip_tabs, end = delimiter
+                pending.append((word, quoted, strip_tabs))
+                index = end
                 continue
         index += 1
     pieces.append(command[copied_to:])

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -441,7 +441,13 @@ def _heredoc_delimiter(
             end = _end_of_single_quote(command, index, escapes=False)
             if end is None:
                 return None
-            delimiter_parts.append(command[index + 1:end])
+            content = command[index + 1:end]
+            if character == '"' and '\\' in content:
+                # Quote removal would drop backslashes here. Rather than
+                # replicate that, report no heredoc: nothing is blanked and
+                # the guards see the body, which is the safe direction.
+                return None
+            delimiter_parts.append(content)
             index = end + 1
         elif character == '\\':
             if index + 1 >= len(command):
@@ -458,9 +464,23 @@ def _heredoc_delimiter(
     return delimiter, quoted, strip_tabs, index
 
 
+def _ends_with_continuation(line: str) -> bool:
+    """
+    Report whether a physical line ends in a backslash-newline pair.
+
+    Args:
+        line: One physical line, without its newline.
+
+    Returns:
+        True when the line ends with an odd number of backslashes, so the
+        last one escapes the newline instead of itself.
+    """
+    return (len(line) - len(line.rstrip('\\'))) % 2 == 1
+
+
 def _end_of_heredoc_body(
-        command: str, start: int, delimiter: str,
-        strip_tabs: bool) -> tuple[int, int] | None:
+        command: str, start: int, delimiter: str, strip_tabs: bool,
+        join_continuations: bool) -> tuple[int, int] | None:
     """
     Find the closing delimiter line of one heredoc body.
 
@@ -469,18 +489,35 @@ def _end_of_heredoc_body(
         start: Index where the body begins (just past a newline).
         delimiter: The delimiter word that ends the body.
         strip_tabs: Whether the '<<-' form allows leading tabs on it.
+        join_continuations: Whether backslash-newline pairs are removed
+            while reading the body, as they are for an unquoted delimiter.
+            A delimiter can then be split over two lines ("EO\\" + "F").
 
     Returns:
-        Tuple (delimiter_start, body_end): the index where the delimiter
-        line begins and the index just past it. None when the body is
-        never closed.
+        Tuple (delimiter_line_start, body_end): the index where the line
+        holding the delimiter begins -- which is where the body ends, and
+        with '<<-' may be a leading tab rather than the delimiter itself
+        -- and the index just past that line. None when the body is never
+        closed.
     """
     line_start = start
     while line_start <= len(command):
-        line_end = command.find('\n', line_start)
-        if line_end == -1:
-            line_end = len(command)
-        line = command[line_start:line_end].removesuffix('\r')
+        # Read one logical line, which may span several physical ones.
+        parts = []
+        scan = line_start
+        while True:
+            line_end = command.find('\n', scan)
+            if line_end == -1:
+                line_end = len(command)
+            part = command[scan:line_end].removesuffix('\r')
+            if (join_continuations and line_end < len(command)
+                    and _ends_with_continuation(part)):
+                parts.append(part[:-1])
+                scan = line_end + 1
+                continue
+            parts.append(part)
+            break
+        line = ''.join(parts)
         if strip_tabs:
             line = line.lstrip('\t')
         if line == delimiter:
@@ -517,12 +554,14 @@ def _heredoc_bodies(
     cursor = start
     expanded_bodies = []
     for delimiter, quoted, strip_tabs, _ in pending:
-        bounds = _end_of_heredoc_body(command, cursor, delimiter, strip_tabs)
+        bounds = _end_of_heredoc_body(
+            command, cursor, delimiter, strip_tabs,
+            join_continuations=not quoted)
         if bounds is None:
             return None
-        delimiter_start, body_end = bounds
+        delimiter_line_start, body_end = bounds
         if not quoted:
-            expanded_bodies.append(command[cursor:delimiter_start])
+            expanded_bodies.append(command[cursor:delimiter_line_start])
         cursor = body_end
     return cursor, expanded_bodies
 
@@ -589,6 +628,13 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
     With an unquoted delimiter (<<EOF) only the body's expansions -- $(...)
     and backticks -- execute.
 
+    Bodies begin after the command line that opens them, which is not the
+    same as the next newline: a backslash-newline continues that line, and
+    a newline inside quotes or inside an unfinished command substitution
+    does not end it. Every heredoc opened on one line is consumed, in
+    order, and a command substitution is its own parsing unit with its own
+    bodies.
+
     Args:
         command: A bash command string, possibly containing heredocs.
 
@@ -611,7 +657,10 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
     quote = None
     # A command substitution is parsed as its own unit, so it has its own
     # command lines and its own heredoc bodies. Track how deep we are in
-    # one, and remember the depth each heredoc was opened at.
+    # one, and remember the depth each heredoc was opened at. Grouping
+    # parentheses are tracked too, so that the ')' of a nested group is not
+    # mistaken for the one closing the substitution.
+    open_parens: list[str] = []
     depth = 0
     in_backtick = False
     # Heredocs opened on the command line now being scanned. Their bodies
@@ -639,6 +688,7 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             continue
         if (quote is None and command.startswith('$(', index)
                 and not command.startswith('$((', index)):
+            open_parens.append('$(')
             depth += 1
             index += 2
             continue
@@ -648,11 +698,12 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             in_backtick = not in_backtick
             index += 1
             continue
-        if quote is None and character == ')' and depth > 0 and not in_backtick:
-            depth -= 1
-            # A heredoc whose substitution closed before any newline never
-            # gets a body: bash reads it from inside that substitution.
-            pending = [item for item in pending if item[3] <= depth]
+        if quote is None and character == ')' and open_parens:
+            if open_parens.pop() == '$(':
+                depth -= 1
+                # A heredoc whose substitution closed before any newline
+                # never gets a body: bash reads it from inside there.
+                pending = [item for item in pending if item[3] <= depth]
             index += 1
             continue
         if quote is None and character == '\n' and pending:
@@ -699,6 +750,14 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             if expansion_end is not None:
                 index = expansion_end
                 continue
+        if quote is None and character == '(':
+            # A grouping or subshell paren. It is not a parsing unit of its
+            # own, but it has to be balanced so that its ')' is not taken
+            # for the one closing a substitution. Checked after the
+            # arithmetic and expansion skips above, which own their parens.
+            open_parens.append('(')
+            index += 1
+            continue
         if (quote is None and command.startswith('<<', index)
                 and not command.startswith('<<<', index)):
             delimiter = _heredoc_delimiter(command, index)

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -753,6 +753,12 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             if expansion_end is not None:
                 index = expansion_end
                 continue
+        if quote is None and command.startswith('$[', index):
+            # $[1 << 2] is the deprecated arithmetic form, still a shift.
+            legacy_end = _end_of_balanced(command, index + 1, '[')
+            if legacy_end is not None:
+                index = legacy_end
+                continue
         if quote is None and character == '(':
             # A grouping or subshell paren. It is not a parsing unit of its
             # own, but it has to be balanced so that its ')' is not taken

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -476,7 +476,7 @@ def _end_of_heredoc_body(
 
 def _heredoc_bodies(
         command: str, start: int,
-        pending: list[tuple[str, bool, bool]]) -> tuple[int, list[str]] | None:
+        pending: list[tuple[str, bool, bool, int]]) -> tuple[int, list[str]] | None:
     """
     Consume the bodies of every heredoc declared on one command line.
 
@@ -488,8 +488,8 @@ def _heredoc_bodies(
         command: The full command string.
         start: Index where the first body begins (just past the newline
             that ends the command line).
-        pending: The (delimiter, quoted, strip_tabs) triples in the order
-            the heredocs were declared.
+        pending: The (delimiter, quoted, strip_tabs, depth) tuples in the
+            order the heredocs were declared; depth is unused here.
 
     Returns:
         Tuple (end, expanded_bodies): the index just past the last body's
@@ -499,7 +499,7 @@ def _heredoc_bodies(
     """
     cursor = start
     expanded_bodies = []
-    for delimiter, quoted, strip_tabs in pending:
+    for delimiter, quoted, strip_tabs, _ in pending:
         bounds = _end_of_heredoc_body(command, cursor, delimiter, strip_tabs)
         if bounds is None:
             return None
@@ -592,9 +592,14 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
     copied_to = 0
     index = 0
     quote = None
+    # A command substitution is parsed as its own unit, so it has its own
+    # command lines and its own heredoc bodies. Track how deep we are in
+    # one, and remember the depth each heredoc was opened at.
+    depth = 0
+    in_backtick = False
     # Heredocs opened on the command line now being scanned. Their bodies
     # all follow that line, in the order the operators appeared.
-    pending: list[tuple[str, bool, bool]] = []
+    pending: list[tuple[str, bool, bool, int]] = []
     while index < len(command):
         character = command[index]
         if character == '\\' and quote != "'":
@@ -615,7 +620,30 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
                 quote = character
             index += 1
             continue
+        if (quote is None and command.startswith('$(', index)
+                and not command.startswith('$((', index)):
+            depth += 1
+            index += 2
+            continue
+        if quote is None and character == '`':
+            # Backticks cannot nest, so one toggles the substitution.
+            depth += -1 if in_backtick else 1
+            in_backtick = not in_backtick
+            index += 1
+            continue
+        if quote is None and character == ')' and depth > 0 and not in_backtick:
+            depth -= 1
+            # A heredoc whose substitution closed before any newline never
+            # gets a body: bash reads it from inside that substitution.
+            pending = [item for item in pending if item[3] <= depth]
+            index += 1
+            continue
         if quote is None and character == '\n' and pending:
+            if pending[0][3] != depth:
+                # This newline is inside a deeper command substitution, so
+                # it does not end the line that opened these heredocs.
+                index += 1
+                continue
             # The command line ended: its heredoc bodies start here.
             bodies = _heredoc_bodies(command, index + 1, pending)
             pending = []
@@ -659,7 +687,7 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             delimiter = _heredoc_delimiter(command, index)
             if delimiter is not None:
                 word, quoted, strip_tabs, end = delimiter
-                pending.append((word, quoted, strip_tabs))
+                pending.append((word, quoted, strip_tabs, depth))
                 index = end
                 continue
         index += 1

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -842,6 +842,15 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
                 index += 1
                 continue
             body_end, expanded = bodies
+            if any('$' in body or '`' in body for body in expanded):
+                # An unquoted body's expansions do run, and finding the
+                # commands among them needs a second parser with the same
+                # divergences: a case pattern's ')' closes '$(' early, and
+                # "${x@P}" runs a substitution held in x with no '$(' in
+                # the body at all. Leave such a body unblanked so the
+                # guards see it whole; quote the delimiter to document
+                # commands.
+                return command, []
             pieces.append(command[copied_to:index + 1])
             pieces.append(''.join(
                 '\n' if char == '\n' else ' '

--- a/plugins/safety-hooks/hooks/command_utils.py
+++ b/plugins/safety-hooks/hooks/command_utils.py
@@ -371,8 +371,17 @@ def _end_of_single_quote(command: str, start: int, escapes: bool) -> int | None:
     return None
 
 
-def _heredoc_delimiter(
-        command: str, start: int) -> tuple[str, bool, bool, int] | None:
+# Returned for a delimiter whose quoting the shell would unescape, which
+# this parser does not replicate. It cannot be treated as "no heredoc":
+# the body would then be scanned as commands, and a '<<' inside that body
+# would be read as a real heredoc, blanking the commands after the body.
+# Scanning stops instead, so nothing further is blanked.
+_UNDECODABLE_DELIMITER = object()
+
+
+def _heredoc_delimiter(command: str, start: int):
+    # Return type is tuple[str, bool, bool, int], None, or the sentinel
+    # above; annotating that adds nothing a reader wants here.
     """
     Parse the delimiter word of the '<<' operator at the given index.
 
@@ -408,10 +417,8 @@ def _heredoc_delimiter(
             content = command[index + 2:end]
             if '\\' in content:
                 # Both forms unescape: $'...' decodes ANSI-C escapes and
-                # $"..." removes double-quote ones. Rather than replicate
-                # that, report no heredoc, which hands the body to the
-                # guards as commands.
-                return None
+                # $"..." removes double-quote ones.
+                return _UNDECODABLE_DELIMITER
             quoted = True
             delimiter_parts.append(content)
             index = end + 1
@@ -439,10 +446,8 @@ def _heredoc_delimiter(
                 return None
             content = command[index + 1:end]
             if character == '"' and '\\' in content:
-                # Quote removal would drop backslashes here. Rather than
-                # replicate that, report no heredoc: nothing is blanked and
-                # the guards see the body, which is the safe direction.
-                return None
+                # Quote removal would drop backslashes here.
+                return _UNDECODABLE_DELIMITER
             delimiter_parts.append(content)
             index = end + 1
         elif character == '\\':
@@ -569,6 +574,29 @@ def _heredoc_bodies(
 # function blank less, i.e. hand MORE text to the guards.
 _COMMENT_PRECEDERS = ' \t\n;&|(<>)'
 
+# A word only counts as a keyword when it stands alone.
+_WORD_PRECEDERS = ' \t\n;&|('
+
+
+def _keyword_at(command: str, index: int, keyword: str) -> bool:
+    """
+    Report whether a standalone keyword starts at the given index.
+
+    Args:
+        command: The full command string.
+        index: Index to test.
+        keyword: The word to look for, e.g. 'case'.
+
+    Returns:
+        True when the keyword is there as a whole word.
+    """
+    if not command.startswith(keyword, index):
+        return False
+    if index and command[index - 1] not in _WORD_PRECEDERS:
+        return False
+    after = index + len(keyword)
+    return after == len(command) or command[after] in ' \t\n;&|)'
+
 
 def _end_of_balanced(command: str, start: int, opener: str) -> int | None:
     """
@@ -659,6 +687,7 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
     # mistaken for the one closing the substitution.
     open_parens: list[str] = []
     depth = 0
+    case_depth = 0
     in_backtick = False
     # Heredocs opened on the command line now being scanned. Their bodies
     # all follow that line, in the order the operators appeared.
@@ -701,7 +730,22 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             in_backtick = not in_backtick
             index += 1
             continue
+        if quote is None and (_keyword_at(command, index, 'case')
+                              or _keyword_at(command, index, 'esac')):
+            # Inside a case statement a ')' ends a pattern, so it must not
+            # be taken for the one closing a substitution.
+            if command[index] == 'c':
+                case_depth += 1
+                index += 4
+            else:
+                case_depth = max(0, case_depth - 1)
+                index += 4
+            continue
         if quote is None and character == ')' and open_parens:
+            if open_parens[-1] == '$(' and case_depth:
+                # A case pattern's ')', not the end of the substitution.
+                index += 1
+                continue
             if open_parens.pop() == '$(':
                 depth -= 1
                 # A heredoc whose substitution closed before any newline
@@ -777,10 +821,20 @@ def strip_heredoc_bodies(command: str) -> tuple[str, list[str]]:
             if subscript_end is not None:
                 index = subscript_end
                 continue
-        if (quote is None and command.startswith('<<', index)
-                and not command.startswith('<<<', index)):
+        if quote is None and command.startswith('<<<', index):
+            # A here-string, whose expansions do run. Step over the whole
+            # operator: leaving the scan on its second '<' would read the
+            # remaining '<<' as a heredoc and blank the lines after it.
+            index += 3
+            continue
+        if quote is None and command.startswith('<<', index):
             delimiter = _heredoc_delimiter(command, index)
-            if delimiter is not None:
+            if delimiter is _UNDECODABLE_DELIMITER:
+                # The body of this one cannot be located. Stop rather than
+                # scan on: text inside that body could otherwise be read as
+                # another heredoc header and blank real commands.
+                break
+            if isinstance(delimiter, tuple):
                 word, quoted, strip_tabs, end = delimiter
                 pending.append((word, quoted, strip_tabs, depth))
                 index = end

--- a/plugins/safety-hooks/hooks/env_file_protection_hook.py
+++ b/plugins/safety-hooks/hooks/env_file_protection_hook.py
@@ -5,7 +5,13 @@ import os
 import re
 import shlex
 import string
+import sys
 from typing import List, Optional, Tuple
+
+# Add the hooks directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from command_utils import strip_heredoc_bodies
 
 BLOCK_REASON = (
     "Blocked: Direct access to .env files is not allowed for security reasons.\n\n"
@@ -377,98 +383,6 @@ def _substitution_commands(command: str) -> List[str]:
                 index = cursor - 1
         index += 1
     return bodies
-
-
-def _heredoc_body(
-        command: str, start: int) -> Optional[Tuple[int, int, int, bool]]:
-    """Return body and delimiter bounds for one simple heredoc."""
-    index = start + 2
-    strip_tabs = index < len(command) and command[index] == '-'
-    if strip_tabs:
-        index += 1
-    while index < len(command) and command[index] in ' \t':
-        index += 1
-    delimiter_parts = []
-    quoted = False
-    while index < len(command) and command[index] not in ' \t\r\n;&|<>()':
-        character = command[index]
-        if character in "'\"":
-            quoted = True
-            end = command.find(character, index + 1)
-            if end == -1:
-                return None
-            delimiter_parts.append(command[index + 1:end])
-            index = end + 1
-        elif character == '\\':
-            if index + 1 >= len(command):
-                return None
-            quoted = True
-            delimiter_parts.append(command[index + 1])
-            index += 2
-        else:
-            delimiter_parts.append(character)
-            index += 1
-    delimiter = ''.join(delimiter_parts)
-    if not delimiter:
-        return None
-    body_start = command.find('\n', index)
-    if body_start == -1:
-        return None
-    body_start += 1
-    line_start = body_start
-    while line_start <= len(command):
-        line_end = command.find('\n', line_start)
-        if line_end == -1:
-            line_end = len(command)
-        line = command[line_start:line_end].removesuffix('\r')
-        if strip_tabs:
-            line = line.lstrip('\t')
-        if line == delimiter:
-            body_end = min(line_end + 1, len(command))
-            return body_start, line_start, body_end, quoted
-        if line_end == len(command):
-            return None
-        line_start = line_end + 1
-    return None
-
-
-def _without_heredoc_bodies(command: str) -> Tuple[str, List[str]]:
-    """Blank heredoc bodies and return bodies whose expansions execute."""
-    executable_bodies = []
-    pieces = []
-    copied_to = 0
-    index = 0
-    quote = None
-    while index < len(command):
-        character = command[index]
-        if character == '\\' and quote != "'":
-            index += 2
-            continue
-        if character in "'\"":
-            quote = None if quote == character else character \
-                if quote is None else quote
-            index += 1
-            continue
-        if (quote is None and command.startswith('<<', index)
-                and not command.startswith('<<<', index)):
-            heredoc = _heredoc_body(command, index)
-            if heredoc is not None:
-                body_start, delimiter_start, body_end, quoted = heredoc
-                pieces.append(command[copied_to:body_start])
-                blanked = ''.join(
-                    '\n' if char == '\n' else ' '
-                    for char in command[body_start:body_end]
-                )
-                pieces.append(blanked)
-                if not quoted:
-                    executable_bodies.append(
-                        command[body_start:delimiter_start])
-                copied_to = body_end
-                index = body_end
-                continue
-        index += 1
-    pieces.append(command[copied_to:])
-    return ''.join(pieces), executable_bodies
 
 
 def _split_env_command(segment: List[str], index: int) -> Optional[List[str]]:
@@ -867,7 +781,7 @@ def _nesting_fallback(command: str) -> bool:
     for _ in range(256):
         if not pending:
             return False
-        current, heredoc_bodies = _without_heredoc_bodies(pending.pop())
+        current, heredoc_bodies = strip_heredoc_bodies(pending.pop())
         pending.extend(_backtick_commands(current))
         pending.extend(_substitution_commands(current))
         for body in heredoc_bodies:
@@ -983,7 +897,7 @@ def check_env_file_access(
         if _nesting_fallback(command):
             return True, BLOCK_REASON
         return False, None
-    command, heredoc_bodies = _without_heredoc_bodies(command)
+    command, heredoc_bodies = strip_heredoc_bodies(command)
     nested_commands = _backtick_commands(command)
     nested_commands.extend(_substitution_commands(command))
     for body in heredoc_bodies:
@@ -1010,7 +924,6 @@ def check_env_file_access(
 # If run as a standalone script
 if __name__ == "__main__":
     import json
-    import sys
 
     data = json.load(sys.stdin)
 

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -523,6 +523,11 @@ class TestStripHeredocBodies(unittest.TestCase):
         "parameter expansion with default": (
             "echo ${x:-<<EOF}\nrm -rf /tmp/x\nEOF}"),
         "array assignment on the line": "a[1<<2]=foo\nrm -rf /tmp/x",
+        "substitution in an unquoted body": (
+            "cat <<EOF\n$(case x in x) echo yes;; esac; rm -rf /tmp/x)\nEOF"),
+        "backticks in an unquoted body": "cat <<EOF\n`rm -rf /tmp/x`\nEOF",
+        "prompt expansion in an unquoted body": (
+            "x='$''(rm -rf /tmp/x)'; cat <<EOF\n${x@P}\nEOF"),
     }
 
     def test_complex_headers_are_never_blanked(self):
@@ -550,8 +555,14 @@ class TestStripHeredocBodies(unittest.TestCase):
         "cat <<OUT $(if true; then case x in x) :;; esac; fi\n"
         "rm -rf /tmp/x\n)\npayload\nOUT",
         "echo a[<<EOF]=x\necho <<X\nEOF]=x\nrm -rf /tmp/x\nX",
+        "cat <<EOF\n$(case x in x) echo yes;; esac; rm -rf /tmp/x)\nEOF",
         "cat <<\"A\\\\B\"\nA\\B\nrm -rf /tmp/x\nA\\\\B",
     ]
+    # Not listed above: "x='$''(rm -rf /tmp/x)'; cat <<EOF\n${x@P}\nEOF".
+    # The scanner leaves that body unblanked (see COMPLEX_HEADERS), but
+    # the rm is then inside a quoted assignment, which no guard inspects:
+    # commands built at run time ("eval", "${x@P}") are outside what the
+    # guards claim to catch, with or without a heredoc.
 
     def test_known_bypasses_reach_the_guards(self):
         """No reviewer-found bypass hides the rm from extract_all_commands."""

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -115,6 +115,16 @@ class TestExtractSubshellCommands(unittest.TestCase):
         result = extract_subshell_commands("echo $(whoami)")
         self.assertEqual(result, ["whoami"])
 
+    def test_ansi_c_quoted_argument_inside_a_substitution(self):
+        """$'don\\'t' is one word: its escaped quote must not end quoting.
+
+        Regression: the quote-aware bracket balancing read the escaped
+        quote as the closing one, then took the real closing quote as an
+        opening one, and never saw the ')' -- hiding the rm.
+        """
+        command = "echo $(rm $'don\\'t')"
+        self.assertEqual(extract_subshell_commands(command), ["rm $'don\\'t'"])
+
     def test_backtick_subshell(self):
         """Extract command from backtick syntax."""
         result = extract_subshell_commands("echo `whoami`")

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -216,6 +216,16 @@ class TestExtractAllCommands(unittest.TestCase):
         result = extract_all_commands("echo $(rm secret)")
         self.assertIn("rm secret", result)
 
+    def test_quoted_paren_does_not_cut_a_subshell_short(self):
+        """A ')' inside quotes is text, so the rm after it is still found."""
+        result = extract_all_commands("echo $(printf ')'; rm foo)")
+        self.assertIn("rm foo", result)
+
+    def test_quoted_paren_in_a_heredoc_body_substitution(self):
+        """Same, for the substitution inside an unquoted heredoc body."""
+        result = extract_all_commands("cat <<EOF\n$(printf ')'; rm foo)\nEOF")
+        self.assertIn("rm foo", result)
+
     def test_quoted_heredoc_backticks_are_literal(self):
         """A quoted delimiter means the shell expands nothing in the body."""
         command = "cat > notes.md <<'MD'\nThe `rm -rf x` guard.\nMD"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -390,6 +390,41 @@ class TestStripHeredocBodies(unittest.TestCase):
         self.assertEqual(bodies, [])
         self.assertNotIn("rm -rf x", stripped)
 
+    def test_newline_in_a_substitution_does_not_start_the_body(self):
+        """An unfinished $( ) holds the command line open past the newline."""
+        command = "cat <<'EOF' $(echo start\nrm -rf /tmp/x)\nliteral\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("literal", stripped)
+
+    def test_newline_in_backticks_does_not_start_the_body(self):
+        """Backtick substitution holds the line open the same way $( ) does."""
+        command = "cat <<'EOF' `echo start\nrm -rf /tmp/x`\nliteral\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("literal", stripped)
+
+    def test_heredoc_inside_a_substitution_takes_its_body_there(self):
+        """A substitution is its own parsing unit, bodies included."""
+        command = "echo $(cat <<'EOF'\nrm -rf /tmp/x\nEOF\n)"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertNotIn("rm -rf /tmp/x", stripped)
+
+    def test_substitution_closing_first_leaves_the_heredoc_bodyless(self):
+        """Bash reads that body inside the substitution, so there is none."""
+        command = "echo $(cat <<'EOF') tail\nrm -rf /tmp/x\nEOF"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_subshell_paren_does_not_delay_the_body(self):
+        """Plain '(' is not a substitution, so the body still starts next."""
+        command = "(cat <<'EOF'\nrm -rf /tmp/x\nEOF\n)"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertNotIn("rm -rf /tmp/x", stripped)
+
     def test_unterminated_second_body_blanks_nothing(self):
         """If any body is unclosed, no body is treated as data."""
         command = "cat <<A <<B\nfirst\nA\nrm -rf /tmp/x"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -410,6 +410,11 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = 'cat <<$"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
+    def test_legacy_arithmetic_shift_is_not_a_heredoc(self):
+        """$[1 << 2] is the deprecated arithmetic form, so '<<' is a shift."""
+        command = "echo $[1 << 2]\nrm -rf /tmp/x\n2]"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
     def test_array_subscript_shift_is_not_a_heredoc(self):
         """'<<' in "a[1<<2]=foo" is a shift: the subscript is arithmetic."""
         command = "a[1<<2]=foo\nrm -rf /tmp/x\n2]=foo"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -284,6 +284,11 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = "# <<END\nrm -rf /tmp/x\nEND"
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
+    def test_comment_after_subshell_close_is_ignored(self):
+        """'(echo x)# <<END' is a comment, so the next lines are commands."""
+        command = "(echo x)# <<END\nrm -rf /tmp/x\nEND"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
     def test_hash_inside_word_is_not_a_comment(self):
         """A '#' that is not word-initial does not start a comment."""
         command = "echo a#b <<'MD'\nrm -rf x\nMD"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -279,6 +279,28 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = "echo 'a << b'\nrm foo"
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
+    def test_heredoc_operator_inside_comment_is_ignored(self):
+        """A '<<' in a comment must not swallow the lines that follow."""
+        command = "# <<END\nrm -rf /tmp/x\nEND"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_hash_inside_word_is_not_a_comment(self):
+        """A '#' that is not word-initial does not start a comment."""
+        command = "echo a#b <<'MD'\nrm -rf x\nMD"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertNotIn("rm", stripped)
+
+    def test_left_shift_in_arithmetic_is_not_a_heredoc(self):
+        """'<<' inside $(( )) is a shift operator, not a heredoc."""
+        command = "echo $((1 << 2))\nrm -rf /tmp/x\n2"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_nested_arithmetic_is_skipped_whole(self):
+        """Nested parentheses inside arithmetic are handled."""
+        command = "echo $(( (1 << 2) + 3 ))\nrm -rf /tmp/x\n3 ))"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
 
 class TestExpandCommandAliases(unittest.TestCase):
     """Tests for expand_command_aliases() with updated operator support."""

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -390,6 +390,33 @@ class TestStripHeredocBodies(unittest.TestCase):
         self.assertEqual(bodies, [])
         self.assertNotIn("rm -rf x", stripped)
 
+    def test_escape_in_a_double_quoted_delimiter_is_not_a_heredoc(self):
+        """Quote removal would drop a backslash, so decline to blank."""
+        command = 'cat <<"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_delimiter_split_over_a_continued_line(self):
+        """An unquoted body loses backslash-newline, so 'EO\\'+'F' ends it."""
+        command = "cat <<EOF\ndata\nEO\\\nF\nrm -rf /tmp/x\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["data\n"])
+        self.assertIn("rm -rf /tmp/x", stripped)
+
+    def test_quoted_body_keeps_a_continued_delimiter_literal(self):
+        """With a quoted delimiter nothing is unescaped, so it does not end."""
+        command = "cat <<'EOF'\ndata\nEO\\\nF\nrm -rf /tmp/x\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertNotIn("rm -rf /tmp/x", stripped)
+
+    def test_nested_group_paren_does_not_close_the_substitution(self):
+        """The ')' of '(echo x)' closes the group, not the '$(' around it."""
+        command = "cat <<EOF $( (echo x)\nrm -rf /tmp/x\n)\nliteral\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["literal\n"])
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("literal", stripped)
+
     def test_substitution_in_a_delimiter_is_literal(self):
         """No expansion runs on a delimiter word, so '$(echo EOF)' ends it."""
         command = "cat <<$(echo EOF)\npayload\n$(echo EOF)\nrm -rf /tmp/x\n$"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -405,6 +405,33 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = 'cat <<"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
+    def test_escape_in_a_localized_delimiter_is_not_a_heredoc(self):
+        """$"..." unescapes just like "..." does, so decline there too."""
+        command = 'cat <<$"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_process_substitution_delays_the_body(self):
+        """A newline inside <( ) does not end the line that opened it."""
+        command = "cat <<EOF <(echo x\nrm -rf /tmp/x\n)\nliteral\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["literal\n"])
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("literal", stripped)
+
+    def test_output_process_substitution_delays_the_body(self):
+        """>( ) is a parsing unit of its own just as <( ) is."""
+        command = "cat <<EOF >(cat\nrm -rf /tmp/x\n)\nliteral\nEOF"
+        stripped, _ = strip_heredoc_bodies(command)
+        self.assertIn("rm -rf /tmp/x", stripped)
+
+    def test_paren_pattern_case_inside_a_substitution(self):
+        """The '(x)' pattern form balances, so the substitution stays open."""
+        command = ("cat <<EOF $(case x in (x) echo yes;; esac\n"
+                   "rm -rf /tmp/x\n)\nliteral\nEOF")
+        stripped, _ = strip_heredoc_bodies(command)
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("literal", stripped)
+
     def test_delimiter_split_over_a_continued_line(self):
         """An unquoted body loses backslash-newline, so 'EO\\'+'F' ends it."""
         command = "cat <<EOF\ndata\nEO\\\nF\nrm -rf /tmp/x\nEOF"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -410,6 +410,21 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = 'cat <<$"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
+    def test_delimiter_word_split_by_a_continuation(self):
+        """The shell removes the backslash-newline, so "E\\"+"OF" is EOF."""
+        command = "cat <<E\\\nOF\necho <<X\nEOF\nrm -rf /tmp/x\nX"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["echo <<X\n"])
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("echo <<X", stripped)
+
+    def test_each_substitution_ends_its_own_heredocs(self):
+        """An outer heredoc does not swallow a newline inside $( )."""
+        command = "cat <<OUT $(cat <<IN\n)\nIN\nrm -rf /tmp/x\n)\nouter\nOUT"
+        stripped, _ = strip_heredoc_bodies(command)
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("outer", stripped)
+
     def test_undecodable_delimiter_stops_the_scan(self):
         """Declining one heredoc must not turn its body into a new header.
 

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -390,6 +390,28 @@ class TestStripHeredocBodies(unittest.TestCase):
         self.assertEqual(bodies, [])
         self.assertNotIn("rm -rf x", stripped)
 
+    def test_substitution_in_a_delimiter_is_literal(self):
+        """No expansion runs on a delimiter word, so '$(echo EOF)' ends it."""
+        command = "cat <<$(echo EOF)\npayload\n$(echo EOF)\nrm -rf /tmp/x\n$"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["payload\n"])
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("payload", stripped)
+
+    def test_parameter_expansion_in_a_delimiter_is_literal(self):
+        """'${x}' is the delimiter itself, not whatever x holds."""
+        command = "cat <<${x}\npayload\n${x}\nrm -rf /tmp/x\n$"
+        stripped, _ = strip_heredoc_bodies(command)
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("payload", stripped)
+
+    def test_backticks_in_a_delimiter_are_literal(self):
+        """A backtick span belongs to the delimiter word, unexpanded."""
+        command = "cat <<`echo EOF`\npayload\n`echo EOF`\nrm -rf /tmp/x\n$"
+        stripped, _ = strip_heredoc_bodies(command)
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("payload", stripped)
+
     def test_newline_in_a_substitution_does_not_start_the_body(self):
         """An unfinished $( ) holds the command line open past the newline."""
         command = "cat <<'EOF' $(echo start\nrm -rf /tmp/x)\nliteral\nEOF"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -410,6 +410,18 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = 'cat <<$"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
+    def test_array_subscript_shift_is_not_a_heredoc(self):
+        """'<<' in "a[1<<2]=foo" is a shift: the subscript is arithmetic."""
+        command = "a[1<<2]=foo\nrm -rf /tmp/x\n2]=foo"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_bracket_that_is_not_a_subscript_still_allows_a_heredoc(self):
+        """A '[' after whitespace is a glob or test, not a subscript."""
+        command = "ls [ab]* ; cat <<EOF\nrm -rf /tmp/x\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["rm -rf /tmp/x\n"])
+        self.assertNotIn("rm -rf /tmp/x", stripped)
+
     def test_process_substitution_delays_the_body(self):
         """A newline inside <( ) does not end the line that opened it."""
         command = "cat <<EOF <(echo x\nrm -rf /tmp/x\n)\nliteral\nEOF"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -301,6 +301,16 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = "echo $((1 << 2))\nrm -rf /tmp/x\n2"
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
+    def test_parameter_expansion_is_not_a_heredoc(self):
+        """'<<' inside ${...} is expansion text, so it opens no heredoc."""
+        command = "echo ${x:-<<EOF}\nrm -rf /tmp/x\nEOF}"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_nested_parameter_expansion_is_skipped_whole(self):
+        """Nested braces inside a parameter expansion are handled."""
+        command = "echo ${x:-${y:-<<EOF}}\nrm -rf /tmp/x\nEOF}}"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
     def test_nested_arithmetic_is_skipped_whole(self):
         """Nested parentheses inside arithmetic are handled."""
         command = "echo $(( (1 << 2) + 3 ))\nrm -rf /tmp/x\n3 ))"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -410,6 +410,36 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = 'cat <<$"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
+    def test_undecodable_delimiter_stops_the_scan(self):
+        """Declining one heredoc must not turn its body into a new header.
+
+        Bash ends the <<$'E\\x4fF' body at EOF and runs the rm after it. The
+        body holds "echo <<X", so scanning on would read that as a heredoc
+        and blank the rm. Nothing after an undecodable delimiter is blanked.
+        """
+        command = "cat <<$'E\\x4fF'\necho <<X\nEOF\nrm -rf /tmp/x\nX"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_case_pattern_paren_does_not_close_a_substitution(self):
+        """A ')' ending a case pattern is not the one closing '$('."""
+        command = ("cat <<EOF $(case x in x) echo yes;; esac\n"
+                   "rm -rf /tmp/x\n)\nliteral\nEOF")
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["literal\n"])
+        self.assertIn("rm -rf /tmp/x", stripped)
+
+    def test_case_outside_a_substitution_still_allows_a_heredoc(self):
+        """'esac' closes the case, so a later heredoc is found normally."""
+        command = "case x in x) echo yes;; esac\ncat <<'EOF'\nrm -rf /tmp/x\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertNotIn("rm -rf /tmp/x", stripped)
+
+    def test_herestring_operator_is_stepped_over_whole(self):
+        """The trailing '<<' of '<<<' must not be read as a heredoc."""
+        command = "cat <<<input\nrm -rf /tmp/x\ninput"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
     def test_legacy_arithmetic_shift_is_not_a_heredoc(self):
         """$[1 << 2] is the deprecated arithmetic form, so '<<' is a shift."""
         command = "echo $[1 << 2]\nrm -rf /tmp/x\n2]"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -341,14 +341,6 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = "echo $(( (1 << 2) + 3 ))\nrm -rf /tmp/x\n3 ))"
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
-    def test_ansi_c_quoted_delimiter_loses_its_dollar(self):
-        """<<$'EOF' ends the body at EOF, not at $EOF."""
-        command = "cat <<$'EOF'\nliteral\nEOF\nrm -rf /tmp/x\n$EOF"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, [])
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("literal", stripped)
-
     def test_ansi_c_escape_in_delimiter_is_not_a_heredoc(self):
         """An undecodable ANSI-C delimiter blanks nothing, so guards see all."""
         command = "cat <<$'E\\tOF'\nrm -rf /tmp/x\nE\tOF"
@@ -363,13 +355,6 @@ class TestStripHeredocBodies(unittest.TestCase):
         """A '}' inside quotes does not end the expansion either."""
         command = "echo ${x:-'}'<<EOF}\nrm -rf /tmp/x\nEOF}"
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
-
-    def test_line_continuation_delays_the_body(self):
-        """A backslash-newline keeps the header open, so the body starts later."""
-        command = "cat <<EOF ; \\\nrm -rf /tmp/x\nliteral\nEOF"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, ["literal\n"])
-        self.assertIn("rm -rf /tmp/x", stripped)
 
     def test_every_heredoc_on_the_line_is_consumed(self):
         """Two heredocs on one header have two bodies, one after the other."""
@@ -393,13 +378,6 @@ class TestStripHeredocBodies(unittest.TestCase):
         self.assertEqual(bodies, [])
         self.assertNotIn("rm -rf x", stripped)
 
-    def test_ansi_c_string_does_not_confuse_quote_tracking(self):
-        """An escaped quote inside $'...' does not leave the scanner quoted."""
-        command = "echo $'don\\'t' <<'MD'\nrm -rf x\nMD"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, [])
-        self.assertNotIn("rm -rf x", stripped)
-
     def test_escape_in_a_double_quoted_delimiter_is_not_a_heredoc(self):
         """Quote removal would drop a backslash, so decline to blank."""
         command = 'cat <<"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
@@ -410,21 +388,6 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = 'cat <<$"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
-    def test_delimiter_word_split_by_a_continuation(self):
-        """The shell removes the backslash-newline, so "E\\"+"OF" is EOF."""
-        command = "cat <<E\\\nOF\necho <<X\nEOF\nrm -rf /tmp/x\nX"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, ["echo <<X\n"])
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("echo <<X", stripped)
-
-    def test_each_substitution_ends_its_own_heredocs(self):
-        """An outer heredoc does not swallow a newline inside $( )."""
-        command = "cat <<OUT $(cat <<IN\n)\nIN\nrm -rf /tmp/x\n)\nouter\nOUT"
-        stripped, _ = strip_heredoc_bodies(command)
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("outer", stripped)
-
     def test_undecodable_delimiter_stops_the_scan(self):
         """Declining one heredoc must not turn its body into a new header.
 
@@ -434,14 +397,6 @@ class TestStripHeredocBodies(unittest.TestCase):
         """
         command = "cat <<$'E\\x4fF'\necho <<X\nEOF\nrm -rf /tmp/x\nX"
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
-
-    def test_case_pattern_paren_does_not_close_a_substitution(self):
-        """A ')' ending a case pattern is not the one closing '$('."""
-        command = ("cat <<EOF $(case x in x) echo yes;; esac\n"
-                   "rm -rf /tmp/x\n)\nliteral\nEOF")
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, ["literal\n"])
-        self.assertIn("rm -rf /tmp/x", stripped)
 
     def test_case_outside_a_substitution_still_allows_a_heredoc(self):
         """'esac' closes the case, so a later heredoc is found normally."""
@@ -465,34 +420,11 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = "a[1<<2]=foo\nrm -rf /tmp/x\n2]=foo"
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
-    def test_bracket_that_is_not_a_subscript_still_allows_a_heredoc(self):
-        """A '[' after whitespace is a glob or test, not a subscript."""
-        command = "ls [ab]* ; cat <<EOF\nrm -rf /tmp/x\nEOF"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, ["rm -rf /tmp/x\n"])
-        self.assertNotIn("rm -rf /tmp/x", stripped)
-
-    def test_process_substitution_delays_the_body(self):
-        """A newline inside <( ) does not end the line that opened it."""
-        command = "cat <<EOF <(echo x\nrm -rf /tmp/x\n)\nliteral\nEOF"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, ["literal\n"])
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("literal", stripped)
-
     def test_output_process_substitution_delays_the_body(self):
         """>( ) is a parsing unit of its own just as <( ) is."""
         command = "cat <<EOF >(cat\nrm -rf /tmp/x\n)\nliteral\nEOF"
         stripped, _ = strip_heredoc_bodies(command)
         self.assertIn("rm -rf /tmp/x", stripped)
-
-    def test_paren_pattern_case_inside_a_substitution(self):
-        """The '(x)' pattern form balances, so the substitution stays open."""
-        command = ("cat <<EOF $(case x in (x) echo yes;; esac\n"
-                   "rm -rf /tmp/x\n)\nliteral\nEOF")
-        stripped, _ = strip_heredoc_bodies(command)
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("literal", stripped)
 
     def test_delimiter_split_over_a_continued_line(self):
         """An unquoted body loses backslash-newline, so 'EO\\'+'F' ends it."""
@@ -504,59 +436,6 @@ class TestStripHeredocBodies(unittest.TestCase):
     def test_quoted_body_keeps_a_continued_delimiter_literal(self):
         """With a quoted delimiter nothing is unescaped, so it does not end."""
         command = "cat <<'EOF'\ndata\nEO\\\nF\nrm -rf /tmp/x\nEOF"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, [])
-        self.assertNotIn("rm -rf /tmp/x", stripped)
-
-    def test_nested_group_paren_does_not_close_the_substitution(self):
-        """The ')' of '(echo x)' closes the group, not the '$(' around it."""
-        command = "cat <<EOF $( (echo x)\nrm -rf /tmp/x\n)\nliteral\nEOF"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, ["literal\n"])
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("literal", stripped)
-
-    def test_substitution_in_a_delimiter_is_literal(self):
-        """No expansion runs on a delimiter word, so '$(echo EOF)' ends it."""
-        command = "cat <<$(echo EOF)\npayload\n$(echo EOF)\nrm -rf /tmp/x\n$"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, ["payload\n"])
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("payload", stripped)
-
-    def test_parameter_expansion_in_a_delimiter_is_literal(self):
-        """'${x}' is the delimiter itself, not whatever x holds."""
-        command = "cat <<${x}\npayload\n${x}\nrm -rf /tmp/x\n$"
-        stripped, _ = strip_heredoc_bodies(command)
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("payload", stripped)
-
-    def test_backticks_in_a_delimiter_are_literal(self):
-        """A backtick span belongs to the delimiter word, unexpanded."""
-        command = "cat <<`echo EOF`\npayload\n`echo EOF`\nrm -rf /tmp/x\n$"
-        stripped, _ = strip_heredoc_bodies(command)
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("payload", stripped)
-
-    def test_newline_in_a_substitution_does_not_start_the_body(self):
-        """An unfinished $( ) holds the command line open past the newline."""
-        command = "cat <<'EOF' $(echo start\nrm -rf /tmp/x)\nliteral\nEOF"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, [])
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("literal", stripped)
-
-    def test_newline_in_backticks_does_not_start_the_body(self):
-        """Backtick substitution holds the line open the same way $( ) does."""
-        command = "cat <<'EOF' `echo start\nrm -rf /tmp/x`\nliteral\nEOF"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, [])
-        self.assertIn("rm -rf /tmp/x", stripped)
-        self.assertNotIn("literal", stripped)
-
-    def test_heredoc_inside_a_substitution_takes_its_body_there(self):
-        """A substitution is its own parsing unit, bodies included."""
-        command = "echo $(cat <<'EOF'\nrm -rf /tmp/x\nEOF\n)"
         stripped, bodies = strip_heredoc_bodies(command)
         self.assertEqual(bodies, [])
         self.assertNotIn("rm -rf /tmp/x", stripped)
@@ -576,17 +455,129 @@ class TestStripHeredocBodies(unittest.TestCase):
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
         self.assertIn("rm -rf /tmp/x", extract_all_commands(command))
 
-    def test_subshell_paren_does_not_delay_the_body(self):
-        """Plain '(' is not a substitution, so the body still starts next."""
-        command = "(cat <<'EOF'\nrm -rf /tmp/x\nEOF\n)"
-        stripped, bodies = strip_heredoc_bodies(command)
-        self.assertEqual(bodies, [])
-        self.assertNotIn("rm -rf /tmp/x", stripped)
+    def test_case_as_an_argument_is_not_the_keyword(self):
+        """Only a 'case' in command position opens a case statement.
+
+        Bash runs the rm: 'echo case' is an argument, so both ')' close
+        their substitutions and the OUT body's '<<X' is literal.
+        """
+        command = ("cat <<OUT $(echo case; echo $(echo hi)\n)\n"
+                   "echo <<X\nOUT\nrm -rf /tmp/x\nX")
+        self.assertIn("rm -rf /tmp/x", extract_all_commands(command))
+
+    def test_bracket_after_an_argument_is_not_a_subscript(self):
+        """'echo a[<<EOF]' is the argument 'a[' plus a heredoc to 'EOF]'.
+
+        Bash runs the rm: the body ends at 'EOF]', and the '<<X' inside
+        it is literal, not a second heredoc.
+        """
+        command = "echo a[<<EOF]\necho <<X\nEOF]\nrm -rf /tmp/x\nX"
+        self.assertIn("rm -rf /tmp/x", extract_all_commands(command))
+
+    def test_assignment_subscript_shift_is_still_not_a_heredoc(self):
+        """The subscript rule still covers the real assignment form."""
+        command = "a[1<<2]=foo\nrm -rf /tmp/x"
+        self.assertIn("rm -rf /tmp/x", extract_all_commands(command))
 
     def test_unterminated_second_body_blanks_nothing(self):
         """If any body is unclosed, no body is treated as data."""
         command = "cat <<A <<B\nfirst\nA\nrm -rf /tmp/x"
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    # Every construct below has, at some point, let the scanner place a
+    # body boundary where bash does not, so that a real command was
+    # blanked as data. The policy is therefore to blank nothing when the
+    # header line carries any of them: the guards then see the whole
+    # command, which can only over-block.
+    COMPLEX_HEADERS = {
+        "ansi-c delimiter": "cat <<$'EOF'\nliteral\nEOF\nrm -rf /tmp/x\n$EOF",
+        "ansi-c string on the line": "echo $'don\\'t' <<'MD'\nrm -rf x\nMD",
+        "backticks in the delimiter": "cat <<`echo EOF`\npayload\n`echo EOF`",
+        "glob bracket on the line": "ls [ab]* ; cat <<EOF\nrm -rf /tmp/x\nEOF",
+        "case pattern in a substitution": (
+            "cat <<EOF $(case x in x) echo yes;; esac\nrm -rf /tmp/x\n)\n"
+            "literal\nEOF"),
+        "delimiter split by a continuation": (
+            "cat <<E\\\nOF\necho <<X\nEOF\nrm -rf /tmp/x\nX"),
+        "nested heredocs": (
+            "cat <<OUT $(cat <<IN\n)\nIN\nrm -rf /tmp/x\n)\nouter\nOUT"),
+        "heredoc inside a substitution": (
+            "echo $(cat <<'EOF'\nrm -rf /tmp/x\nEOF\n)"),
+        "continuation after the header": (
+            "cat <<EOF ; \\\nrm -rf /tmp/x\nliteral\nEOF"),
+        "group inside a substitution": (
+            "cat <<EOF $( (echo x)\nrm -rf /tmp/x\n)\nliteral\nEOF"),
+        "newline inside a substitution": (
+            "cat <<'EOF' $(echo start\nrm -rf /tmp/x)\nliteral\nEOF"),
+        "newline inside backticks": (
+            "cat <<'EOF' `echo start\nrm -rf /tmp/x`\nliteral\nEOF"),
+        "expansion as the delimiter": "cat <<${x}\npayload\n${x}\nrm -rf /tmp/x",
+        "paren case pattern": (
+            "cat <<EOF $(case x in (x) echo yes;; esac\nrm -rf /tmp/x\n)\n"
+            "literal\nEOF"),
+        "process substitution": (
+            "cat <<EOF <(echo x\nrm -rf /tmp/x\n)\nliteral\nEOF"),
+        "subshell group": "(cat <<'EOF'\nrm -rf /tmp/x\nEOF\n)",
+        "substitution as the delimiter": (
+            "cat <<$(echo EOF)\npayload\n$(echo EOF)\nrm -rf /tmp/x"),
+        "parameter expansion with default": (
+            "echo ${x:-<<EOF}\nrm -rf /tmp/x\nEOF}"),
+        "array assignment on the line": "a[1<<2]=foo\nrm -rf /tmp/x",
+    }
+
+    def test_complex_headers_are_never_blanked(self):
+        """A header line with any complex construct disables blanking."""
+        for name, command in self.COMPLEX_HEADERS.items():
+            with self.subTest(name):
+                self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    # Strings reviewers used to blank a real rm. Each is accepted by bash
+    # and runs the rm; each must reach the guards.
+    KNOWN_BYPASSES = [
+        "echo ${x:-<<EOF}\nrm -rf /tmp/x\nEOF}",
+        "echo ${x:-\\}<<EOF}\nrm -rf /tmp/x\nEOF}",
+        "cat <<A <<'B'\nfirst\nA\necho <<X\nB\nrm -rf /tmp/x\nX",
+        "cat <<$'EOF'\nliteral\nEOF\nrm -rf /tmp/x\n$EOF",
+        "cat <<EOF ; \\\nrm -rf /tmp/x\nliteral\nEOF",
+        "cat <<E\\\nOF\necho <<X\nEOF\nrm -rf /tmp/x\nX",
+        "cat <<EOF $( (echo x)\nrm -rf /tmp/x\n)\nliteral\nEOF",
+        "cat <<EOF <(echo x\nrm -rf /tmp/x\n)\nliteral\nEOF",
+        "cat <<OUT $(cat <<IN\n)\nIN\nrm -rf /tmp/x\n)\nouter\nOUT",
+        "echo `cat <<IN ` ; echo `\nrm -rf /tmp/x\nIN\n`",
+        "cat <<OUT $(echo case; echo $(echo hi)\n)\necho <<X\nOUT\n"
+        "rm -rf /tmp/x\nX",
+        "echo a[<<EOF]\necho <<X\nEOF]\nrm -rf /tmp/x\nX",
+        "cat <<OUT $(if true; then case x in x) :;; esac; fi\n"
+        "rm -rf /tmp/x\n)\npayload\nOUT",
+        "echo a[<<EOF]=x\necho <<X\nEOF]=x\nrm -rf /tmp/x\nX",
+        "cat <<\"A\\\\B\"\nA\\B\nrm -rf /tmp/x\nA\\\\B",
+    ]
+
+    def test_known_bypasses_reach_the_guards(self):
+        """No reviewer-found bypass hides the rm from extract_all_commands."""
+        for command in self.KNOWN_BYPASSES:
+            with self.subTest(command):
+                found = [c for c in extract_all_commands(command)
+                         if c.strip().startswith("rm ")]
+                self.assertTrue(found, command)
+
+    def test_plain_variable_on_the_header_still_blanks(self):
+        """'cat > $HOME/x.md <<EOF' is the common case and must work."""
+        command = "cat > $HOME/notes.md <<'EOF'\nrm -rf x is bad\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertNotIn("rm -rf", stripped)
+        command = "cat > ${DIR}/notes.md <<EOF\nrm -rf x is bad\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["rm -rf x is bad\n"])
+        self.assertNotIn("rm -rf", stripped)
+
+    def test_backslash_quoted_plain_delimiter_still_blanks(self):
+        """<<\\EOF is one of the three simple quotings and stays supported."""
+        command = "cat <<\\EOF\n`rm x`\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertNotIn("rm x", stripped)
 
 
 class TestExpandCommandAliases(unittest.TestCase):

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -20,6 +20,7 @@ from command_utils import (
     extract_subshell_commands,
     extract_all_commands,
     expand_command_aliases,
+    strip_heredoc_bodies,
 )
 
 
@@ -199,6 +200,84 @@ class TestExtractAllCommands(unittest.TestCase):
         """Detect rm hidden in subshell - security regression test."""
         result = extract_all_commands("echo $(rm secret)")
         self.assertIn("rm secret", result)
+
+    def test_quoted_heredoc_backticks_are_literal(self):
+        """A quoted delimiter means the shell expands nothing in the body."""
+        command = "cat > notes.md <<'MD'\nThe `rm -rf x` guard.\nMD"
+        result = extract_all_commands(command)
+        self.assertNotIn("rm -rf x", result)
+        self.assertIn("cat > notes.md <<'MD'", result)
+
+    def test_double_quoted_heredoc_backticks_are_literal(self):
+        """A double-quoted delimiter is just as literal as a single-quoted one."""
+        command = 'cat > notes.md <<"MD"\nThe `rm -rf x` guard.\nMD'
+        self.assertNotIn("rm -rf x", extract_all_commands(command))
+
+    def test_backslash_quoted_heredoc_backticks_are_literal(self):
+        """A backslash-escaped delimiter also disables expansion."""
+        command = "cat > notes.md <<\\MD\nThe `rm -rf x` guard.\nMD"
+        self.assertNotIn("rm -rf x", extract_all_commands(command))
+
+    def test_unquoted_heredoc_substitutions_are_extracted(self):
+        """An unquoted delimiter still expands $() and backticks - regression."""
+        backticks = "cat > notes.md <<MD\nThe `rm -rf x` guard.\nMD"
+        self.assertIn("rm -rf x", extract_all_commands(backticks))
+
+        dollar = "cat > notes.md <<MD\nThe $(rm -rf y) guard.\nMD"
+        self.assertIn("rm -rf y", extract_all_commands(dollar))
+
+    def test_unquoted_heredoc_body_text_is_not_a_command(self):
+        """Body lines are data even when the delimiter is unquoted."""
+        command = "cat > notes.md <<MD\nrm -rf /tmp/x\nMD"
+        self.assertNotIn("rm -rf /tmp/x", extract_all_commands(command))
+
+    def test_command_chained_after_heredoc_is_extracted(self):
+        """Only the body is blanked, never the line introducing it."""
+        command = "cat <<'MD' && rm foo\nliteral text\nMD"
+        self.assertIn("rm foo", extract_all_commands(command))
+
+    def test_heredoc_tab_stripped_delimiter(self):
+        """<<- indents the closing delimiter with tabs."""
+        command = "cat > notes.md <<-'MD'\n\tThe `rm -rf x` guard.\n\tMD"
+        self.assertNotIn("rm -rf x", extract_all_commands(command))
+
+    def test_unterminated_heredoc_keeps_current_behavior(self):
+        """Without a closing delimiter nothing is treated as a heredoc body."""
+        command = "cat > notes.md <<'MD'\nThe `rm -rf x` guard."
+        self.assertIn("rm -rf x", extract_all_commands(command))
+
+    def test_herestring_is_not_a_heredoc(self):
+        """<<< is a here-string, whose expansions do execute."""
+        command = "cat <<< `rm -rf x`"
+        self.assertIn("rm -rf x", extract_all_commands(command))
+
+
+class TestStripHeredocBodies(unittest.TestCase):
+    """Tests for strip_heredoc_bodies() heredoc detection."""
+
+    def test_no_heredoc_is_unchanged(self):
+        """Commands without heredocs pass through untouched."""
+        self.assertEqual(strip_heredoc_bodies("ls -la"), ("ls -la", []))
+
+    def test_quoted_body_is_blanked_and_not_returned(self):
+        """A quoted body is removed from the command and never expanded."""
+        command = "cat <<'MD'\nrm -rf x\nMD"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertNotIn("rm", stripped)
+        self.assertEqual(len(stripped), len(command))
+
+    def test_unquoted_body_is_returned(self):
+        """An unquoted body is blanked but returned for expansion scanning."""
+        command = "cat <<MD\nrm -rf x\nMD"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["rm -rf x\n"])
+        self.assertNotIn("rm", stripped)
+
+    def test_heredoc_operator_inside_quotes_is_ignored(self):
+        """A '<<' inside a quoted word does not start a heredoc."""
+        command = "echo 'a << b'\nrm foo"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
 
 class TestExpandCommandAliases(unittest.TestCase):

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -566,6 +566,16 @@ class TestStripHeredocBodies(unittest.TestCase):
         command = "echo $(cat <<'EOF') tail\nrm -rf /tmp/x\nEOF"
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
+    def test_backticks_closing_first_leave_the_heredoc_bodyless(self):
+        """A closed backtick span drops its heredoc, like ')' does.
+
+        Bash runs the rm here: the first span closes before any newline,
+        so its heredoc has no body, and the second span is code.
+        """
+        command = "echo `cat <<IN ` ; echo `\nrm -rf /tmp/x\nIN\n`"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+        self.assertIn("rm -rf /tmp/x", extract_all_commands(command))
+
     def test_subshell_paren_does_not_delay_the_body(self):
         """Plain '(' is not a substitution, so the body still starts next."""
         command = "(cat <<'EOF'\nrm -rf /tmp/x\nEOF\n)"

--- a/plugins/safety-hooks/hooks/test_command_utils.py
+++ b/plugins/safety-hooks/hooks/test_command_utils.py
@@ -52,6 +52,21 @@ class TestExtractSubcommands(unittest.TestCase):
         result = extract_subcommands("echo hello; echo world")
         self.assertEqual(result, ["echo hello", "echo world"])
 
+    def test_newline_operator(self):
+        """A newline ends a command just as ';' does - security regression."""
+        result = extract_subcommands("echo ok\nrm foo")
+        self.assertEqual(result, ["echo ok", "rm foo"])
+
+    def test_newline_inside_quotes_is_not_a_separator(self):
+        """A newline in a quoted word is part of that word, not an operator."""
+        result = extract_subcommands("echo 'first\nrm foo'")
+        self.assertEqual(result, ["echo 'first\nrm foo'"])
+
+    def test_line_continuation_is_joined(self):
+        """A backslash-newline continues the line, so the shell removes it."""
+        result = extract_subcommands("echo ok ; \\\nrm foo")
+        self.assertEqual(result, ["echo ok", "rm foo"])
+
     def test_pipe_operator(self):
         """Split on | (pipe) operator - security regression test."""
         result = extract_subcommands("echo ok | rm foo")
@@ -314,6 +329,70 @@ class TestStripHeredocBodies(unittest.TestCase):
     def test_nested_arithmetic_is_skipped_whole(self):
         """Nested parentheses inside arithmetic are handled."""
         command = "echo $(( (1 << 2) + 3 ))\nrm -rf /tmp/x\n3 ))"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_ansi_c_quoted_delimiter_loses_its_dollar(self):
+        """<<$'EOF' ends the body at EOF, not at $EOF."""
+        command = "cat <<$'EOF'\nliteral\nEOF\nrm -rf /tmp/x\n$EOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertIn("rm -rf /tmp/x", stripped)
+        self.assertNotIn("literal", stripped)
+
+    def test_ansi_c_escape_in_delimiter_is_not_a_heredoc(self):
+        """An undecodable ANSI-C delimiter blanks nothing, so guards see all."""
+        command = "cat <<$'E\\tOF'\nrm -rf /tmp/x\nE\tOF"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_escaped_brace_does_not_close_a_parameter_expansion(self):
+        """'\\}' is expansion text, so '<<EOF' after it opens no heredoc."""
+        command = "echo ${x:-\\}<<EOF}\nrm -rf /tmp/x\nEOF}"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_quoted_brace_does_not_close_a_parameter_expansion(self):
+        """A '}' inside quotes does not end the expansion either."""
+        command = "echo ${x:-'}'<<EOF}\nrm -rf /tmp/x\nEOF}"
+        self.assertEqual(strip_heredoc_bodies(command), (command, []))
+
+    def test_line_continuation_delays_the_body(self):
+        """A backslash-newline keeps the header open, so the body starts later."""
+        command = "cat <<EOF ; \\\nrm -rf /tmp/x\nliteral\nEOF"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["literal\n"])
+        self.assertIn("rm -rf /tmp/x", stripped)
+
+    def test_every_heredoc_on_the_line_is_consumed(self):
+        """Two heredocs on one header have two bodies, one after the other."""
+        command = "cat <<A <<'B'\nfirst\nA\necho <<X\nB\nrm -rf /tmp/x\nX"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["first\n"])
+        self.assertNotIn("echo <<X", stripped)
+        self.assertIn("rm -rf /tmp/x", stripped)
+
+    def test_second_body_of_a_multi_heredoc_line_is_data(self):
+        """The second body is data too, so its literal text is not a command."""
+        command = "cat <<A <<'B'\nliteral a\nA\nThe `rm -rf x` guard\nB"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, ["literal a\n"])
+        self.assertNotIn("rm -rf x", stripped)
+
+    def test_heredoc_after_a_comment_still_has_a_body(self):
+        """A trailing comment does not stop the body from starting."""
+        command = "cat <<'MD' # note\nrm -rf x\nMD"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertNotIn("rm -rf x", stripped)
+
+    def test_ansi_c_string_does_not_confuse_quote_tracking(self):
+        """An escaped quote inside $'...' does not leave the scanner quoted."""
+        command = "echo $'don\\'t' <<'MD'\nrm -rf x\nMD"
+        stripped, bodies = strip_heredoc_bodies(command)
+        self.assertEqual(bodies, [])
+        self.assertNotIn("rm -rf x", stripped)
+
+    def test_unterminated_second_body_blanks_nothing(self):
+        """If any body is unclosed, no body is treated as data."""
+        command = "cat <<A <<B\nfirst\nA\nrm -rf /tmp/x"
         self.assertEqual(strip_heredoc_bodies(command), (command, []))
 
 

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -155,6 +155,11 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command("# <<END\n; rm -rf /tmp/x\nEND")
         self.assertTrue(blocked, "rm after a commented '<<' should be blocked")
 
+    def test_comment_after_subshell_cannot_fake_a_heredoc(self):
+        """A comment right after ')' must not blank out a following rm."""
+        blocked, _ = check_rm_command("(echo x)# <<END\n; rm -rf /tmp/x\nEND")
+        self.assertTrue(blocked, "rm after '(...)# <<' should be blocked")
+
     def test_arithmetic_shift_cannot_fake_a_heredoc(self):
         """A left shift in $(( )) must not blank out a following rm."""
         blocked, _ = check_rm_command("echo $((1 << 2))\n; rm -rf /tmp/x\n2")

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -205,6 +205,18 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command(command)
         self.assertFalse(blocked, "literal rm in the second body is data")
 
+    def test_continued_delimiter_word_cannot_hide_rm(self):
+        """"E\\"+"OF" is the delimiter EOF, so the rm after that body runs."""
+        command = "cat <<E\\\nOF\necho <<X\nEOF\nrm -rf /tmp/x\nX"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm after a continued delimiter word blocks")
+
+    def test_nested_heredoc_in_a_substitution_cannot_hide_rm(self):
+        """The inner heredoc ends inside $( ), leaving the rm a command."""
+        command = "cat <<OUT $(cat <<IN\n)\nIN\nrm -rf /tmp/x\n)\nouter\nOUT"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm inside the substitution should be blocked")
+
     def test_undecodable_delimiter_cannot_hide_rm(self):
         """Bash ends that body at EOF, so the rm after it is a command."""
         command = "cat <<$'E\\x4fF'\necho <<X\nEOF\nrm -rf /tmp/x\nX"

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -205,6 +205,30 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command(command)
         self.assertFalse(blocked, "literal rm in the second body is data")
 
+    def test_rm_in_a_substitution_before_the_body_is_blocked(self):
+        """An unfinished $( ) means the rm runs before the body starts."""
+        command = "cat <<'EOF' $(echo start\nrm -rf /tmp/x)\nliteral\nEOF"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm inside $( ) on the header is a command")
+
+    def test_rm_in_backticks_before_the_body_is_blocked(self):
+        """Backticks hold the header open just as $( ) does."""
+        command = "cat <<'EOF' `echo start\nrm -rf /tmp/x`\nliteral\nEOF"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm inside backticks on the header is a command")
+
+    def test_bodyless_heredoc_in_a_substitution_cannot_hide_rm(self):
+        """The substitution closes first, so the next line is a command."""
+        command = "echo $(cat <<'EOF') tail\nrm -rf /tmp/x\nEOF"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm is not a body when the body never starts")
+
+    def test_documenting_rm_inside_a_substitution_heredoc_is_allowed(self):
+        """A heredoc body inside $( ) is still data."""
+        command = "echo $(cat <<'EOF'\nThe `rm -rf x` guard.\nEOF\n)"
+        blocked, _ = check_rm_command(command)
+        self.assertFalse(blocked, "literal rm in a quoted body is data")
+
     def test_complex_bypass_attempts(self):
         """Complex commands attempting to hide rm are blocked."""
         # Multiple levels of indirection

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -205,6 +205,24 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command(command)
         self.assertFalse(blocked, "literal rm in the second body is data")
 
+    def test_double_quoted_escape_delimiter_cannot_hide_rm(self):
+        """Bash ends that body at 'A\\B', so the next line is a command."""
+        command = 'cat <<"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm after a '\"A\\\\B\"' body should be blocked")
+
+    def test_continued_delimiter_line_cannot_hide_rm(self):
+        """An unquoted body ends at a delimiter split across two lines."""
+        command = "cat <<EOF\ndata\nEO\\\nF\nrm -rf /tmp/x\nEOF"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm after a continued delimiter is a command")
+
+    def test_nested_group_paren_cannot_hide_rm(self):
+        """The substitution is still open, so the rm inside it is a command."""
+        command = "cat <<EOF $( (echo x)\nrm -rf /tmp/x\n)\nliteral\nEOF"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm inside a still-open $( ) should be blocked")
+
     def test_substitution_delimiter_cannot_fake_a_heredoc(self):
         """'<<$(echo EOF)' ends at that literal line, so the rm is a command."""
         command = "cat <<$(echo EOF)\npayload\n$(echo EOF)\nrm -rf /tmp/x\n$"

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -205,6 +205,12 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command(command)
         self.assertFalse(blocked, "literal rm in the second body is data")
 
+    def test_substitution_delimiter_cannot_fake_a_heredoc(self):
+        """'<<$(echo EOF)' ends at that literal line, so the rm is a command."""
+        command = "cat <<$(echo EOF)\npayload\n$(echo EOF)\nrm -rf /tmp/x\n$"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm after a '$(echo EOF)' body should be blocked")
+
     def test_rm_in_a_substitution_before_the_body_is_blocked(self):
         """An unfinished $( ) means the rm runs before the body starts."""
         command = "cat <<'EOF' $(echo start\nrm -rf /tmp/x)\nliteral\nEOF"

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -160,6 +160,11 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command("(echo x)# <<END\n; rm -rf /tmp/x\nEND")
         self.assertTrue(blocked, "rm after '(...)# <<' should be blocked")
 
+    def test_parameter_expansion_cannot_fake_a_heredoc(self):
+        """'<<' in ${x:-<<EOF} must not blank out a following rm."""
+        blocked, _ = check_rm_command("echo ${x:-<<EOF}\n; rm -rf /tmp/x\nEOF}")
+        self.assertTrue(blocked, "rm after '${x:-<<EOF}' should be blocked")
+
     def test_arithmetic_shift_cannot_fake_a_heredoc(self):
         """A left shift in $(( )) must not blank out a following rm."""
         blocked, _ = check_rm_command("echo $((1 << 2))\n; rm -rf /tmp/x\n2")

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -152,22 +152,22 @@ class TestCheckRmCommand(unittest.TestCase):
 
     def test_comment_cannot_fake_a_heredoc(self):
         """A '<<' in a comment must not blank out a following rm."""
-        blocked, _ = check_rm_command("# <<END\n; rm -rf /tmp/x\nEND")
+        blocked, _ = check_rm_command("# <<END\ntrue; rm -rf /tmp/x\nEND")
         self.assertTrue(blocked, "rm after a commented '<<' should be blocked")
 
     def test_comment_after_subshell_cannot_fake_a_heredoc(self):
         """A comment right after ')' must not blank out a following rm."""
-        blocked, _ = check_rm_command("(echo x)# <<END\n; rm -rf /tmp/x\nEND")
+        blocked, _ = check_rm_command("(echo x)# <<END\ntrue; rm -rf /tmp/x\nEND")
         self.assertTrue(blocked, "rm after '(...)# <<' should be blocked")
 
     def test_parameter_expansion_cannot_fake_a_heredoc(self):
         """'<<' in ${x:-<<EOF} must not blank out a following rm."""
-        blocked, _ = check_rm_command("echo ${x:-<<EOF}\n; rm -rf /tmp/x\nEOF}")
+        blocked, _ = check_rm_command("echo ${x:-<<EOF}\ntrue; rm -rf /tmp/x\nEOF}")
         self.assertTrue(blocked, "rm after '${x:-<<EOF}' should be blocked")
 
     def test_arithmetic_shift_cannot_fake_a_heredoc(self):
         """A left shift in $(( )) must not blank out a following rm."""
-        blocked, _ = check_rm_command("echo $((1 << 2))\n; rm -rf /tmp/x\n2")
+        blocked, _ = check_rm_command("echo $((1 << 2))\ntrue; rm -rf /tmp/x\n2")
         self.assertTrue(blocked, "rm after an arithmetic shift should be blocked")
 
     def test_complex_bypass_attempts(self):

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -205,6 +205,11 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command(command)
         self.assertFalse(blocked, "literal rm in the second body is data")
 
+    def test_array_subscript_shift_cannot_fake_a_heredoc(self):
+        """A shift inside an array subscript must not blank a following rm."""
+        blocked, _ = check_rm_command("a[1<<2]=foo\nrm -rf /tmp/x\n2]=foo")
+        self.assertTrue(blocked, "rm after 'a[1<<2]=foo' should be blocked")
+
     def test_process_substitution_cannot_hide_rm(self):
         """The rm runs inside <( ), before the heredoc body starts."""
         command = "cat <<EOF <(echo x\nrm -rf /tmp/x\n)\nliteral\nEOF"

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -205,6 +205,11 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command(command)
         self.assertFalse(blocked, "literal rm in the second body is data")
 
+    def test_legacy_arithmetic_shift_cannot_fake_a_heredoc(self):
+        """A shift in the deprecated $[ ] form must not blank a following rm."""
+        blocked, _ = check_rm_command("echo $[1 << 2]\nrm -rf /tmp/x\n2]")
+        self.assertTrue(blocked, "rm after 'echo $[1 << 2]' should be blocked")
+
     def test_array_subscript_shift_cannot_fake_a_heredoc(self):
         """A shift inside an array subscript must not blank a following rm."""
         blocked, _ = check_rm_command("a[1<<2]=foo\nrm -rf /tmp/x\n2]=foo")

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -129,6 +129,27 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command("cat `rm bar`")
         self.assertTrue(blocked, "rm in backticks should be blocked")
 
+    def test_quoted_heredoc_documenting_rm_is_allowed(self):
+        """Writing a doc that mentions rm in a code span is not deletion.
+
+        Regression test for issue #187: a single-quoted heredoc delimiter
+        disables every expansion, so the backticks in the body are literal.
+        """
+        command = "cat > notes.md <<'MD'\nThe `rm` guard blocks deletions.\nMD"
+        blocked, _ = check_rm_command(command)
+        self.assertFalse(blocked, "literal rm in a quoted heredoc is data")
+
+    def test_unquoted_heredoc_substitution_still_blocked(self):
+        """An unquoted delimiter really does run the substitution."""
+        command = "cat > notes.md <<MD\nThe `rm -rf x` guard.\nMD"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm in an unquoted heredoc should be blocked")
+
+    def test_rm_chained_after_heredoc_still_blocked(self):
+        """Blanking the body must not hide the command that opens it."""
+        blocked, _ = check_rm_command("cat <<'MD' && rm foo\nliteral\nMD")
+        self.assertTrue(blocked, "rm after a heredoc redirect should be blocked")
+
     def test_complex_bypass_attempts(self):
         """Complex commands attempting to hide rm are blocked."""
         # Multiple levels of indirection

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -170,6 +170,41 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command("echo $((1 << 2))\ntrue; rm -rf /tmp/x\n2")
         self.assertTrue(blocked, "rm after an arithmetic shift should be blocked")
 
+    def test_newline_separated_rm_is_blocked(self):
+        """A newline ends a command, so the next line is a command too."""
+        blocked, _ = check_rm_command("echo hi\nrm -rf /tmp/x")
+        self.assertTrue(blocked, "rm on its own line should be blocked")
+
+    def test_ansi_c_delimiter_cannot_fake_a_heredoc(self):
+        """<<$'EOF' ends at EOF, so a later rm is not inside the body."""
+        command = "cat <<$'EOF'\nliteral\nEOF\nrm -rf /tmp/x\n$EOF"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm after a $'EOF' heredoc should be blocked")
+
+    def test_escaped_brace_cannot_fake_a_heredoc(self):
+        """'\\}' does not close ${...}, so '<<EOF' in it opens no heredoc."""
+        blocked, _ = check_rm_command(
+            "echo ${x:-\\}<<EOF}\nrm -rf /tmp/x\nEOF}")
+        self.assertTrue(blocked, "rm after '${x:-\\}<<EOF}' should be blocked")
+
+    def test_line_continuation_cannot_hide_rm_in_a_body(self):
+        """A continued header means the rm runs before the body starts."""
+        command = "cat <<EOF ; \\\nrm -rf /tmp/x\nliteral\nEOF"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm on a continued header should be blocked")
+
+    def test_second_heredoc_body_cannot_hide_rm(self):
+        """Both bodies on a two-heredoc header are data, so the rm is not."""
+        command = "cat <<A <<'B'\nfirst\nA\necho <<X\nB\nrm -rf /tmp/x\nX"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm after two heredoc bodies should be blocked")
+
+    def test_documenting_rm_in_a_second_heredoc_body_is_allowed(self):
+        """The second body is data, so documenting rm in it is not deletion."""
+        command = "cat <<A <<'B'\nliteral a\nA\nThe `rm -rf x` guard\nB"
+        blocked, _ = check_rm_command(command)
+        self.assertFalse(blocked, "literal rm in the second body is data")
+
     def test_complex_bypass_attempts(self):
         """Complex commands attempting to hide rm are blocked."""
         # Multiple levels of indirection

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -299,11 +299,15 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command(command)
         self.assertTrue(blocked, "rm is not a body when the body never starts")
 
-    def test_documenting_rm_inside_a_substitution_heredoc_is_allowed(self):
-        """A heredoc body inside $( ) is still data."""
+    def test_documenting_rm_inside_a_substitution_heredoc_over_blocks(self):
+        """A heredoc inside $( ) is not blanked, so this over-blocks.
+
+        That is the chosen failure direction: substitutions on the header
+        line are where every known bypass lived.
+        """
         command = "echo $(cat <<'EOF'\nThe `rm -rf x` guard.\nEOF\n)"
         blocked, _ = check_rm_command(command)
-        self.assertFalse(blocked, "literal rm in a quoted body is data")
+        self.assertTrue(blocked, "complex header: body is not blanked")
 
     def test_complex_bypass_attempts(self):
         """Complex commands attempting to hide rm are blocked."""

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -205,6 +205,18 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command(command)
         self.assertFalse(blocked, "literal rm in the second body is data")
 
+    def test_process_substitution_cannot_hide_rm(self):
+        """The rm runs inside <( ), before the heredoc body starts."""
+        command = "cat <<EOF <(echo x\nrm -rf /tmp/x\n)\nliteral\nEOF"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm inside <( ) on the header is a command")
+
+    def test_localized_quote_delimiter_cannot_hide_rm(self):
+        """$\"A\\\\B\" unescapes, so bash ends that body before the rm."""
+        command = 'cat <<$"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm after a '$\"A\\\\B\"' body should be blocked")
+
     def test_double_quoted_escape_delimiter_cannot_hide_rm(self):
         """Bash ends that body at 'A\\B', so the next line is a command."""
         command = 'cat <<"A\\\\B"\ndata\nA\\B\nrm -rf /tmp/x\nA\\\\B'

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -150,6 +150,16 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command("cat <<'MD' && rm foo\nliteral\nMD")
         self.assertTrue(blocked, "rm after a heredoc redirect should be blocked")
 
+    def test_comment_cannot_fake_a_heredoc(self):
+        """A '<<' in a comment must not blank out a following rm."""
+        blocked, _ = check_rm_command("# <<END\n; rm -rf /tmp/x\nEND")
+        self.assertTrue(blocked, "rm after a commented '<<' should be blocked")
+
+    def test_arithmetic_shift_cannot_fake_a_heredoc(self):
+        """A left shift in $(( )) must not blank out a following rm."""
+        blocked, _ = check_rm_command("echo $((1 << 2))\n; rm -rf /tmp/x\n2")
+        self.assertTrue(blocked, "rm after an arithmetic shift should be blocked")
+
     def test_complex_bypass_attempts(self):
         """Complex commands attempting to hide rm are blocked."""
         # Multiple levels of indirection

--- a/plugins/safety-hooks/hooks/test_rm_block_hook.py
+++ b/plugins/safety-hooks/hooks/test_rm_block_hook.py
@@ -205,6 +205,24 @@ class TestCheckRmCommand(unittest.TestCase):
         blocked, _ = check_rm_command(command)
         self.assertFalse(blocked, "literal rm in the second body is data")
 
+    def test_undecodable_delimiter_cannot_hide_rm(self):
+        """Bash ends that body at EOF, so the rm after it is a command."""
+        command = "cat <<$'E\\x4fF'\necho <<X\nEOF\nrm -rf /tmp/x\nX"
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm after an escaped delimiter's body blocks")
+
+    def test_case_pattern_paren_cannot_hide_rm(self):
+        """The substitution stays open past a case pattern's ')'."""
+        command = ("cat <<EOF $(case x in x) echo yes;; esac\n"
+                   "rm -rf /tmp/x\n)\nliteral\nEOF")
+        blocked, _ = check_rm_command(command)
+        self.assertTrue(blocked, "rm inside a still-open $( ) should be blocked")
+
+    def test_herestring_cannot_fake_a_heredoc(self):
+        """'cat <<<input' opens no heredoc, so the next line is a command."""
+        blocked, _ = check_rm_command("cat <<<input\nrm -rf /tmp/x\ninput")
+        self.assertTrue(blocked, "rm after a here-string should be blocked")
+
     def test_legacy_arithmetic_shift_cannot_fake_a_heredoc(self):
         """A shift in the deprecated $[ ] form must not blank a following rm."""
         blocked, _ = check_rm_command("echo $[1 << 2]\nrm -rf /tmp/x\n2]")


### PR DESCRIPTION
Fixes #187. Reported and diagnosed by @rex4539, whose suggested fix
(lift the heredoc parser that `env_file_protection_hook` already has into
`command_utils`) is the one implemented here.

## The bug

`command_utils.extract_all_commands()` scanned the whole command string for
`$()` and backticks, including inside a **single-quoted heredoc**, where the
shell expands nothing. So writing a document that mentions the guarded verb in
an inline code span was extracted as a real command and `rm_block_hook` refused
the write — the plugin blocked you from documenting the plugin:

```
cat > notes.md <<'MD'
The `rm` guard blocks deletions.
MD
```

## The fix

`strip_heredoc_bodies()` moves into `command_utils` from
`env_file_protection_hook` (which already parsed this correctly), and
`extract_all_commands()` calls it, so `rm_block_hook` and every future caller
of the shared utility inherit the correct parse. `env_file_protection_hook`
now imports it instead of carrying its own copy — one parser, one place to fix.

Detection is unchanged where expansions really do run:

- `<<EOF` (unquoted delimiter) — the body's `$()` and backticks still execute,
  so they are still extracted. Only the body's literal text is exempt, since
  bash never runs a heredoc body's lines as commands.
- `<<'EOF'`, `<<"EOF"`, `<<\EOF` — nothing in the body executes, so nothing is
  extracted.
- Everything outside the body, including a command chained on the line that
  opens the heredoc (`cat <<'MD' && rm foo`), is unaffected.

Two bypasses that cold review found in the first cut of this change are fixed
and covered by tests: a `<<` inside a comment (`# <<END`) or inside an
arithmetic expansion (`$((1 << 2))`) is not a heredoc, and must not blank the
lines that follow it.

## Verification

- `uv run pytest plugins/safety-hooks/hooks -q` — **327 passed**, 108 subtests
  (303 before this change; the whole `env_file_protection_hook` suite passes
  against the lifted parser).
- Counter-verified: against `origin/main`'s sources the new
  "quoted heredoc is not a deletion" test **fails**, and
  `extract_all_commands` returns the reporter's exact false positive
  `['cat > notes.md <<\'MD\'…', 'rm -rf x']`. The two bypass regression tests
  fail against the first commit of this branch and pass now.
- End-to-end through the real hook scripts over stdin JSON (not just module
  calls): the quoted-heredoc write is `approve`; `rm -rf /tmp/x`,
  `cat <<'MD' && rm foo`, an unquoted-heredoc `` `rm -rf x` ``, `cat .env`, and
  `<<MD` + `$(cat .env)` are all still `deny`.
- `env_file_protection_hook.py` drops below 1000 lines (1049 → 962) as a
  side effect of removing the duplicate.


## Update: five more bypasses of the same parser, and the deferral withdrawn

Review of `c46a60d` found four more shapes where bash executes a command the
parser hid from the guards, and a local cold review found a fifth. Each was
confirmed against **real bash** before being fixed and again after, by
differential testing: the script runs under `bash -c` with `rm` shadowed by a
marker function, so "did bash execute it" is observed rather than assumed, and
compared against what `check_rm_command()` decides.

`138509b` — four bypasses:

- `<<$'EOF'` is ANSI-C quoting, so bash ends the body at `EOF` while the parser
  looked for `$EOF` and blanked the `rm` that followed.
- `\}` inside `${...}` is expansion text, but the brace balancer read it as the
  closing brace, resumed inside the expansion, and took the `<<EOF` there for a
  real heredoc. It now balances with escape and quote rules.
- A backslash-newline continues the command line, so the body starts a line
  later than the first physical newline; the parser blanked the continued
  command as body data.
- A command header may open several heredocs (`cat <<A <<'B'`); consuming only
  the first left the second body to be read as shell syntax. **This withdraws
  the deferral above**: the shape does not only over-block, it under-blocks, and
  bash confirms it. Both directions are now covered by tests.

All four repros also relied on a newline-separated `rm`, which
`extract_subcommands()` did not split on at all — a hole independent of
heredocs, `echo hi` + newline + `rm -rf /tmp/x` was allowed. A newline ends a
command as `;` does, so the splitter breaks on newlines outside quotes and joins
backslash-newline continuations the way the shell removes them. This is the one
change here that reaches beyond heredoc parsing; it is in the more-blocking
direction and `rm_block_hook` is its only consumer.

`619b496` — a command substitution is its own parsing unit. The body used to
start at the first newline after the operator even when that newline was inside
an unfinished `$( )`, so `cat <<'EOF' $(echo start` + newline +
`rm -rf /tmp/x)` blanked a command bash runs. Bash's actual rule, pinned by
differential testing: a heredoc opened inside `$( )` or backticks takes its body
from inside that substitution, one opened outside takes its body after the
substitution closes, and one whose substitution closes first gets no body at all
(`echo $(cat <<'EOF') tail` leaves the next line a command). A plain `(`
subshell is not a separate unit and is left alone, which bash confirms.

`2a1962c` — no expansion runs on a delimiter word, so `<<$(echo EOF)`,
`<<${x}`, `<<$((1))` and ``<<`echo EOF` `` are literal delimiters. The parser
stopped the word at `(` and recorded `$`, blanking everything through a line
holding a bare `$`. Such spans are now kept whole.

### Verification

- `uv run pytest plugins/safety-hooks/hooks -q` — **362 passed**, 108 subtests
  (330 at `37cb0ab`).
- Counter-verified: 15 of the new tests fail against `37cb0ab`'s sources.
- Differential against real bash: every shape bash executes is blocked, and the
  two that are genuinely data (a literal `rm` in a second heredoc body, and one
  inside a `$( )` heredoc body) stay allowed.
- End-to-end through the hook scripts over stdin JSON, not module calls: 17
  `rm_block_hook` decisions and 6 `env_file_protection_hook` decisions all as
  expected, including that documenting `rm` in a heredoc body is still approved
  (#187) and that `.env` reads hidden behind each new shape are denied.
- Local cold-diff review by an independent reviewer: **NO FINDINGS** on the
  final tree.

## Update 2: four more, from the review of `2a1962c`

Same method: reproduce against real bash first, fix, re-verify, regression test.

`a3039f7`:

- A double-quoted delimiter loses a backslash at quote removal, so bash ends
  `<<"A\\B"` at the line `A\B` while the parser searched for `A\\B` and blanked
  the `rm` between them. Such a delimiter is now reported as no heredoc at all
  rather than half-decoded — nothing is blanked, the guards see the body. Same
  policy as an ANSI-C delimiter carrying an escape.
- For an unquoted heredoc bash removes backslash-newline pairs while reading the
  body, so a delimiter split as `EO\` + `F` ends it. The comparison now reads
  one logical line, joining continuations, and only where bash does: with a
  quoted delimiter nothing is unescaped, so such a line stays literal. Both
  directions are tested.
- A `)` closing a nested group was reducing substitution depth, so in
  `cat <<EOF $( (echo x)` the scanner thought the substitution had closed and
  blanked the `rm` that bash runs inside it. Parens are balanced on a stack now,
  and only the `)` that pops a `$(` closes a substitution — checked after the
  `$(( ))` and `${ }` skips, which own their own parens.

`d270c7b` — from the local cold review: `_extract_balanced_paren_content()`
counted parens without tracking quotes, so `$(printf ')'; rm foo)` was cut short
at the quoted `)` and the `rm` after it was never extracted. Through the heredoc
body path this branch adds, that is a clean bypass. It now reuses the same
quote- and escape-aware scan the heredoc code uses. The weakness predates this
branch and is reachable without a heredoc; it is fixed here because this is
where it stops being masked by the naive operator split.

### Verification

- `uv run pytest plugins/safety-hooks/hooks -q` — **371 passed**, 108 subtests.
- End-to-end through the hook scripts over stdin JSON: **23 `rm_block_hook` and
  9 `env_file_protection_hook` decisions**, all as expected — every shape bash
  executes is refused, and the data cases (documenting `rm` in a body, a
  continued delimiter under a *quoted* heredoc, an ordinary commit message) stay
  approved.
- Local cold-diff review of the final tree: **NO FINDINGS**.

### One thing left for you, deliberately not fixed here

`env_file_protection_hook` has its own segment splitter, and it misses
`echo $( (echo x)` + newline + `cat .env` + newline + `)` — a nested group at
the start of a substitution that spans a newline. That is **pre-existing and
identical on `37cb0ab`**, needs no heredoc to reach, and lives in a function
this branch does not touch, so I left it alone rather than grow this PR further.
Worth a follow-up issue.

## Update 3: substitution kinds and arithmetic contexts

`8224cd3` — from the review of `d270c7b`:

- `<( )` and `>( )` are parsing units just as `$( )` is, so a newline inside one
  does not end the command line that opened a heredoc. Only `$(` incremented the
  depth, so bash ran the `rm` in `cat <<EOF <(echo x` + newline + `rm -rf …` +
  newline + `)` while the parser blanked it.
- `$"…"` removes double-quote escapes just as `"…"` does, so the earlier fix now
  covers it: a delimiter of either form holding a backslash is reported as no
  heredoc rather than taken verbatim.

The third finding of that round is **not reproducible**: bash rejects its
evidence with `syntax error near unexpected token ';;'`, because bash closes the
substitution at that `)` exactly as this scanner does. The form bash accepts is
the paren-pattern one, `case x in (x)`, whose parens balance — the scanner
already handles it, and a test now pins it. Details on the thread.

`e964d58`, `dfe9e30` — from local cold review, one class in two spellings: an
arithmetic context whose `<<` is a shift, not a heredoc operator.
`a[1<<2]=foo` (array subscript) and `echo $[1 << 2]` (the deprecated arithmetic
form) both let bash execute the following line while the parser blanked it. Both
are now stepped over like `$(( ))` and `${ }` already were. A `[` that does not
follow a name is the test command or a glob and is left alone, so
`ls [ab]* ; cat <<EOF` still finds its heredoc.

### Verification of the final tree

- `uv run pytest plugins/safety-hooks/hooks -q` — **382 passed**, 108 subtests
  (330 at `37cb0ab`). Counter-verified: **32 of the new tests fail** against
  `37cb0ab`'s sources.
- End-to-end through the hook scripts over stdin JSON: **28 `rm_block_hook` and
  12 `env_file_protection_hook` decisions**, all as expected.
- Every fix in this branch was reproduced against real bash before being made
  and re-checked after, with `rm` shadowed by a marker function so execution is
  observed rather than assumed, and `bash -n` used to reject "bypasses" that are
  really syntax errors.
- Local cold-diff review of the final tree: **NO FINDINGS**.

## Update 4: declining a heredoc has to stop the scan

`df5e514`. The review of `dfe9e30` made the sharpest point of the whole round:
"decline to parse an undecodable delimiter" was **not** the safe direction this
PR claimed. Declining leaves the body to be scanned as commands, and a `<<`
inside that body is then read as a real header — which blanks the commands after
it. Bash runs the `rm` here, and the guard allowed it:

    cat <<$'E\x4fF'
    echo <<X
    EOF
    rm -rf /tmp/x
    X

The fix is not to decode the escapes; replicating ANSI-C and double-quote
unescaping is the kind of near-miss that produces a *wrong* delimiter and blanks
the wrong span. An undecodable delimiter now stops the scan outright, so nothing
after it is blanked. Declining can only ever blank less, never more.

Probing around that turned up one more, self-found: `<<<` was stepped over by a
single character, so the scan landed on its second `<` and read the remaining
`<<` as a heredoc — `cat <<<input` + newline + `rm -rf /tmp/x` + newline +
`input` ran the `rm` with the guard allowing it.

Also in `df5e514`: a `)` ending a `case` pattern no longer closes a
substitution. **Caveat, stated rather than buried:** that one does not reproduce
on this machine, whose `/bin/bash` is 3.2.57 and rejects
`$(case x in x) … esac)` as a syntax error — bash 3.2 closes `$(` by counting
parens, exactly as the scanner did. Bash 4+ parses substitutions recursively and
accepts it, which is where the bypass is real, so it is fixed on the reviewer's
evidence rather than on mine. The fix only ever blanks less, so it is safe on
both.

### Final verification

- `uv run pytest plugins/safety-hooks/hooks -q` — **389 passed**, 108 subtests
  (330 at `37cb0ab`).
- End-to-end through the hook scripts over stdin JSON: **32 `rm_block_hook` and
  14 `env_file_protection_hook` decisions**, all as expected.
- Local cold-diff review of the final tree: **NO FINDINGS**.
