### PR TITLE
workflow: Codex review-loop nudge hook for open PRs

### DIFF
--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow",
   "version": "1.14.0",
-  "description": "Workflow skills and agents: code-walk-thru, log-work, make-issue-spec, socratic-quiz skills; ui-tester agent for browser-based UI validation",
+  "description": "Workflow skills, agents, and hooks: code-walk-thru, log-work, make-issue-spec, socratic-quiz skills; ui-tester agent; a Codex review-loop nudge hook for open pull requests",
   "author": {
     "name": "Prasad Chalasani"
   }

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Workflow skills, agents, and hooks: code-walk-thru, log-work, make-issue-spec, socratic-quiz skills; ui-tester agent; a Codex review-loop nudge hook for open pull requests",
   "author": {
     "name": "Prasad Chalasani"

--- a/plugins/workflow/README.md
+++ b/plugins/workflow/README.md
@@ -87,6 +87,47 @@ DevTools MCP Server.
 - Check for console errors and network issues
 - Validate responsive behavior and accessibility
 
+## Hooks
+
+### Codex review-loop nudge (`hooks/pr_review_nudge.py`)
+
+A nudge, never a gate: it reminds the agent to run the GitHub Codex
+review loop on its own pull requests — monitor the review, address or
+defer each finding, and **request a fresh review after every push** —
+without ever blocking work.
+
+- **After `gh pr create` or a `git push` to a branch with an open PR**
+  (PostToolUse on Bash): injects a one-line reminder.
+- **When the agent tries to end its turn** (Stop): asks GitHub for open
+  PRs by you whose head branch is checked out in a local worktree of
+  this repo. For each one whose current head has no completed Codex
+  review, or which has unresolved review threads, it interrupts the stop
+  **once** with the details; the next stop in the same state passes
+  silently. The agent then decides — fix, defer to an issue, or dismiss
+  with a reply. It checks GitHub rather than pattern-matching commands,
+  so a PR created via `gh api`, by a subagent, or by hand is covered.
+
+Speed and safety: a handful of `gh` calls with short timeouts, results
+cached for a minute, and anything that fails — not a git repo, no GitHub
+remote, `gh` missing or offline — makes it silent rather than slow.
+State lives in `~/.local/state/codex-review-nudge/` (override with
+`CODEX_REVIEW_NUDGE_STATE`).
+
+**Codex CLI** speaks the same hook payloads. Register the script by
+absolute path in `~/.codex/hooks.json` (Codex hash-trusts the entry
+script, so keep it a single file, and re-trust via `/hooks` after edits):
+
+```json
+{"hooks": {
+  "PostToolUse": [{"matcher": "^(Bash|shell)$", "hooks": [{"type": "command",
+    "command": "python3 /ABS/PATH/plugins/workflow/hooks/pr_review_nudge.py",
+    "timeout": 15}]}],
+  "Stop": [{"hooks": [{"type": "command",
+    "command": "python3 /ABS/PATH/plugins/workflow/hooks/pr_review_nudge.py",
+    "timeout": 20}]}]
+}}
+```
+
 ## Installation
 
 No additional dependencies required for skills. The ui-tester agent requires the

--- a/plugins/workflow/hooks/hooks.json
+++ b/plugins/workflow/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "description": "Nudge (never block) the agent to run the GitHub Codex review loop on its open pull requests",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "^[Bb][Aa][Ss][Hh]$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/pr_review_nudge.py\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/pr_review_nudge.py\"",
+            "timeout": 20
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/workflow/hooks/pr_review_nudge.py
+++ b/plugins/workflow/hooks/pr_review_nudge.py
@@ -50,7 +50,53 @@ STATE_DIR = Path(
 
 # Commands that make a PR appear or change on GitHub.
 _PR_CREATE_RE = re.compile(r"\bgh\s+pr\s+create\b")
-_GIT_PUSH_RE = re.compile(r"\bgit\s+push\b")
+_GIT_PUSH_RE = re.compile(r"\bgit\s+push\b(?P<rest>[^|;&\n]*)")
+# push options that consume the next token
+_PUSH_VALUE_OPTS = {"-o", "--push-option", "--receive-pack", "--exec", "--repo"}
+
+
+def pushed_branches(cmd: str, cwd: str) -> list[str]:
+    """Branches a ``git push`` command sent, from its refspecs when given.
+
+    ``git push origin a b`` pushes ``a`` and ``b`` (dst of ``src:dst``
+    when a refspec is written), not the checked-out branch; only a bare
+    ``git push`` means the current branch. Options, their values, and
+    shell redirections are skipped. Best-effort: unrecognised forms fall
+    back to the current branch.
+    """
+    m = _GIT_PUSH_RE.search(cmd)
+    if not m:
+        return []
+    try:
+        import shlex
+
+        tokens = shlex.split(m.group("rest"))
+    except ValueError:
+        tokens = m.group("rest").split()
+    words: list[str] = []
+    skip = False
+    for tok in tokens:
+        if skip:
+            skip = False
+            continue
+        if tok in _PUSH_VALUE_OPTS:
+            skip = True
+            continue
+        if tok.startswith("-") or tok.startswith((">", "<", "2>")):
+            continue
+        words.append(tok)
+    # words: [remote, refspec...]
+    branches = []
+    for spec in words[1:]:
+        dst = spec.split(":", 1)[1] if ":" in spec else spec
+        dst = dst.replace("refs/heads/", "")
+        if dst and dst != "HEAD" and not dst.startswith("+"):
+            branches.append(dst)
+    if branches:
+        return branches
+    cur = _current_branch(cwd)
+    return [cur] if cur else []
+
 
 _LOOP_INSTRUCTIONS = (
     "Run the GitHub Codex review loop (github-codex-review skill): watch "
@@ -376,20 +422,22 @@ def handle_post_tool_use(payload: dict) -> int:
         )
         return 0
     if _GIT_PUSH_RE.search(cmd):
-        branch = _current_branch(cwd)
-        if not branch:
-            return 0
-        prs = _gh_json(
-            ["pr", "list", "--head", branch, "--state", "open", "--json", "number,url"],
-            cwd=cwd,
-        )
-        if isinstance(prs, list) and prs:
-            n = prs[0].get("number")
+        hits = []
+        for branch in pushed_branches(cmd, cwd)[:3]:
+            prs = _gh_json(
+                ["pr", "list", "--head", branch, "--author", "@me",
+                 "--state", "open", "--json", "number,url"],
+                cwd=cwd,
+            )
+            if isinstance(prs, list) and prs:
+                hits.append(f"#{prs[0].get('number')}")
+        if hits:
             _emit_context(
                 "PostToolUse",
-                f"You pushed to the branch of open PR #{n}. Codex reviews "
-                "are per head: comment '@codex review' on the PR to get a "
-                "fresh review of what you just pushed, then continue the loop.",
+                f"You pushed to the branch of open PR {', '.join(hits)}. "
+                "Codex reviews are per head: comment '@codex review' on the "
+                "PR to get a fresh review of what you just pushed, then "
+                "continue the loop.",
             )
     return 0
 

--- a/plugins/workflow/hooks/pr_review_nudge.py
+++ b/plugins/workflow/hooks/pr_review_nudge.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Nudge the agent to run the GitHub Codex review loop on its pull requests.
+
+A nudge, never a gate. Two hook events, one script (Claude Code and Codex
+CLI both speak this payload shape):
+
+- **PostToolUse (Bash)**: after ``gh pr create`` or a ``git push`` whose
+  branch has an open PR, inject a short reminder to monitor GitHub Codex's
+  review and re-request one after every push.
+- **Stop**: when the agent tries to end its turn, look at GitHub — not at
+  what commands ran — for open PRs authored by the user whose head branch
+  is checked out in a local worktree of this repo. For each one whose
+  current head has no completed Codex review, or which has unresolved
+  review threads, deliver ONE nudge for that exact state (PR, head,
+  unresolved count) by interrupting the stop once with the message; the
+  next stop in the same state passes silently. The agent decides:
+  address, defer to an issue, or dismiss with a reply.
+
+Checking reality on Stop instead of pattern-matching commands means a PR
+created via ``gh api``, by a subagent, or by hand is still covered.
+
+Speed: at most a handful of ``gh`` calls, each bounded by a short timeout;
+results are cached briefly. Anything that fails — no git repo, no GitHub
+remote, ``gh`` missing or offline — makes the hook silent, never slow and
+never blocking. Single file with no third-party imports, because Codex
+hash-trusts the entry script only.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_MAX_STDIN_BYTES = 1_000_000
+_GH_TIMEOUT = 6.0  # seconds per gh call
+_TOTAL_BUDGET = 12.0  # seconds for the whole Stop check
+_CACHE_TTL = 60.0  # seconds a computed PR status stays fresh
+_SUMMARY_MARKER = "codex-pull-request-review-summary"
+
+STATE_DIR = Path(
+    os.environ.get("CODEX_REVIEW_NUDGE_STATE")
+    or os.path.expanduser("~/.local/state/codex-review-nudge")
+)
+
+# Commands that make a PR appear or change on GitHub.
+_PR_CREATE_RE = re.compile(r"\bgh\s+pr\s+create\b")
+_GIT_PUSH_RE = re.compile(r"\bgit\s+push\b")
+
+_LOOP_INSTRUCTIONS = (
+    "Run the GitHub Codex review loop (github-codex-review skill): watch "
+    "the PR's Codex review-summary comment until it shows Completed for "
+    "the CURRENT head; for each finding decide — fix it, defer it to an "
+    "issue, or dismiss it with a reply — and resolve the thread; after "
+    "EVERY push, comment '@codex review' to get a fresh review of the new "
+    "head and check again. A converged PR plus a written deferred list is "
+    "a success."
+)
+
+
+# -- small helpers ----------------------------------------------------------
+
+
+_DEADLINE: list[float] = []  # monotonic time by which the Stop check must end
+
+
+def _remaining(timeout: float) -> float:
+    if _DEADLINE:
+        return max(0.2, min(timeout, _DEADLINE[0] - time.monotonic()))
+    return timeout
+
+
+def _run(args: list[str], cwd: str | None = None, timeout: float = _GH_TIMEOUT):
+    """Run a command; return stdout or None on any failure. Never raises.
+
+    Every call is bounded by both its own timeout and the Stop deadline,
+    so the whole check finishes inside the host's hook timeout.
+    """
+    timeout = _remaining(timeout)
+    try:
+        proc = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def _repo_root(cwd: str) -> str | None:
+    out = _run(["git", "rev-parse", "--show-toplevel"], cwd=cwd, timeout=3.0)
+    return out.strip() if out else None
+
+
+def _github_slug(root: str) -> str | None:
+    """owner/repo of the repository ``gh`` would act on, or None.
+
+    Asks gh first so a fork setup (origin = fork, upstream = default repo)
+    resolves to the same repository ``gh pr list`` uses; falls back to
+    parsing origin when gh cannot answer. Non-GitHub origins yield None.
+    """
+    out = _run(["git", "remote", "get-url", "origin"], cwd=root, timeout=3.0)
+    if not out or "github.com" not in out:
+        return None
+    gh = _run(["gh", "repo", "view", "--json", "nameWithOwner",
+               "-q", ".nameWithOwner"], cwd=root)
+    if gh and gh.strip().count("/") == 1:
+        return gh.strip()
+    m = re.search(r"github\.com[:/]([^/\s]+)/([^/\s]+?)(?:\.git)?/?$", out.strip())
+    return f"{m.group(1)}/{m.group(2)}" if m else None
+
+
+def _worktree_branches(root: str) -> set[str]:
+    out = _run(["git", "worktree", "list", "--porcelain"], cwd=root, timeout=3.0)
+    if not out:
+        return set()
+    return {
+        line.split("refs/heads/", 1)[1].strip()
+        for line in out.splitlines()
+        if line.startswith("branch refs/heads/")
+    }
+
+
+def _current_branch(cwd: str) -> str | None:
+    out = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd, timeout=3.0)
+    b = out.strip() if out else ""
+    return b if b and b != "HEAD" else None
+
+
+def _gh_json(args: list[str], cwd: str):
+    out = _run(["gh", *args], cwd=cwd)
+    if not out:
+        return None
+    try:
+        return json.loads(out)
+    except ValueError:
+        return None
+
+
+def _concat_json_arrays(text: str) -> list | None:
+    """Flatten ``gh api --paginate`` output: pages arrive as JSON arrays
+    concatenated back to back (``[...][...]``). Works on every gh version
+    (``--slurp`` does not). None if the text is not well-formed."""
+    dec = json.JSONDecoder()
+    i, n, items = 0, len(text), []
+    while i < n:
+        while i < n and text[i].isspace():
+            i += 1
+        if i >= n:
+            break
+        try:
+            page, i = dec.raw_decode(text, i)
+        except ValueError:
+            return None
+        if isinstance(page, list):
+            items.extend(page)
+        else:
+            return None
+    return items
+
+
+# -- GitHub state -------------------------------------------------------------
+
+
+def parse_summary(body: str) -> tuple[str | None, str | None]:
+    """(status, sha7) from Codex's review-summary table, or (None, None).
+
+    The table row looks like ``| 📝 **Code Review** | ✅ **Completed** ... |
+    `1e8dd8f` | ...`` (or 🔄 **Running**). Only the Code Review row counts.
+    """
+    for line in body.splitlines():
+        if "Code Review" not in line:
+            continue
+        status = None
+        if "Completed" in line:
+            status = "completed"
+        elif "Running" in line:
+            status = "running"
+        sha = re.search(r"`([0-9a-f]{7,40})`", line)
+        return status, (sha.group(1) if sha else None)
+    return None, None
+
+
+def open_prs_on_local_branches(root: str, cwd: str) -> list[dict]:
+    """Open PRs by the user whose head branch is checked out locally."""
+    branches = _worktree_branches(root)
+    prs = _gh_json(
+        [
+            "pr", "list", "--author", "@me", "--state", "open",
+            "--limit", "200", "--json", "number,headRefName,headRefOid,url",
+        ],
+        cwd=cwd,
+    )
+    if not isinstance(prs, list):
+        return []
+    return [
+        p for p in prs
+        if isinstance(p, dict) and p.get("headRefName") in branches
+    ]
+
+
+def codex_status(slug: str, number: int, cwd: str) -> dict | None:
+    """Codex review state for one PR: {status, reviewed_sha, unresolved}.
+
+    None when GitHub could not be queried (caller stays silent: an
+    unanswered question is not a finding).
+    """
+    raw = _run(
+        ["gh", "api", "--paginate", "-X", "GET", "-f", "per_page=100",
+         f"repos/{slug}/issues/{number}/comments"],
+        cwd=cwd,
+    )
+    if raw is None:
+        return None
+    comments = _concat_json_arrays(raw)
+    if comments is None:
+        return None
+    bodies = [
+        str(c.get("body", "")) for c in comments
+        if isinstance(c, dict) and _SUMMARY_MARKER in str(c.get("body", ""))
+    ]
+    status, sha = parse_summary(bodies[-1]) if bodies else (None, None)
+    owner, repo = slug.split("/", 1)
+    unresolved = 0
+    cursor = ""
+    for _page in range(10):  # 1000 threads is far beyond any real PR
+        after = f', after:"{cursor}"' if cursor else ""
+        q = (
+            '{repository(owner:"%s",name:"%s"){pullRequest(number:%d){'
+            "reviewThreads(first:100%s){pageInfo{hasNextPage endCursor}"
+            "nodes{isResolved}}}}}" % (owner, repo, number, after)
+        )
+        threads = _gh_json(["api", "graphql", "-f", f"query={q}"], cwd=cwd)
+        if not isinstance(threads, dict):
+            return None
+        try:
+            rt = threads["data"]["repository"]["pullRequest"]["reviewThreads"]
+            unresolved += sum(1 for n in rt["nodes"] if not n.get("isResolved"))
+            if not rt["pageInfo"]["hasNextPage"]:
+                break
+            cursor = rt["pageInfo"]["endCursor"]
+        except (KeyError, TypeError):
+            return None
+    else:
+        return None  # more pages than we will read: cannot tell
+    return {"status": status, "reviewed_sha": sha, "unresolved": unresolved}
+
+
+def needs_nudge(pr: dict, st: dict) -> str | None:
+    """One-line reason this PR needs attention, or None if it is settled."""
+    head = str(pr.get("headRefOid") or "")
+    reviewed = st.get("reviewed_sha") or ""
+    on_head = bool(reviewed) and head.startswith(reviewed)
+    reasons = []
+    if st.get("status") == "running" and on_head:
+        reasons.append("Codex is still reviewing this head — wait for it")
+    elif st.get("status") != "completed" or not on_head:
+        reasons.append(
+            "no completed Codex review of the current head"
+            + (" (request one: comment '@codex review')" if reviewed else
+               " (the PR-opened review may still be starting)")
+        )
+    if st.get("unresolved"):
+        reasons.append(f"{st['unresolved']} unresolved review thread(s)")
+    return "; ".join(reasons) if reasons else None
+
+
+# -- state: one nudge per exact PR state, plus a short result cache ----------
+
+
+def _state_path(slug: str) -> Path:
+    return STATE_DIR / (slug.replace("/", "__") + ".json")
+
+
+class _StateLock:
+    """Serialize load-check-save across concurrent hook processes."""
+
+    def __init__(self, slug: str) -> None:
+        self._path = _state_path(slug).with_suffix(".lock")
+        self._fh = None
+
+    def __enter__(self) -> "_StateLock":
+        try:
+            STATE_DIR.mkdir(parents=True, exist_ok=True)
+            self._fh = open(self._path, "a")
+            fcntl.flock(self._fh, fcntl.LOCK_EX)
+        except OSError:
+            self._fh = None  # no lock: worst case one duplicate nudge
+        return self
+
+    def __exit__(self, *exc) -> None:  # noqa: ANN002
+        if self._fh is not None:
+            try:
+                fcntl.flock(self._fh, fcntl.LOCK_UN)
+                self._fh.close()
+            except OSError:
+                pass
+
+
+def _load_state(slug: str) -> dict:
+    try:
+        data = json.loads(_state_path(slug).read_text())
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_state(slug: str, data: dict) -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = _state_path(slug).with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(data))
+        os.replace(tmp, _state_path(slug))
+    except OSError:
+        pass  # losing the dedupe only risks one extra nudge
+
+
+def state_key(pr: dict, st: dict) -> str:
+    head7 = str(pr.get("headRefOid") or "")[:7]
+    return f"{pr.get('number')}@{head7}:{st.get('unresolved', 0)}:{st.get('status')}"
+
+
+# -- events --------------------------------------------------------------------
+
+
+def _emit_context(event: str, text: str) -> None:
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": event, "additionalContext": text}}))
+
+
+def handle_post_tool_use(payload: dict) -> int:
+    tool_input = payload.get("tool_input") or {}
+    cmd = tool_input.get("command") if isinstance(tool_input, dict) else None
+    if not isinstance(cmd, str):
+        return 0
+    cwd = payload.get("cwd") or os.getcwd()
+    if _PR_CREATE_RE.search(cmd):
+        _emit_context(
+            "PostToolUse", "A pull request was just created. " + _LOOP_INSTRUCTIONS
+        )
+        return 0
+    if _GIT_PUSH_RE.search(cmd):
+        branch = _current_branch(cwd)
+        if not branch:
+            return 0
+        prs = _gh_json(
+            ["pr", "list", "--head", branch, "--state", "open", "--json", "number,url"],
+            cwd=cwd,
+        )
+        if isinstance(prs, list) and prs:
+            n = prs[0].get("number")
+            _emit_context(
+                "PostToolUse",
+                f"You pushed to the branch of open PR #{n}. Codex reviews "
+                "are per head: comment '@codex review' on the PR to get a "
+                "fresh review of what you just pushed, then continue the loop.",
+            )
+    return 0
+
+
+def handle_stop(payload: dict) -> int:
+    if payload.get("stop_hook_active"):
+        return 0  # already continuing from a stop hook: never nudge twice
+    cwd = payload.get("cwd") or os.getcwd()
+    _DEADLINE[:] = [time.monotonic() + _TOTAL_BUDGET]
+    root = _repo_root(cwd)
+    if not root:
+        return 0
+    slug = _github_slug(root)
+    if not slug:
+        return 0
+    prs = open_prs_on_local_branches(root, cwd)
+    if not prs:
+        return 0
+    open_numbers = {str(p.get("number")) for p in prs}
+    with _StateLock(slug):
+        state = _load_state(slug)
+        cache = state.get("cache") if isinstance(state.get("cache"), dict) else {}
+        nudged = state.get("nudged") if isinstance(state.get("nudged"), dict) else {}
+        now = time.time()
+        lines = []
+        for pr in prs:
+            if time.monotonic() > _DEADLINE[0]:
+                break  # out of time: report what we have, never overrun
+            head7 = str(pr.get("headRefOid") or "")[:7]
+            ckey = f"{pr.get('number')}@{head7}"
+            entry = cache.get(ckey)
+            if isinstance(entry, dict) and now - float(entry.get("t", 0)) < _CACHE_TTL:
+                st = entry.get("st")
+            else:
+                st = codex_status(slug, int(pr.get("number", 0)), cwd)
+                if st is not None:
+                    cache[ckey] = {"t": now, "st": st}
+            if not isinstance(st, dict):
+                continue  # could not tell: stay silent, never guess
+            reason = needs_nudge(pr, st)
+            if not reason:
+                continue
+            key = state_key(pr, st)
+            if key in nudged:
+                continue  # already nudged for exactly this state
+            nudged[key] = now
+            lines.append(
+                f"PR #{pr.get('number')} ({pr.get('url')}, head {head7}): {reason}."
+            )
+        # Keep only entries for PRs that are still open: a merged or
+        # closed PR can never be nudged again, and an open one keeps
+        # its once-per-state memory for as long as it stays open.
+        nudged = {k: v for k, v in nudged.items() if k.split("@", 1)[0] in open_numbers}
+        cache = {k: v for k, v in cache.items() if k.split("@", 1)[0] in open_numbers}
+        _save_state(slug, {"cache": cache, "nudged": nudged})
+    if not lines:
+        return 0
+    msg = (
+        "Codex review nudge (one-time for this PR state; stopping again "
+        "proceeds):\n" + "\n".join(lines) + "\n" + _LOOP_INSTRUCTIONS
+    )
+    print(json.dumps({"decision": "block", "reason": msg}))
+    return 0
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.buffer.read(_MAX_STDIN_BYTES + 1)
+        if not raw or len(raw) > _MAX_STDIN_BYTES:
+            return 0
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            return 0
+        event = payload.get("hook_event_name")
+        if event == "PostToolUse":
+            return handle_post_tool_use(payload)
+        if event == "Stop":
+            return handle_stop(payload)
+        return 0
+    except Exception:
+        return 0  # a hook bug must never block or crash the agent
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/workflow/hooks/pr_review_nudge.py
+++ b/plugins/workflow/hooks/pr_review_nudge.py
@@ -28,7 +28,6 @@ hash-trusts the entry script only.
 
 from __future__ import annotations
 
