### PR TITLE
Show last input age and dormant sessions in amux

### DIFF
--- a/claude_code_tools/amux/activity.py
+++ b/claude_code_tools/amux/activity.py
@@ -1,0 +1,258 @@
+"""Read bounded, session-scoped evidence of submitted agent input.
+
+History timestamps are not pane activity: another pane can resume the same
+conversation. Missing or ambiguous evidence stays unknown. No transcript mtimes,
+launch arguments, or terminal output are used as input timestamps.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import sqlite3
+import subprocess
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from .model import Agent
+
+_HISTORY_LIMIT = 16 * 1024 * 1024
+_UUID = r"[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}"
+_ROLLOUT = re.compile(rf"rollout-.*-({_UUID})\.jsonl$")
+
+
+def _homes(kind: str) -> list[Path]:
+    """Discover immediate profile directories and the explicit current home."""
+    root = Path.home()
+    paths = [root / f".{kind}"]
+    try:
+        paths.extend(p for p in root.iterdir() if p.name.startswith(f".{kind}"))
+    except OSError:
+        pass
+    variable = "CLAUDE_CONFIG_DIR" if kind == "claude" else "CODEX_HOME"
+    configured = os.environ.get(variable)
+    if configured:
+        paths.append(Path(configured).expanduser())
+    result: list[Path] = []
+    for path in paths:
+        try:
+            resolved = path.resolve()
+            if path.is_dir() and resolved not in result:
+                result.append(resolved)
+        except OSError:
+            continue
+    return result
+
+
+def _history(home: Path, kind: str) -> tuple[dict[str, float], str]:
+    """Read a bounded history tail, returning timestamps and read status."""
+    try:
+        with (home / "history.jsonl").open("rb") as stream:
+            size = stream.seek(0, 2)
+            start = max(0, size - _HISTORY_LIMIT)
+            stream.seek(start)
+            data = stream.read(_HISTORY_LIMIT)
+        if start:
+            data = data.partition(b"\n")[2]
+    except OSError:
+        return {}, "unavailable"
+    times: dict[str, float] = {}
+    for line in data.splitlines():
+        try:
+            record = json.loads(line)
+        except (ValueError, UnicodeDecodeError):
+            continue
+        if not isinstance(record, dict):
+            continue
+        submitted = record.get("display" if kind == "claude" else "text", "")
+        if isinstance(submitted, str) and submitted.lstrip().startswith(
+            ("<hook_prompt", "<task-notification", "<subagent", "<system-reminder")
+        ):
+            continue
+        sid = record.get("sessionId" if kind == "claude" else "session_id")
+        timestamp = record.get("timestamp" if kind == "claude" else "ts")
+        if not isinstance(sid, str) or not sid:
+            continue
+        if isinstance(timestamp, bool) or not isinstance(timestamp, (int, float)):
+            continue
+        try:
+            value = float(timestamp) / (1000 if kind == "claude" else 1)
+        except OverflowError:
+            continue
+        if math.isfinite(value) and 0 < value <= time.time():
+            times[sid] = max(times.get(sid, 0), value)
+    return times, "tail" if start else "complete"
+
+
+def _run(args: list[str]) -> str | None:
+    """Run a bounded read-only subprocess; failure is distinct from no records."""
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, timeout=5,
+            env={**os.environ, "TZ": "UTC"},
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout if result.returncode == 0 else None
+
+
+def _starts(pids: set[int]) -> dict[int, str]:
+    """Get process start identities to reject stale PID metadata."""
+    if not pids:
+        return {}
+    output = _run(["ps", "-p", ",".join(map(str, sorted(pids))), "-o", "pid=,lstart="])
+    result: dict[int, str] = {}
+    for line in (output or "").splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            result[int(parts[0])] = " ".join(parts[1].split())
+    return result
+
+
+def _claude_record(home: Path, pid: int, start: str) -> dict[str, Any] | None:
+    """Accept only runtime metadata matching a currently observed process."""
+    try:
+        with (home / "sessions" / f"{pid}.json").open("rb") as stream:
+            record = json.loads(stream.read(64 * 1024))
+    except (OSError, ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(record, dict):
+        return None
+    recorded_start = record.get("procStart")
+    sid = record.get("sessionId")
+    if (
+        record.get("pid") != pid
+        or not isinstance(recorded_start, str)
+        or " ".join(recorded_start.split()) != start
+        or not start
+        or not isinstance(sid, str)
+        or not sid
+    ):
+        return None
+    return record
+
+
+def _codex_pids(agent: Agent, tree: dict[int, list[tuple[int, str]]]) -> set[int]:
+    """Include native Codex children of the selected launcher, bounded in size."""
+    pids = {agent.pid} if agent.pid > 0 else set()
+    queue = list(pids)
+    while queue and len(pids) < 32:
+        for pid, command in tree.get(queue.pop(0), []):
+            # Follow only the launcher/native chain, never arbitrary tool workers.
+            executable = command.split()[0] if command.split() else ""
+            if pid not in pids and Path(executable).name == "codex":
+                pids.add(pid)
+                queue.append(pid)
+    return pids
+
+
+def _rollouts(pids: set[int]) -> tuple[dict[int, set[Path]], bool]:
+    """Identify open rollout descriptors in one lsof query, without reading them."""
+    if not pids:
+        return {}, True
+    output = _run(["lsof", "-nP", "-a", "-p", ",".join(map(str, sorted(pids))), "-Fn"])
+    if output is None:
+        return {}, False
+    found: dict[int, set[Path]] = {}
+    pid = 0
+    for line in output.splitlines():
+        if line.startswith("p") and line[1:].isdigit():
+            pid = int(line[1:])
+        elif pid in pids and line.startswith("n"):
+            path = Path(line[1:])
+            if _ROLLOUT.fullmatch(path.name):
+                found.setdefault(pid, set()).add(path)
+    return found, True
+
+
+def _goal_status(home: Path, sid: str) -> str:
+    """Read only the matched thread's goal status, never its objective."""
+    try:
+        uri = (home / "goals_1.sqlite").as_uri() + "?mode=ro"
+        connection = sqlite3.connect(uri, uri=True, timeout=0.1)
+        try:
+            row = connection.execute(
+                "SELECT status FROM thread_goals WHERE thread_id = ?", (sid,)
+            ).fetchone()
+        finally:
+            connection.close()
+    except (sqlite3.Error, ValueError):
+        return "unknown"
+    return str(row[0]) if row else "none"
+
+
+def enrich(agents: list[Agent], child_map: dict[int, list[tuple[int, str]]]) -> None:
+    """Add last submitted-input evidence without modifying running sessions.
+
+    Args:
+        agents: Live pane records to enrich in place.
+        child_map: Process snapshot containing launcher/native parentage.
+    """
+    homes = {kind: _homes(kind) for kind in {a.kind for a in agents}}
+    histories: dict[tuple[Path, str], tuple[dict[str, float], str]] = {}
+    starts = _starts({a.pid for a in agents if a.kind == "claude" and a.pid > 0})
+    pid_sets = {
+        a.pane: _codex_pids(a, child_map) for a in agents if a.kind == "codex"
+    }
+    paths, lsof_ok = _rollouts(set().union(*pid_sets.values()) if pid_sets else set())
+    identities: list[tuple[Agent, Path, str]] = []
+    for agent in agents:
+        agent.session_id = ""
+        agent.last_input_at = None
+        agent.input_source = "unknown"
+        agent.input_scope = "unknown"
+        matches: list[tuple[Path, str]] = []
+        runtime_records: list[dict[str, Any]] = []
+        if agent.kind == "claude":
+            for home in homes["claude"]:
+                record = _claude_record(home, agent.pid, starts.get(agent.pid, ""))
+                if record:
+                    matches.append((home, record["sessionId"]))
+                    runtime_records.append(record)
+            method = "claude-pid"
+        else:
+            open_paths = set().union(*(paths.get(p, set()) for p in pid_sets[agent.pane]))
+            for path in open_paths:
+                match = _ROLLOUT.fullmatch(path.name)
+                for home in homes["codex"]:
+                    if match and path.is_relative_to(home / "sessions"):
+                        matches.append((home, match.group(1)))
+            method = "codex-open-rollout"
+            agent.extra["activity_probe_ok"] = lsof_ok
+        matches = list(dict.fromkeys(matches))
+        if len(matches) != 1:
+            agent.extra["input_evidence"] = "ambiguous" if matches else "unavailable"
+            continue
+        home, sid = matches[0]
+        agent.session_id = sid
+        if agent.kind == "claude":
+            record = runtime_records[0]
+            status = record.get("status", "unknown")
+            agent.extra["runtime_status"] = status
+            if isinstance(record.get("name"), str) and record["name"]:
+                agent.name = record["name"]
+            if status in ("shell", "working", "running") and agent.state == "idle":
+                agent.state = "bg"
+        else:
+            goal = _goal_status(home, sid)
+            agent.extra["goal_status"] = goal
+            if goal == "active" and agent.state == "idle":
+                agent.state = "bg"
+        agent.input_scope = "session"
+        key = (home, agent.kind)
+        if key not in histories:
+            histories[key] = _history(home, agent.kind)
+        timestamps, status = histories[key]
+        agent.last_input_at = timestamps.get(sid)
+        agent.input_source = f"{method}/history-{status}"
+        agent.extra["activity_home"] = str(home)
+        agent.extra["input_evidence"] = "found" if sid in timestamps else "unavailable"
+        identities.append((agent, home, sid))
+    counts = Counter((home, sid) for _, home, sid in identities)
+    for agent, home, sid in identities:
+        if counts[home, sid] > 1:
+            agent.input_scope = "shared-session"

