### PR TITLE
build: add standalone Visual Brief release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-gdocs node-ui-deps release patch minor major dev-install help clean publish all-patch all-minor all-major release-github lmsh lmsh-install lmsh-publish aichat-search aichat-search-install aichat-search-release aichat-search-patch aichat-search-minor aichat-search-major aichat-search-publish fix-session-metadata fix-session-metadata-apply delete-helper-sessions delete-helper-sessions-apply update-homebrew docs-dev docs-build docs-preview voxtype-version voxtype-test voxtype-install voxtype-build voxtype-release voxtype-publish voxtype-all voxtype-all-patch voxtype-all-minor voxtype-all-major visual-brief-frontend visual-brief-frontend-check visual-brief-test visual-brief-install visual-brief-build visual-brief-release visual-brief-publish
+.PHONY: install install-gdocs node-ui-deps release patch minor major dev-install help clean publish all-patch all-minor all-major release-github lmsh lmsh-install lmsh-publish aichat-search aichat-search-install aichat-search-release aichat-search-patch aichat-search-minor aichat-search-major aichat-search-publish fix-session-metadata fix-session-metadata-apply delete-helper-sessions delete-helper-sessions-apply update-homebrew docs-dev docs-build docs-preview voxtype-version voxtype-test voxtype-install voxtype-build voxtype-release voxtype-publish voxtype-all voxtype-all-patch voxtype-all-minor voxtype-all-major visual-brief-version visual-brief-frontend visual-brief-frontend-check visual-brief-test visual-brief-install visual-brief-build visual-brief-release visual-brief-publish visual-brief-all visual-brief-all-patch visual-brief-all-minor visual-brief-all-major
 
 GIT_PRIMARY_WORKTREE := $(realpath $(shell git rev-parse \
 	--path-format=absolute --git-common-dir)/..)
@@ -46,6 +46,8 @@ help:
 	@echo "  make visual-brief-build   - Build visual-brief wheel and sdist"
 	@echo "  make visual-brief-release [BUMP=patch|minor|major] - Release visual-brief"
 	@echo "  make visual-brief-publish - Publish visual-brief artifacts to PyPI"
+	@echo "  make visual-brief-all-patch / -minor / -major - Bump, release, and build (then: make visual-brief-publish)"
+	@echo "  make visual-brief-all [BUMP=...] - Release and publish visual-brief in one shot"
 
 node-ui-deps:
 	@if command -v npm >/dev/null 2>&1; then \
@@ -439,6 +441,9 @@ VISUAL_BRIEF_FRONTEND := $(VISUAL_BRIEF_DIR)/frontend
 VISUAL_BRIEF_CODEX := plugins/dynamic-workflow
 VISUAL_BRIEF_STAMP := $(VISUAL_BRIEF_DIR)/tools/frontend_stamp.py
 