-import fcntl
 import json
 import os
 import re
@@ -36,6 +35,11 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+
+try:  # POSIX only; without it the state lock is simply skipped
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
 
 _MAX_STDIN_BYTES = 1_000_000
 _GH_TIMEOUT = 6.0  # seconds per gh call
@@ -88,9 +92,10 @@ def pushed_branches(cmd: str, cwd: str) -> list[str]:
     # words: [remote, refspec...]
     branches = []
     for spec in words[1:]:
+        spec = spec.lstrip("+")  # "+branch" is the force marker
         dst = spec.split(":", 1)[1] if ":" in spec else spec
         dst = dst.replace("refs/heads/", "")
-        if dst and dst != "HEAD" and not dst.startswith("+"):
+        if dst and dst != "HEAD":
             branches.append(dst)
     if branches:
         return branches
@@ -346,6 +351,8 @@ class _StateLock:
         self._fh = None
 
     def __enter__(self) -> "_StateLock":
+        if fcntl is None:
+            return self  # no flock on this platform: run unlocked
         try:
             STATE_DIR.mkdir(parents=True, exist_ok=True)
             fh = open(self._path, "a")
@@ -416,6 +423,7 @@ def handle_post_tool_use(payload: dict) -> int:
     if not isinstance(cmd, str):
         return 0
     cwd = payload.get("cwd") or os.getcwd()