--- a/claude_code_tools/amux/activity.py
+++ b/claude_code_tools/amux/activity.py
@@ -215,7 +215,9 @@ def enrich(agents: list[Agent], child_map: dict[int, list[tuple[int, str]]]) -> 
                     runtime_records.append(record)
             method = "claude-pid"
         else:
-            open_paths = set().union(*(paths.get(p, set()) for p in pid_sets[agent.pane]))
+            open_paths = set().union(
+                *(paths.get(p, set()) for p in pid_sets[agent.pane])
+            )
             for path in open_paths:
                 match = _ROLLOUT.fullmatch(path.name)
                 for home in homes["codex"]:

--- a/claude_code_tools/amux/cli.py
+++ b/claude_code_tools/amux/cli.py
@@ -209,6 +209,11 @@ def build_parser() -> argparse.ArgumentParser:
     rows.add_argument("--refresh", action="store_true")
     rows.set_defaults(func=cmd_rows)
 
+    for command in (pick, lst, rows, scan_cmd):
+        command.add_argument(
+            "--max-age", type=_finite_seconds, default=argparse.SUPPRESS,
+            help="seconds a cached scan stays usable (default: 30)",
+        )
     for command in (pick, lst, rows):
         command.add_argument(
             "--dormant", action="store_true",
@@ -234,10 +239,7 @@ def main(argv: list[str] | None = None) -> int:
     # silently used the 30s default.
     known = {"pick", "list", "scan", "rows"}
     if not any(tok in known for tok in raw):
-        index = 2 if raw[:1] == ["--max-age"] else 0
-        if raw and raw[0].startswith("--max-age="):
-            index = 1
-        raw.insert(index, "pick")
+        raw.insert(0, "pick")
     args = parser.parse_args(raw)
     if not scan.tmux_available():
         print("amux: no tmux server running", file=sys.stderr)

--- a/claude_code_tools/amux/cli.py
+++ b/claude_code_tools/amux/cli.py
@@ -238,7 +238,7 @@ def main(argv: list[str] | None = None) -> int:
     # only ["pick"] -- reparsing dropped global options, so `amux --max-age 0`
     # silently used the 30s default.
     known = {"pick", "list", "scan", "rows"}
-    if not any(tok in known for tok in raw):
+    if not any(tok in known | {"-h", "--help"} for tok in raw):
         raw.insert(0, "pick")
     args = parser.parse_args(raw)
     if not scan.tmux_available():

--- a/claude_code_tools/amux/cli.py
+++ b/claude_code_tools/amux/cli.py
@@ -98,6 +98,9 @@ def cmd_pick(args: argparse.Namespace) -> int:
 
     agents, from_cache = _agents_for_display(args.max_age)
     agents = _display(agents, args)
+    if not agents and from_cache:
+        agents = _display(_fresh(), args)
+        from_cache = False
     if not agents:
         print("no matching agents")
         return 0
@@ -113,7 +116,10 @@ def cmd_pick(args: argparse.Namespace) -> int:
         f"ctrl-r:reload({self_cmd} rows --refresh{view_flags})",
         # Opening on cached rows is what makes this instant; refresh the
         # moment the list is up so stale states self-correct without a keypress.
-        f"load:reload-sync({self_cmd} rows --refresh{view_flags})" if from_cache else "",
+        (
+            f"load:reload-sync({self_cmd} rows --refresh{view_flags})"
+            if from_cache else ""
+        ),
     ]
     cmd = [
         "fzf",

--- a/claude_code_tools/amux/cli.py
+++ b/claude_code_tools/amux/cli.py
@@ -24,7 +24,7 @@ from .model import Agent
 
 _FZF_HEADER = (
     "enter=jump  ctrl-r=refresh  esc=quit    "
-    "input=asking you  busy=working  bg=monitors  idle"
+    "input=asking you  busy=working  bg=background  age=last submitted input"
 )
 
 
@@ -44,11 +44,27 @@ def _agents_for_display(max_age: float) -> tuple[list[Agent], bool]:
     return _fresh(), False
 
 
+def _display(agents: list[Agent], args: argparse.Namespace) -> list[Agent]:
+    """Refresh ages even for cached rows, then apply the requested view."""
+    for agent in agents:
+        agent.classify_inactivity(args.dormant_hours)
+    if args.dormant:
+        agents = [a for a in agents if a.inactivity == "dormant"]
+    if args.sort == "oldest":
+        agents = sorted(agents, key=lambda a: (
+            a.last_input_at is None,
+            a.last_input_at if a.last_input_at is not None else 0,
+            a.pane,
+        ))
+    return agents
+
+
 def cmd_list(args: argparse.Namespace) -> int:
     """Print every live agent as a table or JSON."""
     agents = cache.read(max_age=args.max_age)[0] if args.cached else _fresh()
     if not agents and args.cached:
         agents = _fresh()
+    agents = _display(agents, args)
     if args.json:
         print(render.as_json(agents))
     else:
@@ -67,7 +83,7 @@ def cmd_scan(args: argparse.Namespace) -> int:
 def cmd_rows(args: argparse.Namespace) -> int:
     """Emit picker rows (internal: used by fzf's reload binding)."""
     agents = _fresh() if args.refresh else _agents_for_display(args.max_age)[0]
-    print(render.picker_lines(agents, colour=True))
+    print(render.picker_lines(_display(agents, args), colour=True))
     return 0
 
 
@@ -81,18 +97,23 @@ def cmd_pick(args: argparse.Namespace) -> int:
         return 1
 
     agents, from_cache = _agents_for_display(args.max_age)
+    agents = _display(agents, args)
     if not agents:
-        print("no agents running")
+        print("no matching agents")
         return 0
 
     # fzf runs bind commands through a shell, so the interpreter path must be
     # quoted: a venv at "/tmp/my venv/bin/python" would otherwise run "/tmp/my".
     self_cmd = f"{shlex.quote(sys.executable)} -m claude_code_tools.amux"
+    view_flags = (
+        f" --dormant-hours {args.dormant_hours} --sort {args.sort}"
+        + (" --dormant" if args.dormant else "")
+    )
     binds = [
-        f"ctrl-r:reload({self_cmd} rows --refresh)",
+        f"ctrl-r:reload({self_cmd} rows --refresh{view_flags})",
         # Opening on cached rows is what makes this instant; refresh the
         # moment the list is up so stale states self-correct without a keypress.
-        f"load:reload-sync({self_cmd} rows --refresh)" if from_cache else "",
+        f"load:reload-sync({self_cmd} rows --refresh{view_flags})" if from_cache else "",
     ]
     cmd = [
         "fzf",
@@ -182,6 +203,19 @@ def build_parser() -> argparse.ArgumentParser:
     rows.add_argument("--refresh", action="store_true")
     rows.set_defaults(func=cmd_rows)
 
+    for command in (pick, lst, rows):
+        command.add_argument(
+            "--dormant", action="store_true",
+            help="show waiting agents with old known submitted input only",
+        )
+        command.add_argument(
+            "--dormant-hours", type=_finite_seconds, default=72.0,
+            help="input age in hours above which waiting agents are dormant (72)",
+        )
+        command.add_argument(
+            "--sort", choices=("state", "oldest"), default="state",
+            help="sort by current state or oldest known submitted input",
+        )
     return parser
 
 
@@ -194,7 +228,10 @@ def main(argv: list[str] | None = None) -> int:
     # silently used the 30s default.
     known = {"pick", "list", "scan", "rows"}
     if not any(tok in known for tok in raw):
-        raw.append("pick")
+        index = 2 if raw[:1] == ["--max-age"] else 0
+        if raw and raw[0].startswith("--max-age="):
+            index = 1
+        raw.insert(index, "pick")
     args = parser.parse_args(raw)
     if not scan.tmux_available():
         print("amux: no tmux server running", file=sys.stderr)

--- a/claude_code_tools/amux/detect.py
+++ b/claude_code_tools/amux/detect.py
@@ -93,7 +93,9 @@ _BUSY = re.compile(
 #: those can be used). Without this a pane with a working subagent but a free
 #: main prompt reported as idle.
 _BG = re.compile(
-    r"\b\d+\s+monitors?\b|^\s*◯\s+\S",
+    r"\b[1-9]\d*\s+monitors?\b|"
+    r"\b[1-9]\d*\s+shells? still running\b|"
+    r"^\s*⏵⏵.*·\s*[1-9]\d*\s+shells?\b|^\s*◯\s+\S",
     re.MULTILINE,
 )
 
@@ -136,7 +138,11 @@ def detect_state(screen: str, kind: Kind) -> State:
         return "busy"
     if kind == "codex" and _codex_awaiting_answer(tail):
         return "input"
-    if _BG.search(screen):
+    background_lines = "\n".join(
+        line.rstrip() for line in screen.splitlines()
+        if not re.search(r"^\s*◯.*\bidle\s*$", line)
+    )
+    if _BG.search(background_lines):
         return "bg"
     return "idle"
 

--- a/claude_code_tools/amux/model.py
+++ b/claude_code_tools/amux/model.py
@@ -126,6 +126,8 @@ class Agent:
                 or not math.isfinite(value) or value < 0
             ):
                 return None
+        if not isinstance(known.get("extra", {}), dict):
+            return None
         # Literal[...] is a type-checker hint only; a hand-edited cache can
         # still carry kind="vim" or state="waiting" and render as an agent.
         if known.get("kind") not in ("claude", "codex"):

--- a/claude_code_tools/amux/model.py
+++ b/claude_code_tools/amux/model.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+import time
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
@@ -37,6 +39,12 @@ class Agent:
         model: Model string parsed from the harness footer, e.g. ``opus-5``.
         info: One-line context lifted from the pane's footer.
         pid: PID of the agent process itself (not the pane's shell).
+        session_id: Current conversation ID, only when reliably matched.
+        last_input_at: Last recorded submitted user input, Unix seconds.
+        input_source: Identity method and history read status, or unknown.
+        input_scope: Session-level evidence; shared-session for duplicate panes.
+        inactivity: Working, recent, dormant, or unknown input-age classification.
+        input_age_seconds: Age calculated at display time, including cached rows.
     """
 
     pane: str
@@ -50,7 +58,36 @@ class Agent:
     model: str = ""
     info: str = ""
     pid: int = 0
+    session_id: str = ""
+    last_input_at: float | None = None
+    input_source: str = "unknown"
+    input_scope: str = "unknown"
+    inactivity: str = "unknown"
+    input_age_seconds: float | None = None
     extra: dict[str, Any] = field(default_factory=dict)
+
+    def classify_inactivity(
+        self, threshold_hours: float = 72, now: float | None = None
+    ) -> None:
+        """Classify old submitted input independently of current activity."""
+        now = time.time() if now is None else now
+        self.input_age_seconds = (
+            max(0, now - self.last_input_at)
+            if self.last_input_at is not None else None
+        )
+        working = (
+            self.state in ("busy", "bg")
+            or self.extra.get("runtime_status") in ("shell", "working", "running")
+            or self.extra.get("goal_status") == "active"
+        )
+        if working:
+            self.inactivity = "working"
+        elif self.input_age_seconds is None:
+            self.inactivity = "unknown"
+        elif self.input_age_seconds > threshold_hours * 3600:
+            self.inactivity = "dormant"
+        else:
+            self.inactivity = "recent"
 
     @property
     def rank(self) -> int:
@@ -74,13 +111,21 @@ class Agent:
             value = known.get(field_name)
             if value is not None and not isinstance(value, str):
                 return None
-        for field_name in ("name", "cwd", "repo", "branch", "model", "info"):
+        for field_name in ("name", "cwd", "repo", "branch", "model", "info",
+                           "session_id", "input_source", "input_scope", "inactivity"):
             if not isinstance(known.get(field_name, ""), str):
                 return None
         if known.get("pane") is None or known.get("session") is None:
             return None
         if not isinstance(known.get("pid", 0), int):
             return None
+        for key in ("last_input_at", "input_age_seconds"):
+            value = known.get(key)
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, (int, float))
+                or not math.isfinite(value) or value < 0
+            ):
+                return None
         # Literal[...] is a type-checker hint only; a hand-edited cache can
         # still carry kind="vim" or state="waiting" and render as an agent.
         if known.get("kind") not in ("claude", "codex"):

--- a/claude_code_tools/amux/render.py
+++ b/claude_code_tools/amux/render.py
@@ -29,6 +29,18 @@ def _colour(state: str, text: str, colour: bool) -> str:
     return f"\033[{STATE_COLOR.get(state, '0')}m{text}\033[0m"
 
 
+def input_age(agent: Agent) -> str:
+    """Compact age of the last submitted input, never terminal output age."""
+    age = agent.input_age_seconds
+    if age is None:
+        return "unknown"
+    if age >= 86400:
+        return f"{age / 86400:.1f}d"
+    if age >= 3600:
+        return f"{age / 3600:.1f}h"
+    return f"{int(age // 60)}m"
+
+
 def picker_row(agent: Agent, colour: bool = True) -> str:
     """The visible part of an fzf row (no key field); see :func:`picker_lines`."""
     state = _colour(agent.state, f"{agent.state:<{_W_STATE}}", colour)
@@ -36,6 +48,7 @@ def picker_row(agent: Agent, colour: bool = True) -> str:
     where = _clip(f"{agent.repo}{branch}", _W_REPO)
     return (
         f"{_clip(agent.pane, _W_PANE):<{_W_PANE}} {state} {agent.kind:<{_W_KIND}} "
+        f"{input_age(agent):>9} {agent.inactivity:<8} "
         f"{_clip(agent.name or '-', _W_NAME):<{_W_NAME}} "
         f"{where:<{_W_REPO}} {agent.info}"
     )
@@ -74,6 +87,7 @@ def table(agents: list[Agent], colour: bool = True) -> str:
 
     header = (
         f"{'PANE':<{_W_PANE}} {'STATE':<{_W_STATE}} {'KIND':<{_W_KIND}} "
+        f"{'INPUT AGE':>9} {'ACTIVITY':<8} "
         f"{'NAME':<{_W_NAME}} {'REPO@BRANCH':<{_W_REPO}} CONTEXT"
     )
     rule = "─" * min(len(header) + 20, 120)

--- a/claude_code_tools/amux/scan.py
+++ b/claude_code_tools/amux/scan.py
@@ -19,7 +19,7 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from . import detect
+from . import activity, detect
 from .model import Agent
 
 #: Field separator for tmux -F output; chosen to not occur in paths or titles.
@@ -238,6 +238,7 @@ def scan(workers: int = 16) -> list[Agent]:
             )
         )
 
+    activity.enrich(agents, child_map)
     agents.sort(key=lambda a: (a.rank, a.pane))
     return agents
 

--- a/docs-site/src/content/docs/tools/amux.mdx
+++ b/docs-site/src/content/docs/tools/amux.mdx
@@ -41,15 +41,52 @@ Every pane running an agent gets one of four states, sorted most urgent first:
 prompt or an `AskUserQuestion` is invisible among a hundred panes, and it
 will sit there indefinitely until you notice.
 
+## Finding dormant sessions
+
+```bash
+amux list --dormant --sort oldest
+amux pick --dormant --sort oldest
+amux list --dormant-hours 48 --sort oldest --json
+```
+
+Each row shows **INPUT AGE**, the age of the last recorded submitted user
+input, and **ACTIVITY**, independently of the current state:
+
+- `dormant`: waiting at a prompt, with known input older than 72 hours.
+- `recent`: waiting, with input within the threshold.
+- `working`: the current state is `busy` or `bg`, regardless of input age.
+- `unknown`: no reliable last-input evidence is available.
+
+Use `--dormant-hours` to change the threshold. `--sort oldest` puts known
+oldest input first and unknown ages last. Both options work in the picker;
+refresh preserves them. With the usual tmux shortcut, type `dormant` to
+filter the displayed rows, or open the dedicated dormant picker above.
+
+Input timestamps come from the harness's submitted-input history, not file
+modification times, terminal output, or the clock in a status footer. Hooks,
+tool results, and monitor output do not count as submitted input. These are
+**session-level** timestamps: two panes sharing a conversation share its
+last-input time. JSON records identify this as `input_scope: "shared-session"`.
+Unsent drafts are not dated; check the pane before exiting its agent.
+
+Claude's live PID registry identifies its current conversation and name.
+Codex matching requires an open rollout file associated with the running
+agent; an old `resume` command or a matching working directory is insufficient.
+Some Codex clients keep history remotely and therefore show `unknown`.
+
+History reads are bounded, so sufficiently old input outside the retained
+lookup window also shows `unknown`. Personal and alternate account homes are
+checked separately. No sessions are exited or sent input by scanning.
+
 ## What each row shows
 
 ```
-sasy:1.8   input  codex   certify-main    observability@feat/certify-codex   gpt-5.6-sol · …
-└─ pane    state  harness session name    repo@branch                        context
+sasy:1.8   input  codex   4.2d dormant certify-main  observability@main
+└─ pane    state  harness age  activity session name repo@branch
 ```
 
 - **pane** — the tmux target; jump to it manually with `tmux switch-client`
-- **name** — the agent's session name, from its own `--resume`/`--name`
+- **name** — the live Claude registry name when available, otherwise `--resume`/`--name`
   argument, the tmux pane title, or an on-screen banner
 - **repo@branch** — read directly from `.git/HEAD`, so git worktrees resolve
   to the branch they are actually on
@@ -66,7 +103,7 @@ string like `2.1.220` because it runs a versioned binary, and Codex reports
 shell — including under wrappers like `direnv exec` — and matches on
 `argv[0]`, or on the script path when `argv[0]` is an interpreter.
 
-**What is it doing?** From the screen, since only the rendered UI knows.
+**What is it doing?** From the screen and available live runtime metadata.
 Claude's prompts are a structured choice list, so they are recognised
 directly; position disambiguates a *pending* prompt from one you already
 answered, because an answered prompt has the harness footer rendered below
@@ -78,7 +115,8 @@ working. Expect occasional misses and false alarms there.
 
 ## Speed
 
-On a server with 160 panes: **1.1s cold, 0.075s warm.**
+Pane captures run concurrently, and each account history is read once per scan.
+The additional history lookup is bounded to keep refresh work predictable.
 
 The picker opens on cached rows and refreshes in the background, so it feels
 instant regardless of how many panes you have. `--max-age` controls how long
@@ -107,7 +145,9 @@ bind-key a switch-client -l   # return to the session you came from
 ## Scripting
 
 `amux list --json` emits one object per agent with every field — pane,
-session, kind, state, name, cwd, repo, branch, model, info, pid — so you can
+session, kind, state, name, cwd, repo, branch, model, info, pid, `session_id`,
+`last_input_at` (Unix seconds), `input_age_seconds`, `input_source`,
+`input_scope`, and `inactivity` — so you can
 drive alerts or dashboards from it:
 
 ```bash

--- a/tests/test_amux.py
+++ b/tests/test_amux.py
@@ -437,7 +437,7 @@ class TestCli:
 
         import argparse as _ap
 
-        cli.cmd_pick(_ap.Namespace(max_age=30.0))
+        cli.cmd_pick(cli.build_parser().parse_args(["pick"]))
         binds = [c for c in captured["cmd"] if "reload(" in c]
         assert binds, "no reload bind was built"
         inner = binds[0].split("reload(", 1)[1].rstrip(")")
@@ -908,7 +908,7 @@ class TestFzfStderrReachesTheTerminal:
             lambda _: ([_A(pane="a:1.1", session="a", kind="claude")], False),
         )
         monkeypatch.setattr(cli.subprocess, "run", fake_run)
-        cli.cmd_pick(_ap.Namespace(max_age=30.0))
+        cli.cmd_pick(cli.build_parser().parse_args(["pick"]))
 
         assert seen.get("capture_output") is not True, "must not capture stderr"
         assert seen.get("stderr") is None, "stderr must be inherited"

--- a/tests/test_amux_activity.py
+++ b/tests/test_amux_activity.py
@@ -1,0 +1,169 @@
+"""Session input evidence with real history, metadata, and goal fixtures."""
+
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from claude_code_tools.amux import activity
+from claude_code_tools.amux.model import Agent
+
+SID = "12345678-1234-1234-1234-123456789abc"
+START = "Sun Sep  6 10:00:00 2026"
+
+
+def write_history(home: Path, records: list[object]) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "history.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n"
+    )
+
+
+def claude_record(home: Path, pid: int, **extra: object) -> None:
+    (home / "sessions").mkdir(parents=True, exist_ok=True)
+    (home / "sessions" / f"{pid}.json").write_text(
+        json.dumps({"pid": pid, "procStart": START, "sessionId": SID, **extra})
+    )
+
+
+@pytest.fixture
+def profile_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    return tmp_path
+
+
+def test_history_units_maximum_and_invalid_rows(tmp_path: Path) -> None:
+    write_history(tmp_path, [
+        {"sessionId": SID, "timestamp": 5000},
+        {"sessionId": SID, "timestamp": 3000},
+        {"sessionId": SID, "timestamp": True},
+        {"sessionId": SID, "timestamp": float("inf")},
+        ["wrong shape"],
+    ])
+    assert activity._history(tmp_path, "claude") == ({SID: 5.0}, "complete")
+    write_history(tmp_path, [{"session_id": SID, "ts": 8000}])
+    assert activity._history(tmp_path, "codex") == ({SID: 8000.0}, "complete")
+
+
+def test_history_tail_does_not_invent_old_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_history(tmp_path, [
+        {"session_id": "old", "ts": 1},
+        {"session_id": "new", "ts": 2},
+    ])
+    monkeypatch.setattr(activity, "_HISTORY_LIMIT", 40)
+    assert activity._history(tmp_path, "codex") == ({"new": 2.0}, "tail")
+    assert activity._history(tmp_path / "missing", "codex") == ({}, "unavailable")
+
+
+def test_profile_discovery_custom_and_symlink(
+    profile_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    work = profile_root / ".claude-rja"
+    work.mkdir()
+    (profile_root / ".claude-alias").symlink_to(work, target_is_directory=True)
+    custom = profile_root / "custom"
+    custom.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
+    assert set(activity._homes("claude")) == {work, custom}
+
+
+def test_claude_pid_evidence_shared_and_runtime(
+    profile_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = profile_root / ".claude-rja"
+    write_history(home, [{"sessionId": SID, "timestamp": 5000}])
+    claude_record(home, 101, name="current", status="shell")
+    claude_record(home, 102, status="idle")
+    monkeypatch.setattr(activity, "_run", lambda _: f"101 {START}\n102 {START}\n")
+    agents = [Agent("work:1.1", "work", "claude", pid=101),
+              Agent("work:1.2", "work", "claude", pid=102)]
+    activity.enrich(agents, {})
+    assert all(a.last_input_at == 5.0 for a in agents)
+    assert all(a.input_scope == "shared-session" for a in agents)
+    assert agents[0].state == "bg"
+    assert agents[0].name == "current"
+    assert agents[1].state == "idle"
+
+
+def test_stale_pid_record_is_not_evidence(
+    profile_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = profile_root / ".claude"
+    claude_record(home, 101)
+    write_history(home, [{"sessionId": SID, "timestamp": 5000}])
+    monkeypatch.setattr(activity, "_run", lambda _: "101 Mon Sep 7 10:00:00 2026")
+    agent = Agent("a:1.1", "a", "claude", pid=101)
+    activity.enrich([agent], {})
+    assert agent.last_input_at is None
+    assert agent.session_id == ""
+
+
+def test_codex_native_descriptor_and_active_goal(
+    profile_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = profile_root / ".codex-rja"
+    write_history(home, [{"session_id": SID, "ts": 5000}])
+    with sqlite3.connect(home / "goals_1.sqlite") as connection:
+        connection.execute("CREATE TABLE thread_goals(thread_id TEXT, status TEXT)")
+        connection.execute("INSERT INTO thread_goals VALUES (?, 'active')", (SID,))
+    rollout = home / "sessions" / "2026" / f"rollout-2026-09-06-{SID}.jsonl"
+    monkeypatch.setattr(activity, "_run", lambda _: f"p202\nn{rollout}\n")
+    agent = Agent("a:1.1", "a", "codex", pid=201)
+    activity.enrich([agent], {201: [(202, "/vendor/codex --resume wrong")]})
+    assert agent.session_id == SID
+    assert agent.last_input_at == 5000
+    assert agent.input_source == "codex-open-rollout/history-complete"
+    assert agent.state == "bg"
+    assert agent.extra["goal_status"] == "active"
+
+
+def test_codex_argv_is_not_current_session_evidence(
+    profile_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    write_history(profile_root / ".codex", [{"session_id": SID, "ts": 5000}])
+    monkeypatch.setattr(activity, "_run", lambda _: None)
+    agent = Agent("a:1.1", "a", "codex", pid=201)
+    activity.enrich([agent], {201: [(202, f"/vendor/codex resume {SID}")]})
+    assert agent.session_id == ""
+    assert agent.last_input_at is None
+    assert agent.extra["activity_probe_ok"] is False
+
+
+def test_multiple_rollouts_are_ambiguous(
+    profile_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = profile_root / ".codex"
+    home.mkdir()
+    other = "aaaaaaaa-1234-1234-1234-123456789abc"
+    lines = "p201\n" + "".join(
+        f"n{home}/sessions/rollout-2026-{sid}.jsonl\n" for sid in [SID, other]
+    )
+    monkeypatch.setattr(activity, "_run", lambda _: lines)
+    agent = Agent("a:1.1", "a", "codex", pid=201)
+    activity.enrich([agent], {})
+    assert agent.last_input_at is None
+    assert agent.extra["input_evidence"] == "ambiguous"
+
+
+def test_future_and_explicit_synthetic_input_are_ignored(tmp_path: Path) -> None:
+    write_history(tmp_path, [
+        {"session_id": SID, "ts": 100, "text": "real input"},
+        {"session_id": SID, "ts": time.time() + 1000},
+        {"session_id": SID, "ts": 200, "text": "<hook_prompt>nudge"},
+    ])
+    assert activity._history(tmp_path, "codex")[0] == {SID: 100.0}
+
+
+def test_subprocess_uses_utc_for_runtime_process_start_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TZ", "America/New_York")
+    output = activity._run([sys.executable, "-c", "import os; print(os.getenv('TZ'))"])
+    assert output == "UTC\n"

--- a/tests/test_amux_dormancy.py
+++ b/tests/test_amux_dormancy.py
@@ -108,3 +108,23 @@ def test_cached_nonmatching_picker_refreshes(monkeypatch: pytest.MonkeyPatch) ->
     assert cli.cmd_pick(args) == 0
     assert len(calls) == 1
     assert "dormant" in calls[0]
+
+
+@pytest.mark.parametrize("arguments", [
+    ["--dormant", "--max-age", "0"],
+    ["--max-age", "0", "--dormant"],
+    ["--dormant", "--max-age=0"],
+    ["--max-age=0", "--dormant"],
+    ["--max-age", "0", "pick", "--dormant"],
+    ["pick", "--dormant", "--max-age", "0"],
+])
+def test_picker_option_order(
+    arguments: list[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: list[Namespace] = []
+    monkeypatch.setattr(cli.scan, "tmux_available", lambda: True)
+    monkeypatch.setattr(cli, "cmd_pick", lambda args: seen.append(args) or 0)
+    assert cli.main(arguments) == 0
+    assert len(seen) == 1
+    assert seen[0].max_age == 0
+    assert seen[0].dormant is True

--- a/tests/test_amux_dormancy.py
+++ b/tests/test_amux_dormancy.py
@@ -1,0 +1,80 @@
+"""Dormancy is input age plus a waiting state, never output age alone."""
+
+from argparse import Namespace
+
+import pytest
+
+from claude_code_tools.amux import cli, detect, render
+from claude_code_tools.amux.model import Agent
+
+
+@pytest.mark.parametrize(
+    "state,stamp,expected",
+    [("idle", 1, "dormant"), ("input", 1, "dormant"),
+     ("bg", 1, "working"), ("busy", 1, "working"),
+     ("idle", None, "unknown"), ("idle", 300000, "recent")],
+)
+def test_classification(state: str, stamp: float | None, expected: str) -> None:
+    agent = Agent("a:1.1", "a", "claude", state=state, last_input_at=stamp)
+    agent.classify_inactivity(now=300001)
+    assert agent.inactivity == expected
+
+
+def test_threshold_boundary_and_refresh() -> None:
+    agent = Agent("a:1.1", "a", "codex", last_input_at=1)
+    agent.classify_inactivity(now=72 * 3600 + 1)
+    assert agent.inactivity == "recent"
+    agent.classify_inactivity(now=72 * 3600 + 2)
+    assert agent.inactivity == "dormant"
+    agent.classify_inactivity(threshold_hours=100, now=72 * 3600 + 2)
+    assert agent.inactivity == "recent"
+
+
+def test_display_oldest_unknown_last_and_filter() -> None:
+    agents = [Agent("a:1.1", "a", "claude"),
+              Agent("a:1.2", "a", "claude", last_input_at=100),
+              Agent("a:1.3", "a", "codex", state="bg", last_input_at=1)]
+    args = Namespace(dormant_hours=72, dormant=False, sort="oldest")
+    assert [a.pane for a in cli._display(agents, args)] == [
+        "a:1.3", "a:1.2", "a:1.1"]
+    args.dormant = True
+    assert [a.pane for a in cli._display(agents, args)] == ["a:1.2"]
+    row = render.picker_row(agents[1], colour=False)
+    assert "dormant" in row
+    assert "INPUT AGE" in render.table(agents, colour=False)
+
+
+@pytest.mark.parametrize("value", ["nan", "inf", "-1"])
+def test_invalid_threshold(value: str) -> None:
+    with pytest.raises(SystemExit):
+        cli.build_parser().parse_args(["list", "--dormant-hours", value])
+
+
+def test_idle_subagent_rows_do_not_mean_working() -> None:
+    screen = "❯\n⏵⏵ bypass permissions on\n◯ chk4 Checking … idle  "
+    assert detect.detect_state(screen, "claude") == "idle"
+    assert detect.detect_state(screen + "\n◯ chk5 Grepping …", "claude") == "bg"
+
+
+def test_running_shell_keeps_pane_working() -> None:
+    screen = "✻ Baked for 42m · 1 shell still running\n❯\n⏵⏵ bypass permissions"
+    assert detect.detect_state(screen, "claude") == "bg"
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -1, "yesterday"])
+def test_invalid_cached_age_rejected(value: object) -> None:
+    data = Agent("a:1.1", "a", "codex").to_dict()
+    data["last_input_at"] = value
+    assert Agent.from_dict(data) is None
+
+
+def test_past_shell_command_is_not_background() -> None:
+    screen = "Ran 1 shell command\n❯\n⏵⏵ bypass permissions on"
+    assert detect.detect_state(screen, "claude") == "idle"
+
+
+def test_prompt_with_active_goal_is_not_dormant() -> None:
+    agent = Agent("a:1.1", "a", "codex", state="input", last_input_at=1,
+                  extra={"goal_status": "active"})
+    agent.classify_inactivity(now=300001)
+    assert agent.inactivity == "working"

--- a/tests/test_amux_dormancy.py
+++ b/tests/test_amux_dormancy.py
@@ -128,3 +128,15 @@ def test_picker_option_order(
     assert len(seen) == 1
     assert seen[0].max_age == 0
     assert seen[0].dormant is True
+
+
+@pytest.mark.parametrize("arguments", [["--help"], ["--max-age", "0", "--help"]])
+def test_root_help_keeps_subcommand_discovery(
+    arguments: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as result:
+        cli.main(arguments)
+    assert result.value.code == 0
+    output = capsys.readouterr().out
+    assert "usage: amux pick" not in output
+    assert "list" in output and "scan" in output

--- a/tests/test_amux_dormancy.py
+++ b/tests/test_amux_dormancy.py
@@ -78,3 +78,33 @@ def test_prompt_with_active_goal_is_not_dormant() -> None:
                   extra={"goal_status": "active"})
     agent.classify_inactivity(now=300001)
     assert agent.inactivity == "working"
+
+
+@pytest.mark.parametrize("extra", [None, [], "broken"])
+def test_invalid_cached_extra_rejected(extra: object) -> None:
+    data = Agent("a:1.1", "a", "codex").to_dict()
+    data["extra"] = extra
+    assert Agent.from_dict(data) is None
+
+
+def test_cached_nonmatching_picker_refreshes(monkeypatch: pytest.MonkeyPatch) -> None:
+    from subprocess import CompletedProcess
+
+    cached = Agent("a:1.1", "a", "claude", state="busy", last_input_at=1)
+    fresh = Agent("a:1.1", "a", "claude", state="idle", last_input_at=1)
+    calls: list[str] = []
+    monkeypatch.setattr(cli.shutil, "which", lambda _: "/usr/bin/fzf")
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(cli.sys.stdout, "isatty", lambda: True)
+    monkeypatch.setattr(cli, "_agents_for_display", lambda _: ([cached], True))
+    monkeypatch.setattr(cli, "_fresh", lambda: [fresh])
+
+    def run(command: list[str], **kwargs: object) -> CompletedProcess[str]:
+        calls.append(str(kwargs["input"]))
+        return CompletedProcess(command, 1, stdout="")
+
+    monkeypatch.setattr(cli.subprocess, "run", run)
+    args = cli.build_parser().parse_args(["pick", "--dormant", "--sort", "oldest"])
+    assert cli.cmd_pick(args) == 0
+    assert len(calls) == 1
+    assert "dormant" in calls[0]


### PR DESCRIPTION
Amux currently shows a waiting prompt as `idle` whether its last submitted input
was minutes or weeks ago. Add a separate input-age/activity display so dormant
conversations can be found without treating ongoing background work as dormant.

- Add `--dormant`, `--dormant-hours` (72 by default), and `--sort oldest` to
  list/picker views, preserving filters across refreshes and exposing evidence
  and Unix timestamps in JSON.
- Match Claude's live PID registry (including UTC process-start validation) and
  Codex's open rollout descriptors to bounded per-account input histories.
  Ambiguous/unsupported mappings stay unknown; shared conversations are marked
  as session-scoped evidence. No transcript mtime or footer clock inference.
- Correct idle subagent rows and running-shell detection, preserve active-goal
  evidence, and use current Claude registry names instead of stale launch names.

Validation: 155 focused amux tests passed; docs build completed (47 pages).
A read-only live scan completed for all 47 panes and displayed 19 dormant,
10 recent, 3 working, and 15 unknown at that snapshot. No agents were sent input
or stopped. Cold review findings were fixed and the final diff was re-reviewed.

Limitations: some Codex clients expose no authoritative local session identity
and remain unknown. History lookup reads at most 16 MiB per account; input older
than that lookup window can be unknown. Unsent drafts are not dated. Shared
conversation input cannot be attributed to a specific pane. No installation,
version bump, release, or migration is included.