+visual-brief-version:
+	@grep '^version' $(VISUAL_BRIEF_PYPROJECT) | head -1 | cut -d'"' -f2
+
 # Rebuild the committed browser and Codex helper bundles. Installing needs no Node.
 visual-brief-frontend:
 	@command -v npm >/dev/null 2>&1 || { \
@@ -466,7 +471,8 @@ visual-brief-frontend-check:
 	@python3 $(VISUAL_BRIEF_STAMP) check
 
 visual-brief-test: visual-brief-frontend-check
-	uv run --package visual-brief pytest $(VISUAL_BRIEF_DIR)/tests -q
+	uv run --package visual-brief pytest \
+		$(VISUAL_BRIEF_DIR)/tests -q
 
 visual-brief-install:
 	uv tool install --force -e $(VISUAL_BRIEF_DIR)
@@ -510,3 +516,17 @@ visual-brief-publish: visual-brief-frontend-check
 			exit 1; \
 		fi; \
 		UV_PUBLISH_TOKEN="$$PYPI_TOKEN" uv publish dist/visual_brief-*'
+
+# One-shot: bump + tag + push + GitHub release + build + publish to PyPI
+visual-brief-all: visual-brief-release visual-brief-publish
+	@echo "visual-brief released and published!"
+
+# Named bump aliases matching the standalone Voxtype package workflow.
+visual-brief-all-patch:
+	@$(MAKE) visual-brief-release BUMP=patch
+
+visual-brief-all-minor:
+	@$(MAKE) visual-brief-release BUMP=minor
+
+visual-brief-all-major:
+	@$(MAKE) visual-brief-release BUMP=major

--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,9 @@ voxtype-publish:
 		UV_PUBLISH_TOKEN="$$PYPI_TOKEN" uv publish dist/voxtype-*'
 
 # One-shot: bump + tag + push + GitHub release + build + publish to PyPI
-voxtype-all: voxtype-release voxtype-publish
+voxtype-all:
+	@$(MAKE) voxtype-release
+	@$(MAKE) voxtype-publish
 	@echo "voxtype released and published!"
 
 # Named bump aliases mirroring the umbrella's all-patch/minor/major:
@@ -518,7 +520,9 @@ visual-brief-publish: visual-brief-frontend-check
 		UV_PUBLISH_TOKEN="$$PYPI_TOKEN" uv publish dist/visual_brief-*'
 
 # One-shot: bump + tag + push + GitHub release + build + publish to PyPI
-visual-brief-all: visual-brief-release visual-brief-publish
+visual-brief-all:
+	@$(MAKE) visual-brief-release
+	@$(MAKE) visual-brief-publish
 	@echo "visual-brief released and published!"
 
 # Named bump aliases matching the standalone Voxtype package workflow.

--- a/docs-site/src/content/docs/development/make-commands.md
+++ b/docs-site/src/content/docs/development/make-commands.md
@@ -31,7 +31,7 @@ package, but do **not** push or publish:
 | `make major` | Bump major version (X.0.0) and install |
 | `make release` | Alias for `make patch` |
 
-## Publishing (Python)
+## Publishing claude-code-tools (Python)
 
 These commands do everything needed to prepare a
 PyPI release: bump version, push to GitHub, create
@@ -54,6 +54,38 @@ make publish
 
 Linked worktrees automatically use the primary checkout's `.env`. Set
 `PYPI_ENV_FILE=/path/to/file` to load the token from another dotenv file.
+
+## Standalone Python Packages
+
+Voxtype and Visual Brief have independent versions, git tags, builds, and PyPI
+distributions. See [Publishing](../publishing/) for the complete release flow.
+
+### Voxtype
+
+- `make voxtype-version`: print the current version.
+- `make voxtype-test`: run the package tests.
+- `make voxtype-install`: install the package in editable mode.
+- `make voxtype-build`: build the wheel and source distribution.
+- `make voxtype-release BUMP=patch`: test, bump, commit, tag, push, create the
+  GitHub release, and build. Use `minor` or `major` when needed.
+- `make voxtype-publish`: publish `dist/voxtype-*` to PyPI.
+- `make voxtype-all BUMP=patch`: release and publish in one invocation.
+- `make voxtype-all-patch`: prepare a patch release. The `-minor` and `-major`
+  forms select those version parts.
+
+### Visual Brief
+
+- `make visual-brief-version`: print the current version.
+- `make visual-brief-frontend`: rebuild the committed browser bundles.
+- `make visual-brief-test`: verify the bundle and run the package tests.
+- `make visual-brief-install`: install the package in editable mode.
+- `make visual-brief-build`: verify and build the wheel and source distribution.
+- `make visual-brief-release BUMP=patch`: test, bump, commit, tag, push, create
+  the GitHub release, and build. Use `minor` or `major` when needed.
+- `make visual-brief-publish`: publish `dist/visual_brief-*` to PyPI.
+- `make visual-brief-all BUMP=patch`: release and publish in one invocation.
+- `make visual-brief-all-patch`: prepare a patch release. The `-minor` and
+  `-major` forms select those version parts.
 
 ## Rust Binaries
 

--- a/docs-site/src/content/docs/development/publishing.md
+++ b/docs-site/src/content/docs/development/publishing.md
@@ -5,7 +5,17 @@ description: >
   binaries to crates.io.
 ---
 
-## Python Package (PyPI)
+## Python Packages (PyPI)
+
+The repository publishes three independent Python distributions. The root
+package is `claude-code-tools`; `voxtype` and `visual-brief` have their own
+versions, tags, build artifacts, and PyPI releases.
+
+All publish commands load `PYPI_TOKEN` from the primary Git checkout's `.env`
+without printing it. Linked worktrees share that file. To load another dotenv
+file, pass `PYPI_ENV_FILE=/path/to/file` to the publish command.
+
+### claude-code-tools
 
 Use the `all-*` Make commands to prepare a release, then publish:
 
@@ -14,7 +24,7 @@ make all-patch   # or all-minor, all-major
 make publish
 ```
 
-### What the Commands Do
+#### What the Commands Do
 
 Each `all-*` command automatically:
 
@@ -31,16 +41,64 @@ inconsistent lock file stops the build.
 The built package includes its Node dependencies, so users do not need to run
 `npm install`. They need Node.js 18 or newer.
 
-After the build completes, run `make publish` to upload to PyPI. The command
-loads `PYPI_TOKEN` from the primary Git checkout's `.env`, passes it to uv
-without printing it, and requires both wheel and source distributions in
-`dist/`. Linked worktrees therefore share the primary checkout's secret file;
-you do not need to copy `.env` into each worktree.
+After the build completes, run `make publish` to upload to PyPI. It requires
+both wheel and source distributions in `dist/`.
 
-To use another dotenv file, set `PYPI_ENV_FILE`:
+### Voxtype
+
+Prepare a patch release, then publish its wheel and source distribution:
+
+```bash
+make voxtype-all-patch   # or voxtype-all-minor, voxtype-all-major
+make voxtype-publish
+```
+
+The first command runs the Voxtype tests, bumps its independent version,
+updates `uv.lock`, commits the bump, creates and pushes a `voxtype-vX.Y.Z` tag,
+creates the GitHub release, and builds the package. The second command uploads
+only `dist/voxtype-*` to PyPI.
+
+To choose the bump and publish in one invocation, run:
+
+```bash
+make voxtype-all BUMP=patch   # or minor, major
+```
+
+Use `make voxtype-version` to print the current package version.
+
+### Visual Brief
+
+Prepare a patch release, then publish its wheel and source distribution:
+
+```bash
+make visual-brief-all-patch   # or -minor, -major
+make visual-brief-publish
+```
+
+The first command runs the Visual Brief tests, bumps its independent version,
+updates `uv.lock`, commits the bump, creates and pushes a
+`visual-brief-vX.Y.Z` tag, creates the GitHub release, verifies the committed
+browser bundle, and builds the package. The second command uploads only
+`dist/visual_brief-*` to PyPI.
+
+To choose the bump and publish in one invocation, run:
+
+```bash
+make visual-brief-all BUMP=patch   # or minor, major
+```
+
+Use `make visual-brief-version` to print the current package version. Rebuild
+and commit changed browser assets with `make visual-brief-frontend` before
+starting a release.
+
+### Alternate PyPI Credentials
+
+Pass another dotenv file to any publish target when needed:
 
 ```bash
 make publish PYPI_ENV_FILE=~/.config/claude-code-tools/pypi.env
+make voxtype-publish PYPI_ENV_FILE=~/.config/claude-code-tools/pypi.env
+make visual-brief-publish PYPI_ENV_FILE=~/.config/claude-code-tools/pypi.env
 ```
 
 ## Rust Binaries (crates.io)

--- a/packages/visual-brief/pyproject.toml
+++ b/packages/visual-brief/pyproject.toml
@@ -14,6 +14,9 @@ classifiers = [
 ]
 dependencies = []
 
+[dependency-groups]
+dev = ["pytest>=9.0.1"]
+
 [project.urls]
 Homepage = "https://github.com/pchalasani/claude-code-tools"
 

--- a/packages/voxtype/pyproject.toml
+++ b/packages/voxtype/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
     "numpy>=1.26.0",
 ]
 
+[dependency-groups]
+dev = ["pytest>=9.0.1"]
+
 [project.urls]
 Homepage = "https://github.com/pchalasani/claude-code-tools"
 Documentation = "https://pchalasani.github.io/claude-code-tools/tools/voxtype/"

--- a/tests/test_visual_brief_makefile.py
+++ b/tests/test_visual_brief_makefile.py
@@ -30,15 +30,21 @@ def test_visual_brief_has_voxtype_release_target_parity() -> None:
     }
 
     assert expected <= targets
-    assert re.search(
-        r"^visual-brief-all:\s+visual-brief-release\s+visual-brief-publish$",
-        text,
-        flags=re.MULTILINE,
-    )
     for part in ("patch", "minor", "major"):
         recipe = rf"visual-brief-all-{part}:\n\t@\$\(MAKE\) "
         recipe += rf"visual-brief-release BUMP={part}"
         assert re.search(rf"^{recipe}$", text, flags=re.MULTILINE)
+
+
+def test_standalone_one_shot_releases_before_publishing() -> None:
+    """Parallel Make must not publish stale standalone-package artifacts."""
+    text = MAKEFILE.read_text()
+
+    for package in ("voxtype", "visual-brief"):
+        recipe = rf"^{package}-all:\n"
+        recipe += rf"\t@\$\(MAKE\) {package}-release\n"
+        recipe += rf"\t@\$\(MAKE\) {package}-publish$"
+        assert re.search(recipe, text, flags=re.MULTILINE)
 
 
 def test_visual_brief_release_conveniences_appear_in_help() -> None:

--- a/tests/test_visual_brief_makefile.py
+++ b/tests/test_visual_brief_makefile.py
@@ -1,0 +1,82 @@
+"""Tests for the standalone Visual Brief release targets."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAKEFILE = ROOT / "Makefile"
+VOXTYPE_PYPROJECT = ROOT / "packages/voxtype/pyproject.toml"
+VISUAL_BRIEF_PYPROJECT = ROOT / "packages/visual-brief/pyproject.toml"
+PUBLISHING_DOC = ROOT / "docs-site/src/content/docs/development/publishing.md"
+MAKE_COMMANDS_DOC = ROOT / "docs-site/src/content/docs/development/make-commands.md"
+
+
+def test_visual_brief_has_voxtype_release_target_parity() -> None:
+    """Visual Brief should expose the same release conveniences as Voxtype."""
+    text = MAKEFILE.read_text()
+    targets = set(re.findall(r"^([a-z0-9-]+):", text, flags=re.MULTILINE))
+
+    expected = {
+        "visual-brief-version",
+        "visual-brief-all",
+        "visual-brief-all-patch",
+        "visual-brief-all-minor",
+        "visual-brief-all-major",
+    }
+
+    assert expected <= targets
+    assert re.search(
+        r"^visual-brief-all:\s+visual-brief-release\s+visual-brief-publish$",
+        text,
+        flags=re.MULTILINE,
+    )
+    for part in ("patch", "minor", "major"):
+        recipe = rf"visual-brief-all-{part}:\n\t@\$\(MAKE\) "
+        recipe += rf"visual-brief-release BUMP={part}"
+        assert re.search(rf"^{recipe}$", text, flags=re.MULTILINE)
+
+
+def test_visual_brief_release_conveniences_appear_in_help() -> None:
+    """The discoverable Make help should explain both release workflows."""
+    result = subprocess.run(
+        ["make", "help"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "make visual-brief-all [BUMP=...]" in result.stdout
+    assert "make visual-brief-all-patch / -minor / -major" in result.stdout
+
+
+def test_standalone_test_targets_use_package_environments() -> None:
+    """Fresh workspaces should not fall through to an external pytest."""
+    text = MAKEFILE.read_text()
+
+    for package in ("voxtype", "visual-brief"):
+        assert f"uv run --package {package} pytest" in text
+
+    for path in (VOXTYPE_PYPROJECT, VISUAL_BRIEF_PYPROJECT):
+        project = tomllib.loads(path.read_text())
+        dev_dependencies = project["dependency-groups"]["dev"]
+        assert any(dependency.startswith("pytest") for dependency in dev_dependencies)
+
+
+def test_starlight_documents_standalone_python_releases() -> None:
+    """Maintainers should find both standalone package workflows in Starlight."""
+    publishing = PUBLISHING_DOC.read_text()
+    commands = MAKE_COMMANDS_DOC.read_text()
+
+    for package in ("voxtype", "visual-brief"):
+        assert f"make {package}-all-patch" in publishing
+        assert f"make {package}-publish" in publishing
+        assert f"make {package}-all" in publishing
+        assert f"make {package}-all-patch" in commands
+        assert f"make {package}-publish" in commands
+        assert f"make {package}-all" in commands

--- a/uv.lock
+++ b/uv.lock
@@ -2676,6 +2676,16 @@ name = "visual-brief"
 version = "0.1.0"
 source = { editable = "packages/visual-brief" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.1" }]
+
 [[package]]
 name = "voxtype"
 version = "0.1.8"
@@ -2696,6 +2706,11 @@ moonshine = [
     { name = "moonshine-voice" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "moonshine-voice", marker = "extra == 'moonshine'", specifier = ">=0.0.69" },
@@ -2708,6 +2723,9 @@ requires-dist = [
     { name = "sherpa-onnx-core", specifier = ">=1.12.0,<1.13" },
     { name = "sounddevice", specifier = ">=0.5.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.1" }]
 
 [[package]]
 name = "wcwidth"


### PR DESCRIPTION
## Summary

- confirm Visual Brief is already a standalone Python distribution and add Voxtype-parity release aliases
- sequence one-shot release and publish targets so parallel Make cannot upload stale artifacts
- declare test dependencies for both standalone packages so release tests work from a fresh checkout
- document Voxtype and Visual Brief release workflows in the Starlight developer section

## Verification

- 5 focused release-workflow tests passed
- Visual Brief: 581 tests passed
- Voxtype: 282 tests passed
- both standalone wheels and source distributions built successfully
- the built Visual Brief wheel ran its CLI help successfully
- Starlight: 47 pages built and both changed pages rendered without browser errors
- context-free Codex review of exact commit 79f2cd6: no findings