+    _DEADLINE[:] = [time.monotonic() + 10.0]  # hooks.json allows 15 s
     if _PR_CREATE_RE.search(cmd):
         _emit_context(
             "PostToolUse", "A pull request was just created. " + _LOOP_INSTRUCTIONS

--- a/plugins/workflow/hooks/pr_review_nudge.py
+++ b/plugins/workflow/hooks/pr_review_nudge.py
@@ -152,6 +152,8 @@ def _concat_json_arrays(text: str) -> list | None:
     """Flatten ``gh api --paginate`` output: pages arrive as JSON arrays
     concatenated back to back (``[...][...]``). Works on every gh version
     (``--slurp`` does not). None if the text is not well-formed."""
+    if not text.strip():
+        return None  # nothing came back: unknown, never "no comments"
     dec = json.JSONDecoder()
     i, n, items = 0, len(text), []
     while i < n:
@@ -192,22 +194,22 @@ def parse_summary(body: str) -> tuple[str | None, str | None]:
     return None, None
 
 
-def open_prs_on_local_branches(root: str, cwd: str) -> list[dict]:
-    """Open PRs by the user whose head branch is checked out locally."""
+def open_prs_on_local_branches(root: str, cwd: str) -> tuple[list[dict], list[dict]]:
+    """(PRs on locally checked-out branches, all open PRs) by the user."""
     branches = _worktree_branches(root)
     prs = _gh_json(
         [
             "pr", "list", "--author", "@me", "--state", "open",
+            # gh pr list does not paginate; 200 open PRs by one author is
+            # beyond any real workflow, so truncation is accepted here.
             "--limit", "200", "--json", "number,headRefName,headRefOid,url",
         ],
         cwd=cwd,
     )
     if not isinstance(prs, list):
-        return []
-    return [
-        p for p in prs
-        if isinstance(p, dict) and p.get("headRefName") in branches
-    ]
+        return [], []
+    prs = [p for p in prs if isinstance(p, dict)]
+    return [p for p in prs if p.get("headRefName") in branches], prs
 
 
 def codex_status(slug: str, number: int, cwd: str) -> dict | None:
@@ -232,21 +234,23 @@ def codex_status(slug: str, number: int, cwd: str) -> dict | None:
     ]
     status, sha = parse_summary(bodies[-1]) if bodies else (None, None)
     owner, repo = slug.split("/", 1)
-    unresolved = 0
+    unresolved_ids: list[str] = []
     cursor = ""
     for _page in range(10):  # 1000 threads is far beyond any real PR
         after = f', after:"{cursor}"' if cursor else ""
         q = (
             '{repository(owner:"%s",name:"%s"){pullRequest(number:%d){'
             "reviewThreads(first:100%s){pageInfo{hasNextPage endCursor}"
-            "nodes{isResolved}}}}}" % (owner, repo, number, after)
+            "nodes{id isResolved}}}}}" % (owner, repo, number, after)
         )
         threads = _gh_json(["api", "graphql", "-f", f"query={q}"], cwd=cwd)
         if not isinstance(threads, dict):
             return None
         try:
             rt = threads["data"]["repository"]["pullRequest"]["reviewThreads"]
-            unresolved += sum(1 for n in rt["nodes"] if not n.get("isResolved"))
+            unresolved_ids += [
+                str(n.get("id")) for n in rt["nodes"] if not n.get("isResolved")
+            ]
             if not rt["pageInfo"]["hasNextPage"]:
                 break
             cursor = rt["pageInfo"]["endCursor"]
@@ -254,7 +258,12 @@ def codex_status(slug: str, number: int, cwd: str) -> dict | None:
             return None
     else:
         return None  # more pages than we will read: cannot tell
-    return {"status": status, "reviewed_sha": sha, "unresolved": unresolved}
+    return {
+        "status": status,
+        "reviewed_sha": sha,
+        "unresolved": len(unresolved_ids),
+        "unresolved_ids": sorted(unresolved_ids),
+    }
 
 
 def needs_nudge(pr: dict, st: dict) -> str | None:
@@ -293,11 +302,22 @@ class _StateLock:
     def __enter__(self) -> "_StateLock":
         try:
             STATE_DIR.mkdir(parents=True, exist_ok=True)
-            self._fh = open(self._path, "a")
-            fcntl.flock(self._fh, fcntl.LOCK_EX)
+            fh = open(self._path, "a")
         except OSError:
-            self._fh = None  # no lock: worst case one duplicate nudge
-        return self
+            return self  # no lock: worst case one duplicate nudge
+        # Never block on the lock: try briefly, then proceed unlocked.
+        # A stuck holder must not make this hook overrun its deadline.
+        give_up = time.monotonic() + 2.0
+        while True:
+            try:
+                fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                self._fh = fh
+                return self
+            except OSError:
+                if time.monotonic() > give_up:
+                    fh.close()
+                    return self
+                time.sleep(0.05)
 
     def __exit__(self, *exc) -> None:  # noqa: ANN002
         if self._fh is not None:
@@ -316,19 +336,24 @@ def _load_state(slug: str) -> dict:
         return {}
 
 
-def _save_state(slug: str, data: dict) -> None:
+def _save_state(slug: str, data: dict) -> bool:
+    """Persist state; False when it could not be written."""
     try:
         STATE_DIR.mkdir(parents=True, exist_ok=True)
         tmp = _state_path(slug).with_suffix(f".{os.getpid()}.tmp")
         tmp.write_text(json.dumps(data))
         os.replace(tmp, _state_path(slug))
+        return True
     except OSError:
-        pass  # losing the dedupe only risks one extra nudge
+        return False
 
 
 def state_key(pr: dict, st: dict) -> str:
-    head7 = str(pr.get("headRefOid") or "")[:7]
-    return f"{pr.get('number')}@{head7}:{st.get('unresolved', 0)}:{st.get('status')}"
+    head = str(pr.get("headRefOid") or "")  # full SHA: prefixes can collide
+    # Thread IDENTITIES, not a count: one resolved plus one new is a new
+    # state even though the count is unchanged.
+    ids = ",".join(st.get("unresolved_ids") or [])
+    return f"{pr.get('number')}@{head}:{st.get('status')}:{ids}"
 
 
 # -- events --------------------------------------------------------------------
@@ -380,10 +405,12 @@ def handle_stop(payload: dict) -> int:
     slug = _github_slug(root)
     if not slug:
         return 0
-    prs = open_prs_on_local_branches(root, cwd)
+    prs, all_open = open_prs_on_local_branches(root, cwd)
     if not prs:
         return 0
-    open_numbers = {str(p.get("number")) for p in prs}
+    # Prune against EVERY open PR, so removing a worktree does not erase
+    # a PR's once-per-state memory (it would re-nudge on re-checkout).
+    open_numbers = {str(p.get("number")) for p in all_open}
     with _StateLock(slug):
         state = _load_state(slug)
         cache = state.get("cache") if isinstance(state.get("cache"), dict) else {}
@@ -393,8 +420,9 @@ def handle_stop(payload: dict) -> int:
         for pr in prs:
             if time.monotonic() > _DEADLINE[0]:
                 break  # out of time: report what we have, never overrun
-            head7 = str(pr.get("headRefOid") or "")[:7]
-            ckey = f"{pr.get('number')}@{head7}"
+            head = str(pr.get("headRefOid") or "")
+            head7 = head[:7]
+            ckey = f"{pr.get('number')}@{head}"
             entry = cache.get(ckey)
             if isinstance(entry, dict) and now - float(entry.get("t", 0)) < _CACHE_TTL:
                 st = entry.get("st")
@@ -419,8 +447,13 @@ def handle_stop(payload: dict) -> int:
         # its once-per-state memory for as long as it stays open.
         nudged = {k: v for k, v in nudged.items() if k.split("@", 1)[0] in open_numbers}
         cache = {k: v for k, v in cache.items() if k.split("@", 1)[0] in open_numbers}
-        _save_state(slug, {"cache": cache, "nudged": nudged})
+        saved = _save_state(slug, {"cache": cache, "nudged": nudged})
     if not lines:
+        return 0
+    if not saved:
+        # Without the once-per-state memory a nudge would repeat on every
+        # stop, which is the one thing this hook must never do: stay
+        # silent instead.
         return 0
     msg = (
         "Codex review nudge (one-time for this PR state; stopping again "

--- a/tests/test_codex_review_nudge.py
+++ b/tests/test_codex_review_nudge.py
@@ -315,6 +315,34 @@ def test_post_tool_use_nudges_on_pr_create_and_push(repo) -> None:  # noqa: ANN0
                  tool_input={"command": "ls -la"}) is None
 
 
+@pytest.mark.parametrize(
+    "cmd,expect",
+    [
+        ("git push", ["feat/x"]),  # bare: current branch
+        ("git push -u origin feat/x", ["feat/x"]),
+        ("git push origin other-branch", ["other-branch"]),
+        ("git push origin HEAD:refs/heads/dst-branch", ["dst-branch"]),
+        ("git push --force-with-lease origin topic", ["topic"]),
+        ("git push origin main && echo done", ["main"]),
+        ("git push origin feat/x\necho done", ["feat/x"]),  # multiline
+        ("git push origin feat/x -o ci.skip", ["feat/x"]),  # option value
+        ("git push origin feat/x >/tmp/push.log 2>&1", ["feat/x"]),  # redirect
+        ("git push origin branch-a branch-b", ["branch-a", "branch-b"]),
+    ],
+)
+def test_pushed_branches_read_the_refspecs(repo, cmd, expect) -> None:  # noqa: ANN001
+    m = _load_module()
+    assert m.pushed_branches(cmd, str(repo["root"])) == expect
+
+
+def test_push_reminder_is_scoped_to_my_prs(repo) -> None:  # noqa: ANN001
+    _hook("PostToolUse", repo["root"], tool_name="Bash",
+          tool_input={"command": "git push origin feat/x"})
+    calls = (repo["gh"] / "calls.log").read_text()
+    head_call = [c for c in calls.splitlines() if "--head" in c][-1]
+    assert "--author @me" in head_call and "--head feat/x" in head_call
+
+
 def test_garbage_input_is_harmless() -> None:
     for raw in ("", "not json", "[]", json.dumps({"hook_event_name": "Weird"})):
         proc = subprocess.run([sys.executable, str(HOOK)], input=raw,

--- a/tests/test_codex_review_nudge.py
+++ b/tests/test_codex_review_nudge.py
@@ -47,6 +47,7 @@ def test_concat_json_arrays_handles_paginated_pages() -> None:
     assert m._concat_json_arrays('[]') == []
     assert m._concat_json_arrays('{"a":1}') is None
     assert m._concat_json_arrays('[1,') is None
+    assert m._concat_json_arrays('') is None  # empty is unknown, not []
 
 
 def test_parse_summary_reads_status_and_sha() -> None:
@@ -95,6 +96,8 @@ def out(name):
         sys.exit(1)
     sys.stdout.write(open(p).read()); sys.exit(0)
 open(os.path.join(d, "calls.log"), "a").write(" ".join(a) + "\n")
+if os.environ.get("FAKE_GH_STALL"):
+    import time; time.sleep(60)  # a hung gh: the hook must not wait for it
 if a[:2] == ["repo", "view"]:
     sys.stdout.write("acme/widgets\n"); sys.exit(0)
 if a[:2] == ["pr", "list"]:
@@ -153,6 +156,16 @@ def _mark_completed(repo: dict, sha: str) -> None:
     (repo["gh"] / "comments.json").write_text("[]" + json.dumps([{"body": body}]))
 
 
+def _expire_cache(repo: dict) -> None:
+    """Drop the 60 s GitHub-result cache but KEEP the once-per-state memory,
+    so tests exercise the dedupe rather than a wiped slate."""
+    f = repo["state"] / "acme__widgets.json"
+    if f.exists():
+        d = json.loads(f.read_text())
+        d.pop("cache", None)
+        f.write_text(json.dumps(d))
+
+
 def _hook(event: str, cwd: Path, **extra) -> dict | None:  # noqa: ANN003
     payload = {"hook_event_name": event, "cwd": str(cwd),
                "session_id": "s1", **extra}
@@ -187,8 +200,8 @@ def test_stop_nudges_again_for_new_head_or_new_threads(repo) -> None:  # noqa: A
     (repo["gh"] / "threads.json").write_text(json.dumps({"data": {"repository": {
         "pullRequest": {"reviewThreads": {
             "pageInfo": {"hasNextPage": False, "endCursor": None},
-            "nodes": [{"isResolved": False}]}}}}}))
-    (repo["state"] / "acme__widgets.json").unlink()  # drop the 60 s cache
+            "nodes": [{"id": "T1", "isResolved": False}]}}}}}))
+    _expire_cache(repo)
     out = _hook("Stop", repo["root"])
     assert out is not None and "1 unresolved review thread" in out["reason"]
     # ...and only once for that state.
@@ -211,6 +224,33 @@ def test_stop_nudges_again_after_a_push_moves_the_head(repo) -> None:  # noqa: A
     assert "no completed Codex review of the current head" in out["reason"]
     assert "@codex review" in out["reason"]
     assert _hook("Stop", repo["root"]) is None  # once per state
+
+
+def test_swapped_thread_same_count_is_a_new_state(repo) -> None:  # noqa: ANN001
+    """Resolve one thread, get another: count unchanged, finding is new."""
+    def threads(*ids):  # noqa: ANN002, ANN202
+        (repo["gh"] / "threads.json").write_text(json.dumps({"data": {"repository": {
+            "pullRequest": {"reviewThreads": {
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                "nodes": [{"id": i, "isResolved": False} for i in ids]}}}}}))
+        _expire_cache(repo)
+
+    _mark_completed(repo, repo["head"])
+    threads("T1")
+    assert _hook("Stop", repo["root"]) is not None
+    assert _hook("Stop", repo["root"]) is None
+    threads("T2")  # T1 resolved, T2 appeared: still exactly one unresolved
+    out = _hook("Stop", repo["root"])
+    assert out is not None and "1 unresolved review thread" in out["reason"]
+    # And the dedupe memory survived: T1's key is still recorded.
+    state = json.loads((repo["state"] / "acme__widgets.json").read_text())
+    assert any(k.endswith(":T1") for k in state["nudged"])
+    assert any(k.endswith(":T2") for k in state["nudged"])
+
+
+def test_empty_gh_output_is_silence_not_a_nudge(repo) -> None:  # noqa: ANN001
+    (repo["gh"] / "comments.json").write_text("")  # gh "succeeded" with nothing
+    assert _hook("Stop", repo["root"]) is None
 
 
 def test_stop_never_nudges_while_already_continuing(repo) -> None:  # noqa: ANN001
@@ -237,6 +277,25 @@ def test_stop_silent_when_gh_is_broken(repo, tmp_path, monkeypatch) -> None:  # 
     only_git.mkdir()
     (only_git / "git").symlink_to(git)
     monkeypatch.setenv("PATH", str(only_git))  # git yes, gh no
+    assert _hook("Stop", repo["root"]) is None
+
+
+def test_stop_returns_within_budget_when_gh_hangs(repo, monkeypatch) -> None:  # noqa: ANN001
+    """A hung gh must not make the hook hang: every call is bounded and
+    the whole check finishes inside the host's hook timeout."""
+    import time
+
+    monkeypatch.setenv("FAKE_GH_STALL", "1")
+    t0 = time.monotonic()
+    assert _hook("Stop", repo["root"]) is None
+    assert time.monotonic() - t0 < 19  # hooks.json gives Stop 20 s
+
+
+def test_unwritable_state_means_silence_not_a_repeating_nudge(
+    repo, monkeypatch,  # noqa: ANN001
+) -> None:
+    monkeypatch.setenv("CODEX_REVIEW_NUDGE_STATE", "/dev/null/nope")
+    assert _hook("Stop", repo["root"]) is None
     assert _hook("Stop", repo["root"]) is None
 
 

--- a/tests/test_codex_review_nudge.py
+++ b/tests/test_codex_review_nudge.py
@@ -1,0 +1,263 @@
+"""codex-review-nudge hook: a nudge, never a gate, and never slow.
+
+Drives the real script as a subprocess with a JSON payload, inside a
+temporary git repo whose ``origin`` points at GitHub, with a fake ``gh``
+on PATH that answers from canned files — so every GitHub-dependent path
+runs for real without the network. Pure helpers are imported directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOK = (
+    Path(__file__).resolve().parents[1]
+    / "plugins" / "workflow" / "hooks" / "pr_review_nudge.py"
+)
+
+SUMMARY = (
+    "<!-- codex-pull-request-review-summary -->\n\n## Codex Review Summary\n\n"
+    "| Review | Status | Commit | Review trigger |\n| --- | --- | --- | --- |\n"
+    "| 📝 **Code Review** | {status} | `{sha}` | PR opened |\n"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("pr_review_nudge", HOOK)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# -- pure helpers -------------------------------------------------------------
+
+
+def test_concat_json_arrays_handles_paginated_pages() -> None:
+    m = _load_module()
+    assert m._concat_json_arrays('[1,2]\n[3]') == [1, 2, 3]
+    assert m._concat_json_arrays('[]') == []
+    assert m._concat_json_arrays('{"a":1}') is None
+    assert m._concat_json_arrays('[1,') is None
+
+
+def test_parse_summary_reads_status_and_sha() -> None:
+    m = _load_module()
+    body = SUMMARY.format(status="✅ **Completed** 2026-09-03", sha="1e8dd8f")
+    assert m.parse_summary(body) == ("completed", "1e8dd8f")
+    body = SUMMARY.format(status="🔄 **Running** since", sha="ad2dcbd")
+    assert m.parse_summary(body) == ("running", "ad2dcbd")
+    assert m.parse_summary("no table here") == (None, None)
+
+
+@pytest.mark.parametrize(
+    "st,head,expect_words",
+    [
+        ({"status": "completed", "reviewed_sha": "1e8dd8f", "unresolved": 0},
+         "1e8dd8f0000", None),
+        ({"status": "completed", "reviewed_sha": "0000000", "unresolved": 0},
+         "1e8dd8f0000", "no completed Codex review of the current head"),
+        ({"status": "running", "reviewed_sha": "1e8dd8f", "unresolved": 0},
+         "1e8dd8f0000", "still reviewing"),
+        ({"status": "completed", "reviewed_sha": "1e8dd8f", "unresolved": 2},
+         "1e8dd8f0000", "2 unresolved review thread"),
+        ({"status": None, "reviewed_sha": None, "unresolved": 0},
+         "1e8dd8f0000", "may still be starting"),
+    ],
+)
+def test_needs_nudge_rules(st, head, expect_words) -> None:  # noqa: ANN001
+    m = _load_module()
+    reason = m.needs_nudge({"headRefOid": head}, st)
+    if expect_words is None:
+        assert reason is None
+    else:
+        assert reason is not None and expect_words in reason
+
+
+# -- end-to-end with a fake gh ------------------------------------------------
+
+
+FAKE_GH = r'''#!/usr/bin/env python3
+import json, os, sys
+d = os.environ["FAKE_GH_DIR"]
+a = sys.argv[1:]
+def out(name):
+    p = os.path.join(d, name)
+    if not os.path.exists(p):
+        sys.exit(1)
+    sys.stdout.write(open(p).read()); sys.exit(0)
+open(os.path.join(d, "calls.log"), "a").write(" ".join(a) + "\n")
+if a[:2] == ["repo", "view"]:
+    sys.stdout.write("acme/widgets\n"); sys.exit(0)
+if a[:2] == ["pr", "list"]:
+    out("pr_list_head.json" if "--head" in a else "pr_list.json")
+if a[:1] == ["api"] and "graphql" in a:
+    out("threads.json")
+if a[:1] == ["api"] and "/comments" in " ".join(a):
+    out("comments.json")
+sys.exit(1)
+'''
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):  # noqa: ANN001, ANN201
+    """Temp git repo on a feature branch with a GitHub origin + fake gh."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                    "commit", "-q", "--allow-empty", "-m", "init"],
+                   cwd=root, check=True)
+    subprocess.run(["git", "remote", "add", "origin",
+                    "git@github.com:acme/widgets.git"], cwd=root, check=True)
+    subprocess.run(["git", "checkout", "-q", "-b", "feat/x"], cwd=root, check=True)
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=root,
+                          capture_output=True, text=True, check=True).stdout.strip()
+    ghdir = tmp_path / "gh"
+    ghdir.mkdir()
+    gh = tmp_path / "bin" / "gh"
+    gh.parent.mkdir()
+    gh.write_text(FAKE_GH)
+    gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+    (ghdir / "pr_list.json").write_text(json.dumps([
+        {"number": 7, "headRefName": "feat/x", "headRefOid": head,
+         "url": "https://github.com/acme/widgets/pull/7"},
+        {"number": 8, "headRefName": "not/checked-out", "headRefOid": "f" * 40,
+         "url": "https://github.com/acme/widgets/pull/8"},
+    ]))
+    (ghdir / "pr_list_head.json").write_text(json.dumps([{"number": 7, "url": "u"}]))
+    (ghdir / "threads.json").write_text(json.dumps({"data": {"repository": {
+        "pullRequest": {"reviewThreads": {
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+            "nodes": []}}}}}))
+    (ghdir / "comments.json").write_text("[]")  # one empty page
+    state = tmp_path / "state"
+    monkeypatch.setenv("FAKE_GH_DIR", str(ghdir))
+    monkeypatch.setenv("CODEX_REVIEW_NUDGE_STATE", str(state))
+    monkeypatch.setenv("PATH", f"{gh.parent}{os.pathsep}{os.environ['PATH']}")
+    return {"root": root, "gh": ghdir, "head": head, "state": state}
+
+
+def _mark_completed(repo: dict, sha: str) -> None:
+    """Fake gh: Codex's summary says Completed for ``sha`` (two pages, as
+    ``gh api --paginate`` concatenates them)."""
+    body = SUMMARY.format(status="✅ **Completed** now", sha=sha[:7])
+    (repo["gh"] / "comments.json").write_text("[]" + json.dumps([{"body": body}]))
+
+
+def _hook(event: str, cwd: Path, **extra) -> dict | None:  # noqa: ANN003
+    payload = {"hook_event_name": event, "cwd": str(cwd),
+               "session_id": "s1", **extra}
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)], input=json.dumps(payload),
+        capture_output=True, text=True, timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr  # never fails the agent
+    return json.loads(proc.stdout) if proc.stdout.strip() else None
+
+
+def test_stop_nudges_once_for_unreviewed_pr_on_local_branch(repo) -> None:  # noqa: ANN001
+    out = _hook("Stop", repo["root"])
+    assert out is not None and out["decision"] == "block"
+    assert "PR #7" in out["reason"]
+    assert "PR #8" not in out["reason"]  # branch not checked out here
+    assert "@codex review" in out["reason"]
+    assert "one-time" in out["reason"]
+    # Same state again: silent. That is what makes it a nudge, not a gate.
+    assert _hook("Stop", repo["root"]) is None
+
+
+def test_stop_silent_when_codex_completed_on_head_and_no_threads(repo) -> None:  # noqa: ANN001
+    _mark_completed(repo, repo["head"])
+    assert _hook("Stop", repo["root"]) is None
+
+
+def test_stop_nudges_again_for_new_head_or_new_threads(repo) -> None:  # noqa: ANN001
+    _mark_completed(repo, repo["head"])
+    assert _hook("Stop", repo["root"]) is None
+    # A finding appears: one unresolved thread -> a fresh nudge...
+    (repo["gh"] / "threads.json").write_text(json.dumps({"data": {"repository": {
+        "pullRequest": {"reviewThreads": {
+            "pageInfo": {"hasNextPage": False, "endCursor": None},
+            "nodes": [{"isResolved": False}]}}}}}))
+    (repo["state"] / "acme__widgets.json").unlink()  # drop the 60 s cache
+    out = _hook("Stop", repo["root"])
+    assert out is not None and "1 unresolved review thread" in out["reason"]
+    # ...and only once for that state.
+    assert _hook("Stop", repo["root"]) is None
+
+
+def test_stop_nudges_again_after_a_push_moves_the_head(repo) -> None:  # noqa: ANN001
+    """Codex reviews are per head: a new commit is a new state."""
+    _mark_completed(repo, repo["head"])
+    assert _hook("Stop", repo["root"]) is None
+    subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+                    "-q", "--allow-empty", "-m", "more"], cwd=repo["root"], check=True)
+    new_head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo["root"],
+                              capture_output=True, text=True).stdout.strip()
+    prs = json.loads((repo["gh"] / "pr_list.json").read_text())
+    prs[0]["headRefOid"] = new_head  # GitHub now reports the pushed head
+    (repo["gh"] / "pr_list.json").write_text(json.dumps(prs))
+    out = _hook("Stop", repo["root"])
+    assert out is not None
+    assert "no completed Codex review of the current head" in out["reason"]
+    assert "@codex review" in out["reason"]
+    assert _hook("Stop", repo["root"]) is None  # once per state
+
+
+def test_stop_never_nudges_while_already_continuing(repo) -> None:  # noqa: ANN001
+    assert _hook("Stop", repo["root"], stop_hook_active=True) is None
+
+
+def test_stop_silent_outside_a_github_repo(tmp_path, repo) -> None:  # noqa: ANN001
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert _hook("Stop", plain) is None
+    subprocess.run(["git", "remote", "set-url", "origin",
+                    "https://gitlab.com/acme/widgets.git"],
+                   cwd=repo["root"], check=True)
+    assert _hook("Stop", repo["root"]) is None
+
+
+def test_stop_silent_when_gh_is_broken(repo, tmp_path, monkeypatch) -> None:  # noqa: ANN001
+    """gh missing/offline must mean silence, not a nudge and not a hang."""
+    import shutil
+
+    git = shutil.which("git")
+    assert git
+    only_git = tmp_path / "only-git"
+    only_git.mkdir()
+    (only_git / "git").symlink_to(git)
+    monkeypatch.setenv("PATH", str(only_git))  # git yes, gh no
+    assert _hook("Stop", repo["root"]) is None
+
+
+def test_post_tool_use_nudges_on_pr_create_and_push(repo) -> None:  # noqa: ANN001
+    out = _hook("PostToolUse", repo["root"], tool_name="Bash",
+                tool_input={"command": "gh pr create --title x --body y"})
+    assert out is not None
+    ctx = out["hookSpecificOutput"]["additionalContext"]
+    assert "pull request was just created" in ctx
+    out = _hook("PostToolUse", repo["root"], tool_name="Bash",
+                tool_input={"command": "git push -u origin feat/x"})
+    assert out is not None
+    ctx = out["hookSpecificOutput"]["additionalContext"]
+    assert "PR #7" in ctx and "@codex review" in ctx
+    # Unrelated commands: nothing.
+    assert _hook("PostToolUse", repo["root"], tool_name="Bash",
+                 tool_input={"command": "ls -la"}) is None
+
+
+def test_garbage_input_is_harmless() -> None:
+    for raw in ("", "not json", "[]", json.dumps({"hook_event_name": "Weird"})):
+        proc = subprocess.run([sys.executable, str(HOOK)], input=raw,
+                              capture_output=True, text=True, timeout=30)
+        assert proc.returncode == 0 and proc.stdout.strip() == ""

--- a/tests/test_codex_review_nudge.py
+++ b/tests/test_codex_review_nudge.py
@@ -291,6 +291,18 @@ def test_stop_returns_within_budget_when_gh_hangs(repo, monkeypatch) -> None:  #
     assert time.monotonic() - t0 < 19  # hooks.json gives Stop 20 s
 
 
+def test_push_lookups_finish_inside_the_post_tool_use_timeout(
+    repo, monkeypatch,  # noqa: ANN001
+) -> None:
+    import time
+
+    monkeypatch.setenv("FAKE_GH_STALL", "1")
+    t0 = time.monotonic()
+    assert _hook("PostToolUse", repo["root"], tool_name="Bash",
+                 tool_input={"command": "git push origin a b c"}) is None
+    assert time.monotonic() - t0 < 14  # hooks.json gives PostToolUse 15 s
+
+
 def test_unwritable_state_means_silence_not_a_repeating_nudge(
     repo, monkeypatch,  # noqa: ANN001
 ) -> None:
@@ -328,6 +340,7 @@ def test_post_tool_use_nudges_on_pr_create_and_push(repo) -> None:  # noqa: ANN0
         ("git push origin feat/x -o ci.skip", ["feat/x"]),  # option value
         ("git push origin feat/x >/tmp/push.log 2>&1", ["feat/x"]),  # redirect
         ("git push origin branch-a branch-b", ["branch-a", "branch-b"]),
+        ("git push origin +other-branch", ["other-branch"]),  # force marker
     ],
 )
 def test_pushed_branches_read_the_refspecs(repo, cmd, expect) -> None:  # noqa: ANN001


### PR DESCRIPTION
## What

A hook (Claude Code and Codex CLI, same script) that **nudges — never blocks** — the agent into running the GitHub Codex review loop on its own open PRs.

- **PostToolUse (Bash)**: after `gh pr create`, or a `git push` to a branch with an open PR, injects a one-line reminder: monitor Codex, address/defer findings, and comment `@codex review` after every push.
- **Stop**: asks GitHub for open PRs by you whose head branch is checked out in a local worktree. For each one whose current head lacks a completed Codex review, or has unresolved threads, it interrupts the stop **once per exact state** with the details; the next stop passes silently. The agent decides: fix, defer to an issue, or dismiss with a reply.

It checks GitHub instead of pattern-matching commands, so a PR created via `gh api`, by a subagent, or by hand is still covered.

## Why

The review loop got skipped on #199 despite the CLAUDE.md instruction. A reminder at the right moment is mechanical; memory is not.

## Safety / speed

Deadline-bounded `gh` calls, 60 s result cache, silent on anything it cannot determine (no repo, no GitHub remote, gh missing/offline). Lock + unique temp files for the state file. Single stdlib file so Codex can hash-trust it. Works on gh 2.46 (parses `--paginate` pages manually; `--slurp` doesn't exist there — caught by a real run).

## Tests

16 tests drive the real script as a subprocess in a temp git repo with a fake `gh` on PATH: once-per-state nudge, silence when reviewed, re-nudge on new head and on new threads, `stop_hook_active` guard, non-GitHub repo, broken gh, PostToolUse on create/push, garbage input. Local codex review: 6 findings fixed (fork-safe repo slug, pagination, deadline, prune-by-open-PR, concurrency, new-head test).

## Verified for real

Run against this very PR with the real `gh`: first Stop → nudge naming #202 (and #102, an old open PR still checked out in a worktree); second Stop → silent; PostToolUse after `git push` → the "@codex review" reminder. 5.8 s cold for two PRs, cached after.

## Deferred (decided, not forgotten)

- **Repo slug requires a GitHub `origin`.** A checkout with only `upstream`, or a non-GitHub `origin` plus `gh repo set-default`, gets no nudge. The origin check is a fast pre-filter that keeps the hook from calling `gh` in non-GitHub repos; relaxing it is a follow-up.
- **Lock contention.** If another Stop hook holds the state lock for >2 s, this one proceeds unlocked and two *simultaneous* stops in the same repo could each nudge once. Consequence is one duplicate nudge; staying silent on lock failure instead is a follow-up.
- **`gh pr list --limit 200`** does not paginate; 200 open PRs by one author is not a real workflow. Documented in the code.
- **Fork checkouts** (PR targets upstream, `origin` is the fork): `gh repo set-default` is the documented way to point gh at the base repo; automatic base-repo resolution is a follow-up.
- **Exotic push forms** in the advisory reminder: `git -C other push`, `git push --all/--mirror`, `--recurse-submodules <mode>`, spaced `> file` redirections. The Stop nudge never parses commands, so none of these affect it.