### PR TITLE
Add bidirectional aichat session transfer with artifact recovery

### DIFF
--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -17,7 +17,6 @@ etc.) are still available.
 """
 
 import click
-
 from claude_code_tools.session_cli_resolution import (
     resolve_cli_session as _resolve_cli_session,
     resolve_export_session as _resolve_export_session,
@@ -210,7 +209,7 @@ def main(ctx, claude_home, codex_home):
     help_mode = any(arg in cli_args for arg in ('-h', '--help'))
     should_skip = (
         help_mode
-        or ctx.invoked_subcommand in ('port', 'resolve', 'trim-in-place')
+        or ctx.invoked_subcommand in ('port', 'resolve', 'trim-in-place', 'transfer')
         or ctx.invoked_subcommand in skip_auto_index_cmds
         or any(cmd in sys.argv for cmd in skip_auto_index_cmds)
     )

--- a/claude_code_tools/aichat.py
+++ b/claude_code_tools/aichat.py
@@ -3357,6 +3357,7 @@ def search(
                     pass
             # Continue loop to return to Rust TUI
 
-
+from claude_code_tools.transfer_session import transfer
+main.add_command(transfer)
 if __name__ == "__main__":
     main()

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -137,7 +137,7 @@ def export_session(
     destination_home: Path,
     destination_project: Path,
     staging: Path,
-    path_mappings: dict[str, str] | None = None,
+    path_mappings: dict[str, str] | list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """Stage one conversation and its supported persistent companion files.
 
@@ -155,6 +155,8 @@ def export_session(
     Raises:
         ValueError: Session is ambiguous, malformed, or uses unsupported artifacts.
     """
+    if isinstance(path_mappings, list):
+        path_mappings = {item["source"]: item["destination"] for item in path_mappings}
     if str(UUID(session_id)) != session_id:
         raise ValueError("Expected canonical full session UUID")
     if not destination_home.is_absolute() or not destination_project.is_absolute():

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -389,7 +389,7 @@ def export_session(
             "/private/tmp"
         ):
             mappings[str(source)[len("/private") :]] = str(destination_home / relative)
-    for record in records:
+    for record in scratch_records:
         snapshot = record.get("snapshot")
         backups = (
             snapshot.get("trackedFileBackups", {}) if isinstance(snapshot, dict) else {}

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -170,6 +170,38 @@ def export_session(
     if len(matches) != 1:
         raise ValueError(f"Expected one Claude transcript; found {len(matches)}")
     transcript = matches[0]
+    resolved_home = source_home.resolve()
+    source_project_prefix = transcript.parent.relative_to(source_home)
+    destination_project_prefix = Path("projects") / encode_claude_project_path(
+        str(destination_project)
+    )
+    account_aliases: dict[str, str] = {}
+    for old, new in path_mappings.items():
+        old_path = Path(old)
+        if old_path.is_relative_to(source_home):
+            relative = old_path.relative_to(source_home)
+        elif old_path.resolve().is_relative_to(resolved_home):
+            relative = old_path.resolve().relative_to(resolved_home)
+        else:
+            continue
+        relocated = (
+            destination_project_prefix / relative.relative_to(source_project_prefix)
+            if relative.is_relative_to(source_project_prefix)
+            else relative
+        )
+        expected = posixpath.normpath(str(destination_home / relocated))
+        if posixpath.normpath(new) != expected:
+            raise ValueError(
+                "Account home mapping conflicts with destination_home; "
+                "profile paths must retain their location within the selected account."
+            )
+        path_mappings[old] = expected
+        if source_project_prefix.is_relative_to(relative):
+            alias = old_path / source_project_prefix.relative_to(relative)
+            account_aliases[str(alias)] = str(
+                destination_home / destination_project_prefix
+            )
+    path_mappings.update(account_aliases)
     if transcript.parent.is_symlink():
         raise ValueError(f"Cannot transfer symlink: {transcript.parent}")
     _regular_files(transcript)
@@ -345,6 +377,7 @@ def export_session(
             )
     mappings = {
         str(source_home): str(destination_home),
+        str(transcript.parent): str(destination_home / project_relative),
         source_project: destination,
         **(path_mappings or {}),
     }

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import posixpath
 import re
 import shutil
 from pathlib import Path
@@ -73,7 +74,15 @@ def _map_record(
 ) -> dict[str, Any]:
     """Rewrite operational metadata, never historical message/tool prose."""
     if isinstance(record.get("cwd"), str):
-        record["cwd"] = _remap(record["cwd"], source, destination)
+        try:
+            relative = Path(posixpath.normpath(record["cwd"])).relative_to(
+                Path(posixpath.normpath(source))
+            )
+        except ValueError as error:
+            raise ValueError(
+                f"Claude artifact cwd needs an explicit mapping: {record['cwd']}"
+            ) from error
+        record["cwd"] = str(Path(destination) / relative)
     if record.get("type") == "file-history-snapshot":
         snapshot = record.get("snapshot", {})
         if isinstance(snapshot, dict):

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -255,6 +255,8 @@ def export_session(
         ),
     ]
 
+    operational_cwds: set[tuple[str, str]] = set()
+
     def stage(source: Path, relative: Path, rewrite: bool = False) -> None:
         """Copy a verified file into a fresh private staging directory."""
         target = staging / "files" / relative
@@ -262,10 +264,13 @@ def export_session(
         if target.exists() or target.is_symlink():
             raise ValueError(f"Staging collision: {relative}")
         if rewrite:
-            transformed = [
-                _map_record(record, source_project, destination, path_mappings)
-                for record in _read_records(source)
-            ]
+            transformed = []
+            for record in _read_records(source):
+                original_cwd = record.get("cwd")
+                mapped = _map_record(record, source_project, destination, path_mappings)
+                if isinstance(original_cwd, str) and original_cwd.startswith("/"):
+                    operational_cwds.add((original_cwd, mapped["cwd"]))
+                transformed.append(mapped)
             target.write_text("".join(json.dumps(r) + "\n" for r in transformed))
         else:
             shutil.copyfile(source, target)
@@ -400,6 +405,9 @@ def export_session(
         "ok": True,
         "files": sorted(files),
         "shared_files": sorted(shared_files),
+        "operational_cwds": [
+            {"source": old, "destination": new} for old, new in sorted(operational_cwds)
+        ],
         "source_project": source_project,
         "warnings": warnings,
         "missing_at_source": missing_at_source,

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -11,6 +11,7 @@ from typing import Any
 from uuid import UUID
 
 from claude_code_tools.session_utils import encode_claude_project_path
+from claude_code_tools.transfer_claude_artifacts import discover_scratch
 
 
 def _regular_files(root: Path) -> list[Path]:
@@ -82,11 +83,23 @@ def _remap(
 
 
 def _map_record(
-    record: dict[str, Any], source: str, destination: str
+    record: dict[str, Any],
+    source: str,
+    destination: str,
+    path_mappings: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Rewrite operational metadata, never historical message/tool prose."""
+    mappings = {source: destination, **(path_mappings or {})}
+
+    def map_path(path: str, **kwargs: Any) -> str:
+        for old in sorted(mappings, key=len, reverse=True):
+            normalized = posixpath.normpath(path)
+            if normalized == old or normalized.startswith(old.rstrip("/") + "/"):
+                return _remap(path, old, mappings[old], **kwargs)
+        return _remap(path, source, destination, **kwargs)
+
     if isinstance(record.get("cwd"), str):
-        record["cwd"] = _remap(record["cwd"], source, destination, label="artifact cwd")
+        record["cwd"] = map_path(record["cwd"], label="artifact cwd")
     if record.get("type") == "file-history-snapshot":
         snapshot = record.get("snapshot", {})
         if isinstance(snapshot, dict):
@@ -94,16 +107,14 @@ def _map_record(
             if isinstance(backups, dict):
                 mapped: dict[str, Any] = {}
                 for path, value in backups.items():
-                    key = _remap(path, source, destination, relative_ok=True)
+                    key = map_path(path, relative_ok=True)
                     if key in mapped:
                         raise ValueError(f"Normalized file-history collision: {path}")
                     if isinstance(value, dict):
                         parent = value.get("realParentDir")
                         if isinstance(parent, str):
-                            value["realParentDir"] = _remap(
+                            value["realParentDir"] = map_path(
                                 parent,
-                                source,
-                                destination,
                                 label="file-history realParentDir",
                             )
                         backup_name = value.get("backupFileName")
@@ -126,6 +137,7 @@ def export_session(
     destination_home: Path,
     destination_project: Path,
     staging: Path,
+    path_mappings: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Stage one conversation and its supported persistent companion files.
 
@@ -135,6 +147,7 @@ def export_session(
         destination_home: Absolute remote account home (not accessed locally).
         destination_project: Absolute project directory on the destination.
         staging: Empty local bundle directory; payload is written under files/.
+        path_mappings: Additional absolute source-to-destination project mappings.
 
     Returns:
         A manifest fragment listing destination-home-relative files and warnings.
@@ -163,7 +176,7 @@ def export_session(
         for record in records
         if isinstance(record.get("cwd"), str) and record["cwd"].startswith("/")
     }
-    if len(cwds) != 1:
+    if len(cwds) != 1 and not path_mappings:
         raise ValueError(
             "Claude transcript must identify exactly one project cwd; "
             f"found {len(cwds)}. Map multiple working directories manually."
@@ -195,7 +208,16 @@ def export_session(
     before = inventory()
     if any(before.get(path) != value for path, value in transcript_before.items()):
         raise ValueError("Source changed during export: transcript metadata")
-    source_project = next(iter(cwds))
+    if not cwds:
+        raise ValueError("Claude transcript has no absolute cwd")
+    source_project = next(
+        (
+            cwd
+            for cwd in sorted(cwds)
+            if encode_claude_project_path(cwd) == transcript.parent.name
+        ),
+        min(cwds),
+    )
     if source_project == "/":
         raise ValueError("Transferring a filesystem-root project is unsupported")
     destination = str(destination_project)
@@ -225,7 +247,7 @@ def export_session(
             raise ValueError(f"Staging collision: {relative}")
         if rewrite:
             transformed = [
-                _map_record(record, source_project, destination)
+                _map_record(record, source_project, destination, path_mappings)
                 for record in _read_records(source)
             ]
             target.write_text("".join(json.dumps(r) + "\n" for r in transformed))
@@ -243,7 +265,7 @@ def export_session(
         stage(
             source,
             project_relative / session_id / relative,
-            rewrite=source.suffix == ".jsonl",
+            rewrite=relative.parts[0] == "subagents" and source.suffix == ".jsonl",
         )
     for category in ("file-history", "tasks"):
         root = source_home / category
@@ -263,10 +285,13 @@ def export_session(
     plans_root = source_home / "plans"
     if plans and plans_root.is_symlink():
         raise ValueError(f"Cannot transfer symlink: {plans_root}")
+    missing_at_source: list[dict[str, str]] = []
     for plan in plans:
         if plan.exists():
             stage(plan, plan.relative_to(source_home))
             shared_files.append(plan.relative_to(source_home).as_posix())
+        else:
+            missing_at_source.append({"path": str(plan), "reason": "missing_at_source"})
     memory = transcript.parent / "memory"
     for source in _regular_files(memory):
         relative = project_relative / "memory" / source.relative_to(memory)
@@ -285,6 +310,40 @@ def export_session(
                 f"Session-linked {category} runtime exists and is excluded; "
                 "recreate any needed background work explicitly."
             )
+    mappings = {
+        str(source_home): str(destination_home),
+        source_project: destination,
+        **(path_mappings or {}),
+    }
+    scratch, gaps = discover_scratch(records, session_id)
+    missing_at_source.extend(gaps)
+    for source, relative in scratch:
+        old = source.stat()
+        stage(source, relative)
+        new = source.stat()
+        if (old.st_size, old.st_mtime_ns) != (new.st_size, new.st_mtime_ns):
+            raise ValueError("Source scratch file changed during export")
+        mappings[str(source)] = str(destination_home / relative)
+    for record in records:
+        snapshot = record.get("snapshot")
+        backups = (
+            snapshot.get("trackedFileBackups", {}) if isinstance(snapshot, dict) else {}
+        )
+        if not isinstance(backups, dict):
+            continue
+        for value in backups.values():
+            name = value.get("backupFileName") if isinstance(value, dict) else None
+            if isinstance(name, str):
+                backup = source_home / "file-history" / session_id / name
+                if not backup.is_file():
+                    missing_at_source.append(
+                        {"path": str(backup), "reason": "missing_at_source"}
+                    )
+    if scratch:
+        warnings.append(
+            "Scratch symlinks are materialized as regular files; "
+            "consult path mappings for historical references."
+        )
     if inventory() != before:
         raise ValueError("Source changed during export; stop the session and retry")
     return {
@@ -293,4 +352,6 @@ def export_session(
         "shared_files": sorted(shared_files),
         "source_project": source_project,
         "warnings": warnings,
+        "missing_at_source": missing_at_source,
+        "path_mappings": mappings,
     }

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,18 @@ def _regular_files(root: Path) -> list[Path]:
     result: list[Path] = []
     for child in sorted(root.iterdir()):
         result.extend(_regular_files(child))
+    return result
+
+
+def _fingerprint(paths: list[Path]) -> dict[str, tuple[int, int, int, int]]:
+    """Capture source identity and write timestamps for a stable export."""
+    result: dict[str, tuple[int, int, int, int]] = {}
+    for root in paths:
+        for path in _regular_files(root):
+            stat = path.stat()
+            result[str(path)] = (
+                stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns
+            )
     return result
 
 
@@ -106,6 +119,7 @@ def export_session(
     if transcript.parent.is_symlink():
         raise ValueError(f"Cannot transfer symlink: {transcript.parent}")
     _regular_files(transcript)
+    transcript_before = _fingerprint([transcript])
     records = _read_records(transcript)
     cwds = {
         record["cwd"] for record in records
@@ -116,6 +130,29 @@ def export_session(
             "Claude transcript must identify exactly one project cwd; "
             f"found {len(cwds)}. Map multiple working directories manually."
         )
+    plans = sorted({
+        source_home / "plans" / f"{record['slug']}.md"
+        for record in records
+        if isinstance(record.get("slug"), str)
+        and re.fullmatch(r"[A-Za-z0-9_-]+", record["slug"])
+    })
+    roots = [
+        transcript, transcript.with_suffix(""), transcript.parent / "memory",
+        source_home / "file-history" / session_id,
+        source_home / "tasks" / session_id,
+        *plans,
+    ]
+
+    def inventory() -> dict[str, tuple[int, int, int, int]]:
+        """Include newly added companions and detect duplicate transcripts."""
+        if list(projects.glob(f"*/{session_id}.jsonl")) != matches:
+            raise ValueError("Source changed during export: transcript discovery")
+        todos = sorted((source_home / "todos").glob(f"{session_id}-agent-*.json"))
+        return _fingerprint([*roots, *todos])
+
+    before = inventory()
+    if any(before.get(path) != value for path, value in transcript_before.items()):
+        raise ValueError("Source changed during export: transcript metadata")
     source_project = next(iter(cwds))
     if source_project == "/":
         raise ValueError("Transferring a filesystem-root project is unsupported")
@@ -174,6 +211,13 @@ def export_session(
     for todo in sorted(todos.glob(f"{session_id}-agent-*.json")):
         _regular_files(todo)
         stage(todo, todo.relative_to(source_home))
+    plans_root = source_home / "plans"
+    if plans and plans_root.is_symlink():
+        raise ValueError(f"Cannot transfer symlink: {plans_root}")
+    for plan in plans:
+        if plan.exists():
+            stage(plan, plan.relative_to(source_home))
+            shared_files.append(plan.relative_to(source_home).as_posix())
     memory = transcript.parent / "memory"
     for source in _regular_files(memory):
         relative = project_relative / "memory" / source.relative_to(memory)
@@ -181,7 +225,7 @@ def export_session(
         shared_files.append(relative.as_posix())
     if shared_files:
         warnings.append(
-            "Project memory is shared across conversations; destination files "
+            "Project memory and plan files may be shared; destination files "
             "must be absent or byte-identical. Memory prose retains source paths."
         )
     for category in ("tasks", "teams", "workflows", "session-env"):
@@ -194,6 +238,8 @@ def export_session(
                     f"Session-linked {category} runtime exists and is excluded; "
                     "recreate any needed background work explicitly."
                 )
+    if inventory() != before:
+        raise ValueError("Source changed during export; stop the session and retry")
     return {
         "ok": True,
         "files": sorted(files),

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -325,7 +325,7 @@ def export_session(
             previous = json.loads(old_guide.read_text())
             for old, current in previous.get("path_mappings", {}).items():
                 if not isinstance(old, str) or not isinstance(current, str):
-                    raise ValueError("Invalid prior path mapping")
+                    raise ValueError("Invalid prior path mapping")  # noqa: TRY004
                 for source_prefix in sorted(mappings, key=len, reverse=True):
                     if current == source_prefix or current.startswith(
                         source_prefix + "/"

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -364,7 +364,7 @@ def export_session(
         relative = source.relative_to(source_home)
         stage(source, relative)
         mappings[str(source)] = str(destination_home / relative)
-    scratch, gaps = discover_scratch(records, session_id, source_project)
+    scratch, gaps = discover_scratch(records, session_id, source_project, sidecar)
     missing_at_source.extend(
         gap for gap in gaps if gap["path"] not in available_aliases
     )

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -6,6 +6,7 @@ import json
 import posixpath
 import re
 import shutil
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 from uuid import UUID
@@ -257,6 +258,7 @@ def export_session(
     ]
 
     operational_cwds: set[tuple[str, str]] = set()
+    scratch_records: list[dict[str, Any]] = []
 
     def stage(source: Path, relative: Path, rewrite: bool = False) -> None:
         """Copy a verified file into a fresh private staging directory."""
@@ -267,6 +269,7 @@ def export_session(
         if rewrite:
             transformed = []
             for record in _read_records(source):
+                scratch_records.append(deepcopy(record))
                 original_cwd = record.get("cwd")
                 mapped = _map_record(record, source_project, destination, path_mappings)
                 if isinstance(original_cwd, str) and original_cwd.startswith("/"):
@@ -365,7 +368,13 @@ def export_session(
         relative = source.relative_to(source_home)
         stage(source, relative)
         mappings[str(source)] = str(destination_home / relative)
-    scratch, gaps = discover_scratch(records, session_id, source_project, sidecar)
+    scratch, gaps = discover_scratch(
+        scratch_records,
+        session_id,
+        source_project,
+        sidecar,
+        additional_projects=[old for old, _ in operational_cwds],
+    )
     missing_at_source.extend(
         gap for gap in gaps if gap["path"] not in available_aliases
     )

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -60,13 +60,25 @@ def _read_records(path: Path) -> list[dict[str, Any]]:
     return records
 
 
-def _remap(path: str, source: str, destination: str) -> str:
-    """Map one absolute project path using a directory boundary."""
-    if path == source:
-        return destination
-    if path.startswith(source.rstrip("/") + "/"):
-        return destination.rstrip("/") + path[len(source.rstrip("/")) :]
-    return path
+def _remap(
+    path: str,
+    source: str,
+    destination: str,
+    *,
+    relative_ok: bool = False,
+    label: str = "file-history path",
+) -> str:
+    """Map a normalized project path, preserving valid relative backup keys."""
+    original = Path(path)
+    root = Path(posixpath.normpath(source))
+    candidate = root / original if relative_ok else original
+    try:
+        relative = Path(posixpath.normpath(str(candidate))).relative_to(root)
+    except ValueError as error:
+        raise ValueError(f"Claude {label} needs an explicit mapping: {path}") from error
+    if relative_ok and not original.is_absolute():
+        return str(relative)
+    return str(Path(destination) / relative)
 
 
 def _map_record(
@@ -74,24 +86,37 @@ def _map_record(
 ) -> dict[str, Any]:
     """Rewrite operational metadata, never historical message/tool prose."""
     if isinstance(record.get("cwd"), str):
-        try:
-            relative = Path(posixpath.normpath(record["cwd"])).relative_to(
-                Path(posixpath.normpath(source))
-            )
-        except ValueError as error:
-            raise ValueError(
-                f"Claude artifact cwd needs an explicit mapping: {record['cwd']}"
-            ) from error
-        record["cwd"] = str(Path(destination) / relative)
+        record["cwd"] = _remap(record["cwd"], source, destination, label="artifact cwd")
     if record.get("type") == "file-history-snapshot":
         snapshot = record.get("snapshot", {})
         if isinstance(snapshot, dict):
             backups = snapshot.get("trackedFileBackups")
             if isinstance(backups, dict):
-                snapshot["trackedFileBackups"] = {
-                    _remap(path, source, destination): value
-                    for path, value in backups.items()
-                }
+                mapped: dict[str, Any] = {}
+                for path, value in backups.items():
+                    key = _remap(path, source, destination, relative_ok=True)
+                    if key in mapped:
+                        raise ValueError(f"Normalized file-history collision: {path}")
+                    if isinstance(value, dict):
+                        parent = value.get("realParentDir")
+                        if isinstance(parent, str):
+                            value["realParentDir"] = _remap(
+                                parent,
+                                source,
+                                destination,
+                                label="file-history realParentDir",
+                            )
+                        backup_name = value.get("backupFileName")
+                        if isinstance(backup_name, str):
+                            normalized = Path(posixpath.normpath(backup_name))
+                            if normalized.is_absolute() or ".." in normalized.parts:
+                                raise ValueError(
+                                    "File-history backupFileName leaves its session "
+                                    f"backup directory: {backup_name}"
+                                )
+                            value["backupFileName"] = str(normalized)
+                    mapped[key] = value
+                snapshot["trackedFileBackups"] = mapped
     return record
 
 

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -357,6 +357,10 @@ def export_session(
         if (old.st_size, old.st_mtime_ns) != (new.st_size, new.st_mtime_ns):
             raise ValueError("Source scratch file changed during export")
         mappings[str(source)] = str(destination_home / relative)
+        if str(source).startswith("/private/tmp/") and Path("/tmp").resolve() == Path(
+            "/private/tmp"
+        ):
+            mappings[str(source)[len("/private") :]] = str(destination_home / relative)
     for record in records:
         snapshot = record.get("snapshot")
         backups = (

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -320,12 +320,15 @@ def export_session(
     }
     support = source_home / "transfer-support" / session_id
     old_guide = support / "path-map.json"
+    available_aliases: set[str] = set()
     if old_guide.is_file():
         try:
             previous = json.loads(old_guide.read_text())
             for old, current in previous.get("path_mappings", {}).items():
                 if not isinstance(old, str) or not isinstance(current, str):
                     raise ValueError("Invalid prior path mapping")  # noqa: TRY004
+                if Path(current).is_file():
+                    available_aliases.add(old)
                 for source_prefix in sorted(mappings, key=len, reverse=True):
                     if current == source_prefix or current.startswith(
                         source_prefix + "/"
@@ -344,7 +347,9 @@ def export_session(
         stage(source, relative)
         mappings[str(source)] = str(destination_home / relative)
     scratch, gaps = discover_scratch(records, session_id, source_project)
-    missing_at_source.extend(gaps)
+    missing_at_source.extend(
+        gap for gap in gaps if gap["path"] not in available_aliases
+    )
     for source, relative in scratch:
         old = source.stat()
         stage(source, relative)

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -198,6 +198,7 @@ def export_session(
         source_home / "file-history" / session_id,
         source_home / "tasks" / session_id,
         *plans,
+        source_home / "transfer-support" / session_id,
     ]
 
     def inventory() -> dict[str, tuple[int, int, int, int]]:
@@ -317,6 +318,31 @@ def export_session(
         source_project: destination,
         **(path_mappings or {}),
     }
+    support = source_home / "transfer-support" / session_id
+    old_guide = support / "path-map.json"
+    if old_guide.is_file():
+        try:
+            previous = json.loads(old_guide.read_text())
+            for old, current in previous.get("path_mappings", {}).items():
+                if not isinstance(old, str) or not isinstance(current, str):
+                    raise ValueError("Invalid prior path mapping")
+                for source_prefix in sorted(mappings, key=len, reverse=True):
+                    if current == source_prefix or current.startswith(
+                        source_prefix + "/"
+                    ):
+                        mappings[old] = (
+                            mappings[source_prefix] + current[len(source_prefix) :]
+                        )
+                        break
+            missing_at_source.extend(previous.get("missing_at_source", []))
+        except (OSError, ValueError, AttributeError) as error:
+            raise ValueError("Cannot read prior transfer path guide") from error
+    for source in _regular_files(support):
+        if source == old_guide:
+            continue
+        relative = source.relative_to(source_home)
+        stage(source, relative)
+        mappings[str(source)] = str(destination_home / relative)
     scratch, gaps = discover_scratch(records, session_id, source_project)
     missing_at_source.extend(gaps)
     for source, relative in scratch:

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -35,7 +35,10 @@ def _fingerprint(paths: list[Path]) -> dict[str, tuple[int, int, int, int]]:
         for path in _regular_files(root):
             stat = path.stat()
             result[str(path)] = (
-                stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns
+                stat.st_ino,
+                stat.st_size,
+                stat.st_mtime_ns,
+                stat.st_ctime_ns,
             )
     return result
 
@@ -51,7 +54,7 @@ def _read_records(path: Path) -> list[dict[str, Any]]:
         except ValueError as exc:
             raise ValueError(f"Invalid JSON in {path}, line {number}") from exc
         if not isinstance(record, dict):
-            raise ValueError(f"Expected object in {path}, line {number}")
+            raise ValueError(f"Expected object in {path}, line {number}")  # noqa: TRY004
         records.append(record)
     return records
 
@@ -61,7 +64,7 @@ def _remap(path: str, source: str, destination: str) -> str:
     if path == source:
         return destination
     if path.startswith(source.rstrip("/") + "/"):
-        return destination.rstrip("/") + path[len(source.rstrip("/")):]
+        return destination.rstrip("/") + path[len(source.rstrip("/")) :]
     return path
 
 
@@ -122,7 +125,8 @@ def export_session(
     transcript_before = _fingerprint([transcript])
     records = _read_records(transcript)
     cwds = {
-        record["cwd"] for record in records
+        record["cwd"]
+        for record in records
         if isinstance(record.get("cwd"), str) and record["cwd"].startswith("/")
     }
     if len(cwds) != 1:
@@ -130,14 +134,18 @@ def export_session(
             "Claude transcript must identify exactly one project cwd; "
             f"found {len(cwds)}. Map multiple working directories manually."
         )
-    plans = sorted({
-        source_home / "plans" / f"{record['slug']}.md"
-        for record in records
-        if isinstance(record.get("slug"), str)
-        and re.fullmatch(r"[A-Za-z0-9_-]+", record["slug"])
-    })
+    plans = sorted(
+        {
+            source_home / "plans" / f"{record['slug']}.md"
+            for record in records
+            if isinstance(record.get("slug"), str)
+            and re.fullmatch(r"[A-Za-z0-9_-]+", record["slug"])
+        }
+    )
     roots = [
-        transcript, transcript.with_suffix(""), transcript.parent / "memory",
+        transcript,
+        transcript.with_suffix(""),
+        transcript.parent / "memory",
         source_home / "file-history" / session_id,
         source_home / "tasks" / session_id,
         *plans,
@@ -161,12 +169,18 @@ def export_session(
     files: list[str] = []
     shared_files: list[str] = []
     warnings = [
-        "Historical message/tool text retains original paths; inspect referenced "
-        "external files, plans and attachments before resuming.",
-        "Credentials, settings, plugins, shell environment, live processes, "
-        "scheduled jobs and workflow/team runtime are not transferred.",
-        "Submitted-input history and project-wide session indexes are not merged; "
-        "resume using the printed session UUID.",
+        (
+            "Historical message/tool text retains original paths; inspect referenced "
+            "external files, plans and attachments before resuming."
+        ),
+        (
+            "Credentials, settings, plugins, shell environment, live processes, "
+            "scheduled jobs and workflow/team runtime are not transferred."
+        ),
+        (
+            "Submitted-input history and project-wide session indexes are not merged; "
+            "resume using the printed session UUID."
+        ),
     ]
 
     def stage(source: Path, relative: Path, rewrite: bool = False) -> None:
@@ -193,7 +207,8 @@ def export_session(
         if relative.parts[0] not in {"subagents", "tool-results"}:
             raise ValueError(f"Unsupported Claude session sidecar: {relative}")
         stage(
-            source, project_relative / session_id / relative,
+            source,
+            project_relative / session_id / relative,
             rewrite=source.suffix == ".jsonl",
         )
     for category in ("file-history", "tasks"):
@@ -230,14 +245,12 @@ def export_session(
         )
     for category in ("tasks", "teams", "workflows", "session-env"):
         root = source_home / category
-        if (root / session_id).exists() or (
-            root / f"session-{session_id[:8]}"
-        ).exists():
-            if category != "tasks" or (root / f"session-{session_id[:8]}").exists():
-                warnings.append(
-                    f"Session-linked {category} runtime exists and is excluded; "
-                    "recreate any needed background work explicitly."
-                )
+        short_runtime = (root / f"session-{session_id[:8]}").exists()
+        if short_runtime or (category != "tasks" and (root / session_id).exists()):
+            warnings.append(
+                f"Session-linked {category} runtime exists and is excluded; "
+                "recreate any needed background work explicitly."
+            )
     if inventory() != before:
         raise ValueError("Source changed during export; stop the session and retry")
     return {

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -155,8 +155,9 @@ def export_session(
     Raises:
         ValueError: Session is ambiguous, malformed, or uses unsupported artifacts.
     """
-    if isinstance(path_mappings, list):
-        path_mappings = {item["source"]: item["destination"] for item in path_mappings}
+    from claude_code_tools.transfer_paths import normalize_path_mappings
+
+    path_mappings = normalize_path_mappings(path_mappings)
     if str(UUID(session_id)) != session_id:
         raise ValueError("Expected canonical full session UUID")
     if not destination_home.is_absolute() or not destination_project.is_absolute():

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -185,10 +185,16 @@ def export_session(
             "Claude transcript must identify exactly one project cwd; "
             f"found {len(cwds)}. Map multiple working directories manually."
         )
+    subagents = transcript.with_suffix("") / "subagents"
+    subagent_before = _fingerprint([subagents])
+    plan_records = list(records)
+    for source in _regular_files(subagents):
+        if source.suffix == ".jsonl":
+            plan_records.extend(_read_records(source))
     plans = sorted(
         {
             source_home / "plans" / f"{record['slug']}.md"
-            for record in records
+            for record in plan_records
             if isinstance(record.get("slug"), str)
             and re.fullmatch(r"[A-Za-z0-9_-]+", record["slug"])
         }
@@ -211,6 +217,8 @@ def export_session(
         return _fingerprint([*roots, *todos])
 
     before = inventory()
+    if _fingerprint([subagents]) != subagent_before:
+        raise ValueError("Source changed during export: subagent plan discovery")
     if any(before.get(path) != value for path, value in transcript_before.items()):
         raise ValueError("Source changed during export: transcript metadata")
     if not cwds:

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -1,0 +1,203 @@
+"""Stage portable Claude conversation artifacts without copying machine state."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from claude_code_tools.session_utils import encode_claude_project_path
+
+
+def _regular_files(root: Path) -> list[Path]:
+    """List regular files, refusing symlinks rather than following them."""
+    if root.is_symlink():
+        raise ValueError(f"Cannot transfer symlink: {root}")
+    if not root.exists():
+        return []
+    if root.is_file():
+        return [root]
+    if not root.is_dir():
+        raise ValueError(f"Unsupported artifact: {root}")
+    result: list[Path] = []
+    for child in sorted(root.iterdir()):
+        result.extend(_regular_files(child))
+    return result
+
+
+def _read_records(path: Path) -> list[dict[str, Any]]:
+    """Read complete JSONL records, rejecting corrupt or partial transcripts."""
+    records: list[dict[str, Any]] = []
+    for number, line in enumerate(path.read_text().splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except ValueError as exc:
+            raise ValueError(f"Invalid JSON in {path}, line {number}") from exc
+        if not isinstance(record, dict):
+            raise ValueError(f"Expected object in {path}, line {number}")
+        records.append(record)
+    return records
+
+
+def _remap(path: str, source: str, destination: str) -> str:
+    """Map one absolute project path using a directory boundary."""
+    if path == source:
+        return destination
+    if path.startswith(source.rstrip("/") + "/"):
+        return destination.rstrip("/") + path[len(source.rstrip("/")):]
+    return path
+
+
+def _map_record(
+    record: dict[str, Any], source: str, destination: str
+) -> dict[str, Any]:
+    """Rewrite operational metadata, never historical message/tool prose."""
+    if isinstance(record.get("cwd"), str):
+        record["cwd"] = _remap(record["cwd"], source, destination)
+    if record.get("type") == "file-history-snapshot":
+        snapshot = record.get("snapshot", {})
+        if isinstance(snapshot, dict):
+            backups = snapshot.get("trackedFileBackups")
+            if isinstance(backups, dict):
+                snapshot["trackedFileBackups"] = {
+                    _remap(path, source, destination): value
+                    for path, value in backups.items()
+                }
+    return record
+
+
+def export_session(
+    source_home: Path,
+    session_id: str,
+    destination_home: Path,
+    destination_project: Path,
+    staging: Path,
+) -> dict[str, Any]:
+    """Stage one conversation and its supported persistent companion files.
+
+    Args:
+        source_home: Explicit Claude account home.
+        session_id: Full conversation UUID.
+        destination_home: Absolute remote account home (not accessed locally).
+        destination_project: Absolute project directory on the destination.
+        staging: Empty local bundle directory; payload is written under files/.
+
+    Returns:
+        A manifest fragment listing destination-home-relative files and warnings.
+
+    Raises:
+        ValueError: Session is ambiguous, malformed, or uses unsupported artifacts.
+    """
+    if str(UUID(session_id)) != session_id:
+        raise ValueError("Expected canonical full session UUID")
+    if not destination_home.is_absolute() or not destination_project.is_absolute():
+        raise ValueError("Destination home and project must be absolute")
+    projects = source_home / "projects"
+    if projects.is_symlink():
+        raise ValueError(f"Cannot transfer symlink: {projects}")
+    matches = list(projects.glob(f"*/{session_id}.jsonl"))
+    if len(matches) != 1:
+        raise ValueError(f"Expected one Claude transcript; found {len(matches)}")
+    transcript = matches[0]
+    if transcript.parent.is_symlink():
+        raise ValueError(f"Cannot transfer symlink: {transcript.parent}")
+    _regular_files(transcript)
+    records = _read_records(transcript)
+    cwds = {
+        record["cwd"] for record in records
+        if isinstance(record.get("cwd"), str) and record["cwd"].startswith("/")
+    }
+    if len(cwds) != 1:
+        raise ValueError(
+            "Claude transcript must identify exactly one project cwd; "
+            f"found {len(cwds)}. Map multiple working directories manually."
+        )
+    source_project = next(iter(cwds))
+    if source_project == "/":
+        raise ValueError("Transferring a filesystem-root project is unsupported")
+    destination = str(destination_project)
+    project_relative = Path("projects") / encode_claude_project_path(destination)
+    files: list[str] = []
+    shared_files: list[str] = []
+    warnings = [
+        "Historical message/tool text retains original paths; inspect referenced "
+        "external files, plans and attachments before resuming.",
+        "Credentials, settings, plugins, shell environment, live processes, "
+        "scheduled jobs and workflow/team runtime are not transferred.",
+        "Submitted-input history and project-wide session indexes are not merged; "
+        "resume using the printed session UUID.",
+    ]
+
+    def stage(source: Path, relative: Path, rewrite: bool = False) -> None:
+        """Copy a verified file into a fresh private staging directory."""
+        target = staging / "files" / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists() or target.is_symlink():
+            raise ValueError(f"Staging collision: {relative}")
+        if rewrite:
+            transformed = [
+                _map_record(record, source_project, destination)
+                for record in _read_records(source)
+            ]
+            target.write_text("".join(json.dumps(r) + "\n" for r in transformed))
+        else:
+            shutil.copyfile(source, target)
+        target.chmod(0o600)
+        files.append(relative.as_posix())
+
+    stage(transcript, project_relative / transcript.name, rewrite=True)
+    sidecar = transcript.with_suffix("")
+    for source in _regular_files(sidecar):
+        relative = source.relative_to(sidecar)
+        if relative.parts[0] not in {"subagents", "tool-results"}:
+            raise ValueError(f"Unsupported Claude session sidecar: {relative}")
+        stage(
+            source, project_relative / session_id / relative,
+            rewrite=source.suffix == ".jsonl",
+        )
+    for category in ("file-history", "tasks"):
+        root = source_home / category
+        if root.is_symlink():
+            raise ValueError(f"Cannot transfer symlink: {root}")
+        artifact = root / session_id
+        for source in _regular_files(artifact):
+            if source.name == ".lock":
+                continue
+            stage(source, source.relative_to(source_home))
+    todos = source_home / "todos"
+    if todos.is_symlink():
+        raise ValueError(f"Cannot transfer symlink: {todos}")
+    for todo in sorted(todos.glob(f"{session_id}-agent-*.json")):
+        _regular_files(todo)
+        stage(todo, todo.relative_to(source_home))
+    memory = transcript.parent / "memory"
+    for source in _regular_files(memory):
+        relative = project_relative / "memory" / source.relative_to(memory)
+        stage(source, relative)
+        shared_files.append(relative.as_posix())
+    if shared_files:
+        warnings.append(
+            "Project memory is shared across conversations; destination files "
+            "must be absent or byte-identical. Memory prose retains source paths."
+        )
+    for category in ("tasks", "teams", "workflows", "session-env"):
+        root = source_home / category
+        if (root / session_id).exists() or (
+            root / f"session-{session_id[:8]}"
+        ).exists():
+            if category != "tasks" or (root / f"session-{session_id[:8]}").exists():
+                warnings.append(
+                    f"Session-linked {category} runtime exists and is excluded; "
+                    "recreate any needed background work explicitly."
+                )
+    return {
+        "ok": True,
+        "files": sorted(files),
+        "shared_files": sorted(shared_files),
+        "source_project": source_project,
+        "warnings": warnings,
+    }

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -48,7 +48,7 @@ def _fingerprint(paths: list[Path]) -> dict[str, tuple[int, int, int, int]]:
 def _read_records(path: Path) -> list[dict[str, Any]]:
     """Read complete JSONL records, rejecting corrupt or partial transcripts."""
     records: list[dict[str, Any]] = []
-    for number, line in enumerate(path.read_text().splitlines(), 1):
+    for number, line in enumerate(path.read_text().split("\n"), 1):
         if not line.strip():
             continue
         try:

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -224,6 +224,19 @@ def export_session(
     if source_project == "/":
         raise ValueError("Transferring a filesystem-root project is unsupported")
     destination = str(destination_project)
+    for old, new in (path_mappings or {}).items():
+        if posixpath.normpath(old) == posixpath.normpath(source_project) and (
+            posixpath.normpath(new) != posixpath.normpath(destination)
+        ):
+            raise ValueError(
+                "Primary project mapping conflicts with destination_project; "
+                "use the same destination for the primary project."
+            )
+    path_mappings = {
+        old: new
+        for old, new in (path_mappings or {}).items()
+        if posixpath.normpath(old) != posixpath.normpath(source_project)
+    }
     project_relative = Path("projects") / encode_claude_project_path(destination)
     files: list[str] = []
     shared_files: list[str] = []

--- a/claude_code_tools/transfer_claude.py
+++ b/claude_code_tools/transfer_claude.py
@@ -315,7 +315,7 @@ def export_session(
         source_project: destination,
         **(path_mappings or {}),
     }
-    scratch, gaps = discover_scratch(records, session_id)
+    scratch, gaps = discover_scratch(records, session_id, source_project)
     missing_at_source.extend(gaps)
     for source, relative in scratch:
         old = source.stat()

--- a/claude_code_tools/transfer_claude_artifacts.py
+++ b/claude_code_tools/transfer_claude_artifacts.py
@@ -15,15 +15,17 @@ def discover_scratch(
     records: list[dict[str, Any]],
     session_id: str,
     source_project: str | None = None,
+    sidecar_root: Path | None = None,
 ) -> tuple[list[tuple[Path, Path]], list[dict[str, str]]]:
     """Inventory referenced temporary files and session-owned scratch directories.
 
     Only Claude temporary buckets explicitly mentioned in the transcript qualify.
     Arbitrary absolute paths in conversation text are not permission to copy files.
-    Symlinks are materialized only when they target a regular Claude subagent log.
+    Symlinks are materialized only for subagent logs inside selected session roots.
     """
     text = json.dumps(records, ensure_ascii=False)
     references = set(re.findall(r"/(?:private/)?tmp/claude-[^\s\"'<>\\]+", text))
+    allowed_roots = [sidecar_root.resolve()] if sidecar_root else []
     if source_project:
         from claude_code_tools.session_utils import encode_claude_project_path
 
@@ -34,6 +36,7 @@ def discover_scratch(
             root = base / f"claude-{os.getuid()}" / project / session_id
             if root.is_dir() and not root.is_symlink():
                 references.add(str(root.resolve()))
+                allowed_roots.append(root.resolve())
     files: dict[Path, Path] = {}
     missing: list[dict[str, str]] = []
     for raw in sorted(references):
@@ -56,6 +59,7 @@ def discover_scratch(
                     target.is_file()
                     and target.suffix == ".jsonl"
                     and target.parent.name == "subagents"
+                    and any(target.is_relative_to(root) for root in allowed_roots)
                 ):
                     missing.append(
                         {"path": str(candidate), "reason": "unsupported_symlink_target"}

--- a/claude_code_tools/transfer_claude_artifacts.py
+++ b/claude_code_tools/transfer_claude_artifacts.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import re
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -29,7 +30,7 @@ def discover_scratch(
         project = encode_claude_project_path(source_project)
         # Native Unix Claude scratch convention. Probe exact session paths only;
         # never inventory another session or recursively search temporary roots.
-        for base in (Path("/tmp"), Path("/private/tmp")):
+        for base in (Path(tempfile.gettempdir()), Path("/tmp"), Path("/private/tmp")):
             root = base / f"claude-{os.getuid()}" / project / session_id
             if root.is_dir() and not root.is_symlink():
                 references.add(str(root.resolve()))

--- a/claude_code_tools/transfer_claude_artifacts.py
+++ b/claude_code_tools/transfer_claude_artifacts.py
@@ -16,6 +16,7 @@ def discover_scratch(
     session_id: str,
     source_project: str | None = None,
     sidecar_root: Path | None = None,
+    additional_projects: list[str] | None = None,
 ) -> tuple[list[tuple[Path, Path]], list[dict[str, str]]]:
     """Inventory referenced temporary files and session-owned scratch directories.
 
@@ -26,10 +27,13 @@ def discover_scratch(
     text = json.dumps(records, ensure_ascii=False)
     references = set(re.findall(r"/(?:private/)?tmp/claude-[^\s\"'<>\\]+", text))
     allowed_roots = [sidecar_root.resolve()] if sidecar_root else []
+    source_projects = set(additional_projects or [])
     if source_project:
+        source_projects.add(source_project)
+    for source_path in sorted(source_projects):
         from claude_code_tools.session_utils import encode_claude_project_path
 
-        project = encode_claude_project_path(source_project)
+        project = encode_claude_project_path(source_path)
         # Native Unix Claude scratch convention. Probe exact session paths only;
         # never inventory another session or recursively search temporary roots.
         for base in (Path(tempfile.gettempdir()), Path("/tmp"), Path("/private/tmp")):

--- a/claude_code_tools/transfer_claude_artifacts.py
+++ b/claude_code_tools/transfer_claude_artifacts.py
@@ -1,0 +1,57 @@
+"""Discover narrowly scoped Claude scratch references without scanning user homes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def discover_scratch(
+    records: list[dict[str, Any]], session_id: str
+) -> tuple[list[tuple[Path, Path]], list[dict[str, str]]]:
+    """Inventory referenced temporary files and session-owned scratch directories.
+
+    Only Claude temporary buckets explicitly mentioned in the transcript qualify.
+    Arbitrary absolute paths in conversation text are not permission to copy files.
+    Symlinks are materialized only when they target a regular Claude subagent log.
+    """
+    text = json.dumps(records, ensure_ascii=False)
+    references = set(re.findall(r"/(?:private/)?tmp/claude-[^\s\"'<>\\]+", text))
+    files: dict[Path, Path] = {}
+    missing: list[dict[str, str]] = []
+    for raw in sorted(references):
+        path = Path(raw.rstrip(".,;:)"))
+        if ".." in path.parts:
+            continue
+        if not path.exists():
+            missing.append({"path": str(path), "reason": "missing_at_source"})
+            continue
+        candidates = [path] if path.is_file() else []
+        # Enumerate only a UUID-owned directory, never the whole project bucket.
+        for parent in (path, *path.parents):
+            if session_id in parent.name and parent.is_dir():
+                candidates.extend(parent.rglob("*"))
+                break
+        for candidate in candidates:
+            if candidate.is_symlink():
+                target = candidate.resolve()
+                if not (
+                    target.is_file()
+                    and target.suffix == ".jsonl"
+                    and target.parent.name == "subagents"
+                ):
+                    missing.append(
+                        {"path": str(candidate), "reason": "unsupported_symlink_target"}
+                    )
+                    continue
+            elif not candidate.is_file():
+                continue
+            # A hash separates equal basenames in different source directories.
+            key = hashlib.sha256(str(candidate).encode()).hexdigest()[:16]
+            files[candidate] = (
+                Path("transfer-support") / session_id / "scratch" / key / candidate.name
+            )
+    return sorted(files.items()), missing

--- a/claude_code_tools/transfer_claude_artifacts.py
+++ b/claude_code_tools/transfer_claude_artifacts.py
@@ -49,7 +49,11 @@ def discover_scratch(
         candidates = [path] if path.is_file() else []
         # Enumerate only a UUID-owned directory, never the whole project bucket.
         for parent in (path, *path.parents):
-            if session_id in parent.name and parent.is_dir():
+            if (
+                parent.name == session_id
+                and parent.is_dir()
+                and parent.resolve() in allowed_roots
+            ):
                 candidates.extend(parent.rglob("*"))
                 break
         for candidate in candidates:
@@ -66,6 +70,13 @@ def discover_scratch(
                     )
                     continue
             elif not candidate.is_file():
+                continue
+            elif not any(
+                candidate.resolve().is_relative_to(root) for root in allowed_roots
+            ):
+                missing.append(
+                    {"path": str(candidate), "reason": "outside_selected_session"}
+                )
                 continue
             # A hash separates equal basenames in different source directories.
             key = hashlib.sha256(str(candidate).encode()).hexdigest()[:16]

--- a/claude_code_tools/transfer_claude_artifacts.py
+++ b/claude_code_tools/transfer_claude_artifacts.py
@@ -34,7 +34,14 @@ def discover_scratch(
         # never inventory another session or recursively search temporary roots.
         for base in (Path(tempfile.gettempdir()), Path("/tmp"), Path("/private/tmp")):
             root = base / f"claude-{os.getuid()}" / project / session_id
-            if root.is_dir() and not root.is_symlink():
+            # Trust the temp base itself (including macOS /tmp), but never a
+            # redirected UID bucket, encoded project, or selected session root.
+            if any(
+                component.is_symlink()
+                for component in (root, root.parent, root.parent.parent)
+            ):
+                raise ValueError("Native Claude scratch root uses a symlinked ancestor")
+            if root.is_dir():
                 references.add(str(root.resolve()))
                 allowed_roots.append(root.resolve())
     files: dict[Path, Path] = {}

--- a/claude_code_tools/transfer_claude_artifacts.py
+++ b/claude_code_tools/transfer_claude_artifacts.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any
 
 
 def discover_scratch(
-    records: list[dict[str, Any]], session_id: str
+    records: list[dict[str, Any]],
+    session_id: str,
+    source_project: str | None = None,
 ) -> tuple[list[tuple[Path, Path]], list[dict[str, str]]]:
     """Inventory referenced temporary files and session-owned scratch directories.
 
@@ -20,6 +23,16 @@ def discover_scratch(
     """
     text = json.dumps(records, ensure_ascii=False)
     references = set(re.findall(r"/(?:private/)?tmp/claude-[^\s\"'<>\\]+", text))
+    if source_project:
+        from claude_code_tools.session_utils import encode_claude_project_path
+
+        project = encode_claude_project_path(source_project)
+        # Native Unix Claude scratch convention. Probe exact session paths only;
+        # never inventory another session or recursively search temporary roots.
+        for base in (Path("/tmp"), Path("/private/tmp")):
+            root = base / f"claude-{os.getuid()}" / project / session_id
+            if root.is_dir() and not root.is_symlink():
+                references.add(str(root.resolve()))
     files: dict[Path, Path] = {}
     missing: list[dict[str, str]] = []
     for raw in sorted(references):

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -1,0 +1,490 @@
+"""Selective Codex session export and transactional database import.
+
+Supports the explicitly recognized Codex SQLite schemas. This module uses only
+stdlib so the transfer transport can execute it on a remote Python interpreter.
+Rollouts remain byte-exact because paginated history stores byte offsets.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+# PRAGMA table_info contracts, captured from Codex 0.153.4. Never guess how to
+# migrate an unknown internal schema; initialize matching Codex on the target.
+SCHEMAS: dict[str, dict[str, list[list[Any]]]] = {
+    "state_5.sqlite": {
+        "threads": [
+            [0, "id", "TEXT", 0, None, 1],
+            [1, "rollout_path", "TEXT", 1, None, 0],
+            [2, "created_at", "INTEGER", 1, None, 0],
+            [3, "updated_at", "INTEGER", 1, None, 0],
+            [4, "source", "TEXT", 1, None, 0],
+            [5, "model_provider", "TEXT", 1, None, 0],
+            [6, "cwd", "TEXT", 1, None, 0],
+            [7, "title", "TEXT", 1, None, 0],
+            [8, "sandbox_policy", "TEXT", 1, None, 0],
+            [9, "approval_mode", "TEXT", 1, None, 0],
+            [10, "tokens_used", "INTEGER", 1, "0", 0],
+            [11, "has_user_event", "INTEGER", 1, "0", 0],
+            [12, "archived", "INTEGER", 1, "0", 0],
+            [13, "archived_at", "INTEGER", 0, None, 0],
+            [14, "git_sha", "TEXT", 0, None, 0],
+            [15, "git_branch", "TEXT", 0, None, 0],
+            [16, "git_origin_url", "TEXT", 0, None, 0],
+            [17, "cli_version", "TEXT", 1, "''", 0],
+            [18, "first_user_message", "TEXT", 1, "''", 0],
+            [19, "agent_nickname", "TEXT", 0, None, 0],
+            [20, "agent_role", "TEXT", 0, None, 0],
+            [21, "memory_mode", "TEXT", 1, "'enabled'", 0],
+            [22, "model", "TEXT", 0, None, 0],
+            [23, "reasoning_effort", "TEXT", 0, None, 0],
+            [24, "agent_path", "TEXT", 0, None, 0],
+            [25, "created_at_ms", "INTEGER", 0, None, 0],
+            [26, "updated_at_ms", "INTEGER", 0, None, 0],
+            [27, "thread_source", "TEXT", 0, None, 0],
+            [28, "preview", "TEXT", 1, "''", 0],
+            [29, "recency_at", "INTEGER", 1, "0", 0],
+            [30, "recency_at_ms", "INTEGER", 1, "0", 0],
+            [31, "history_mode", "TEXT", 1, "'legacy'", 0],
+            [32, "name", "TEXT", 0, None, 0],
+            [33, "is_pinned", "INTEGER", 1, "0", 0],
+            [34, "thread_section_id", "TEXT", 0, None, 0],
+            [35, "section_position", "INTEGER", 0, None, 0],
+            [36, "section_entered_at_ms", "INTEGER", 0, None, 0],
+            [37, "project_id", "TEXT", 0, None, 0],
+        ],
+        "thread_dynamic_tools": [
+            [0, "thread_id", "TEXT", 1, None, 1],
+            [1, "position", "INTEGER", 1, None, 2],
+            [2, "name", "TEXT", 1, None, 0],
+            [3, "description", "TEXT", 1, None, 0],
+            [4, "input_schema", "TEXT", 1, None, 0],
+            [5, "defer_loading", "INTEGER", 1, "0", 0],
+            [6, "namespace", "TEXT", 0, None, 0],
+        ],
+        "thread_spawn_edges": [
+            [0, "parent_thread_id", "TEXT", 1, None, 0],
+            [1, "child_thread_id", "TEXT", 1, None, 1],
+            [2, "status", "TEXT", 1, None, 0],
+        ],
+        "thread_artifacts": [
+            [0, "id", "TEXT", 0, None, 1],
+            [1, "thread_id", "TEXT", 1, None, 0],
+            [2, "artifact_type", "TEXT", 1, None, 0],
+            [3, "identity_key", "TEXT", 1, None, 0],
+            [4, "payload", "TEXT", 1, None, 0],
+            [5, "created_at", "INTEGER", 1, None, 0],
+        ],
+    },
+    "thread_history_1.sqlite": {
+        "thread_turns": [
+            [0, "thread_id", "TEXT", 1, None, 1],
+            [1, "turn_id", "TEXT", 1, None, 2],
+            [2, "rollout_ordinal", "INTEGER", 1, None, 0],
+            [3, "status", "TEXT", 1, None, 0],
+            [4, "error_json", "TEXT", 0, None, 0],
+            [5, "started_at", "INTEGER", 0, None, 0],
+            [6, "completed_at", "INTEGER", 0, None, 0],
+            [7, "duration_ms", "INTEGER", 0, None, 0],
+            [8, "first_user_item_id", "TEXT", 0, None, 0],
+            [9, "final_agent_item_id", "TEXT", 0, None, 0],
+            [10, "rollout_byte_offset", "INTEGER", 0, None, 0],
+            [11, "rollout_end_ordinal", "INTEGER", 0, None, 0],
+            [12, "rollout_end_byte_offset", "INTEGER", 0, None, 0],
+        ],
+        "thread_items": [
+            [0, "thread_id", "TEXT", 1, None, 1],
+            [1, "turn_id", "TEXT", 1, None, 2],
+            [2, "item_id", "TEXT", 1, None, 3],
+            [3, "rollout_ordinal", "INTEGER", 1, None, 0],
+            [4, "created_at_ms", "INTEGER", 1, None, 0],
+            [5, "item_json", "TEXT", 1, None, 0],
+            [6, "item_type", "TEXT", 1, "''", 0],
+            [7, "updated_at_ordinal", "INTEGER", 1, "0", 0],
+        ],
+        "thread_history_projection_state": [
+            [0, "thread_id", "TEXT", 0, None, 1],
+            [1, "next_rollout_byte_offset", "INTEGER", 1, None, 0],
+            [2, "next_rollout_ordinal", "INTEGER", 1, None, 0],
+        ],
+        "thread_realtime_items": [
+            [0, "thread_id", "TEXT", 1, None, 1],
+            [1, "item_id", "TEXT", 1, None, 2],
+            [2, "rollout_ordinal", "INTEGER", 1, None, 0],
+            [3, "created_at_ms", "INTEGER", 1, None, 0],
+            [4, "item_type", "TEXT", 1, None, 0],
+            [5, "item_json", "TEXT", 1, None, 0],
+        ],
+    },
+    "goals_1.sqlite": {
+        "thread_goals": [
+            [0, "thread_id", "TEXT", 1, None, 1],
+            [1, "goal_id", "TEXT", 1, None, 0],
+            [2, "objective", "TEXT", 1, None, 0],
+            [3, "status", "TEXT", 1, None, 0],
+            [4, "token_budget", "INTEGER", 0, None, 0],
+            [5, "tokens_used", "INTEGER", 1, "0", 0],
+            [6, "time_used_seconds", "INTEGER", 1, "0", 0],
+            [7, "created_at_ms", "INTEGER", 1, None, 0],
+            [8, "updated_at_ms", "INTEGER", 1, None, 0],
+        ],
+        "thread_goal_continuation_deferrals": [[0, "thread_id", "TEXT", 1, None, 1]],
+    },
+    "memories_1.sqlite": {
+        "stage1_outputs": [
+            [0, "thread_id", "TEXT", 0, None, 1],
+            [1, "source_updated_at", "INTEGER", 1, None, 0],
+            [2, "raw_memory", "TEXT", 1, None, 0],
+            [3, "rollout_summary", "TEXT", 1, None, 0],
+            [4, "rollout_slug", "TEXT", 0, None, 0],
+            [5, "generated_at", "INTEGER", 1, None, 0],
+            [6, "usage_count", "INTEGER", 0, None, 0],
+            [7, "last_usage", "INTEGER", 0, None, 0],
+            [8, "selected_for_phase2", "INTEGER", 1, "0", 0],
+            [9, "selected_for_phase2_source_updated_at", "INTEGER", 0, None, 0],
+        ]
+    },
+    "queue_1.sqlite": {
+        "queued_items": [
+            [0, "id", "TEXT", 1, None, 1],
+            [1, "thread_id", "TEXT", 1, None, 0],
+            [2, "payload_json", "TEXT", 1, None, 0],
+            [3, "queue_order", "INTEGER", 1, None, 0],
+            [4, "created_at_ms", "INTEGER", 1, None, 0],
+            [5, "updated_at_ms", "INTEGER", 1, None, 0],
+        ]
+    },
+}
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    """Open an existing database without creating or modifying it."""
+    connection = sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def _schema(connection: sqlite3.Connection, table: str) -> list[list[Any]]:
+    """Return a table's complete column contract."""
+    return [list(row) for row in connection.execute(f'PRAGMA table_info("{table}")')]
+
+
+def _check_schema(connection: sqlite3.Connection, database: str) -> None:
+    """Reject unknown formats instead of silently dropping persistent state."""
+    for table, expected in SCHEMAS[database].items():
+        if _schema(connection, table) != expected:
+            raise ValueError(f"Unsupported Codex schema: {database}/{table}")
+    for row in connection.execute("SELECT name FROM sqlite_master WHERE type='table'"):
+        table = row[0]
+        # New per-thread tables may contain essential state we do not understand.
+        if table not in SCHEMAS[database]:
+            if not table.replace("_", "").isalnum():
+                raise ValueError(f"Unsupported Codex table name: {table!r}")
+            columns = {column[1] for column in _schema(connection, table)}
+            if "thread_id" in columns:
+                raise ValueError(f"Unsupported Codex thread table: {database}/{table}")
+
+
+def _rows(
+    connection: sqlite3.Connection, table: str, ids: list[str], key: str = "thread_id"
+) -> list[dict[str, Any]]:
+    """Select only the requested conversations."""
+    placeholders = ",".join("?" for _ in ids)
+    query = f'SELECT * FROM "{table}" WHERE "{key}" IN ({placeholders})'
+    return [dict(row) for row in connection.execute(query, ids)]
+
+
+def _mapped_cwd(cwd: str, source: Path, destination: Path) -> str:
+    """Map working directories within the selected project only."""
+    try:
+        return str(destination / Path(cwd).relative_to(source))
+    except ValueError as exc:
+        raise ValueError(
+            f"Descendant working directory needs a mapping: {cwd}"
+        ) from exc
+
+
+def export_session(
+    source_home: Path,
+    session_id: str,
+    destination_home: Path,
+    destination_project: Path,
+    staging: Path,
+) -> dict[str, Any]:
+    """Stage a session and descendants without copying unrelated account data.
+
+    Args:
+        source_home: Existing local Codex profile directory.
+        session_id: Exact indexed thread identifier.
+        destination_home: Absolute profile directory on the destination machine.
+        destination_project: Absolute relocated working directory.
+        staging: Private transfer staging directory; files are stored below files/.
+
+    Returns:
+        A JSON-serializable manifest describing files and selected database rows.
+
+    Raises:
+        ValueError: State is active, incomplete, unsupported, or cannot be mapped.
+    """
+    source_home = source_home.resolve()
+    if not destination_home.is_absolute() or not destination_project.is_absolute():
+        raise ValueError("Destination home and project must be absolute paths")
+    connections: dict[str, sqlite3.Connection] = {}
+    try:
+        for database in SCHEMAS:
+            path = source_home / database
+            if not path.exists():
+                if database == "state_5.sqlite":
+                    raise ValueError("Codex state_5.sqlite is required")
+                continue
+            connection = _connect(path)
+            connections[database] = connection
+            connection.execute("BEGIN")
+            _check_schema(connection, database)
+        state = connections["state_5.sqlite"]
+        root = state.execute(
+            "SELECT * FROM threads WHERE id=?", (session_id,)
+        ).fetchone()
+        if root is None:
+            raise ValueError(f"Codex session not indexed: {session_id}")
+        ids = [session_id]
+        for current in ids:
+            children = state.execute(
+                "SELECT child_thread_id FROM thread_spawn_edges "
+                "WHERE parent_thread_id=?",
+                (current,),
+            )
+            for child in children:
+                if child[0] not in ids:
+                    ids.append(child[0])
+        threads = _rows(state, "threads", ids, "id")
+        if len(threads) != len(ids):
+            raise ValueError("A descendant thread is missing from the source index")
+        source_project = Path(root["cwd"])
+        rollout_stats = {}
+        for thread in threads:
+            path = Path(thread["rollout_path"])
+            stat = path.stat()
+            rollout_stats[thread["id"]] = (stat.st_size, stat.st_mtime_ns)
+        warnings = [
+            (
+                "Historical rollout paths and conversation prose are preserved; "
+                "resume with --cd pointing to the destination project."
+            ),
+            (
+                "Shared account settings, plugins, and consolidated memories are "
+                "not transferred. Configure them separately."
+            ),
+        ]
+        databases: list[dict[str, Any]] = []
+        for database, connection in connections.items():
+            tables: list[dict[str, Any]] = []
+            for table, schema in SCHEMAS[database].items():
+                if table == "threads":
+                    rows = threads
+                elif table == "thread_spawn_edges":
+                    rows = _rows(connection, table, ids, "parent_thread_id")
+                else:
+                    rows = _rows(connection, table, ids)
+                if table == "queued_items" and rows:
+                    raise ValueError(
+                        "Session has queued input; drain it before transfer"
+                    )
+                if table == "thread_dynamic_tools" and rows:
+                    warnings.append(
+                        "Dynamic tool definitions are copied; their implementations "
+                        "must be configured separately on the destination."
+                    )
+                if table == "thread_artifacts" and rows:
+                    raise ValueError("Session has unsupported thread artifacts")
+                if table == "thread_turns" and any(
+                    row["status"] not in ("completed", "interrupted", "failed")
+                    for row in rows
+                ):
+                    raise ValueError("Session has an unfinished turn; stop it first")
+                if table == "thread_goals":
+                    for row in rows:
+                        if row["status"] == "active":
+                            row["status"] = "paused"
+                            warnings.append("An active goal is imported paused.")
+                if rows:
+                    tables.append({"name": table, "schema": schema, "rows": rows})
+            if tables:
+                databases.append({"name": database, "tables": tables})
+        history = connections.get("thread_history_1.sqlite")
+        for thread in threads:
+            if thread["history_mode"] not in ("legacy", "paginated"):
+                raise ValueError("Unsupported Codex history mode")
+            if thread["history_mode"] == "paginated" and (
+                history is None
+                or not _rows(history, "thread_history_projection_state", [thread["id"]])
+            ):
+                raise ValueError("Paginated session is missing its history projection")
+        files: list[str] = []
+        for thread in threads:
+            rollout = Path(thread["rollout_path"])
+            try:
+                relative = rollout.resolve().relative_to(source_home)
+            except ValueError as exc:
+                raise ValueError("Rollout is outside the source profile") from exc
+            if relative.parts[0] not in ("sessions", "archived_sessions"):
+                raise ValueError("Unexpected Codex rollout location")
+            if rollout.is_symlink() or not rollout.is_file():
+                raise ValueError(f"Missing or symlinked rollout: {relative}")
+            target = staging / "files" / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            before = rollout.stat()
+            if (before.st_size, before.st_mtime_ns) != rollout_stats[thread["id"]]:
+                raise ValueError(
+                    "Rollout changed during export; stop the session first"
+                )
+            if history is not None:
+                for table, fields in (
+                    ("thread_history_projection_state", ["next_rollout_byte_offset"]),
+                    (
+                        "thread_turns",
+                        ["rollout_byte_offset", "rollout_end_byte_offset"],
+                    ),
+                ):
+                    for row in _rows(history, table, [thread["id"]]):
+                        if any(
+                            row[field] is not None
+                            and not (0 <= row[field] <= before.st_size)
+                            for field in fields
+                        ):
+                            raise ValueError(
+                                "History offset exceeds the source rollout"
+                            )
+            shutil.copyfile(rollout, target)
+            after = rollout.stat()
+            if (before.st_size, before.st_mtime_ns) != (
+                after.st_size,
+                after.st_mtime_ns,
+            ):
+                raise ValueError(
+                    "Rollout changed during export; stop the session first"
+                )
+            files.append(str(relative))
+            thread["rollout_path"] = str(destination_home / relative)
+            policy = json.loads(thread["sandbox_policy"])
+            if not isinstance(policy, dict) or "file_system" in policy:
+                raise ValueError(
+                    "Unsupported sandbox policy; configure portable policy"
+                )
+            if "writable_roots" in policy:
+                if not isinstance(policy["writable_roots"], list):
+                    raise ValueError("Unsupported sandbox writable roots")
+                roots = []
+                for root_path in policy["writable_roots"]:
+                    if not isinstance(root_path, str):
+                        raise ValueError("Unsupported sandbox writable root")  # noqa: TRY004
+                    roots.append(
+                        _mapped_cwd(root_path, source_project, destination_project)
+                    )
+                policy["writable_roots"] = roots
+            thread["sandbox_policy"] = json.dumps(policy)
+            thread["cwd"] = _mapped_cwd(
+                thread["cwd"], source_project, destination_project
+            )
+            # Destination UI collections belong to that machine/account.
+            for key in (
+                "project_id",
+                "thread_section_id",
+                "section_position",
+                "section_entered_at_ms",
+            ):
+                thread[key] = None
+        return {
+            "ok": True,
+            "agent": "codex",
+            "session_id": session_id,
+            "session_ids": ids,
+            "source_project": str(source_project),
+            "files": files,
+            "databases": databases,
+            "warnings": warnings,
+        }
+    finally:
+        for connection in connections.values():
+            connection.close()
+
+
+def validate_databases(manifest: dict[str, Any], destination_home: Path) -> None:
+    """Check destination schemas and conflicts without changing any database."""
+    for database in manifest.get("databases", []):
+        name = database["name"]
+        if name not in SCHEMAS:
+            raise ValueError(f"Unsupported Codex database: {name}")
+        path = destination_home / name
+        if not path.is_file() or path.is_symlink():
+            raise ValueError(
+                f"Initialize matching Codex on destination: missing {name}"
+            )
+        with closing(_connect(path)) as connection:
+            _check_schema(connection, name)
+            for table in database["tables"]:
+                table_name = table["name"]
+                if table_name not in SCHEMAS[name]:
+                    raise ValueError(f"Unsupported table: {table_name}")
+                if table["schema"] != SCHEMAS[name][table_name]:
+                    raise ValueError(f"Incompatible transfer schema: {table_name}")
+                columns = [column[1] for column in table["schema"]]
+                keys = [column[1] for column in table["schema"] if column[5]]
+                for row in table["rows"]:
+                    if set(row) != set(columns):
+                        raise ValueError(f"Invalid row columns: {table_name}")
+                    where = " AND ".join(f'"{key}"=?' for key in keys)
+                    existing = connection.execute(
+                        f'SELECT 1 FROM "{table_name}" WHERE {where}',
+                        [row[key] for key in keys],
+                    ).fetchone()
+                    if existing:
+                        raise ValueError(
+                            f"Destination session state exists: {table_name}"
+                        )
+
+
+def import_databases(
+    manifest: dict[str, Any], destination_home: Path, dry_run: bool = False
+) -> dict[str, Any]:
+    """Insert selected rows atomically on SQL failure, refusing existing state.
+
+    Files must already be installed and verified by the caller. This transaction
+    is the last import step. SQLite rolls back all attached databases on SQL
+    errors; crash atomicity across WAL databases is not guaranteed by SQLite.
+    """
+    validate_databases(manifest, destination_home)
+    if dry_run:
+        return {"ok": True, "dry_run": True}
+    with closing(sqlite3.connect(":memory:")) as connection:
+        try:
+            for number, database in enumerate(manifest.get("databases", [])):
+                connection.execute(
+                    f"ATTACH DATABASE ? AS d{number}",
+                    (str(destination_home / database["name"]),),
+                )
+            connection.execute("PRAGMA foreign_keys=ON")
+            connection.execute("BEGIN IMMEDIATE")
+            for number, database in enumerate(manifest.get("databases", [])):
+                for table in database["tables"]:
+                    columns = [column[1] for column in table["schema"]]
+                    names = ",".join(f'"{column}"' for column in columns)
+                    placeholders = ",".join("?" for _ in columns)
+                    query = (
+                        f'INSERT INTO d{number}."{table["name"]}" ({names}) '
+                        f"VALUES ({placeholders})"
+                    )
+                    connection.executemany(
+                        query,
+                        [[row[column] for column in columns] for row in table["rows"]],
+                    )
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+    return {"ok": True, "dry_run": False}

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -291,6 +291,24 @@ def export_session(
         if len(threads) != len(ids):
             raise ValueError("A descendant thread is missing from the source index")
         source_project = Path(root["cwd"])
+        mappings = (
+            path_mappings.items()
+            if isinstance(path_mappings, dict)
+            else path_mappings or []
+        )
+        for old, new in mappings:
+            if posixpath.normpath(old) == posixpath.normpath(str(source_project)) and (
+                posixpath.normpath(new) != posixpath.normpath(str(destination_project))
+            ):
+                raise ValueError(
+                    "Primary project mapping conflicts with destination_project; "
+                    "use the same destination for the primary project."
+                )
+        path_mappings = [
+            (old, new)
+            for old, new in mappings
+            if posixpath.normpath(old) != posixpath.normpath(str(source_project))
+        ]
         artifacts = CodexArtifacts(
             source_home,
             destination_home,

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import shutil
 import sqlite3
+from collections.abc import Callable
 from contextlib import closing
 from pathlib import Path
 from typing import Any
@@ -474,12 +475,17 @@ def validate_databases(manifest: dict[str, Any], destination_home: Path) -> None
 
 
 def import_databases(
-    manifest: dict[str, Any], destination_home: Path, dry_run: bool = False
+    manifest: dict[str, Any],
+    destination_home: Path,
+    dry_run: bool = False,
+    before_commit: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     """Insert selected rows atomically on SQL failure, refusing existing state.
 
     Files must already be installed and verified by the caller. This transaction
-    is the last import step. SQLite rolls back all attached databases on SQL
+    is the last import step. ``before_commit`` marks when callers must retain
+    files on interruption because the commit outcome may be unknown.
+    SQLite rolls back all attached databases on SQL
     errors; crash atomicity across WAL databases is not guaranteed by SQLite.
     """
     validate_databases(manifest, destination_home)
@@ -507,6 +513,8 @@ def import_databases(
                         query,
                         [[row[column] for column in columns] for row in table["rows"]],
                     )
+            if before_commit is not None:
+                before_commit()
             connection.commit()
         except Exception:
             connection.rollback()

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -295,8 +295,12 @@ def export_session(
 
         mappings = normalize_path_mappings(path_mappings).items()
         for old, new in mappings:
-            if Path(old).is_relative_to(source_home):
-                expected_home_path = Path(destination_home) / Path(old).relative_to(
+            # Keep lexical containment, but also recognize an existing symlink
+            # alias (and any not-yet-created suffix beneath that alias).
+            for source_endpoint in {Path(old), Path(old).resolve()}:
+                if not source_endpoint.is_relative_to(source_home):
+                    continue
+                expected_home_path = destination_home / source_endpoint.relative_to(
                     source_home
                 )
                 if posixpath.normpath(new) != posixpath.normpath(

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -486,6 +486,9 @@ def export_session(
                     roots.append(artifacts.map_required(root_path))
                 policy["writable_roots"] = roots
             thread["sandbox_policy"] = json.dumps(policy)
+            artifacts.operational_cwds.add(
+                (thread["cwd"], artifacts.map_required(thread["cwd"]))
+            )
             thread["cwd"] = artifacts.map_required(thread["cwd"])
             # Destination UI collections belong to that machine/account.
             for key in (

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -506,6 +506,38 @@ def export_session(
 
 def validate_databases(manifest: dict[str, Any], destination_home: Path) -> None:
     """Check destination schemas and conflicts without changing any database."""
+    # Absence is selected state too: an omitted source table/database must not
+    # inherit an unrelated destination goal, queue, memory, or history row.
+    selected_ids = manifest.get("session_ids", [])
+    exported = {
+        database["name"]: {table["name"]: table["rows"] for table in database["tables"]}
+        for database in manifest.get("databases", [])
+    }
+    for name, tables in SCHEMAS.items():
+        path = destination_home / name
+        if not path.exists():
+            continue
+        if path.is_symlink() or not path.is_file():
+            raise ValueError("Destination database must be a regular file")
+        with closing(_connect(path)) as connection:
+            _check_schema(connection, name)
+            for table in tables:
+                if table in exported.get(name, {}):
+                    continue
+                key = (
+                    "id"
+                    if table == "threads"
+                    else (
+                        "parent_thread_id"
+                        if table == "thread_spawn_edges"
+                        else "thread_id"
+                    )
+                )
+                if selected_ids and _rows(connection, table, selected_ids, key):
+                    raise ValueError(
+                        f"Destination-only session state exists and differs: {name}/{table}. "
+                        "Use a separate account home; conversations are never merged."
+                    )
     for database in manifest.get("databases", []):
         name = database["name"]
         if name not in SCHEMAS:

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -182,6 +182,9 @@ def _check_schema(connection: sqlite3.Connection, database: str) -> None:
     for row in connection.execute("SELECT name FROM sqlite_master WHERE type='table'"):
         table = row[0]
         # New per-thread tables may contain essential state we do not understand.
+        if database == "queue_1.sqlite" and table == "queued_thread_revisions":
+            # A wake-up counter, not queued content; never restart remote work.
+            continue
         if table not in SCHEMAS[database]:
             if not table.replace("_", "").isalnum():
                 raise ValueError(f"Unsupported Codex table name: {table!r}")

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -295,6 +295,17 @@ def export_session(
 
         mappings = normalize_path_mappings(path_mappings).items()
         for old, new in mappings:
+            if Path(old).is_relative_to(source_home):
+                expected_home_path = Path(destination_home) / Path(old).relative_to(
+                    source_home
+                )
+                if posixpath.normpath(new) != posixpath.normpath(
+                    str(expected_home_path)
+                ):
+                    raise ValueError(
+                        "Account home mapping conflicts with destination_home; "
+                        "profile paths must retain their location within the selected account."
+                    )
             if posixpath.normpath(old) == posixpath.normpath(str(source_project)) and (
                 posixpath.normpath(new) != posixpath.normpath(str(destination_project))
             ):
@@ -306,6 +317,7 @@ def export_session(
             (old, new)
             for old, new in mappings
             if posixpath.normpath(old) != posixpath.normpath(str(source_project))
+            and old != str(source_home)
         ]
         artifacts = CodexArtifacts(
             source_home,

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -205,6 +205,21 @@ def _rows(
     return [dict(row) for row in connection.execute(query, ids)]
 
 
+def _destination_rows(
+    connection: sqlite3.Connection, table: str, ids: list[str], key: str
+) -> list[dict[str, Any]]:
+    """Include both endpoints when checking destination graph relationships."""
+    if table != "thread_spawn_edges":
+        return _rows(connection, table, ids, key)
+    placeholders = ",".join("?" for _ in ids)
+    query = (
+        "SELECT * FROM thread_spawn_edges "
+        f"WHERE parent_thread_id IN ({placeholders}) "
+        f"OR child_thread_id IN ({placeholders})"
+    )
+    return [dict(row) for row in connection.execute(query, ids + ids)]
+
+
 def _mapped_cwd(cwd: str, source: Path, destination: Path) -> str:
     """Map working directories within the selected project only."""
     try:
@@ -533,7 +548,9 @@ def validate_databases(manifest: dict[str, Any], destination_home: Path) -> None
                         else "thread_id"
                     )
                 )
-                if selected_ids and _rows(connection, table, selected_ids, key):
+                if selected_ids and _destination_rows(
+                    connection, table, selected_ids, key
+                ):
                     raise ValueError(
                         f"Destination-only session state exists and differs: {name}/{table}. "
                         "Use a separate account home; conversations are never merged."
@@ -566,7 +583,7 @@ def validate_databases(manifest: dict[str, Any], destination_home: Path) -> None
                 )
                 selected_ids = manifest.get("session_ids", [])
                 if selected_ids:
-                    existing_rows = _rows(
+                    existing_rows = _destination_rows(
                         connection, table_name, selected_ids, selection_key
                     )
                     expected_rows = {

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -8,6 +8,7 @@ Rollouts remain byte-exact because paginated history stores byte offsets.
 from __future__ import annotations
 
 import json
+import posixpath
 import shutil
 import sqlite3
 from collections.abc import Callable
@@ -206,7 +207,10 @@ def _rows(
 def _mapped_cwd(cwd: str, source: Path, destination: Path) -> str:
     """Map working directories within the selected project only."""
     try:
-        return str(destination / Path(cwd).relative_to(source))
+        relative = Path(posixpath.normpath(cwd)).relative_to(
+            Path(posixpath.normpath(str(source)))
+        )
+        return str(Path(posixpath.normpath(str(destination))) / relative)
     except ValueError as exc:
         raise ValueError(
             f"Descendant working directory needs a mapping: {cwd}"
@@ -389,7 +393,7 @@ def export_session(
                 for entry in filesystem.get("entries", []):
                     location = entry["path"]
                     if location["type"] == "path":
-                        original_path = Path(location["path"])
+                        original_path = Path(posixpath.normpath(location["path"]))
                         if original_path.is_relative_to(source_home):
                             location["path"] = str(
                                 destination_home

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -291,11 +291,9 @@ def export_session(
         if len(threads) != len(ids):
             raise ValueError("A descendant thread is missing from the source index")
         source_project = Path(root["cwd"])
-        mappings = (
-            path_mappings.items()
-            if isinstance(path_mappings, dict)
-            else path_mappings or []
-        )
+        from claude_code_tools.transfer_paths import normalize_path_mappings
+
+        mappings = normalize_path_mappings(path_mappings).items()
         for old, new in mappings:
             if posixpath.normpath(old) == posixpath.normpath(str(source_project)) and (
                 posixpath.normpath(new) != posixpath.normpath(str(destination_project))

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -2,19 +2,20 @@
 
 Supports the explicitly recognized Codex SQLite schemas. This module uses only
 stdlib so the transfer transport can execute it on a remote Python interpreter.
-Rollouts remain byte-exact because paginated history stores byte offsets.
+Structural rollout paths are mapped with corresponding history byte offsets.
 """
 
 from __future__ import annotations
 
 import json
 import posixpath
-import shutil
 import sqlite3
 from collections.abc import Callable
 from contextlib import closing
 from pathlib import Path
 from typing import Any
+
+from claude_code_tools.transfer_codex_artifacts import CodexArtifacts
 
 # PRAGMA table_info contracts, captured from Codex 0.153.4. Never guess how to
 # migrate an unknown internal schema; initialize matching Codex on the target.
@@ -223,6 +224,7 @@ def export_session(
     destination_home: Path,
     destination_project: Path,
     staging: Path,
+    path_mappings: list[tuple[str, str]] | dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Stage a session and descendants without copying unrelated account data.
 
@@ -274,6 +276,15 @@ def export_session(
         if len(threads) != len(ids):
             raise ValueError("A descendant thread is missing from the source index")
         source_project = Path(root["cwd"])
+        artifacts = CodexArtifacts(
+            source_home,
+            destination_home,
+            source_project,
+            destination_project,
+            staging,
+            session_id,
+            path_mappings,
+        )
         rollout_stats = {}
         for thread in threads:
             path = Path(thread["rollout_path"])
@@ -281,7 +292,7 @@ def export_session(
             rollout_stats[thread["id"]] = (stat.st_size, stat.st_mtime_ns)
         warnings = [
             (
-                "Historical rollout paths and conversation prose are preserved; "
+                "Historical conversation prose is preserved; "
                 "resume with --cd pointing to the destination project."
             ),
             (
@@ -290,6 +301,7 @@ def export_session(
             ),
         ]
         databases: list[dict[str, Any]] = []
+        source_rows: list[tuple[str, str, str, list[dict[str, Any]]]] = []
         for database, connection in connections.items():
             tables: list[dict[str, Any]] = []
             for table, schema in SCHEMAS[database].items():
@@ -299,6 +311,16 @@ def export_session(
                     rows = _rows(connection, table, ids, "parent_thread_id")
                 else:
                     rows = _rows(connection, table, ids)
+                key = (
+                    "id"
+                    if table == "threads"
+                    else (
+                        "parent_thread_id"
+                        if table == "thread_spawn_edges"
+                        else "thread_id"
+                    )
+                )
+                source_rows.append((database, table, key, json.loads(json.dumps(rows))))
                 if table == "queued_items" and rows:
                     raise ValueError(
                         "Session has queued input; drain it before transfer"
@@ -308,18 +330,16 @@ def export_session(
                         "Dynamic tool definitions are copied; their implementations "
                         "must be configured separately on the destination."
                     )
-                if table == "thread_artifacts" and rows:
-                    raise ValueError("Session has unsupported thread artifacts")
+                if table == "thread_artifacts":
+                    for row in rows:
+                        artifacts.discover(row["payload"])
                 if table == "thread_turns" and any(
                     row["status"] not in ("completed", "interrupted", "failed")
                     for row in rows
                 ):
                     raise ValueError("Session has an unfinished turn; stop it first")
-                if table == "thread_goals":
-                    for row in rows:
-                        if row["status"] == "active":
-                            row["status"] = "paused"
-                            warnings.append("An active goal is imported paused.")
+                for row in rows:
+                    artifacts.discover(json.dumps(row))
                 if rows:
                     tables.append({"name": table, "schema": schema, "rows": rows})
             if tables:
@@ -368,7 +388,25 @@ def export_session(
                             raise ValueError(
                                 "History offset exceeds the source rollout"
                             )
-            shutil.copyfile(rollout, target)
+            offset_mapping = artifacts.rollout(rollout, target)
+            for database in databases:
+                if database["name"] != "thread_history_1.sqlite":
+                    continue
+                for table in database["tables"]:
+                    for row in table["rows"]:
+                        if row["thread_id"] != thread["id"]:
+                            continue
+                        for field in (
+                            "rollout_byte_offset",
+                            "rollout_end_byte_offset",
+                            "next_rollout_byte_offset",
+                        ):
+                            if row.get(field) is not None:
+                                if row[field] not in offset_mapping:
+                                    raise ValueError(
+                                        "History offset is not a record boundary"
+                                    )
+                                row[field] = offset_mapping[row[field]]
             after = rollout.stat()
             if (before.st_size, before.st_mtime_ns) != (
                 after.st_size,
@@ -400,8 +438,8 @@ def export_session(
                                 / original_path.relative_to(source_home)
                             )
                         else:
-                            location["path"] = _mapped_cwd(
-                                str(original_path), source_project, destination_project
+                            location["path"] = artifacts.map_required(
+                                str(original_path)
                             )
                     elif location["type"] != "special":
                         raise ValueError("Unsupported managed sandbox path")
@@ -412,14 +450,10 @@ def export_session(
                 for root_path in policy["writable_roots"]:
                     if not isinstance(root_path, str):
                         raise ValueError("Unsupported sandbox writable root")  # noqa: TRY004
-                    roots.append(
-                        _mapped_cwd(root_path, source_project, destination_project)
-                    )
+                    roots.append(artifacts.map_required(root_path))
                 policy["writable_roots"] = roots
             thread["sandbox_policy"] = json.dumps(policy)
-            thread["cwd"] = _mapped_cwd(
-                thread["cwd"], source_project, destination_project
-            )
+            thread["cwd"] = artifacts.map_required(thread["cwd"])
             # Destination UI collections belong to that machine/account.
             for key in (
                 "project_id",
@@ -428,7 +462,34 @@ def export_session(
                 "section_entered_at_ms",
             ):
                 thread[key] = None
+        support = artifacts.finish(ids)
+        # Re-read outside each original snapshot: any selected state change means
+        # the independent database snapshots cannot be treated as one export.
+        for database, table, key, original_rows in source_rows:
+            with closing(_connect(source_home / database)) as fresh:
+                actual_rows = _rows(fresh, table, ids, key)
+                canonical = lambda rows: sorted(
+                    json.dumps(row, sort_keys=True) for row in rows
+                )
+                if canonical(actual_rows) != canonical(original_rows):
+                    raise ValueError(
+                        "Source database changed during export; stop it first"
+                    )
+        for thread_id, (size, modified) in rollout_stats.items():
+            original_thread = next(
+                row
+                for db, table, key, rows in source_rows
+                if table == "threads"
+                for row in rows
+                if row["id"] == thread_id
+            )
+            final_stat = Path(original_thread["rollout_path"]).stat()
+            if (final_stat.st_size, final_stat.st_mtime_ns) != (size, modified):
+                raise ValueError("Source rollout changed during export; stop it first")
+        files.extend(support.pop("files"))
         return {
+            **support,
+            "ran": True,
             "ok": True,
             "agent": "codex",
             "session_id": session_id,
@@ -462,6 +523,31 @@ def validate_databases(manifest: dict[str, Any], destination_home: Path) -> None
                     raise ValueError(f"Unsupported table: {table_name}")
                 if table["schema"] != SCHEMAS[name][table_name]:
                     raise ValueError(f"Incompatible transfer schema: {table_name}")
+                selection_key = (
+                    "id"
+                    if table_name == "threads"
+                    else (
+                        "parent_thread_id"
+                        if table_name == "thread_spawn_edges"
+                        else "thread_id"
+                    )
+                )
+                selected_ids = manifest.get("session_ids", [])
+                if selected_ids:
+                    existing_rows = _rows(
+                        connection, table_name, selected_ids, selection_key
+                    )
+                    expected_rows = {
+                        json.dumps(row, sort_keys=True) for row in table["rows"]
+                    }
+                    if any(
+                        json.dumps(row, sort_keys=True) not in expected_rows
+                        for row in existing_rows
+                    ):
+                        raise ValueError(
+                            f"Destination session state exists and differs: {table_name}. "
+                            "Use a separate account home; conversations are never merged."
+                        )
                 columns = [column[1] for column in table["schema"]]
                 keys = [column[1] for column in table["schema"] if column[5]]
                 for row in table["rows"]:
@@ -469,12 +555,14 @@ def validate_databases(manifest: dict[str, Any], destination_home: Path) -> None
                         raise ValueError(f"Invalid row columns: {table_name}")
                     where = " AND ".join(f'"{key}"=?' for key in keys)
                     existing = connection.execute(
-                        f'SELECT 1 FROM "{table_name}" WHERE {where}',
+                        f'SELECT * FROM "{table_name}" WHERE {where}',
                         [row[key] for key in keys],
                     ).fetchone()
-                    if existing:
+                    if existing and dict(existing) != row:
                         raise ValueError(
-                            f"Destination session state exists: {table_name}"
+                            f"Destination session state exists and differs: {table_name}. "
+                            "Use a separate destination account home; independently "
+                            "continued conversations are never merged."
                         )
 
 
@@ -513,14 +601,39 @@ def import_databases(
                         f'INSERT INTO d{number}."{table["name"]}" ({names}) '
                         f"VALUES ({placeholders})"
                     )
-                    connection.executemany(
-                        query,
-                        [[row[column] for column in columns] for row in table["rows"]],
-                    )
+                    keys = [c[1] for c in table["schema"] if c[5]]
+                    where = " AND ".join(f'"{key}"=?' for key in keys)
+                    for row in table["rows"]:
+                        existing = connection.execute(
+                            f'SELECT {names} FROM d{number}."{table["name"]}" WHERE {where}',
+                            [row[key] for key in keys],
+                        ).fetchone()
+                        values = [row[column] for column in columns]
+                        if existing is None:
+                            connection.execute(query, values)
+                        elif list(existing) != values:
+                            raise ValueError("Destination changed during import")
             if before_commit is not None:
                 before_commit()
             connection.commit()
         except Exception:
             connection.rollback()
             raise
-    return {"ok": True, "dry_run": False}
+    verify_databases(manifest, destination_home)
+    return {"ran": True, "ok": True, "dry_run": False}
+
+
+def verify_databases(manifest: dict[str, Any], destination_home: Path) -> None:
+    """Require every imported row to exist and equal the selected snapshot."""
+    for database in manifest.get("databases", []):
+        with closing(_connect(destination_home / database["name"])) as connection:
+            for table in database["tables"]:
+                keys = [c[1] for c in table["schema"] if c[5]]
+                where = " AND ".join(f'"{key}"=?' for key in keys)
+                for row in table["rows"]:
+                    actual = connection.execute(
+                        f'SELECT * FROM "{table["name"]}" WHERE {where}',
+                        [row[key] for key in keys],
+                    ).fetchone()
+                    if actual is None or dict(actual) != row:
+                        raise ValueError("Imported database row verification failed")

--- a/claude_code_tools/transfer_codex.py
+++ b/claude_code_tools/transfer_codex.py
@@ -372,10 +372,31 @@ def export_session(
             files.append(str(relative))
             thread["rollout_path"] = str(destination_home / relative)
             policy = json.loads(thread["sandbox_policy"])
-            if not isinstance(policy, dict) or "file_system" in policy:
-                raise ValueError(
+            if not isinstance(policy, dict):
+                raise ValueError(  # noqa: TRY004
                     "Unsupported sandbox policy; configure portable policy"
                 )
+            if "file_system" in policy:
+                filesystem = policy["file_system"]
+                if not isinstance(filesystem, dict) or filesystem.get("type") != (
+                    "restricted"
+                ):
+                    raise ValueError("Unsupported managed sandbox policy")
+                for entry in filesystem.get("entries", []):
+                    location = entry["path"]
+                    if location["type"] == "path":
+                        original_path = Path(location["path"])
+                        if original_path.is_relative_to(source_home):
+                            location["path"] = str(
+                                destination_home
+                                / original_path.relative_to(source_home)
+                            )
+                        else:
+                            location["path"] = _mapped_cwd(
+                                str(original_path), source_project, destination_project
+                            )
+                    elif location["type"] != "special":
+                        raise ValueError("Unsupported managed sandbox path")
             if "writable_roots" in policy:
                 if not isinstance(policy["writable_roots"], list):
                     raise ValueError("Unsupported sandbox writable roots")

--- a/claude_code_tools/transfer_codex_artifacts.py
+++ b/claude_code_tools/transfer_codex_artifacts.py
@@ -22,7 +22,7 @@ def latest_session_index(home: Path) -> dict[str, dict[str, Any]]:
                 continue
             row = json.loads(line)
             if not isinstance(row, dict) or not isinstance(row.get("id"), str):
-                raise ValueError("Malformed Codex session index row")
+                raise ValueError("Malformed Codex session index row")  # noqa: TRY004
             latest[row["id"]] = row
     return latest
 

--- a/claude_code_tools/transfer_codex_artifacts.py
+++ b/claude_code_tools/transfer_codex_artifacts.py
@@ -27,6 +27,60 @@ def latest_session_index(home: Path) -> dict[str, dict[str, Any]]:
     return latest
 
 
+def reference_candidates(text: str) -> set[str]:
+    """Extract complete structured/quoted paths before scanning unquoted prose."""
+    candidates: set[str] = set()
+
+    def visit(value: Any, key: str = "") -> None:
+        if isinstance(value, dict):
+            for field, child in value.items():
+                visit(child, field)
+            return
+        if isinstance(value, list):
+            for child in value:
+                visit(child, key)
+            return
+        if not isinstance(value, str):
+            return
+        # Some database artifact payloads contain a JSON document as a string.
+        if value.startswith(("{", "[")):
+            try:
+                nested = json.loads(value)
+            except json.JSONDecodeError:
+                pass
+            else:
+                visit(nested)
+                return
+        if (
+            value.startswith("/")
+            and "\n" not in value
+            and (
+                key
+                in {"path", "file_path", "attachment_path", "image_path", "local_path"}
+                or Path(value).exists()
+            )
+        ):
+            candidates.add(value)
+            return
+        # Mask quoted spans so the fallback cannot also invent a truncated path.
+        quoted = re.compile(r"([\"'`])(/[^\n]*?)\1")
+
+        def collect(match: re.Match[str]) -> str:
+            candidates.add(match.group(2))
+            return " " * len(match.group(0))
+
+        remaining = quoted.sub(collect, value)
+        for path in re.findall(r'/[^\s"\'<>`]+', remaining):
+            candidates.add(path.rstrip(".,:;)\\"))
+
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError:
+        document = text
+    visit(document)
+    return candidates
+
+
 class CodexArtifacts:
     """Collect selected references without copying account configuration or auth."""
 
@@ -99,8 +153,7 @@ class CodexArtifacts:
 
     def discover(self, text: str) -> None:
         """Recognize literal support references in the selected session only."""
-        for value in re.findall(r'/[^\s"\'<>`]+', text):
-            value = value.rstrip(".,:;)\\")
+        for value in reference_candidates(text):
             for mapping in self.historical:
                 try:
                     tail = Path(value).relative_to(mapping["source"])

--- a/claude_code_tools/transfer_codex_artifacts.py
+++ b/claude_code_tools/transfer_codex_artifacts.py
@@ -112,6 +112,11 @@ class CodexArtifacts:
                 if value.startswith(("/tmp/", "/private/tmp/")):
                     self.references.add(value)
                 continue
+            if len(relative.parts) > 2 and relative.parts[:2] == (
+                "transfer-support",
+                self.session_id,
+            ):
+                self.references.add(value)
             if relative.parts and relative.parts[0] in {
                 "attachments",
                 "memories",

--- a/claude_code_tools/transfer_codex_artifacts.py
+++ b/claude_code_tools/transfer_codex_artifacts.py
@@ -165,6 +165,39 @@ class CodexArtifacts:
         target.write_bytes(output)
         return offsets
 
+    def checked_artifact(self, source: Path) -> Path:
+        """Reject linked artifacts and escapes from the approved lexical root."""
+        for component in (source, *source.parents):
+            if component.is_symlink():
+                # macOS's system temporary-directory alias is the sole exception.
+                if component == Path("/tmp") and component.resolve() == Path(
+                    "/private/tmp"
+                ):
+                    continue
+                raise ValueError(
+                    "Symlinked support artifact or parent is not transferable"
+                )
+        try:
+            relative = source.relative_to(self.source_home)
+            approved = self.source_home / relative.parts[0]
+            if relative.parts[0] == "transfer-support":
+                approved /= self.session_id
+        except ValueError:
+            approved = None
+            for old, _ in self.explicit_mappings:
+                if source.is_relative_to(Path(old)):
+                    approved = Path(old)
+                    break
+            if approved is None and self.session_id in source.parts:
+                index = source.parts.index(self.session_id)
+                approved = Path(*source.parts[: index + 1])
+            if approved is None:
+                raise ValueError("Support artifact has no approved source root")
+        resolved = source.resolve()
+        if not resolved.is_relative_to(approved.resolve()):
+            raise ValueError("Support artifact escapes its approved source root")
+        return resolved
+
     def finish(self, ids: list[str]) -> dict[str, Any]:
         """Stage references and return shared-index updates for a guarded merge."""
         updates = []
@@ -194,13 +227,13 @@ class CodexArtifacts:
                 )
         for value in sorted(self.references):
             source = Path(value)
+            resolved = self.checked_artifact(source)
             if source.is_dir():
                 continue
             if not source.is_file():
                 self.missing.append(value)
                 continue
             # Never follow a reference into configuration or an authentication file.
-            resolved = source.resolve()
             if any(
                 part
                 in {

--- a/claude_code_tools/transfer_codex_artifacts.py
+++ b/claude_code_tools/transfer_codex_artifacts.py
@@ -61,6 +61,7 @@ class CodexArtifacts:
             self.historical.sort(key=lambda item: len(item["source"]), reverse=True)
         self.mappings.sort(key=lambda pair: len(pair[0]), reverse=True)
         self.references: set[str] = set()
+        self.operational_cwds: set[tuple[str, str]] = set()
         self.files: list[str] = []
         self.missing: list[str] = []
         self.excluded: set[str] = set()
@@ -154,6 +155,10 @@ class CodexArtifacts:
             before = json.dumps(record, sort_keys=True)
             if record.get("type") in ("session_meta", "turn_context"):
                 payload = record.get("payload", {})
+                if isinstance(payload.get("cwd"), str):
+                    self.operational_cwds.add(
+                        (payload["cwd"], self.map_required(payload["cwd"]))
+                    )
                 for key in ("cwd", "sandbox_policy", "permissions"):
                     if key in payload:
                         payload[key] = self.structural(payload[key])
@@ -274,6 +279,10 @@ class CodexArtifacts:
             )
         materialized_sources = {item["source"] for item in self.reference_mappings}
         return {
+            "operational_cwds": [
+                {"source": old, "destination": new}
+                for old, new in sorted(self.operational_cwds)
+            ],
             "excluded_artifacts": [
                 {
                     "path": value,

--- a/claude_code_tools/transfer_codex_artifacts.py
+++ b/claude_code_tools/transfer_codex_artifacts.py
@@ -53,6 +53,11 @@ class CodexArtifacts:
             (str(source_project), str(destination_project)),
             (str(source_home), str(destination_home)),
         ]
+        self.historical: list[dict[str, str]] = []
+        prior_map = source_home / "transfer-support" / session_id / "path-map.json"
+        if prior_map.is_file():
+            self.historical = json.loads(prior_map.read_text()).get("path_mappings", [])
+            self.historical.sort(key=lambda item: len(item["source"]), reverse=True)
         self.mappings.sort(key=lambda pair: len(pair[0]), reverse=True)
         self.references: set[str] = set()
         self.files: list[str] = []
@@ -93,6 +98,13 @@ class CodexArtifacts:
         """Recognize literal support references in the selected session only."""
         for value in re.findall(r'/[^\s"\'<>`]+', text):
             value = value.rstrip(".,:;)\\")
+            for mapping in self.historical:
+                try:
+                    tail = Path(value).relative_to(mapping["source"])
+                    value = str(Path(mapping["destination"]) / tail)
+                    break
+                except ValueError:
+                    continue
             path = Path(value)
             try:
                 relative = path.relative_to(self.source_home)
@@ -163,6 +175,8 @@ class CodexArtifacts:
                 )
         for value in sorted(self.references):
             source = Path(value)
+            if source.is_dir():
+                continue
             if not source.is_file():
                 self.missing.append(value)
                 continue
@@ -212,6 +226,13 @@ class CodexArtifacts:
             "path_mappings": [
                 {"source": old, "destination": new} for old, new in self.mappings
             ]
-            + self.reference_mappings,
+            + self.reference_mappings
+            + [
+                {
+                    "source": item["source"],
+                    "destination": self.map_path(item["destination"]),
+                }
+                for item in self.historical
+            ],
             "metadata_updates": updates,
         }

--- a/claude_code_tools/transfer_codex_artifacts.py
+++ b/claude_code_tools/transfer_codex_artifacts.py
@@ -10,6 +10,23 @@ from pathlib import Path
 from typing import Any
 
 
+def latest_session_index(home: Path) -> dict[str, dict[str, Any]]:
+    """Read the last appended index row per ID, as native rename history does."""
+    path = home / "session_index.jsonl"
+    if not path.is_file():
+        return {}
+    latest = {}
+    with path.open() as stream:
+        for line in stream:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict) or not isinstance(row.get("id"), str):
+                raise ValueError("Malformed Codex session index row")
+            latest[row["id"]] = row
+    return latest
+
+
 class CodexArtifacts:
     """Collect selected references without copying account configuration or auth."""
 
@@ -131,7 +148,7 @@ class CodexArtifacts:
             rows = (
                 json.loads(data).get(container, [])
                 if container
-                else [json.loads(line) for line in data.splitlines() if line]
+                else list(latest_session_index(self.source_home).values())
             )
             selected = [row for row in rows if row.get(key) in ids]
             if selected:

--- a/claude_code_tools/transfer_codex_artifacts.py
+++ b/claude_code_tools/transfer_codex_artifacts.py
@@ -49,7 +49,8 @@ class CodexArtifacts:
             if isinstance(path_mappings, dict)
             else path_mappings or []
         )
-        self.mappings = list(additional) + [
+        self.explicit_mappings = list(additional)
+        self.mappings = self.explicit_mappings + [
             (str(source_project), str(destination_project)),
             (str(source_home), str(destination_home)),
         ]
@@ -62,6 +63,7 @@ class CodexArtifacts:
         self.references: set[str] = set()
         self.files: list[str] = []
         self.missing: list[str] = []
+        self.excluded: set[str] = set()
         self.reference_mappings: list[dict[str, str]] = []
 
     def map_path(self, value: str) -> str:
@@ -110,7 +112,19 @@ class CodexArtifacts:
                 relative = path.relative_to(self.source_home)
             except ValueError:
                 if value.startswith(("/tmp/", "/private/tmp/")):
-                    self.references.add(value)
+                    normalized = Path(posixpath.normpath(value))
+                    explicit = any(
+                        normalized.is_relative_to(Path(posixpath.normpath(old)))
+                        for old, _ in self.explicit_mappings
+                    )
+                    owned = (
+                        self.session_id in normalized.parts
+                        and self.session_id in normalized.resolve().parts
+                    )
+                    if explicit or owned:
+                        self.references.add(value)
+                    else:
+                        self.excluded.add(value)
                 continue
             if len(relative.parts) > 2 and relative.parts[:2] == (
                 "transfer-support",
@@ -225,11 +239,22 @@ class CodexArtifacts:
                     "destination": str(self.destination_home / relative),
                 }
             )
+        materialized_sources = {item["source"] for item in self.reference_mappings}
         return {
+            "excluded_artifacts": [
+                {
+                    "path": value,
+                    "reason": "External temporary reference is not session-owned; "
+                    "use an explicit --map opt-in or copy it manually.",
+                }
+                for value in sorted(self.excluded)
+            ],
             "files": self.files,
             "missing_at_source": self.missing,
             "path_mappings": [
-                {"source": old, "destination": new} for old, new in self.mappings
+                {"source": old, "destination": new}
+                for old, new in self.mappings
+                if old not in materialized_sources
             ]
             + self.reference_mappings
             + [

--- a/claude_code_tools/transfer_codex_artifacts.py
+++ b/claude_code_tools/transfer_codex_artifacts.py
@@ -103,8 +103,19 @@ class CodexArtifacts:
             if isinstance(path_mappings, dict)
             else path_mappings or []
         )
-        self.explicit_mappings = list(additional)
-        self.mappings = self.explicit_mappings + [
+        additional = list(additional)
+        self.account_aliases = [
+            (old, str(Path(old).resolve()))
+            for old, _ in additional
+            if Path(old).resolve().is_relative_to(source_home)
+        ]
+        self.account_aliases.sort(key=lambda pair: len(pair[0]), reverse=True)
+        self.explicit_mappings = [
+            (old, new)
+            for old, new in additional
+            if not Path(old).resolve().is_relative_to(source_home)
+        ]
+        self.mappings = additional + [
             (str(source_project), str(destination_project)),
             (str(source_home), str(destination_home)),
         ]
@@ -154,6 +165,16 @@ class CodexArtifacts:
     def discover(self, text: str) -> None:
         """Recognize literal support references in the selected session only."""
         for value in reference_candidates(text):
+            # Declared account aliases are operational mappings, not consent to
+            # collect arbitrary external files. Read their canonical in-profile
+            # path while preserving the alias-to-destination mapping for prose.
+            for alias, canonical in self.account_aliases:
+                try:
+                    tail = Path(value).relative_to(alias)
+                except ValueError:
+                    continue
+                value = str(Path(canonical) / tail)
+                break
             for mapping in self.historical:
                 try:
                     tail = Path(value).relative_to(mapping["source"])

--- a/claude_code_tools/transfer_codex_artifacts.py
+++ b/claude_code_tools/transfer_codex_artifacts.py
@@ -1,0 +1,200 @@
+"""Codex structural path translation and referenced supporting artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import posixpath
+import re
+from pathlib import Path
+from typing import Any
+
+
+class CodexArtifacts:
+    """Collect selected references without copying account configuration or auth."""
+
+    def __init__(
+        self,
+        source_home: Path,
+        destination_home: Path,
+        source_project: Path,
+        destination_project: Path,
+        staging: Path,
+        session_id: str,
+        path_mappings: list[tuple[str, str]] | dict[str, str] | None,
+    ) -> None:
+        self.source_home = source_home
+        self.destination_home = destination_home
+        self.staging = staging
+        self.session_id = session_id
+        additional = (
+            path_mappings.items()
+            if isinstance(path_mappings, dict)
+            else path_mappings or []
+        )
+        self.mappings = list(additional) + [
+            (str(source_project), str(destination_project)),
+            (str(source_home), str(destination_home)),
+        ]
+        self.mappings.sort(key=lambda pair: len(pair[0]), reverse=True)
+        self.references: set[str] = set()
+        self.files: list[str] = []
+        self.missing: list[str] = []
+        self.reference_mappings: list[dict[str, str]] = []
+
+    def map_path(self, value: str) -> str:
+        """Translate only an absolute path's longest explicitly mapped prefix."""
+        for old, new in self.mappings:
+            try:
+                return str(Path(new) / Path(value).relative_to(old))
+            except ValueError:
+                continue
+        return value
+
+    def map_required(self, value: str) -> str:
+        """Refuse operational paths outside all configured mappings."""
+        normalized = posixpath.normpath(value)
+        result = self.map_path(normalized)
+        if result == normalized and not any(
+            normalized == old or normalized.startswith(old + "/")
+            for old, _ in self.mappings
+        ):
+            raise ValueError(f"Descendant working directory needs a mapping: {value}")
+        return result
+
+    def structural(self, value: Any) -> Any:
+        """Translate path-valued structural metadata, leaving prose elsewhere alone."""
+        if isinstance(value, str) and value.startswith("/"):
+            return self.map_required(value)
+        if isinstance(value, list):
+            return [self.structural(item) for item in value]
+        if isinstance(value, dict):
+            return {key: self.structural(item) for key, item in value.items()}
+        return value
+
+    def discover(self, text: str) -> None:
+        """Recognize literal support references in the selected session only."""
+        for value in re.findall(r'/[^\s"\'<>`]+', text):
+            value = value.rstrip(".,:;)\\")
+            path = Path(value)
+            try:
+                relative = path.relative_to(self.source_home)
+            except ValueError:
+                if value.startswith(("/tmp/", "/private/tmp/")):
+                    self.references.add(value)
+                continue
+            if relative.parts and relative.parts[0] in {
+                "attachments",
+                "memories",
+                "shell_snapshots",
+                "tool-results",
+                "scratch",
+            }:
+                self.references.add(value)
+
+    def rollout(self, source: Path, target: Path) -> dict[int, int]:
+        """Rewrite structural JSONL fields and return exact record-boundary offsets."""
+        raw = source.read_bytes()
+        output = bytearray()
+        offsets = {}
+        position = 0
+        for line in raw.splitlines(keepends=True):
+            offsets[position] = len(output)
+            original_length = len(line)
+            record = json.loads(line)
+            self.discover(line.decode())
+            before = json.dumps(record, sort_keys=True)
+            if record.get("type") in ("session_meta", "turn_context"):
+                payload = record.get("payload", {})
+                for key in ("cwd", "sandbox_policy", "permissions"):
+                    if key in payload:
+                        payload[key] = self.structural(payload[key])
+            if json.dumps(record, sort_keys=True) != before:
+                line = (json.dumps(record, ensure_ascii=False) + "\n").encode()
+            output.extend(line)
+            position += original_length
+        offsets[len(raw)] = len(output)
+        target.write_bytes(output)
+        return offsets
+
+    def finish(self, ids: list[str]) -> dict[str, Any]:
+        """Stage references and return shared-index updates for a guarded merge."""
+        updates = []
+        for name, key, container in (
+            ("session_index.jsonl", "id", None),
+            ("external_agent_session_imports.json", "imported_thread_id", "records"),
+        ):
+            path = self.source_home / name
+            if not path.is_file():
+                continue
+            data = path.read_text()
+            rows = (
+                json.loads(data).get(container, [])
+                if container
+                else [json.loads(line) for line in data.splitlines() if line]
+            )
+            selected = [row for row in rows if row.get(key) in ids]
+            if selected:
+                updates.append(
+                    {
+                        "path": name,
+                        "format": "json" if container else "jsonl",
+                        "key": key,
+                        "container": container,
+                        "rows": selected,
+                    }
+                )
+        for value in sorted(self.references):
+            source = Path(value)
+            if not source.is_file():
+                self.missing.append(value)
+                continue
+            # Never follow a reference into configuration or an authentication file.
+            resolved = source.resolve()
+            if any(
+                part
+                in {
+                    "auth.json",
+                    "credentials.json",
+                    ".credentials.json",
+                    ".ssh",
+                    ".aws",
+                    ".config",
+                }
+                for part in resolved.parts
+            ):
+                raise ValueError(
+                    "Referenced support artifact resolves to credentials/config"
+                )
+            try:
+                relative = str(source.relative_to(self.source_home))
+            except ValueError:
+                digest = hashlib.sha256(value.encode()).hexdigest()[:16]
+                relative = f"transfer-support/{self.session_id}/{digest}/{source.name}"
+            target = self.staging / "files" / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            before = source.stat()
+            data = source.read_bytes()
+            after = source.stat()
+            if (before.st_size, before.st_mtime_ns) != (
+                after.st_size,
+                after.st_mtime_ns,
+            ):
+                raise ValueError("Supporting artifact changed during export")
+            target.write_bytes(data)
+            self.files.append(relative)
+            self.reference_mappings.append(
+                {
+                    "source": value,
+                    "destination": str(self.destination_home / relative),
+                }
+            )
+        return {
+            "files": self.files,
+            "missing_at_source": self.missing,
+            "path_mappings": [
+                {"source": old, "destination": new} for old, new in self.mappings
+            ]
+            + self.reference_mappings,
+            "metadata_updates": updates,
+        }

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -373,12 +373,7 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                         and not words[1].startswith("-")
                         else None
                     )
-                    shell_inline = (
-                        launcher_name in {"bash", "sh", "zsh"}
-                        and len(words) > 2
-                        and words[1] == "-c"
-                    )
-                    if interpreter and script_operand is None and not shell_inline:
+                    if interpreter and script_operand is None:
                         instruction = (
                             "Inspect interpreter options to identify the actual hook "
                             "script or inline program, then use a safe runtime check."

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -356,7 +356,7 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                         word
                         for word in words
                         if not word.startswith(("/", "-"))
-                        and word.endswith((".py", ".sh"))
+                        and word.endswith((".py", ".sh", ".js", ".mjs", ".cjs"))
                     ]
                     if relative_scripts:
                         instruction = (
@@ -380,8 +380,11 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                         for word in words
                         for path in (
                             [word]
-                            if word.startswith("/") and word.endswith((".py", ".sh"))
-                            else re.findall(r"/[^\s\"'<>;]+\.(?:py|sh)\b", word)
+                            if word.startswith("/")
+                            and word.endswith((".py", ".sh", ".js", ".mjs", ".cjs"))
+                            else re.findall(
+                                r"/[^\s\"'<>;]+\.(?:py|sh|js|mjs|cjs)\b", word
+                            )
                         )
                     ]
                     missing_paths = sum(not Path(path).is_file() for path in paths)

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -223,7 +223,14 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
     hooks_file = home / "hooks.json"
     if hooks_file.is_file():
         try:
-            hook_sources.append(json.loads(hooks_file.read_text()))
+            content = json.loads(hooks_file.read_text())
+            if isinstance(content, dict):
+                hook_sources.append(content)
+            else:
+                warnings.append(
+                    "The account hooks.json must contain an object; "
+                    "its hook declarations were not inspected."
+                )
         except (OSError, ValueError):
             warnings.append("The account hooks.json cannot be parsed.")
     installed = home / "plugins" / "installed_plugins.json"
@@ -352,13 +359,50 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                         )
                         remediation.append(instruction)
                         continue
+                    launcher_name = Path(words[0]).name if words else ""
+                    interpreter = bool(
+                        re.fullmatch(
+                            r"(?:python(?:[0-9]+(?:\.[0-9]+)?)?|node|nodejs|bash|sh|zsh)",
+                            launcher_name,
+                        )
+                    )
+                    script_operand = (
+                        words[1]
+                        if interpreter
+                        and len(words) > 1
+                        and not words[1].startswith("-")
+                        else None
+                    )
+                    shell_inline = (
+                        launcher_name in {"bash", "sh", "zsh"}
+                        and len(words) > 2
+                        and words[1] == "-c"
+                    )
+                    if interpreter and script_operand is None and not shell_inline:
+                        instruction = (
+                            "Inspect interpreter options to identify the actual hook "
+                            "script or inline program, then use a safe runtime check."
+                        )
+                        hook_checks.append(
+                            {
+                                "ran": False,
+                                "ok": False,
+                                "reason": "Interpreter hook operand is unverified",
+                                "runtime_executed": False,
+                                "remediation": instruction,
+                            }
+                        )
+                        remediation.append(instruction)
+                        continue
                     relative_scripts = [
                         word
                         for word in words
                         if not word.startswith(("/", "-"))
                         and word.endswith((".py", ".sh", ".js", ".mjs", ".cjs"))
                     ]
-                    if relative_scripts:
+                    if relative_scripts or (
+                        script_operand and not Path(script_operand).is_absolute()
+                    ):
                         instruction = (
                             "Resolve relative hook script paths against the agent's "
                             "actual working directory, or use explicit absolute paths; "
@@ -387,6 +431,9 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                             )
                         )
                     ]
+                    if script_operand is not None:
+                        paths.append(script_operand)
+                    paths = sorted(set(paths))
                     missing_paths = sum(not Path(path).is_file() for path in paths)
                     launcher = words[0] if words else ""
                     found = bool(shutil.which(launcher)) if launcher else False

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -9,6 +9,7 @@ import shlex
 import shutil
 import socket
 import subprocess
+import tempfile
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -67,7 +68,7 @@ def _registrations(value: Any) -> list[dict[str, Any]]:
     return result
 
 
-def inspect_environment(agent: str, home: Path) -> dict[str, Any]:
+def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str, Any]:
     """Inspect versions, effective plugin discovery, overrides and hook dependencies.
 
     Hooks are never executed. Configuration is inspected without returning command
@@ -77,7 +78,9 @@ def inspect_environment(agent: str, home: Path) -> dict[str, Any]:
     if agent not in {"claude", "codex"}:
         raise ValueError("Agent must be claude or codex")
     environment = dict(os.environ)
-    environment["CLAUDE_CONFIG_DIR" if agent == "claude" else "CODEX_HOME"] = str(home)
+    environment["CLAUDE_CONFIG_DIR" if agent == "claude" else "CODEX_HOME"] = str(
+        runtime_home
+    )
     checks: dict[str, Any] = {}
     warnings: list[str] = []
     remediation: list[str] = []
@@ -89,8 +92,6 @@ def inspect_environment(agent: str, home: Path) -> dict[str, Any]:
     }
     if executable:
         version_environment = dict(environment)
-        version_environment.pop("CLAUDE_CONFIG_DIR", None)
-        version_environment.pop("CODEX_HOME", None)
         checks["native_version"] = _version(
             [executable, "--version"], version_environment
         )
@@ -281,3 +282,29 @@ def inspect_environment(agent: str, home: Path) -> dict[str, Any]:
         "warnings": warnings,
         "remediation": remediation,
     }
+
+
+def inspect_environment(agent: str, home: Path) -> dict[str, Any]:
+    """Inspect an account while containing native CLI writes in a private snapshot."""
+    with tempfile.TemporaryDirectory(prefix="aichat-environment-") as directory:
+        runtime_home = Path(directory)
+        for relative in (
+            "settings.json",
+            "config.toml",
+            "plugins/installed_plugins.json",
+            "plugins/known_marketplaces.json",
+        ):
+            source = home / relative
+            if source.is_file():
+                target = runtime_home / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source, target)
+                target.chmod(0o600)
+        result = _inspect_environment(agent, home, runtime_home)
+        result["checks"]["native_probe_isolation"] = {
+            "ran": True,
+            "ok": True,
+            "account_writes": "temporary snapshot",
+            "cache_paths": "registrations may reference existing read-only inputs",
+        }
+        return result

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -274,6 +274,11 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                     )
                     try:
                         words = shlex.split(command)
+                        lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+                        lexer.whitespace_split = True
+                        compound = any(
+                            re.fullmatch(r"[;&|()<>]+", token) for token in lexer
+                        )
                     except ValueError:
                         hook_checks.append(
                             {
@@ -285,6 +290,62 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                         continue
                     while words and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", words[0]):
                         words.pop(0)
+                    builtins = {
+                        "cd",
+                        "export",
+                        "source",
+                        ".",
+                        "exec",
+                        "eval",
+                        "set",
+                        "unset",
+                        "readonly",
+                        "alias",
+                        "unalias",
+                        "return",
+                        "break",
+                        "continue",
+                        "trap",
+                        "umask",
+                        "ulimit",
+                        "wait",
+                        "read",
+                        "printf",
+                        "echo",
+                        "test",
+                        "[",
+                        "true",
+                        "false",
+                        "type",
+                        "command",
+                        "builtin",
+                        "hash",
+                        "enable",
+                        "dirs",
+                        "pushd",
+                        "popd",
+                        "declare",
+                        "local",
+                        "typeset",
+                        "let",
+                    }
+                    if compound or (words and words[0] in builtins):
+                        instruction = (
+                            "Inspect this compound or builtin hook manually and use "
+                            "a safe runtime input to verify it; the transfer probe "
+                            "does not evaluate shell syntax."
+                        )
+                        hook_checks.append(
+                            {
+                                "ran": False,
+                                "ok": False,
+                                "reason": "Compound or shell-builtin hook is unverified",
+                                "runtime_executed": False,
+                                "remediation": instruction,
+                            }
+                        )
+                        remediation.append(instruction)
+                        continue
                     paths = [
                         path
                         for word in words

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -352,6 +352,29 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                         )
                         remediation.append(instruction)
                         continue
+                    relative_scripts = [
+                        word
+                        for word in words
+                        if not word.startswith(("/", "-"))
+                        and word.endswith((".py", ".sh"))
+                    ]
+                    if relative_scripts:
+                        instruction = (
+                            "Resolve relative hook script paths against the agent's "
+                            "actual working directory, or use explicit absolute paths; "
+                            "then perform a safe runtime check."
+                        )
+                        hook_checks.append(
+                            {
+                                "ran": False,
+                                "ok": False,
+                                "reason": "Relative hook script path is unverified without runtime cwd",
+                                "runtime_executed": False,
+                                "remediation": instruction,
+                            }
+                        )
+                        remediation.append(instruction)
+                        continue
                     paths = [
                         path
                         for word in words

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -108,7 +108,19 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                 if not isinstance(parsed, (dict, list)):
                     raise ValueError("Unsupported plugin JSON")  # noqa: TRY004
                 registrations = _registrations(parsed)
-                if parsed and not registrations:
+                collections = (
+                    [
+                        parsed[key]
+                        for key in ("plugins", "installed", "available", "marketplaces")
+                        if key in parsed
+                    ]
+                    if isinstance(parsed, dict)
+                    else []
+                )
+                known_empty = bool(collections) and all(
+                    isinstance(value, list) and not value for value in collections
+                )
+                if parsed and not registrations and not known_empty:
                     raise ValueError("Unrecognized plugin JSON schema")
             except ValueError:
                 native["ok"] = False
@@ -308,3 +320,51 @@ def inspect_environment(agent: str, home: Path) -> dict[str, Any]:
             "cache_paths": "registrations may reference existing read-only inputs",
         }
         return result
+
+
+def compare_environments(
+    source: dict[str, Any], target: dict[str, Any]
+) -> dict[str, Any]:
+    """Compare discovered plugin availability and explicit skill disablement."""
+    left = source.get("checks", {})
+    right = target.get("checks", {})
+    source_plugins = left.get("native_plugins", {})
+    target_plugins = right.get("native_plugins", {})
+    ran = all(
+        item.get("ran") is True and item.get("ok") is True
+        for item in (source_plugins, target_plugins)
+    )
+    missing: list[str] = []
+    if ran:
+        desired = {
+            item["id"]
+            for item in source_plugins.get("registrations", [])
+            if item.get("enabled") is not False
+        }
+        available = {
+            item["id"]
+            for item in target_plugins.get("registrations", [])
+            if item.get("enabled") is not False
+        }
+        missing = sorted(desired - available)
+    source_overrides = left.get("skill_registration_overrides", {})
+    disabled = sorted(
+        name
+        for name, value in right.get("skill_registration_overrides", {}).items()
+        if value == "off" and source_overrides.get(name) != "off"
+    )
+    return {
+        "ran": ran,
+        "ok": ran and not missing and not disabled,
+        "missing_or_disabled_plugins": missing,
+        "newly_disabled_skills": disabled,
+        "remediation": (
+            ["Plugin availability could not be compared; complete both native checks."]
+            if not ran
+            else [
+                "Install/enable the listed plugins and review the destination skill overrides."
+            ]
+            if missing or disabled
+            else []
+        ),
+    }

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -514,10 +514,15 @@ def compare_environments(
         }
         missing = sorted(desired - available)
     source_overrides = left.get("skill_registration_overrides", {})
+    source_disabled = {
+        name
+        for name, value in source_overrides.items()
+        if value is False or value == "off"
+    }
     disabled = sorted(
         name
         for name, value in right.get("skill_registration_overrides", {}).items()
-        if value == "off" and source_overrides.get(name) != "off"
+        if (value is False or value == "off") and name not in source_disabled
     )
     denied = sorted(
         set(right.get("skill_overrides", [])) - set(left.get("skill_overrides", []))

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -240,6 +240,12 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                     definition = Path(root) / "hooks" / "hooks.json"
                     if definition.is_file():
                         content = json.loads(definition.read_text())
+                        if not isinstance(content, dict):
+                            warnings.append(
+                                "Installed plugin hooks.json must contain an object; "
+                                "its hook declarations were not inspected."
+                            )
+                            continue
                         content["_plugin_root"] = root
                         hook_sources.append(content)
         except (OSError, ValueError, AttributeError):
@@ -277,6 +283,8 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                             }
                         )
                         continue
+                    while words and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", words[0]):
+                        words.pop(0)
                     paths = [
                         path
                         for word in words

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -368,6 +368,21 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                             "runtime_executed": False,
                         }
                     )
+    failed_simple_hooks = [
+        check for check in hook_checks if check.get("ran") and not check.get("ok")
+    ]
+    if failed_simple_hooks:
+        warnings.append(
+            f"{len(failed_simple_hooks)} configured hook check(s) failed: "
+            "a command could not be parsed, a launcher was unavailable, or a "
+            "referenced script was missing."
+        )
+        remediation.append(
+            "Inspect the selected account's hook declarations and enabled plugin "
+            "hook files. Correct missing script paths or install missing launchers "
+            "on the agent PATH, repair invalid quoting, then rerun the preflight. "
+            "Command text is withheld because it may contain secrets."
+        )
     checks["configured_hooks"] = hook_checks
     warnings.append(
         "Hook commands were inspected, not executed. Plugin hook imports "

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -263,6 +263,9 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                     command = hook.get("command", "")
                     if not isinstance(command, str):
                         continue
+                    command = command.replace(
+                        "${CLAUDE_PLUGIN_ROOT}", source.get("_plugin_root", "")
+                    )
                     try:
                         words = shlex.split(command)
                     except ValueError:
@@ -274,10 +277,15 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                             }
                         )
                         continue
-                    command = command.replace(
-                        "${CLAUDE_PLUGIN_ROOT}", source.get("_plugin_root", "")
-                    )
-                    paths = re.findall(r"/[^\s\"'<>;]+\.(?:py|sh)\b", command)
+                    paths = [
+                        path
+                        for word in words
+                        for path in (
+                            [word]
+                            if word.startswith("/") and word.endswith((".py", ".sh"))
+                            else re.findall(r"/[^\s\"'<>;]+\.(?:py|sh)\b", word)
+                        )
+                    ]
                     missing_paths = sum(not Path(path).is_file() for path in paths)
                     launcher = words[0] if words else ""
                     found = bool(shutil.which(launcher)) if launcher else False

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -52,7 +52,7 @@ def _registrations(value: Any) -> list[dict[str, Any]]:
         for item in value:
             result.extend(_registrations(item))
     elif isinstance(value, dict):
-        identity = value.get("id") or value.get("name") or value.get("pluginId")
+        identity = value.get("pluginId") or value.get("id") or value.get("name")
         if isinstance(identity, str) and re.fullmatch(r"[\w@./:-]{1,200}", identity):
             item = {"id": identity}
             for key in ("enabled", "version", "scope"):
@@ -96,7 +96,16 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
             [executable, "--version"], version_environment
         )
         native = (
-            _run([executable, "plugin", "list", "--json"], environment)
+            _run(
+                [
+                    executable,
+                    "plugin",
+                    "list",
+                    "--json",
+                    *(_codex_marketplace_args(home) if agent == "codex" else []),
+                ],
+                environment,
+            )
             if home.is_dir()
             else {"ran": False, "ok": False, "error": "Account not initialized"}
         )
@@ -127,6 +136,21 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                 native["error"] = "Unrecognized plugin JSON schema"
         native["registrations"] = registrations
         native["count"] = len(registrations)
+        if agent == "codex":
+            cached = _codex_cached_registrations(home)
+            native["cached_registrations"] = cached
+            native["command_ok"] = native["ok"]
+            native["scope"] = "unauthenticated isolated native discovery"
+            omitted = sorted(set(cached) - {item["id"] for item in registrations})
+            native["cached_not_in_native_probe"] = omitted
+            native["complete"] = native["ok"] and not omitted
+            if omitted:
+                native["ok"] = False
+                warnings.append(
+                    "The isolated Codex plugin probe omits cached plugins; "
+                    "bundled/remote availability may depend on account auth. "
+                    "Cache presence alone does not prove effective availability."
+                )
         checks["native_plugins"] = native
     else:
         remediation.append(f"Install {agent}, then rerun the environment check.")
@@ -284,8 +308,20 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
     )
     if not checks.get("native_plugins", {}).get("ok", False):
         remediation.append(
-            f"Run {agent} plugin list --json with the selected account "
-            "home; repair registrations without copying credentials."
+            "Run "
+            + shlex.join(
+                [
+                    "env",
+                    ("CODEX_HOME=" if agent == "codex" else "CLAUDE_CONFIG_DIR=")
+                    + str(home),
+                    agent,
+                    "plugin",
+                    "list",
+                    "--json",
+                ]
+            )
+            + " in the original account to verify authenticated availability; "
+            "repair registrations without copying credentials."
         )
     return {
         "ran": True,
@@ -309,6 +345,12 @@ def inspect_environment(agent: str, home: Path) -> dict[str, Any]:
             source = home / relative
             if source.is_file():
                 target = runtime_home / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source, target)
+                target.chmod(0o600)
+        if agent == "codex":
+            for source in _codex_metadata_files(home):
+                target = runtime_home / source.relative_to(home)
                 target.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(source, target)
                 target.chmod(0o600)
@@ -358,6 +400,12 @@ def compare_environments(
         "ok": ran and not missing and not disabled,
         "missing_or_disabled_plugins": missing,
         "newly_disabled_skills": disabled,
+        "static_cache_only_in_source": sorted(
+            set(source_plugins.get("cached_registrations", []))
+            - set(target_plugins.get("cached_registrations", []))
+        ),
+        "runtime_parity_verified": ran,
+        "static_cache_note": "Cache differences are advisory, not proof of effective availability.",
         "remediation": (
             ["Plugin availability could not be compared; complete both native checks."]
             if not ran
@@ -368,3 +416,56 @@ def compare_environments(
             else []
         ),
     }
+
+
+def _codex_metadata_files(home: Path) -> list[Path]:
+    """List manifest-only cache metadata; exclude auth, executables and databases."""
+    root = home / "plugins/cache"
+    return sorted(
+        {
+            path
+            for pattern in (
+                "*/*/*/.codex-plugin/plugin.json",
+                "*/*/*/.claude-plugin/plugin.json",
+                "*/*/.codex-remote-plugin-install.json",
+            )
+            for path in root.glob(pattern)
+            if path.is_file()
+        }
+    )
+
+
+def _codex_cached_registrations(home: Path) -> list[str]:
+    """Identify cache candidates separately from proven native availability."""
+    root = home / "plugins/cache"
+    return sorted(
+        {
+            f"{path.relative_to(root).parts[1]}@{path.relative_to(root).parts[0]}"
+            for path in _codex_metadata_files(home)
+        }
+    )
+
+
+def _codex_marketplace_args(home: Path) -> list[str]:
+    """Point git marketplace discovery at existing checkouts, never fetch or clone."""
+    try:
+        settings = tomllib.loads((home / "config.toml").read_text())
+    except (OSError, ValueError):
+        return []
+    args: list[str] = []
+    for name, value in settings.get("marketplaces", {}).items():
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", name) or not isinstance(value, dict):
+            continue
+        if value.get("source_type") != "git":
+            continue
+        checkout = home / ".tmp/marketplaces" / name
+        if checkout.is_dir():
+            args.extend(
+                [
+                    "-c",
+                    f'marketplaces.{name}.source_type="local"',
+                    "-c",
+                    f"marketplaces.{name}.source={json.dumps(str(checkout))}",
+                ]
+            )
+    return args

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -329,9 +329,11 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                         "typeset",
                         "let",
                     }
-                    if compound or (words and words[0] in builtins):
+                    env_wrapper = bool(words and Path(words[0]).name == "env")
+                    if compound or (words and words[0] in builtins) or env_wrapper:
                         instruction = (
-                            "Inspect this compound or builtin hook manually and use "
+                            "Inspect this compound, builtin, or environment-wrapper hook "
+                            "manually and use "
                             "a safe runtime input to verify it; the transfer probe "
                             "does not evaluate shell syntax."
                         )
@@ -339,7 +341,11 @@ def _inspect_environment(agent: str, home: Path, runtime_home: Path) -> dict[str
                             {
                                 "ran": False,
                                 "ok": False,
-                                "reason": "Compound or shell-builtin hook is unverified",
+                                "reason": (
+                                    "Environment-wrapper hook is unverified"
+                                    if env_wrapper
+                                    else "Compound or shell-builtin hook is unverified"
+                                ),
                                 "runtime_executed": False,
                                 "remediation": instruction,
                             }
@@ -487,16 +493,20 @@ def compare_environments(
         for name, value in right.get("skill_registration_overrides", {}).items()
         if value == "off" and source_overrides.get(name) != "off"
     )
+    denied = sorted(
+        set(right.get("skill_overrides", [])) - set(left.get("skill_overrides", []))
+    )
     return {
         "ran": ran,
-        "ok": ran and not missing and not disabled,
+        "ok": ran and not missing and not disabled and not denied,
         "missing_or_disabled_plugins": missing,
         "newly_disabled_skills": disabled,
+        "newly_denied_skills": denied,
         "static_cache_only_in_source": sorted(
             set(source_plugins.get("cached_registrations", []))
             - set(target_plugins.get("cached_registrations", []))
         ),
-        "runtime_parity_verified": ran and not missing and not disabled,
+        "runtime_parity_verified": ran and not missing and not disabled and not denied,
         "static_cache_note": "Cache differences are advisory, not proof of effective availability.",
         "remediation": (
             ["Plugin availability could not be compared; complete both native checks."]
@@ -504,7 +514,7 @@ def compare_environments(
             else [
                 "Install/enable the listed plugins and review the destination skill overrides."
             ]
-            if missing or disabled
+            if missing or disabled or denied
             else []
         ),
     }

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -1,0 +1,262 @@
+"""Read-only destination prerequisite checks without running hooks or model calls."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Any
+
+
+def _run(argv: list[str], environment: dict[str, str]) -> dict[str, Any]:
+    """Capture a bounded diagnostic without exposing raw stdout or stderr."""
+    try:
+        result = subprocess.run(
+            argv,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return {"ran": False, "ok": False, "error": type(error).__name__}
+    return {
+        "ran": True,
+        "ok": result.returncode == 0,
+        "exit_code": result.returncode,
+        "output": result.stdout[:2_000_000],
+    }
+
+
+def _version(argv: list[str], environment: dict[str, str]) -> dict[str, Any]:
+    """Return only the version number from a native command."""
+    result = _run(argv, environment)
+    match = re.search(r"\b\d+\.\d+\.\d+\b", result.pop("output", ""))
+    result["version"] = match.group() if match else None
+    result["ok"] = result["ok"] and match is not None
+    return result
+
+
+def _registrations(value: Any) -> list[dict[str, Any]]:
+    """Extract comparable non-secret identity and enabled fields from native JSON."""
+    result: list[dict[str, Any]] = []
+    if isinstance(value, list):
+        for item in value:
+            result.extend(_registrations(item))
+    elif isinstance(value, dict):
+        identity = value.get("id") or value.get("name") or value.get("pluginId")
+        if isinstance(identity, str) and re.fullmatch(r"[\w@./:-]{1,200}", identity):
+            item = {"id": identity}
+            for key in ("enabled", "version", "scope"):
+                field = value.get(key)
+                if isinstance(field, bool) or (
+                    isinstance(field, str) and re.fullmatch(r"[\w.@/-]{1,100}", field)
+                ):
+                    item[key] = field
+            result.append(item)
+        for key in ("plugins", "installed", "marketplaces", "data"):
+            if key in value:
+                result.extend(_registrations(value[key]))
+    return result
+
+
+def inspect_environment(agent: str, home: Path) -> dict[str, Any]:
+    """Inspect versions, effective plugin discovery, overrides and hook dependencies.
+
+    Hooks are never executed. Configuration is inspected without returning command
+    text, environment values, MCP arguments, or authentication material. A successful
+    inspection means the checks ran, not that every prerequisite is satisfied.
+    """
+    if agent not in {"claude", "codex"}:
+        raise ValueError("Agent must be claude or codex")
+    environment = dict(os.environ)
+    environment["CLAUDE_CONFIG_DIR" if agent == "claude" else "CODEX_HOME"] = str(home)
+    checks: dict[str, Any] = {}
+    warnings: list[str] = []
+    remediation: list[str] = []
+    executable = shutil.which(agent)
+    checks["native_cli"] = {
+        "ran": True,
+        "ok": executable is not None,
+        "path": executable,
+    }
+    if executable:
+        checks["native_version"] = _version([executable, "--version"], environment)
+        native = _run([executable, "plugin", "list", "--json"], environment)
+        raw = native.pop("output", "")
+        registrations: list[dict[str, Any]] = []
+        if native["ok"]:
+            try:
+                parsed = json.loads(raw)
+                if not isinstance(parsed, (dict, list)):
+                    raise ValueError("Unsupported plugin JSON")  # noqa: TRY004
+                registrations = _registrations(parsed)
+                if parsed and not registrations:
+                    raise ValueError("Unrecognized plugin JSON schema")
+            except ValueError:
+                native["ok"] = False
+                native["error"] = "Unrecognized plugin JSON schema"
+        native["registrations"] = registrations
+        native["count"] = len(registrations)
+        checks["native_plugins"] = native
+    else:
+        remediation.append(f"Install {agent}, then rerun the environment check.")
+    python = shutil.which("python3")
+    checks["hook_python"] = {"ran": True, "ok": False, "path": python}
+    if python:
+        checks["hook_python"].update(_version([python, "--version"], environment))
+        version = checks["hook_python"].get("version")
+        if version and tuple(map(int, version.split("."))) < (3, 11, 0):
+            warnings.append("The selected python3 is older than Python 3.11.")
+            remediation.append(
+                "Put Python 3.11+ before older Python on the agent PATH; "
+                "restart the shell and recheck hook interpreter selection."
+            )
+            checks["hook_python"]["ok"] = False
+    settings: dict[str, Any] = {}
+    config = home / ("settings.json" if agent == "claude" else "config.toml")
+    try:
+        if config.exists():
+            settings = (
+                json.loads(config.read_text())
+                if agent == "claude"
+                else tomllib.loads(config.read_text())
+            )
+        if not isinstance(settings, dict):
+            raise ValueError("Configuration must be an object")  # noqa: TRY004
+        checks["configuration"] = {"ran": True, "ok": True, "present": config.exists()}
+    except (OSError, ValueError):
+        checks["configuration"] = {"ran": True, "ok": False}
+        remediation.append("Repair the selected account configuration syntax.")
+        settings = {}
+    enabled = settings.get("enabledPlugins", {})
+    checks["plugin_overrides"] = (
+        {key: val for key, val in enabled.items() if isinstance(val, bool)}
+        if isinstance(enabled, dict)
+        else {}
+    )
+    skills = (
+        settings.get("permissions", {}).get("deny", [])
+        if isinstance(settings.get("permissions", {}), dict)
+        else []
+    )
+    checks["skill_overrides"] = [
+        item
+        for item in skills
+        if isinstance(item, str) and re.fullmatch(r"Skill\([\w:.*@/-]+\)", item)
+    ]
+    skill_root = home / "skills"
+    checks["skill_files"] = {
+        "ran": True,
+        "ok": True,
+        "count": sum((child / "SKILL.md").is_file() for child in skill_root.iterdir())
+        if skill_root.is_dir()
+        else 0,
+    }
+    hook_checks = []
+    hook_sources = [settings]
+    hooks_file = home / "hooks.json"
+    if hooks_file.is_file():
+        try:
+            hook_sources.append(json.loads(hooks_file.read_text()))
+        except (OSError, ValueError):
+            warnings.append("The account hooks.json cannot be parsed.")
+    installed = home / "plugins" / "installed_plugins.json"
+    if installed.is_file():
+        try:
+            registry = json.loads(installed.read_text()).get("plugins", {})
+            for plugin_id, entries in registry.items():
+                if isinstance(enabled, dict) and enabled.get(plugin_id) is False:
+                    continue
+                for entry in entries if isinstance(entries, list) else []:
+                    root = entry.get("installPath")
+                    if not isinstance(root, str):
+                        continue
+                    definition = Path(root) / "hooks" / "hooks.json"
+                    if definition.is_file():
+                        content = json.loads(definition.read_text())
+                        content["_plugin_root"] = root
+                        hook_sources.append(content)
+        except (OSError, ValueError, AttributeError):
+            warnings.append(
+                "Installed plugin hook registrations could not be inspected."
+            )
+    for source in hook_sources:
+        events = source.get("hooks", {}) if isinstance(source, dict) else {}
+        if not isinstance(events, dict):
+            warnings.append("Hook configuration has an unsupported structure.")
+            continue
+        for groups in events.values():
+            if not isinstance(groups, list):
+                continue
+            for group in groups:
+                if not isinstance(group, dict):
+                    continue
+                for hook in group.get("hooks", []):
+                    if not isinstance(hook, dict):
+                        continue
+                    command = hook.get("command", "")
+                    if not isinstance(command, str):
+                        continue
+                    try:
+                        words = shlex.split(command)
+                    except ValueError:
+                        hook_checks.append(
+                            {
+                                "ran": True,
+                                "ok": False,
+                                "reason": "Cannot parse hook command",
+                            }
+                        )
+                        continue
+                    command = command.replace(
+                        "${CLAUDE_PLUGIN_ROOT}", source.get("_plugin_root", "")
+                    )
+                    paths = re.findall(r"/[^\s\"'<>;]+\.(?:py|sh)\b", command)
+                    missing_paths = sum(not Path(path).is_file() for path in paths)
+                    launcher = words[0] if words else ""
+                    found = bool(shutil.which(launcher)) if launcher else False
+                    hook_checks.append(
+                        {
+                            "ran": True,
+                            "ok": found and not missing_paths,
+                            "launcher_available": found,
+                            "script_paths_checked": len(paths),
+                            "missing_script_paths": missing_paths,
+                            "runtime_executed": False,
+                        }
+                    )
+    checks["configured_hooks"] = hook_checks
+    warnings.append(
+        "Hook commands were inspected, not executed. Plugin hook imports "
+        "and machine services require a separate safe runtime check."
+    )
+    checks["chrome_loopback"] = {"ran": True, "ok": False, "port": 9222}
+    try:
+        with socket.create_connection(("127.0.0.1", 9222), timeout=0.2):
+            checks["chrome_loopback"]["ok"] = True
+    except OSError:
+        pass
+    warnings.append(
+        "A Chrome port listener does not prove a logged-in browser or MCP "
+        "connection; browser authentication is machine-specific."
+    )
+    if not checks.get("native_plugins", {}).get("ok", False):
+        remediation.append(
+            f"Run {agent} plugin list --json with the selected account "
+            "home; repair registrations without copying credentials."
+        )
+    return {
+        "ran": True,
+        "ok": True,
+        "checks": checks,
+        "warnings": warnings,
+        "remediation": remediation,
+    }

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -404,7 +404,7 @@ def compare_environments(
             set(source_plugins.get("cached_registrations", []))
             - set(target_plugins.get("cached_registrations", []))
         ),
-        "runtime_parity_verified": ran,
+        "runtime_parity_verified": ran and not missing and not disabled,
         "static_cache_note": "Cache differences are advisory, not proof of effective availability.",
         "remediation": (
             ["Plugin availability could not be compared; complete both native checks."]

--- a/claude_code_tools/transfer_environment.py
+++ b/claude_code_tools/transfer_environment.py
@@ -88,8 +88,17 @@ def inspect_environment(agent: str, home: Path) -> dict[str, Any]:
         "path": executable,
     }
     if executable:
-        checks["native_version"] = _version([executable, "--version"], environment)
-        native = _run([executable, "plugin", "list", "--json"], environment)
+        version_environment = dict(environment)
+        version_environment.pop("CLAUDE_CONFIG_DIR", None)
+        version_environment.pop("CODEX_HOME", None)
+        checks["native_version"] = _version(
+            [executable, "--version"], version_environment
+        )
+        native = (
+            _run([executable, "plugin", "list", "--json"], environment)
+            if home.is_dir()
+            else {"ran": False, "ok": False, "error": "Account not initialized"}
+        )
         raw = native.pop("output", "")
         registrations: list[dict[str, Any]] = []
         if native["ok"]:
@@ -152,6 +161,18 @@ def inspect_environment(agent: str, home: Path) -> dict[str, Any]:
         for item in skills
         if isinstance(item, str) and re.fullmatch(r"Skill\([\w:.*@/-]+\)", item)
     ]
+    overrides = settings.get("skillOverrides", {})
+    checks["skill_registration_overrides"] = (
+        {
+            key: value
+            for key, value in overrides.items()
+            if isinstance(key, str)
+            and isinstance(value, (bool, str))
+            and (isinstance(value, bool) or value in {"off", "on"})
+        }
+        if isinstance(overrides, dict)
+        else {}
+    )
     skill_root = home / "skills"
     checks["skill_files"] = {
         "ran": True,

--- a/claude_code_tools/transfer_journal.py
+++ b/claude_code_tools/transfer_journal.py
@@ -1,0 +1,219 @@
+"""Private transfer backups, durable progress, and conservative shared indexes."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+import uuid
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write(path: Path, data: bytes, replace: bool = False) -> None:
+    """Publish fully flushed private bytes; default refuses an existing target."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=".transfer-", dir=path.parent)
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(data)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if replace:
+            os.replace(temporary_path, path)
+        else:
+            os.link(temporary_path, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def owner_alive(pid: int | None) -> bool:
+    """Treat inaccessible or reused live PIDs conservatively as active."""
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def check_active_sessions(ids: list[str]) -> dict[str, Any]:
+    """Refuse observable native resume processes; do not claim full detection."""
+    result = subprocess.run(
+        ["ps", "-axo", "pid=,command="],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+    )
+    ids = [sid for sid in ids if sid]
+    for line in result.stdout.splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) != 2 or int(parts[0]) == os.getpid():
+            continue
+        command = parts[1]
+        if any(sid in command for sid in ids) and any(
+            executable in command.split()[:2]
+            or any(token.endswith("/" + executable) for token in command.split()[:2])
+            for executable in ("claude", "codex")
+        ):
+            raise ValueError("Selected destination session has a live agent process")
+    return {
+        "ran": True,
+        "ok": True,
+        "scope": "Native command lines containing selected IDs; renamed or server-hosted "
+        "sessions cannot be proven inactive. Exit destination sessions first.",
+    }
+
+
+class TransferJournal:
+    """Retain recoverable evidence without ever rolling back newer user work."""
+
+    def __init__(self, home: Path, manifest: dict[str, Any], recover: bool) -> None:
+        self.home = home
+        self.lock = home / ".aichat-transfer.lock"
+        digest = hashlib.sha256(
+            json.dumps(manifest, sort_keys=True).encode()
+        ).hexdigest()
+        home.mkdir(parents=True, exist_ok=True)
+        self.guard = os.open(
+            home / ".aichat-transfer.guard", os.O_CREAT | os.O_RDWR, 0o600
+        )
+        try:
+            fcntl.flock(self.guard, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            os.close(self.guard)
+            self.guard = None
+            raise ValueError("Transfer owner is still alive; import refused")
+        try:
+            self.lock.mkdir(mode=0o700)
+        except FileExistsError:
+            if not recover:
+                raise ValueError(
+                    "Transfer lock exists; use --recover for the same plan"
+                )
+            record_path = self.lock / "owner.json"
+            if not record_path.is_file():
+                raise ValueError("Transfer lock has no journal; inspect it manually")
+            previous = json.loads(record_path.read_text())
+            if owner_alive(previous.get("pid")):
+                raise ValueError("Transfer owner is still alive; recovery refused")
+            if previous["digest"] != digest:
+                raise ValueError("Recovery requires the identical transfer plan")
+            self.directory = Path(previous["directory"])
+            self.record = previous
+            self.record["pid"] = os.getpid()
+            self.save("recovering")
+            return
+        self.directory = home / ".aichat-transfer-backups" / uuid.uuid4().hex
+        self.directory.mkdir(parents=True, mode=0o700)
+        self.record = {
+            "pid": os.getpid(),
+            "digest": digest,
+            "directory": str(self.directory),
+            "phase": "created",
+            "backups_complete": False,
+        }
+        atomic_write(self.directory / "manifest.json", json.dumps(manifest).encode())
+        self.save("created")
+
+    def __del__(self) -> None:
+        """Release the kernel guard if initialization fails."""
+        self.release()
+
+    def release(self) -> None:
+        """Close the per-account kernel lock after finishing or failing."""
+        if getattr(self, "guard", None) is not None:
+            os.close(self.guard)
+            self.guard = None
+
+    def save(self, phase: str) -> None:
+        """Persist intent both in the lock and the retained private evidence."""
+        self.record["phase"] = phase
+        data = json.dumps(self.record).encode()
+        atomic_write(self.directory / "journal.json", data, replace=True)
+        atomic_write(self.lock / "owner.json", data, replace=True)
+
+    def backup(self, manifest: dict[str, Any]) -> None:
+        """Snapshot databases and index files before the first destination write."""
+        if self.record["backups_complete"]:
+            return
+        backup = self.directory / "before"
+        backup.mkdir(exist_ok=True, mode=0o700)
+        for database in manifest.get("databases", []):
+            path = self.home / database["name"]
+            target = backup / database["name"]
+            target.unlink(missing_ok=True)
+            with (
+                closing(sqlite3.connect(path.as_uri() + "?mode=ro", uri=True)) as src,
+                closing(sqlite3.connect(target)) as dest,
+            ):
+                src.backup(dest)
+                if dest.execute("PRAGMA quick_check").fetchone()[0] != "ok":
+                    raise ValueError("Database backup verification failed")
+            target.chmod(0o600)
+        for update in manifest.get("metadata_updates", []):
+            path = self.home / update["path"]
+            if path.exists():
+                target = backup / update["path"]
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(path, target)
+                target.chmod(0o600)
+        self.record["backups_complete"] = True
+        self.save("backed_up")
+
+    def failed(self) -> None:
+        """Permit explicit recovery after an ordinary failure in a live harness."""
+        self.record["pid"] = None
+        self.save("interrupted")
+        self.release()
+
+    def complete(self) -> None:
+        """Retain backups and release only this owned import lock."""
+        self.record["pid"] = None
+        self.save("complete")
+        (self.lock / "owner.json").unlink()
+        self.lock.rmdir()
+        self.release()
+
+
+def metadata_content(path: Path, update: dict[str, Any]) -> bytes:
+    """Merge selected keys only, refusing differing destination history."""
+    raw = path.read_bytes() if path.exists() else b""
+    container = update.get("container")
+    if update["format"] == "jsonl":
+        rows = [json.loads(line) for line in raw.splitlines() if line]
+        document = None
+    elif update["format"] == "json" and container == "records":
+        document = json.loads(raw) if raw else {"records": []}
+        rows = document["records"]
+    else:
+        raise ValueError("Unsupported metadata update format")
+    key = update["key"]
+    by_key = {row[key]: row for row in rows if key in row}
+    for row in update["rows"]:
+        identity = row[key]
+        if identity in by_key:
+            if by_key[identity] != row:
+                raise ValueError(f"Destination metadata differs: {path.name}")
+        else:
+            rows.append(row)
+            by_key[identity] = row
+    if document is None:
+        return b"".join((json.dumps(row) + "\n").encode() for row in rows)
+    return json.dumps(document).encode()

--- a/claude_code_tools/transfer_journal.py
+++ b/claude_code_tools/transfer_journal.py
@@ -90,7 +90,7 @@ class TransferJournal:
         digest = hashlib.sha256(
             json.dumps(manifest, sort_keys=True).encode()
         ).hexdigest()
-        home.mkdir(parents=True, exist_ok=True)
+        home.mkdir(parents=True, exist_ok=True, mode=0o700)
         self.guard = os.open(
             home / ".aichat-transfer.guard", os.O_CREAT | os.O_RDWR, 0o600
         )
@@ -217,3 +217,53 @@ def metadata_content(path: Path, update: dict[str, Any]) -> bytes:
     if document is None:
         return b"".join((json.dumps(row) + "\n").encode() for row in rows)
     return json.dumps(document).encode()
+
+
+def missing_jsonl_rows(path: Path, update: dict[str, Any]) -> list[dict[str, Any]]:
+    """Plan only missing selected index entries without rewriting prior bytes."""
+    raw = path.read_bytes() if path.exists() else b""
+    if raw and not raw.endswith(b"\n"):
+        raise ValueError("Incomplete destination index tail; inspect before recovery")
+    rows = [json.loads(line) for line in raw.splitlines() if line]
+    key = update["key"]
+    existing = {row[key]: row for row in rows if key in row}
+    missing = []
+    for row in update["rows"]:
+        if row[key] in existing:
+            if existing[row[key]] != row:
+                raise ValueError(f"Destination metadata differs: {path.name}")
+        else:
+            missing.append(row)
+            existing[row[key]] = row
+    return missing
+
+
+def append_jsonl_rows(
+    path: Path, update: dict[str, Any], pending: list[dict[str, Any]]
+) -> None:
+    """Append complete selected records, preserving concurrent unrelated appends.
+
+    Each record uses one O_APPEND write. A short write is never repaired by
+    truncating the index: retain the journal and require inspection instead.
+    """
+    # Recheck before publication: a concurrently completed identical import need
+    # not append duplicate rows, and a selected-key change is still a conflict.
+    missing = missing_jsonl_rows(path, update)
+    allowed = {json.dumps(row, sort_keys=True) for row in pending}
+    if any(json.dumps(row, sort_keys=True) not in allowed for row in missing):
+        raise ValueError("Destination index changed before append")
+    if missing:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            for row in missing:
+                data = (json.dumps(row) + "\n").encode()
+                if os.write(descriptor, data) != len(data):
+                    raise ValueError(
+                        "Partial index append; retained bytes require inspection "
+                        "before recovery, never truncate newer destination work"
+                    )
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    if missing_jsonl_rows(path, update):
+        raise ValueError("Appended metadata verification failed")

--- a/claude_code_tools/transfer_journal.py
+++ b/claude_code_tools/transfer_journal.py
@@ -193,14 +193,14 @@ class TransferJournal:
 
 
 def metadata_content(path: Path, update: dict[str, Any]) -> bytes:
-    """Merge selected keys only, refusing differing destination history."""
+    """Plan selected metadata; never rewrite an existing shared JSON document."""
     raw = path.read_bytes() if path.exists() else b""
     container = update.get("container")
     if update["format"] == "jsonl":
         rows = [json.loads(line) for line in raw.splitlines() if line]
         document = None
     elif update["format"] == "json" and container == "records":
-        document = json.loads(raw) if raw else {"records": []}
+        document = json.loads(raw) if path.exists() else {"records": []}
         rows = document["records"]
     else:
         raise ValueError("Unsupported metadata update format")
@@ -212,11 +212,17 @@ def metadata_content(path: Path, update: dict[str, Any]) -> bytes:
             if by_key[identity] != row:
                 raise ValueError(f"Destination metadata differs: {path.name}")
         else:
+            if document is not None and path.exists():
+                raise ValueError(
+                    "Existing shared JSON metadata requires additions; transfer "
+                    "cannot safely replace a document native agents may update. "
+                    "Use a separate destination account home."
+                )
             rows.append(row)
             by_key[identity] = row
     if document is None:
         return b"".join((json.dumps(row) + "\n").encode() for row in rows)
-    return json.dumps(document).encode()
+    return raw if path.exists() else json.dumps(document).encode()
 
 
 def missing_jsonl_rows(path: Path, update: dict[str, Any]) -> list[dict[str, Any]]:
@@ -267,3 +273,19 @@ def append_jsonl_rows(
             os.close(descriptor)
     if missing_jsonl_rows(path, update):
         raise ValueError("Appended metadata verification failed")
+
+
+def publish_json_metadata(path: Path, update: dict[str, Any]) -> None:
+    """Verify existing selected records or publish an absent document without clobber."""
+    if path.exists():
+        metadata_content(path, update)
+        return
+    data = metadata_content(path, update)
+    try:
+        atomic_write(path, data)
+    except FileExistsError as error:
+        raise ValueError(
+            "Shared JSON metadata appeared during publication and was preserved. "
+            "Inspect it or use a separate destination account home before retrying."
+        ) from error
+    metadata_content(path, update)

--- a/claude_code_tools/transfer_paths.py
+++ b/claude_code_tools/transfer_paths.py
@@ -1,0 +1,29 @@
+"""Shared lexical normalization for user-supplied transfer path mappings."""
+
+from __future__ import annotations
+
+import posixpath
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def normalize_path_mappings(
+    mappings: Mapping[str, str] | Sequence[Any] | None,
+) -> dict[str, str]:
+    """Coalesce equivalent absolute endpoints and reject ambiguous destinations."""
+    pairs = mappings.items() if isinstance(mappings, Mapping) else mappings or []
+    result: dict[str, str] = {}
+    for pair in pairs:
+        if isinstance(pair, Mapping):
+            old, new = pair["source"], pair["destination"]
+        else:
+            old, new = pair
+        if not all(
+            isinstance(path, str) and path.startswith("/") for path in (old, new)
+        ):
+            raise ValueError("--map requires two absolute paths")
+        old, new = ("/" + posixpath.normpath(path).lstrip("/") for path in (old, new))
+        if old in result and result[old] != new:
+            raise ValueError("Conflicting destinations for the same --map source")
+        result[old] = new
+    return result

--- a/claude_code_tools/transfer_remote.py
+++ b/claude_code_tools/transfer_remote.py
@@ -109,9 +109,11 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any]:
         )
     from claude_code_tools.transfer_journal import (
         TransferJournal,
+        append_jsonl_rows,
         atomic_write,
         check_active_sessions,
         metadata_content,
+        missing_jsonl_rows,
     )
 
     activity = check_active_sessions(
@@ -172,6 +174,10 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any]:
             )
         journal.save("updating_metadata")
         for path, update in metadata_paths:
+            if update["format"] == "jsonl":
+                pending = missing_jsonl_rows(path, update)
+                append_jsonl_rows(path, update, pending)
+                continue
             before = path.read_bytes() if path.exists() else None
             data = metadata_content(path, update)
             if before != (path.read_bytes() if path.exists() else None):

--- a/claude_code_tools/transfer_remote.py
+++ b/claude_code_tools/transfer_remote.py
@@ -108,6 +108,14 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any]:
             "crash inspect partial artifacts before removing this directory."
         ) from error
     created: list[Path] = []
+    commit_started = False
+    retain_lock = False
+
+    def mark_commit_started() -> None:
+        """Stop destructive cleanup before entering a possibly durable commit."""
+        nonlocal commit_started
+        commit_started = True
+
     try:
         validate_files(home, manifest)
         for relative, metadata in manifest["artifacts"].items():
@@ -131,16 +139,24 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any]:
         if manifest["agent"] == "codex":
             from claude_code_tools.transfer_codex import import_databases
 
-            import_databases(manifest, home)
+            import_databases(manifest, home, before_commit=mark_commit_started)
         result["imported_files"] = len(created)
         result["verified_files"] = len(manifest["artifacts"])
         return result
-    except BaseException:
+    except BaseException as error:
+        if commit_started:
+            retain_lock = True
+            raise ValueError(
+                f"Database commit outcome may be uncertain. Verified files and "
+                f"recovery lock were retained at {lock}; inspect destination "
+                "database rows before retrying or removing the lock."
+            ) from error
         for target in reversed(created):
             target.unlink(missing_ok=True)
         raise
     finally:
-        lock.rmdir()
+        if not retain_lock:
+            lock.rmdir()
 
 
 def main() -> None:

--- a/claude_code_tools/transfer_remote.py
+++ b/claude_code_tools/transfer_remote.py
@@ -51,6 +51,19 @@ def safe_target(home: Path, relative: str) -> Path:
 def validate_files(home: Path, manifest: dict[str, Any]) -> list[str]:
     """Identify exact existing copies and reject conflicting destination files."""
     identical = []
+    if manifest.get("agent") == "claude":
+        filename = f"{manifest['session_id']}.jsonl"
+        planned = {
+            home / relative
+            for relative in manifest["artifacts"]
+            if PurePosixPath(relative).name == filename
+        }
+        for existing in (home / "projects").glob(f"*/{filename}"):
+            if existing not in planned:
+                raise ValueError(
+                    f"Claude session ID already exists in another project: {existing}. "
+                    "Use its existing project or a separate destination account home."
+                )
     for relative, metadata in manifest["artifacts"].items():
         target = safe_target(home, relative)
         if target.exists():

--- a/claude_code_tools/transfer_remote.py
+++ b/claude_code_tools/transfer_remote.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
-import os
 import subprocess
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -69,11 +68,19 @@ def validate_files(home: Path, manifest: dict[str, Any]) -> list[str]:
 
 def handle_request(request: dict[str, Any]) -> dict[str, Any]:
     """Probe, validate, or import an explicitly scoped session bundle."""
+    if request["operation"] == "export":
+        from claude_code_tools.transfer_source import export_request
+
+        return export_request(request)
     home = Path(request["destination_home"]).expanduser().resolve()
     project = Path(request["destination_project"]).expanduser().resolve()
     state = project_state(project)
-    result = {"ok": True, "destination_home": str(home), "project": state}
+    result = {"ran": True, "ok": True, "destination_home": str(home), "project": state}
     if request["operation"] == "probe":
+        if request.get("agent"):
+            from claude_code_tools.transfer_environment import inspect_environment
+
+            result["environment"] = inspect_environment(request["agent"], home)
         return result
     manifest = request["manifest"]
     expected = manifest["project_state"]
@@ -87,76 +94,98 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any]:
             "Destination revision/project subdirectory differs. Fetch and check "
             f"out {expected['head']} in the destination worktree first."
         )
+    from claude_code_tools.transfer_journal import (
+        TransferJournal,
+        atomic_write,
+        check_active_sessions,
+        metadata_content,
+    )
+
+    activity = check_active_sessions(
+        manifest.get("session_ids", [manifest.get("session_id", "")])
+    )
     identical = validate_files(home, manifest)
     if manifest["agent"] == "codex":
         from claude_code_tools.transfer_codex import validate_databases
 
         validate_databases(manifest, home)
-    result["identical_files"] = identical
+    metadata_paths = []
+    for update in manifest.get("metadata_updates", []):
+        if update["path"] not in (
+            "session_index.jsonl",
+            "external_agent_session_imports.json",
+        ):
+            raise ValueError("Unsupported shared metadata path")
+        path = safe_target(home, update["path"])
+        metadata_content(path, update)
+        metadata_paths.append((path, update))
+    result.update({"identical_files": identical, "activity_check": activity})
     if request["operation"] == "validate":
         return result
     if request["operation"] != "import":
         raise ValueError("Unknown transfer operation")
-    # A second importer must not race file creation/rollback or database commit.
-    home.mkdir(parents=True, exist_ok=True)
-    lock = home / ".aichat-transfer.lock"
+    # Validate the entire bundle before publishing any destination artifact.
+    decoded = {}
+    for relative, metadata in manifest["artifacts"].items():
+        data = base64.b64decode(request["data"][relative], validate=True)
+        if (
+            len(data) != metadata["size"]
+            or hashlib.sha256(data).hexdigest() != metadata["sha256"]
+        ):
+            raise ValueError(f"Bundle integrity check failed: {relative}")
+        decoded[relative] = data
+    journal = TransferJournal(home, manifest, bool(request.get("recover")))
+    created = 0
     try:
-        lock.mkdir()
-    except FileExistsError as error:
-        raise ValueError(
-            f"Transfer lock exists: {lock}. Check for another transfer; after a "
-            "crash inspect partial artifacts before removing this directory."
-        ) from error
-    created: list[Path] = []
-    commit_started = False
-    retain_lock = False
-
-    def mark_commit_started() -> None:
-        """Stop destructive cleanup before entering a possibly durable commit."""
-        nonlocal commit_started
-        commit_started = True
-
-    try:
+        check_active_sessions(
+            manifest.get("session_ids", [manifest.get("session_id", "")])
+        )
         validate_files(home, manifest)
-        for relative, metadata in manifest["artifacts"].items():
-            data = base64.b64decode(request["data"][relative], validate=True)
-            if len(data) != metadata["size"] or (
-                hashlib.sha256(data).hexdigest() != metadata["sha256"]
-            ):
-                raise ValueError(f"Bundle integrity check failed: {relative}")
+        journal.backup(manifest)
+        journal.save("publishing_files")
+        for relative, data in decoded.items():
             target = safe_target(home, relative)
-            if target.exists():
-                continue
-            target.parent.mkdir(parents=True, exist_ok=True)
-            with target.open("xb") as stream:
-                created.append(target)
-                os.chmod(target, 0o600)
-                stream.write(data)
-                stream.flush()
-                os.fsync(stream.fileno())
-            if hashlib.sha256(target.read_bytes()).hexdigest() != metadata["sha256"]:
-                raise ValueError(f"Destination verification failed: {target}")
+            if not target.exists():
+                atomic_write(target, data)
+                created += 1
+        validate_files(home, manifest)
         if manifest["agent"] == "codex":
             from claude_code_tools.transfer_codex import import_databases
 
-            import_databases(manifest, home, before_commit=mark_commit_started)
-        result["imported_files"] = len(created)
-        result["verified_files"] = len(manifest["artifacts"])
+            import_databases(
+                manifest,
+                home,
+                before_commit=lambda: journal.save("database_commit_started"),
+            )
+        journal.save("updating_metadata")
+        for path, update in metadata_paths:
+            before = path.read_bytes() if path.exists() else None
+            data = metadata_content(path, update)
+            if before != (path.read_bytes() if path.exists() else None):
+                raise ValueError("Destination metadata changed during import")
+            if before != data:
+                atomic_write(path, data, replace=before is not None)
+            if metadata_content(path, update) != path.read_bytes():
+                raise ValueError("Metadata verification failed")
+        validate_files(home, manifest)
+        result.update(
+            {
+                "imported_files": created,
+                "verified_files": len(manifest["artifacts"]),
+                "verified_metadata": len(metadata_paths),
+                "backup_directory": str(journal.directory),
+            }
+        )
+        journal.complete()
         return result
     except BaseException as error:
-        if commit_started:
-            retain_lock = True
-            raise ValueError(
-                f"Database commit outcome may be uncertain. Verified files and "
-                f"recovery lock were retained at {lock}; inspect destination "
-                "database rows before retrying or removing the lock."
-            ) from error
-        for target in reversed(created):
-            target.unlink(missing_ok=True)
-        raise
-    finally:
-        if not retain_lock:
-            lock.rmdir()
+        journal.failed()
+        raise ValueError(
+            f"Transfer interrupted; database commit outcome may be uncertain; "
+            f"verified or partial state and backups retained at "
+            f"{journal.directory}. Use --recover with the identical plan; "
+            "never delete newer destination work."
+        ) from error
 
 
 def main() -> None:

--- a/claude_code_tools/transfer_remote.py
+++ b/claude_code_tools/transfer_remote.py
@@ -114,6 +114,7 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any]:
         check_active_sessions,
         metadata_content,
         missing_jsonl_rows,
+        publish_json_metadata,
     )
 
     activity = check_active_sessions(
@@ -178,14 +179,7 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any]:
                 pending = missing_jsonl_rows(path, update)
                 append_jsonl_rows(path, update, pending)
                 continue
-            before = path.read_bytes() if path.exists() else None
-            data = metadata_content(path, update)
-            if before != (path.read_bytes() if path.exists() else None):
-                raise ValueError("Destination metadata changed during import")
-            if before != data:
-                atomic_write(path, data, replace=before is not None)
-            if metadata_content(path, update) != path.read_bytes():
-                raise ValueError("Metadata verification failed")
+            publish_json_metadata(path, update)
         validate_files(home, manifest)
         result.update(
             {

--- a/claude_code_tools/transfer_remote.py
+++ b/claude_code_tools/transfer_remote.py
@@ -1,0 +1,155 @@
+"""Standard-library destination checks and non-overwriting session import."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import subprocess
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+def project_state(project: Path) -> dict[str, Any]:
+    """Read a Git worktree's revision and cleanliness without changing it."""
+
+    def git(*args: str) -> str:
+        result = subprocess.run(
+            ["git", "--no-optional-locks", "-C", str(project), *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+
+    if not project.is_dir():
+        raise ValueError(f"Project does not exist: {project}")
+    root = Path(git("rev-parse", "--show-toplevel")).resolve()
+    return {
+        "path": str(project.resolve()),
+        "root": str(root),
+        "relative": str(project.resolve().relative_to(root)),
+        "head": git("rev-parse", "HEAD"),
+        "changes": git("status", "--porcelain", "--untracked-files=all"),
+    }
+
+
+def safe_target(home: Path, relative: str) -> Path:
+    """Reject traversal and links inside the explicitly selected account home."""
+    path = PurePosixPath(relative)
+    if path.is_absolute() or not path.parts or ".." in path.parts:
+        raise ValueError(f"Unsafe artifact path: {relative}")
+    target = home.joinpath(*path.parts)
+    for item in (target, *target.parents):
+        if item == home:
+            break
+        if item.is_symlink():
+            raise ValueError(f"Destination artifact uses a symlink: {item}")
+    return target
+
+
+def validate_files(home: Path, manifest: dict[str, Any]) -> list[str]:
+    """Identify exact existing copies and reject conflicting destination files."""
+    identical = []
+    for relative, metadata in manifest["artifacts"].items():
+        target = safe_target(home, relative)
+        if target.exists():
+            if not target.is_file():
+                raise ValueError(f"Destination is not a regular file: {target}")
+            digest = hashlib.sha256(target.read_bytes()).hexdigest()
+            if digest != metadata["sha256"]:
+                raise ValueError(
+                    f"Destination artifact differs: {target}. "
+                    "Use a separate destination account home or reconcile it first."
+                )
+            identical.append(relative)
+    return identical
+
+
+def handle_request(request: dict[str, Any]) -> dict[str, Any]:
+    """Probe, validate, or import an explicitly scoped session bundle."""
+    home = Path(request["destination_home"]).expanduser().resolve()
+    project = Path(request["destination_project"]).expanduser().resolve()
+    state = project_state(project)
+    result = {"ok": True, "destination_home": str(home), "project": state}
+    if request["operation"] == "probe":
+        return result
+    manifest = request["manifest"]
+    expected = manifest["project_state"]
+    if state["changes"] or expected["changes"]:
+        raise ValueError(
+            "Both worktrees must be clean, including untracked files. Commit and "
+            "sync intended changes first; ignored files are a separate prerequisite."
+        )
+    if (state["head"], state["relative"]) != (expected["head"], expected["relative"]):
+        raise ValueError(
+            "Destination revision/project subdirectory differs. Fetch and check "
+            f"out {expected['head']} in the destination worktree first."
+        )
+    identical = validate_files(home, manifest)
+    if manifest["agent"] == "codex":
+        from claude_code_tools.transfer_codex import validate_databases
+
+        validate_databases(manifest, home)
+    result["identical_files"] = identical
+    if request["operation"] == "validate":
+        return result
+    if request["operation"] != "import":
+        raise ValueError("Unknown transfer operation")
+    # A second importer must not race file creation/rollback or database commit.
+    home.mkdir(parents=True, exist_ok=True)
+    lock = home / ".aichat-transfer.lock"
+    try:
+        lock.mkdir()
+    except FileExistsError as error:
+        raise ValueError(
+            f"Transfer lock exists: {lock}. Check for another transfer; after a "
+            "crash inspect partial artifacts before removing this directory."
+        ) from error
+    created: list[Path] = []
+    try:
+        validate_files(home, manifest)
+        for relative, metadata in manifest["artifacts"].items():
+            data = base64.b64decode(request["data"][relative], validate=True)
+            if len(data) != metadata["size"] or (
+                hashlib.sha256(data).hexdigest() != metadata["sha256"]
+            ):
+                raise ValueError(f"Bundle integrity check failed: {relative}")
+            target = safe_target(home, relative)
+            if target.exists():
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open("xb") as stream:
+                created.append(target)
+                os.chmod(target, 0o600)
+                stream.write(data)
+                stream.flush()
+                os.fsync(stream.fileno())
+            if hashlib.sha256(target.read_bytes()).hexdigest() != metadata["sha256"]:
+                raise ValueError(f"Destination verification failed: {target}")
+        if manifest["agent"] == "codex":
+            from claude_code_tools.transfer_codex import import_databases
+
+            import_databases(manifest, home)
+        result["imported_files"] = len(created)
+        result["verified_files"] = len(manifest["artifacts"])
+        return result
+    except BaseException:
+        for target in reversed(created):
+            target.unlink(missing_ok=True)
+        raise
+    finally:
+        lock.rmdir()
+
+
+def main() -> None:
+    """Serve one JSON request over an SSH pipe, with an explicit success flag."""
+    import sys
+
+    try:
+        response = handle_request(json.load(sys.stdin))
+    except Exception as error:
+        print(json.dumps({"ok": False, "error": str(error)}))
+        raise SystemExit(1) from error
+    print(json.dumps(response))

--- a/claude_code_tools/transfer_remote.py
+++ b/claude_code_tools/transfer_remote.py
@@ -34,6 +34,36 @@ def project_state(project: Path) -> dict[str, Any]:
     }
 
 
+def capture_operational_projects(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Record Git evidence for actual rewritten cwd paths, not artifact mappings."""
+    return [
+        {
+            "source": project_state(Path(pair["source"])),
+            "destination": pair["destination"],
+        }
+        for pair in manifest.get("operational_cwds", [])
+    ]
+
+
+def validate_operational_projects(manifest: dict[str, Any]) -> None:
+    """Require every operational worktree to match before publishing session data."""
+    for pair in manifest.get("operational_projects", []):
+        source = pair["source"]
+        destination = project_state(Path(pair["destination"]))
+        if source["changes"] or destination["changes"]:
+            raise ValueError(
+                f"Operational worktree must be clean: {source['path']} -> {destination['path']}"
+            )
+        if (source["head"], source["relative"]) != (
+            destination["head"],
+            destination["relative"],
+        ):
+            raise ValueError(
+                f"Operational worktree revision/subdirectory differs: "
+                f"{source['path']} -> {destination['path']}"
+            )
+
+
 def safe_target(home: Path, relative: str) -> Path:
     """Reject traversal and links inside the explicitly selected account home."""
     path = PurePosixPath(relative)
@@ -107,6 +137,7 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any]:
             "Destination revision/project subdirectory differs. Fetch and check "
             f"out {expected['head']} in the destination worktree first."
         )
+    validate_operational_projects(manifest)
     from claude_code_tools.transfer_journal import (
         TransferJournal,
         append_jsonl_rows,
@@ -157,6 +188,7 @@ def handle_request(request: dict[str, Any]) -> dict[str, Any]:
             manifest.get("session_ids", [manifest.get("session_id", "")])
         )
         validate_files(home, manifest)
+        validate_operational_projects(manifest)
         journal.backup(manifest)
         journal.save("publishing_files")
         for relative, data in decoded.items():

--- a/claude_code_tools/transfer_session.py
+++ b/claude_code_tools/transfer_session.py
@@ -28,21 +28,38 @@ from claude_code_tools.transfer_remote import handle_request, project_state
 
 def remote_bootstrap() -> str:
     """Build a standard-library helper; the destination need not install aichat."""
-    modules = {}
-    for name in ("transfer_codex", "transfer_remote"):
-        path = Path(__file__).with_name(f"{name}.py")
-        modules[f"claude_code_tools.{name}"] = path.read_text()
-    encoded = base64.b64encode(json.dumps(modules).encode()).decode()
-    return (
-        "import sys,types,json,base64; "
-        "assert sys.version_info >= (3,11), 'Python 3.11+ is required'; "
-        "sys.modules['claude_code_tools']=types.ModuleType('claude_code_tools'); "
-        f"sources=json.loads(base64.b64decode('{encoded}')); "
-        "\nfor name,source in sources.items():\n"
-        " module=types.ModuleType(name); sys.modules[name]=module; "
-        "exec(compile(source,name,'exec'),module.__dict__)\n"
-        "sys.modules['claude_code_tools.transfer_remote'].main()"
+    import inspect
+    import zlib
+
+    from claude_code_tools.session_utils import encode_claude_project_path
+
+    modules = {
+        f"claude_code_tools.{path.stem}": path.read_text()
+        for path in Path(__file__).parent.glob("transfer_*.py")
+        if path.stem != "transfer_session"
+    }
+    modules["claude_code_tools.session_utils"] = inspect.getsource(
+        encode_claude_project_path
     )
+    encoded = base64.b64encode(zlib.compress(json.dumps(modules).encode())).decode()
+    return f"""import sys, types, json, base64, zlib, importlib.abc, importlib.util
+assert sys.version_info >= (3,11), 'Python 3.11+ is required'
+sources = json.loads(zlib.decompress(base64.b64decode({encoded!r})))
+package = types.ModuleType('claude_code_tools')
+package.__path__ = []
+sys.modules['claude_code_tools'] = package
+class Loader(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname in sources:
+            return importlib.util.spec_from_loader(fullname, self)
+    def create_module(self, spec):
+        return None
+    def exec_module(self, module):
+        exec(compile(sources[module.__name__], module.__name__, 'exec'), module.__dict__)
+sys.meta_path.insert(0, Loader())
+from claude_code_tools.transfer_remote import main
+main()
+"""
 
 
 def destination_request(
@@ -80,6 +97,7 @@ def prepare_transfer(
     destination_home: Path,
     destination_project: Path,
     staging: Path,
+    path_mappings: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Resolve a unique session and build a scoped, checksummed transfer plan."""
     if agent == "codex":
@@ -108,6 +126,7 @@ def prepare_transfer(
         destination_home,
         destination_project,
         staging,
+        path_mappings=path_mappings,
     )
     if manifest.get("ok") is not True:
         raise ValueError("Session adapter did not report successful export")
@@ -155,13 +174,41 @@ def prepare_transfer(
     return manifest
 
 
+def stage_path_guide(manifest: dict[str, Any], staging: Path) -> None:
+    """Persist artifact mappings without rewriting historical conversation text."""
+    relative = f"transfer-support/{manifest['session_id']}/path-map.json"
+    guide = {
+        "purpose": "Resolve historical artifact paths on this destination",
+        "instructions": (
+            "Use the longest matching source prefix in path_mappings. "
+            "Conversation text is unchanged. missing_at_source entries were "
+            "already absent before this copy and may need to be recreated."
+        ),
+        "path_mappings": manifest.get("path_mappings", {}),
+        "missing_at_source": manifest.get("missing_at_source", []),
+    }
+    content = (json.dumps(guide, indent=2) + "\n").encode()
+    target = staging / "files" / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(content)
+    manifest["files"].append(relative)
+    manifest["artifacts"][relative] = {
+        "size": len(content),
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
+    manifest["path_guide"] = str(Path(manifest["destination_home"]) / relative)
+
+
 @click.command("transfer")
 @click.argument("session")
 @click.option("--agent", type=click.Choice(["claude", "codex"]), required=True)
 @click.option(
     "--source-home",
-    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    type=click.Path(file_okay=False, path_type=Path),
     help="Source profile (defaults to the agent's configured home).",
+)
+@click.option(
+    "--from", "source_host", default="local", help="Source SSH alias, or local."
 )
 @click.option("--to", "host", required=True, help="SSH host/alias, or 'local'.")
 @click.option("--destination-home", required=True, help="Destination agent profile.")
@@ -172,6 +219,19 @@ def prepare_transfer(
     show_default=True,
     help="Python 3.11+ executable on the SSH destination.",
 )
+@click.option(
+    "--map",
+    "path_mappings",
+    type=(str, str),
+    multiple=True,
+    help="Additional source/destination path pair; repeat as needed.",
+)
+@click.option(
+    "--recover",
+    is_flag=True,
+    help="With --apply, retry the same interrupted transfer plan.",
+)
+@click.option("--apply", is_flag=True, help="Apply the verified copy plan.")
 @click.option(
     "--dry-run",
     is_flag=True,
@@ -184,29 +244,49 @@ def transfer(
     session: str,
     agent: str,
     source_home: Path | None,
+    source_host: str,
     host: str,
     destination_home: str,
     destination_project: str,
     remote_python: str,
     dry_run: bool,
+    apply: bool,
+    recover: bool,
+    path_mappings: tuple[tuple[str, str], ...],
     as_json: bool,
 ) -> None:
     """Copy a saved conversation and supported artifacts, preserving the source.
 
     Exit the source agent first. Prepare a clean destination Git worktree at the
-    same commit. Inspect --dry-run before copying. Existing differing artifacts
+    same commit. Inspect the default dry-run plan, then use --apply to copy. Existing differing artifacts
     are never overwritten; account credentials/settings are not transferred.
     Quote destination paths beginning with ~ so the destination expands them.
     """
+    if apply and dry_run:
+        raise click.UsageError("Use either --apply or --dry-run, not both.")
+    if recover and not apply:
+        raise click.UsageError("--recover requires --apply")
+    mapped: dict[str, str] = {}
+    for old, new in path_mappings:
+        if not Path(old).is_absolute() or not Path(new).is_absolute():
+            raise click.UsageError("--map requires two absolute paths")
+        if old in mapped and mapped[old] != new:
+            raise click.UsageError("Conflicting destinations for the same --map source")
+        mapped[old] = new
+    dry_run = not apply
     variable = "CODEX_HOME" if agent == "codex" else "CLAUDE_CONFIG_DIR"
     configured = (ctx.obj or {}).get(f"{agent}_home")
-    source_home = (
-        Path(source_home or configured or os.environ.get(variable, f"~/.{agent}"))
-        .expanduser()
-        .resolve()
-    )
+    if source_host == "local":
+        source_home = (
+            Path(source_home or configured or os.environ.get(variable, f"~/.{agent}"))
+            .expanduser()
+            .resolve()
+        )
+    else:
+        source_home = Path(source_home or f"~/.{agent}")
     request = {
         "operation": "probe",
+        "agent": agent,
         "destination_home": destination_home,
         "destination_project": destination_project,
     }
@@ -215,18 +295,53 @@ def transfer(
         probe = destination_request(host, remote_python, request)
         with tempfile.TemporaryDirectory(prefix="aichat-transfer-") as directory:
             staging = Path(directory)
-            manifest = prepare_transfer(
-                agent,
-                source_home,
-                session,
-                Path(probe["destination_home"]),
-                Path(probe["project"]["path"]),
-                staging,
-            )
+            if source_host == "local":
+                manifest = prepare_transfer(
+                    agent,
+                    source_home,
+                    session,
+                    Path(probe["destination_home"]),
+                    Path(probe["project"]["path"]),
+                    staging,
+                    dict(path_mappings),
+                )
+            else:
+                bundle = destination_request(
+                    source_host,
+                    remote_python,
+                    {
+                        "operation": "export",
+                        "agent": agent,
+                        "path_mappings": dict(path_mappings),
+                        "source_home": str(source_home),
+                        "session": session,
+                        "destination_home": probe["destination_home"],
+                        "destination_project": probe["project"]["path"],
+                    },
+                )
+                manifest = bundle["manifest"]
+                from claude_code_tools.transfer_remote import safe_target
+
+                for relative, encoded in bundle["data"].items():
+                    target = safe_target(staging / "files", relative)
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_bytes(base64.b64decode(encoded, validate=True))
+                command = ["env", f"{variable}={probe['destination_home']}", agent]
+                if agent == "codex":
+                    command += ["--cd", probe["project"]["path"], "resume"]
+                else:
+                    command += ["--resume"]
+                command.append(manifest["session_id"])
+                manifest["resume_command"] = (
+                    f"cd {shlex.quote(probe['project']['path'])} && "
+                    + shlex.join(command)
+                )
+            stage_path_guide(manifest, staging)
             request.update({"operation": "validate", "manifest": manifest})
             result = destination_request(host, remote_python, request)
             if not dry_run:
                 request["operation"] = "import"
+                request["recover"] = recover
                 request["data"] = {
                     relative: base64.b64encode(
                         (staging / "files" / relative).read_bytes()
@@ -235,13 +350,15 @@ def transfer(
                 }
                 result = destination_request(host, remote_python, request)
             report = {
+                "ran": True,
                 "ok": True,
                 "dry_run": dry_run,
                 "plan": manifest,
                 "destination": result,
+                "environment": probe.get("environment"),
             }
     except (OSError, ValueError, sqlite3.Error, subprocess.SubprocessError) as error:
-        report = {"ok": False, "error": str(error), "plan": manifest}
+        report = {"ran": True, "ok": False, "error": str(error), "plan": manifest}
     if as_json:
         click.echo(json.dumps(report, indent=2))
     elif not report["ok"]:
@@ -260,6 +377,12 @@ def transfer(
                 )
         for warning in manifest["warnings"]:
             click.echo(f"Note: {warning}")
+        environment = report.get("environment") or {}
+        for warning in environment.get("warnings", []):
+            click.echo(f"Environment: {warning}")
+        for remedy in environment.get("remediation", []):
+            click.echo(f"Remediation: {remedy}")
+        click.echo(f"Artifact path guide: {manifest['path_guide']}")
         click.echo(f"Resume on destination:\n  {manifest['resume_command']}")
     if not report["ok"]:
         ctx.exit(1)

--- a/claude_code_tools/transfer_session.py
+++ b/claude_code_tools/transfer_session.py
@@ -199,6 +199,20 @@ def stage_path_guide(manifest: dict[str, Any], staging: Path) -> None:
     manifest["path_guide"] = str(Path(manifest["destination_home"]) / relative)
 
 
+def public_report(report: dict[str, Any]) -> dict[str, Any]:
+    """Summarize imported records without printing conversation or goal contents."""
+    import copy
+
+    result = copy.deepcopy(report)
+    plan = result.get("plan") or {}
+    for database in plan.get("databases", []):
+        for table in database.get("tables", []):
+            table["row_count"] = len(table.pop("rows", []))
+    for update in plan.get("metadata_updates", []):
+        update["row_count"] = len(update.pop("rows", []))
+    return result
+
+
 @click.command("transfer")
 @click.argument("session")
 @click.option("--agent", type=click.Choice(["claude", "codex"]), required=True)
@@ -372,7 +386,7 @@ def transfer(
     except (OSError, ValueError, sqlite3.Error, subprocess.SubprocessError) as error:
         report = {"ran": True, "ok": False, "error": str(error), "plan": manifest}
     if as_json:
-        click.echo(json.dumps(report, indent=2))
+        click.echo(json.dumps(public_report(report), indent=2))
     elif not report["ok"]:
         click.echo(f"Transfer cannot proceed: {report['error']}", err=True)
     else:

--- a/claude_code_tools/transfer_session.py
+++ b/claude_code_tools/transfer_session.py
@@ -1,0 +1,243 @@
+"""Inspect and copy one agent conversation to a local or SSH destination."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib
+import json
+import os
+import shlex
+import sqlite3
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import click
+
+from claude_code_tools.move_account import (
+    find_codex_sessions_in_home,
+    find_sessions_in_home,
+)
+from claude_code_tools.transfer_remote import handle_request, project_state
+
+
+def remote_bootstrap() -> str:
+    """Build a standard-library helper; the destination need not install aichat."""
+    modules = {}
+    for name in ("transfer_codex", "transfer_remote"):
+        path = Path(__file__).with_name(f"{name}.py")
+        modules[f"claude_code_tools.{name}"] = path.read_text()
+    encoded = base64.b64encode(json.dumps(modules).encode()).decode()
+    return (
+        "import sys,types,json,base64; "
+        "assert sys.version_info >= (3,11), 'Python 3.11+ is required'; "
+        "sys.modules['claude_code_tools']=types.ModuleType('claude_code_tools'); "
+        f"sources=json.loads(base64.b64decode('{encoded}')); "
+        "\nfor name,source in sources.items():\n"
+        " module=types.ModuleType(name); sys.modules[name]=module; "
+        "exec(compile(source,name,'exec'),module.__dict__)\n"
+        "sys.modules['claude_code_tools.transfer_remote'].main()"
+    )
+
+
+def destination_request(
+    host: str, python: str, request: dict[str, Any]
+) -> dict[str, Any]:
+    """Execute a destination operation without bypassing SSH host verification."""
+    if host == "local":
+        return handle_request(request)
+    if host.startswith("-") or any(char.isspace() for char in host):
+        raise ValueError("--to must be an SSH host/alias (or 'local'), not options")
+    command = shlex.join([python, "-c", remote_bootstrap()])
+    result = subprocess.run(
+        ["ssh", "-o", "BatchMode=yes", "--", host, command],
+        input=json.dumps(request),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    try:
+        response = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise ValueError(
+            f"Destination helper failed (exit {result.returncode}): "
+            f"{result.stderr.strip() or result.stdout[:500]}"
+        ) from error
+    if result.returncode != 0 or response.get("ok") is not True:
+        raise ValueError(response.get("error", result.stderr.strip()))
+    return response
+
+
+def prepare_transfer(
+    agent: str,
+    source_home: Path,
+    session: str,
+    destination_home: Path,
+    destination_project: Path,
+    staging: Path,
+) -> dict[str, Any]:
+    """Resolve a unique session and build a scoped, checksummed transfer plan."""
+    finder = find_codex_sessions_in_home if agent == "codex" else find_sessions_in_home
+    matches = finder(source_home, session)
+    if len(matches) != 1:
+        candidates = ", ".join(candidate.session_id for candidate in matches[:10])
+        raise ValueError(
+            f"Expected one {agent} session in {source_home}; found {len(matches)}. "
+            f"Use a full UUID. Candidates: {candidates or '(none)'}"
+        )
+    adapter = importlib.import_module(f"claude_code_tools.transfer_{agent}")
+    manifest = adapter.export_session(
+        source_home,
+        matches[0].session_id,
+        destination_home,
+        destination_project,
+        staging,
+    )
+    if manifest.get("ok") is not True:
+        raise ValueError("Session adapter did not report successful export")
+    manifest.update(
+        {
+            "agent": agent,
+            "session_id": matches[0].session_id,
+            "source_home": str(source_home),
+            "destination_home": str(destination_home),
+            "destination_project": str(destination_project),
+            "project_state": project_state(Path(manifest["source_project"])),
+        }
+    )
+    artifacts = {}
+    for relative in manifest["files"]:
+        data = (staging / "files" / relative).read_bytes()
+        artifacts[relative] = {
+            "size": len(data),
+            "sha256": hashlib.sha256(data).hexdigest(),
+        }
+    manifest["artifacts"] = artifacts
+    variable = "CODEX_HOME" if agent == "codex" else "CLAUDE_CONFIG_DIR"
+    command = ["env", f"{variable}={destination_home}", agent]
+    if agent == "codex":
+        command += ["--cd", str(destination_project), "resume", matches[0].session_id]
+    else:
+        command += ["--resume", matches[0].session_id]
+    manifest["resume_command"] = (
+        f"cd {shlex.quote(str(destination_project))} && {shlex.join(command)}"
+    )
+    manifest.setdefault("warnings", []).extend(
+        [
+            (
+                "Exit the source agent before copying; do not continue both copies. "
+                "Live processes and running shell tasks are not relocated."
+            ),
+            (
+                "Git revision and cleanliness are checked. Ignored files, credentials, "
+                "dependencies, plugins, shared settings, and external services must be "
+                "prepared separately on the destination."
+            ),
+            "The destination agent is not started. Source files are retained.",
+        ]
+    )
+    return manifest
+
+
+@click.command("transfer")
+@click.argument("session")
+@click.option("--agent", type=click.Choice(["claude", "codex"]), required=True)
+@click.option(
+    "--source-home",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Source profile (defaults to the agent's configured home).",
+)
+@click.option("--to", "host", required=True, help="SSH host/alias, or 'local'.")
+@click.option("--destination-home", required=True, help="Destination agent profile.")
+@click.option("--destination-project", required=True, help="Prepared Git worktree.")
+@click.option(
+    "--remote-python",
+    default="python3",
+    show_default=True,
+    help="Python 3.11+ executable on the SSH destination.",
+)
+@click.option("--dry-run", is_flag=True, help="Inspect without destination writes.")
+@click.option("--json", "as_json", is_flag=True, help="Print a structured report.")
+@click.pass_context
+def transfer(
+    ctx: click.Context,
+    session: str,
+    agent: str,
+    source_home: Path | None,
+    host: str,
+    destination_home: str,
+    destination_project: str,
+    remote_python: str,
+    dry_run: bool,
+    as_json: bool,
+) -> None:
+    """Copy a saved conversation and supported artifacts, preserving the source.
+
+    Exit the source agent first. Prepare a clean destination Git worktree at the
+    same commit. Inspect --dry-run before copying. Existing differing artifacts
+    are never overwritten; account credentials/settings are not transferred.
+    Quote destination paths beginning with ~ so the destination expands them.
+    """
+    variable = "CODEX_HOME" if agent == "codex" else "CLAUDE_CONFIG_DIR"
+    configured = (ctx.obj or {}).get(f"{agent}_home")
+    source_home = (
+        Path(source_home or configured or os.environ.get(variable, f"~/.{agent}"))
+        .expanduser()
+        .resolve()
+    )
+    request = {
+        "operation": "probe",
+        "destination_home": destination_home,
+        "destination_project": destination_project,
+    }
+    manifest: dict[str, Any] | None = None
+    try:
+        probe = destination_request(host, remote_python, request)
+        with tempfile.TemporaryDirectory(prefix="aichat-transfer-") as directory:
+            staging = Path(directory)
+            manifest = prepare_transfer(
+                agent,
+                source_home,
+                session,
+                Path(probe["destination_home"]),
+                Path(probe["project"]["path"]),
+                staging,
+            )
+            request.update({"operation": "validate", "manifest": manifest})
+            result = destination_request(host, remote_python, request)
+            if not dry_run:
+                request["operation"] = "import"
+                request["data"] = {
+                    relative: base64.b64encode(
+                        (staging / "files" / relative).read_bytes()
+                    ).decode()
+                    for relative in manifest["files"]
+                }
+                result = destination_request(host, remote_python, request)
+            report = {
+                "ok": True,
+                "dry_run": dry_run,
+                "plan": manifest,
+                "destination": result,
+            }
+    except (OSError, ValueError, sqlite3.Error, subprocess.SubprocessError) as error:
+        report = {"ok": False, "error": str(error), "plan": manifest}
+    if as_json:
+        click.echo(json.dumps(report, indent=2))
+    elif not report["ok"]:
+        click.echo(f"Transfer cannot proceed: {report['error']}", err=True)
+    else:
+        assert manifest is not None
+        click.echo("Transfer plan verified." if dry_run else "Transfer verified.")
+        click.echo(f"{agent} {manifest['session_id']} → {host}:{destination_home}")
+        for relative, metadata in manifest["artifacts"].items():
+            click.echo(f"  {relative} ({metadata['size']} bytes)")
+        for database in manifest.get("databases", []):
+            click.echo(f"  Database records: {database['name']}")
+        for warning in manifest["warnings"]:
+            click.echo(f"Note: {warning}")
+        click.echo(f"Resume on destination:\n  {manifest['resume_command']}")
+    if not report["ok"]:
+        ctx.exit(1)

--- a/claude_code_tools/transfer_session.py
+++ b/claude_code_tools/transfer_session.py
@@ -402,7 +402,8 @@ def transfer(
                     f"({len(table['rows'])} records)"
                 )
         for gap in manifest.get("missing_at_source", []):
-            click.echo(f"Missing at source (not copied): {gap['path']}")
+            path = gap["path"] if isinstance(gap, dict) else gap
+            click.echo(f"Missing at source (not copied): {path}")
         for warning in manifest["warnings"]:
             click.echo(f"Note: {warning}")
         comparison = report.get("environment_comparison", {})

--- a/claude_code_tools/transfer_session.py
+++ b/claude_code_tools/transfer_session.py
@@ -401,6 +401,8 @@ def transfer(
                     f"  {database['name']}:{table['name']} "
                     f"({len(table['rows'])} records)"
                 )
+        for gap in manifest.get("missing_at_source", []):
+            click.echo(f"Missing at source (not copied): {gap['path']}")
         for warning in manifest["warnings"]:
             click.echo(f"Note: {warning}")
         comparison = report.get("environment_comparison", {})

--- a/claude_code_tools/transfer_session.py
+++ b/claude_code_tools/transfer_session.py
@@ -130,6 +130,8 @@ def prepare_transfer(
     )
     if manifest.get("ok") is not True:
         raise ValueError("Session adapter did not report successful export")
+    from claude_code_tools.transfer_remote import capture_operational_projects
+
     manifest.update(
         {
             "agent": agent,
@@ -138,6 +140,7 @@ def prepare_transfer(
             "destination_home": str(destination_home),
             "destination_project": str(destination_project),
             "project_state": project_state(Path(manifest["source_project"])),
+            "operational_projects": capture_operational_projects(manifest),
         }
     )
     artifacts = {}
@@ -414,7 +417,11 @@ def transfer(
         for warning in manifest["warnings"]:
             click.echo(f"Note: {warning}")
         comparison = report.get("environment_comparison", {})
-        for field in ("missing_or_disabled_plugins", "newly_disabled_skills"):
+        for field in (
+            "missing_or_disabled_plugins",
+            "newly_disabled_skills",
+            "newly_denied_skills",
+        ):
             if comparison.get(field):
                 click.echo(f"Environment {field}: {', '.join(comparison[field])}")
         for remedy in comparison.get("remediation", []):

--- a/claude_code_tools/transfer_session.py
+++ b/claude_code_tools/transfer_session.py
@@ -283,13 +283,12 @@ def transfer(
         raise click.UsageError("Use either --apply or --dry-run, not both.")
     if recover and not apply:
         raise click.UsageError("--recover requires --apply")
-    mapped: dict[str, str] = {}
-    for old, new in path_mappings:
-        if not Path(old).is_absolute() or not Path(new).is_absolute():
-            raise click.UsageError("--map requires two absolute paths")
-        if old in mapped and mapped[old] != new:
-            raise click.UsageError("Conflicting destinations for the same --map source")
-        mapped[old] = new
+    from claude_code_tools.transfer_paths import normalize_path_mappings
+
+    try:
+        mapped = normalize_path_mappings(path_mappings)
+    except ValueError as error:
+        raise click.UsageError(str(error)) from error
     dry_run = not apply
     variable = "CODEX_HOME" if agent == "codex" else "CLAUDE_CONFIG_DIR"
     configured = (ctx.obj or {}).get(f"{agent}_home")
@@ -320,7 +319,7 @@ def transfer(
                     Path(probe["destination_home"]),
                     Path(probe["project"]["path"]),
                     staging,
-                    dict(path_mappings),
+                    mapped,
                 )
             else:
                 bundle = destination_request(
@@ -329,7 +328,7 @@ def transfer(
                     {
                         "operation": "export",
                         "agent": agent,
-                        "path_mappings": dict(path_mappings),
+                        "path_mappings": mapped,
                         "source_home": str(source_home),
                         "session": session,
                         "destination_home": probe["destination_home"],

--- a/claude_code_tools/transfer_session.py
+++ b/claude_code_tools/transfer_session.py
@@ -11,15 +11,18 @@ import shlex
 import sqlite3
 import subprocess
 import tempfile
+from contextlib import closing
 from pathlib import Path
 from typing import Any
 
 import click
 
 from claude_code_tools.move_account import (
-    find_codex_sessions_in_home,
+    SessionCandidate,
+    _tiered_match,
     find_sessions_in_home,
 )
+from claude_code_tools.resolve_session_names import codex_thread_names
 from claude_code_tools.transfer_remote import handle_request, project_state
 
 
@@ -79,8 +82,19 @@ def prepare_transfer(
     staging: Path,
 ) -> dict[str, Any]:
     """Resolve a unique session and build a scoped, checksummed transfer plan."""
-    finder = find_codex_sessions_in_home if agent == "codex" else find_sessions_in_home
-    matches = finder(source_home, session)
+    if agent == "codex":
+        database = source_home / "state_5.sqlite"
+        names = codex_thread_names(source_home)
+        with closing(sqlite3.connect(database.as_uri() + "?mode=ro", uri=True)) as db:
+            candidates = [
+                SessionCandidate(Path(path), sid, name or names.get(sid, ""))
+                for sid, path, name in db.execute(
+                    "SELECT id, rollout_path, name FROM threads"
+                )
+            ]
+        matches = _tiered_match(candidates, session)
+    else:
+        matches = find_sessions_in_home(source_home, session)
     if len(matches) != 1:
         candidates = ", ".join(candidate.session_id for candidate in matches[:10])
         raise ValueError(
@@ -158,7 +172,11 @@ def prepare_transfer(
     show_default=True,
     help="Python 3.11+ executable on the SSH destination.",
 )
-@click.option("--dry-run", is_flag=True, help="Inspect without destination writes.")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Inspect without importing destination account data.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Print a structured report.")
 @click.pass_context
 def transfer(
@@ -235,7 +253,11 @@ def transfer(
         for relative, metadata in manifest["artifacts"].items():
             click.echo(f"  {relative} ({metadata['size']} bytes)")
         for database in manifest.get("databases", []):
-            click.echo(f"  Database records: {database['name']}")
+            for table in database["tables"]:
+                click.echo(
+                    f"  {database['name']}:{table['name']} "
+                    f"({len(table['rows'])} records)"
+                )
         for warning in manifest["warnings"]:
             click.echo(f"Note: {warning}")
         click.echo(f"Resume on destination:\n  {manifest['resume_command']}")

--- a/claude_code_tools/transfer_session.py
+++ b/claude_code_tools/transfer_session.py
@@ -404,6 +404,13 @@ def transfer(
         for gap in manifest.get("missing_at_source", []):
             path = gap["path"] if isinstance(gap, dict) else gap
             click.echo(f"Missing at source (not copied): {path}")
+        for excluded in manifest.get("excluded_artifacts", []):
+            click.echo(f"Excluded external artifact: {excluded['path']}")
+        if manifest.get("excluded_artifacts"):
+            click.echo(
+                "Note: Copy these files manually or explicitly opt in with a "
+                "narrow --map source/destination pair."
+            )
         for warning in manifest["warnings"]:
             click.echo(f"Note: {warning}")
         comparison = report.get("environment_comparison", {})

--- a/claude_code_tools/transfer_session.py
+++ b/claude_code_tools/transfer_session.py
@@ -336,6 +336,12 @@ def transfer(
                     f"cd {shlex.quote(probe['project']['path'])} && "
                     + shlex.join(command)
                 )
+            if source_host == "local":
+                from claude_code_tools.transfer_environment import inspect_environment
+
+                source_environment = inspect_environment(agent, source_home)
+            else:
+                source_environment = bundle.get("environment", {})
             stage_path_guide(manifest, staging)
             request.update({"operation": "validate", "manifest": manifest})
             result = destination_request(host, remote_python, request)
@@ -349,13 +355,19 @@ def transfer(
                     for relative in manifest["files"]
                 }
                 result = destination_request(host, remote_python, request)
+            from claude_code_tools.transfer_environment import compare_environments
+
             report = {
+                "environment_comparison": compare_environments(
+                    source_environment, probe.get("environment", {})
+                ),
                 "ran": True,
                 "ok": True,
                 "dry_run": dry_run,
                 "plan": manifest,
                 "destination": result,
                 "environment": probe.get("environment"),
+                "source_environment": source_environment,
             }
     except (OSError, ValueError, sqlite3.Error, subprocess.SubprocessError) as error:
         report = {"ran": True, "ok": False, "error": str(error), "plan": manifest}
@@ -377,6 +389,12 @@ def transfer(
                 )
         for warning in manifest["warnings"]:
             click.echo(f"Note: {warning}")
+        comparison = report.get("environment_comparison", {})
+        for field in ("missing_or_disabled_plugins", "newly_disabled_skills"):
+            if comparison.get(field):
+                click.echo(f"Environment {field}: {', '.join(comparison[field])}")
+        for remedy in comparison.get("remediation", []):
+            click.echo(f"Remediation: {remedy}")
         environment = report.get("environment") or {}
         for warning in environment.get("warnings", []):
             click.echo(f"Environment: {warning}")

--- a/claude_code_tools/transfer_source.py
+++ b/claude_code_tools/transfer_source.py
@@ -20,9 +20,14 @@ def resolve_session(home: Path, agent: str, query: str) -> str:
             (home / "state_5.sqlite").as_uri() + "?mode=ro", uri=True
         ) as db:
             columns = {r[1] for r in db.execute("PRAGMA table_info(threads)")}
-            name = "name" if "name" in columns else "title"
-            for sid, title in db.execute(f"SELECT id, {name} FROM threads"):
-                candidates[sid] = {title or ""}
+            fields = [field for field in ("name", "title") if field in columns]
+            for row in db.execute("SELECT id," + ",".join(fields) + " FROM threads"):
+                candidates[row[0]] = {value for value in row[1:] if value}
+        from claude_code_tools.transfer_codex_artifacts import latest_session_index
+
+        for sid, row in latest_session_index(home).items():
+            if sid in candidates and isinstance(row.get("thread_name"), str):
+                candidates[sid].add(row["thread_name"])
     else:
         for path in (home / "projects").glob("*/*.jsonl"):
             names = candidates.setdefault(path.stem, set())
@@ -93,4 +98,12 @@ def export_request(request: dict[str, Any]) -> dict[str, Any]:
             }
             data[relative] = base64.b64encode(content).decode()
         manifest["artifacts"] = artifacts
-        return {"ran": True, "ok": True, "manifest": manifest, "data": data}
+        from claude_code_tools.transfer_environment import inspect_environment
+
+        return {
+            "ran": True,
+            "ok": True,
+            "manifest": manifest,
+            "data": data,
+            "environment": inspect_environment(agent, home),
+        }

--- a/claude_code_tools/transfer_source.py
+++ b/claude_code_tools/transfer_source.py
@@ -1,0 +1,96 @@
+"""Resolve and export a session on a local or SSH source using only stdlib."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def resolve_session(home: Path, agent: str, query: str) -> str:
+    """Resolve exact IDs, unique ID prefixes, or saved conversation names."""
+    candidates: dict[str, set[str]] = {}
+    if agent == "codex":
+        with sqlite3.connect(
+            (home / "state_5.sqlite").as_uri() + "?mode=ro", uri=True
+        ) as db:
+            columns = {r[1] for r in db.execute("PRAGMA table_info(threads)")}
+            name = "name" if "name" in columns else "title"
+            for sid, title in db.execute(f"SELECT id, {name} FROM threads"):
+                candidates[sid] = {title or ""}
+    else:
+        for path in (home / "projects").glob("*/*.jsonl"):
+            names = candidates.setdefault(path.stem, set())
+            if query == path.stem:
+                return path.stem
+            with path.open() as stream:
+                for line in stream:
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(record, dict):
+                        for key in ("customTitle", "custom_title", "name"):
+                            if isinstance(record.get(key), str):
+                                names.add(record[key])
+    if query in candidates:
+        return query
+    for matches in (
+        [sid for sid in candidates if sid.startswith(query)],
+        [sid for sid, names in candidates.items() if query in names],
+    ):
+        if matches:
+            if len(matches) == 1:
+                return matches[0]
+            raise ValueError("Ambiguous session; use a full UUID")
+    raise ValueError("No matching session in the selected source account")
+
+
+def export_request(request: dict[str, Any]) -> dict[str, Any]:
+    """Export a checksummed bundle; never launch the source agent."""
+    from claude_code_tools.transfer_remote import project_state
+
+    agent = request["agent"]
+    if agent not in {"claude", "codex"}:
+        raise ValueError("Unsupported agent")
+    home = Path(request["source_home"]).expanduser().resolve()
+    sid = resolve_session(home, agent, request["session"])
+    adapter = importlib.import_module(f"claude_code_tools.transfer_{agent}")
+    with tempfile.TemporaryDirectory(prefix="aichat-source-") as directory:
+        staging = Path(directory)
+        manifest = adapter.export_session(
+            home,
+            sid,
+            Path(request["destination_home"]),
+            Path(request["destination_project"]),
+            staging,
+            path_mappings=request.get("path_mappings"),
+        )
+        if manifest.get("ok") is not True:
+            raise ValueError("Source adapter did not confirm export")
+        manifest.update(
+            {
+                "agent": agent,
+                "session_id": sid,
+                "source_home": str(home),
+                "destination_home": request["destination_home"],
+                "destination_project": request["destination_project"],
+                "project_state": project_state(Path(manifest["source_project"])),
+            }
+        )
+        artifacts = {}
+        data = {}
+        for relative in manifest["files"]:
+            content = (staging / "files" / relative).read_bytes()
+            artifacts[relative] = {
+                "size": len(content),
+                "sha256": hashlib.sha256(content).hexdigest(),
+            }
+            data[relative] = base64.b64encode(content).decode()
+        manifest["artifacts"] = artifacts
+        return {"ran": True, "ok": True, "manifest": manifest, "data": data}

--- a/claude_code_tools/transfer_source.py
+++ b/claude_code_tools/transfer_source.py
@@ -58,7 +58,10 @@ def resolve_session(home: Path, agent: str, query: str) -> str:
 
 def export_request(request: dict[str, Any]) -> dict[str, Any]:
     """Export a checksummed bundle; never launch the source agent."""
-    from claude_code_tools.transfer_remote import project_state
+    from claude_code_tools.transfer_remote import (
+        capture_operational_projects,
+        project_state,
+    )
 
     agent = request["agent"]
     if agent not in {"claude", "codex"}:
@@ -86,6 +89,7 @@ def export_request(request: dict[str, Any]) -> dict[str, Any]:
                 "destination_home": request["destination_home"],
                 "destination_project": request["destination_project"],
                 "project_state": project_state(Path(manifest["source_project"])),
+                "operational_projects": capture_operational_projects(manifest),
             }
         )
         artifacts = {}

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -55,6 +55,10 @@ export default defineConfig({
                   slug: "tools/aichat/port",
                 },
                 {
+                  label: "Transfer Between Machines",
+                  slug: "tools/aichat/transfer",
+                },
+                {
                   label: "Move Account",
                   slug: "tools/aichat/move-account",
                 },

--- a/docs-site/src/content/docs/tools/aichat/index.mdx
+++ b/docs-site/src/content/docs/tools/aichat/index.mdx
@@ -169,3 +169,5 @@ interactive terminal shows a numbered Rich table. Enter `q`, press Ctrl-C, or
 send end-of-input to cancel without changing anything. Non-terminal and JSON
 modes list the ambiguity and exit nonzero instead of prompting. See
 [Resolve](./resolve/) for the complete command list and match precedence.
+
+See [Transfer Between Machines](./transfer/) to copy a saved conversation over SSH.

--- a/docs-site/src/content/docs/tools/aichat/transfer.mdx
+++ b/docs-site/src/content/docs/tools/aichat/transfer.mdx
@@ -133,7 +133,9 @@ Apply reported remedies on the destination. In particular, a copied Chrome MCP
 configuration does not carry a logged-in browser or extension connection.
 A listening port is not proof of browser authentication or a working MCP session.
 Hook scripts are not executed by preflight; path checks do not prove runtime
-imports or every hook's behavior. Use safe synthetic hook tests when diagnosing
+imports or every hook's behavior. Shell compounds and builtin launchers are
+reported as unverified rather than interpreted as missing executables. Use safe
+synthetic hook tests when diagnosing
 an actual runtime failure.
 
 ## Interrupted copies and recovery

--- a/docs-site/src/content/docs/tools/aichat/transfer.mdx
+++ b/docs-site/src/content/docs/tools/aichat/transfer.mdx
@@ -91,7 +91,12 @@ Codex supports the recognized native SQLite schemas, including selected threads
 and descendants, paginated history, memory records, and native goals. Goal status
 is preserved. Selected session-index and import-provenance records are merged
 without replacing unrelated records. Recognized referenced attachments and
-supporting files are included. Initialize a compatible Codex account schema on
+supporting files are included. Unscoped external temporary files are not copied
+merely because their paths appear in conversation text. The plan lists excluded
+paths. Use a narrow explicit `--map OLD NEW` pair to opt in, or copy them manually.
+Opted-in artifacts are stored under account-scoped `transfer-support`; consult
+the generated path guide for the actual location. Initialize a compatible Codex
+account schema on
 the destination first; unknown schemas, unfinished turns, queued input, and
 unsupported thread artifacts produce explicit errors.
 
@@ -143,7 +148,11 @@ an actual runtime failure.
 Payloads are checksummed, existing differing files/records are refused, and
 new files are published atomically. Before import, a private journal and backups
 are retained under `.aichat-transfer-backups/` inside the destination account.
-Unrelated destination database rows and metadata are preserved.
+Unrelated destination database rows and metadata are preserved. Codex session
+index records are appended without replacing concurrent unrelated entries.
+An existing `external_agent_session_imports.json` that needs additional selected
+records is refused because native writers offer no safe concurrent merge. Use
+a separate destination account; already-present identical records need no write.
 
 After interruption, rerun the same command with `--apply --recover`. Recovery
 requires the same plan and refuses a live competing importer. It verifies

--- a/docs-site/src/content/docs/tools/aichat/transfer.mdx
+++ b/docs-site/src/content/docs/tools/aichat/transfer.mdx
@@ -71,9 +71,10 @@ Each SSH peer needs Git and Python 3.11+, but does not need `aichat` installed.
 - `--json`: structured plan, checksums, sizes, database row counts, and check results.
 
 Use a full UUID for an exact reference. Unique saved names and ID prefixes also
-work within the selected account. Reports summarize database rows without printing conversation or goal contents.
-They still contain account paths and session identifiers; handle them as private. A completed file transfer
-and a successful environment inspection are separate results; inspect individual
+work within the selected account. Reports summarize database rows without printing
+conversation or goal contents. They still contain account paths and session
+identifiers; handle them as private. A completed file transfer and a successful
+environment inspection are separate results; inspect individual
 checks and remediation rather than treating a top-level inspection flag as proof
 that every dependency works.
 

--- a/docs-site/src/content/docs/tools/aichat/transfer.mdx
+++ b/docs-site/src/content/docs/tools/aichat/transfer.mdx
@@ -121,6 +121,12 @@ loopback availability. Native discovery uses temporary account configuration
 snapshots and does not copy authentication into them. An absent destination
 account is reported as uninitialized rather than created by inspection.
 
+An auth-free Codex snapshot may omit account-dependent bundled or remote plugins.
+Preflight reports that discovery as incomplete, lists cached registrations
+separately, and does not label native omissions as missing destination plugins.
+Run `codex plugin list --json` in the original account to verify its authenticated
+view. Cached manifests and enabled flags alone do not prove runtime availability.
+
 Settings, plugins, credentials, jobs, and machine services are not synchronized.
 Apply reported remedies on the destination. In particular, a copied Chrome MCP
 configuration does not carry a logged-in browser or extension connection.

--- a/docs-site/src/content/docs/tools/aichat/transfer.mdx
+++ b/docs-site/src/content/docs/tools/aichat/transfer.mdx
@@ -68,11 +68,11 @@ Each SSH peer needs Git and Python 3.11+, but does not need `aichat` installed.
 - `--apply`: perform the copy after validation.
 - `--dry-run`: explicitly request the default inspection; incompatible with apply.
 - `--recover`: with apply, retry the identical plan after an interrupted import.
-- `--json`: structured plan, checksums, sizes, database records, and check results.
+- `--json`: structured plan, checksums, sizes, database row counts, and check results.
 
 Use a full UUID for an exact reference. Unique saved names and ID prefixes also
-work within the selected account. Treat JSON reports as private: selected
-conversation database rows can contain message text. A completed file transfer
+work within the selected account. Reports summarize database rows without printing conversation or goal contents.
+They still contain account paths and session identifiers; handle them as private. A completed file transfer
 and a successful environment inspection are separate results; inspect individual
 checks and remediation rather than treating a top-level inspection flag as proof
 that every dependency works.

--- a/docs-site/src/content/docs/tools/aichat/transfer.mdx
+++ b/docs-site/src/content/docs/tools/aichat/transfer.mdx
@@ -1,0 +1,113 @@
+---
+title: "Transfer Between Machines"
+---
+
+`aichat transfer` copies a saved Claude or Codex conversation to another account
+home, locally or over SSH. It preserves the source and prints a command to resume
+in the destination project. It does not start an agent or move a running process.
+
+## Prepare and inspect
+
+Exit the source agent. Prepare the destination's authentication, settings, plugins,
+dependencies, and ignored project files separately. Both Git worktrees must be
+clean, including untracked files, and checked out at the same commit. If the
+session started in a repository subdirectory, select that same subdirectory on the
+destination. The command checks these conditions; it does not push commits or copy
+repository contents.
+
+Use an SSH alias from your SSH configuration, or `user@host`:
+
+```bash
+aichat transfer SESSION_UUID \
+  --agent claude \
+  --source-home ~/.claude-work \
+  --to workstation \
+  --destination-home '~/.claude-work' \
+  --destination-project '~/Git/project' \
+  --dry-run
+```
+
+Quote destination paths starting with `~`, so the destination expands them. SSH
+uses your normal keys, configuration, and host verification, with batch mode
+requiring authentication to work without an interactive prompt. The destination
+needs Git and Python 3.11 or later. Use `--remote-python /path/to/python3` when its
+noninteractive SSH environment selects an older interpreter. It need not have
+`aichat` installed.
+
+The report lists copied paths, database imports, omissions, conflicts, and the
+resume command. Add `--json` for checksums, byte counts, and structured database
+records. Treat JSON reports as private: database rows contain conversation text.
+Dry-run performs checks without importing account data. SQLite readers may use
+WAL reader-coordination files when inspecting an existing database.
+
+Remove `--dry-run` to copy. Run the printed resume command on the destination,
+then continue that copy of the conversation. To transfer in the reverse direction,
+run the command on the other machine with the account and project paths reversed.
+A changed conversation already present at the destination causes a conflict;
+reconcile or preserve it in a separate account home before importing.
+
+## Options
+
+- `--agent claude|codex`: required; selects the source format.
+- `--source-home PATH`: source account home. Defaults to the corresponding global
+  `--claude-home`/`--codex-home` option, environment variable, or standard home.
+- `--to HOST`: required SSH destination, or `local` for a local copy.
+- `--destination-home PATH`: required destination account home.
+- `--destination-project PATH`: required prepared Git project directory.
+- `--remote-python PATH`: destination interpreter; defaults to `python3`.
+- `--dry-run`: inspect and validate without importing.
+- `--json`: output an explicit `ok` flag and a detailed plan.
+
+A full UUID is the least ambiguous session reference. Unique names and partial
+UUIDs also work within the selected source home. Ambiguous matches fail and list
+candidate UUIDs.
+
+## Included state
+
+### Claude
+
+Transfers the conversation transcript, subagent transcripts, saved tool results,
+session tasks/todos, file-history backups, project memory, and plans explicitly
+referenced by transcript slug. Operational working-directory and file-backup
+metadata are remapped. Historical message text keeps its original paths.
+
+Project memory and plans may be shared with other conversations. Existing files
+must be absent or byte-identical; differing destination files are never overwritten.
+Multiple recorded project directories, symbolic-link artifacts, malformed records,
+and unknown sidecar types require manual handling and produce an error.
+
+### Codex
+
+Supports the recognized SQLite column schemas from Codex 0.153.4. Initialize a
+matching Codex version in the destination account first. Unknown schemas fail with
+an explicit error rather than discarding history. Older JSONL-only profiles are
+not supported by this command.
+
+Transfers the selected thread and its descendants, rollout files, paginated
+history records, per-thread memory records, and goals. Active goals are imported
+paused. Pending queued input, unfinished turns, and unknown thread artifacts
+prevent transfer. Dynamic tool definitions can be retained, but the corresponding
+tool implementations must exist on the destination.
+
+Rollout bytes remain unchanged because paginated history stores byte offsets into
+those files. Working-directory and rollout-path database metadata are remapped;
+the resume command explicitly selects the destination project. Historical paths
+in messages remain historical. Destination UI project/section membership is reset.
+
+## Boundaries and recovery
+
+Settings, credentials, plugins, jobs, terminal processes, and workflow/team runtime
+are not copied. Input-history files and global session indexes are not merged;
+resume by the printed UUID. References to external files in old messages are not
+proof that those files were transferred.
+
+Payload files are checksummed before and after import. Existing differing files
+or Codex database rows stop the operation. Ordinary import failures roll back new
+files and database inserts; the source remains intact. SQLite cannot guarantee
+crash atomicity across multiple WAL databases. If the machine or process crashes,
+inspect the destination before retrying. A retained `.aichat-transfer.lock`
+directory signals that an import may have been interrupted. Do not remove it
+while another transfer is running.
+
+The transfer uses local temporary staging and an in-memory SSH payload. Available
+memory and temporary disk space must accommodate the selected session history.

--- a/docs-site/src/content/docs/tools/aichat/transfer.mdx
+++ b/docs-site/src/content/docs/tools/aichat/transfer.mdx
@@ -11,7 +11,10 @@ resume command. The default operation is a dry run; add `--apply` to copy.
 Exit the source agent and prepare the destination project and authentication.
 Transfer copies conversation state, not the repository, running processes, or
 credentials. Both Git worktrees must be clean, including untracked files, at the
-same commit. Select corresponding subdirectories if the conversation used one.
+same commit. This also applies to each secondary working directory actually used
+by a child session or sidecar, including those supplied through `--map`. Artifact
+locations and sandbox-only paths do not trigger Git checks. Select corresponding
+subdirectories if the conversation used one.
 
 Inspect a copy to an SSH host:
 
@@ -141,7 +144,8 @@ Apply reported remedies on the destination. In particular, a copied Chrome MCP
 configuration does not carry a logged-in browser or extension connection.
 A listening port is not proof of browser authentication or a working MCP session.
 Hook scripts are not executed by preflight; path checks do not prove runtime
-imports or every hook's behavior. Shell compounds and builtin launchers are
+imports or every hook's behavior. Shell compounds, builtin launchers, and `env`
+wrappers are
 reported as unverified rather than interpreted as missing executables. Use safe
 synthetic hook tests when diagnosing
 an actual runtime failure.

--- a/docs-site/src/content/docs/tools/aichat/transfer.mdx
+++ b/docs-site/src/content/docs/tools/aichat/transfer.mdx
@@ -103,7 +103,9 @@ proof that those files were transferred.
 
 Payload files are checksummed before and after import. Existing differing files
 or Codex database rows stop the operation. Ordinary import failures roll back new
-files and database inserts; the source remains intact. SQLite cannot guarantee
+files and database inserts; the source remains intact. If a database commit is
+interrupted or raises an error, verified files and the recovery lock remain for
+inspection. SQLite cannot guarantee
 crash atomicity across multiple WAL databases. If the machine or process crashes,
 inspect the destination before retrying. A retained `.aichat-transfer.lock`
 directory signals that an import may have been interrupted. Do not remove it

--- a/docs-site/src/content/docs/tools/aichat/transfer.mdx
+++ b/docs-site/src/content/docs/tools/aichat/transfer.mdx
@@ -63,7 +63,8 @@ Each SSH peer needs Git and Python 3.11+, but does not need `aichat` installed.
 - `--destination-home PATH`: required destination account home.
 - `--destination-project PATH`: required prepared Git project directory.
 - `--map OLD NEW`: additional absolute source/destination path pair; repeat for
-  descendant worktrees or other operational paths outside the main project.
+  descendant worktrees or other operational paths outside the main project. A pair
+  cannot override the primary `--destination-project` mapping.
 - `--remote-python PATH`: SSH helper interpreter; defaults to `python3`.
 - `--apply`: perform the copy after validation.
 - `--dry-run`: explicitly request the default inspection; incompatible with apply.
@@ -94,7 +95,9 @@ without replacing unrelated records. Recognized referenced attachments and
 supporting files are included. Unscoped external temporary files are not copied
 merely because their paths appear in conversation text. The plan lists excluded
 paths. Use a narrow explicit `--map OLD NEW` pair to opt in, or copy them manually.
-Opted-in artifacts are stored under account-scoped `transfer-support`; consult
+Codex support artifacts must not use symlinked files or directories to escape
+their approved location. Opted-in artifacts use account-scoped `transfer-support`;
+consult
 the generated path guide for the actual location. Initialize a compatible Codex
 account schema on
 the destination first; unknown schemas, unfinished turns, queued input, and

--- a/docs-site/src/content/docs/tools/aichat/transfer.mdx
+++ b/docs-site/src/content/docs/tools/aichat/transfer.mdx
@@ -2,20 +2,18 @@
 title: "Transfer Between Machines"
 ---
 
-`aichat transfer` copies a saved Claude or Codex conversation to another account
-home, locally or over SSH. It preserves the source and prints a command to resume
-in the destination project. It does not start an agent or move a running process.
+`aichat transfer` copies a saved Claude or Codex conversation between account
+homes, locally or over SSH. It preserves the source and prints the destination
+resume command. The default operation is a dry run; add `--apply` to copy.
 
-## Prepare and inspect
+## Inspect, copy, and resume
 
-Exit the source agent. Prepare the destination's authentication, settings, plugins,
-dependencies, and ignored project files separately. Both Git worktrees must be
-clean, including untracked files, and checked out at the same commit. If the
-session started in a repository subdirectory, select that same subdirectory on the
-destination. The command checks these conditions; it does not push commits or copy
-repository contents.
+Exit the source agent and prepare the destination project and authentication.
+Transfer copies conversation state, not the repository, running processes, or
+credentials. Both Git worktrees must be clean, including untracked files, at the
+same commit. Select corresponding subdirectories if the conversation used one.
 
-Use an SSH alias from your SSH configuration, or `user@host`:
+Inspect a copy to an SSH host:
 
 ```bash
 aichat transfer SESSION_UUID \
@@ -23,93 +21,134 @@ aichat transfer SESSION_UUID \
   --source-home ~/.claude-work \
   --to workstation \
   --destination-home '~/.claude-work' \
-  --destination-project '~/Git/project' \
-  --dry-run
+  --destination-project '~/Git/project'
 ```
 
-Quote destination paths starting with `~`, so the destination expands them. SSH
-uses your normal keys, configuration, and host verification, with batch mode
-requiring authentication to work without an interactive prompt. The destination
-needs Git and Python 3.11 or later. Use `--remote-python /path/to/python3` when its
-noninteractive SSH environment selects an older interpreter. It need not have
-`aichat` installed.
+Read the plan, source gaps, environment checks, and any conflicts. Repeat the
+command with `--apply` to copy. The source remains intact. Run the printed resume
+command on the destination; the transfer itself never starts that conversation.
 
-The report lists copied paths, database imports, omissions, conflicts, and the
-resume command. Add `--json` for checksums, byte counts, and structured database
-records. Treat JSON reports as private: database rows contain conversation text.
-Dry-run performs checks without importing account data. SQLite readers may use
-WAL reader-coordination files when inspecting an existing database.
+Pull a session back from SSH using the same local installation:
 
-Remove `--dry-run` to copy. Run the printed resume command on the destination,
-then continue that copy of the conversation. To transfer in the reverse direction,
-run the command on the other machine with the account and project paths reversed.
-A changed conversation already present at the destination causes a conflict;
-reconcile or preserve it in a separate account home before importing.
+```bash
+aichat transfer SESSION_UUID \
+  --agent claude \
+  --from workstation \
+  --source-home '~/.claude-work' \
+  --to local \
+  --destination-home ~/.claude-returned \
+  --destination-project ~/Git/project \
+  --apply
+```
 
-## Options
+This example uses a separate return account so an earlier local conversation
+cannot be overwritten. Prepare that account's authentication locally. If both
+copies advanced independently, transfer refuses differing destination state; it
+never merges two conversations automatically. Preserve both copies and select
+an explicit destination account rather than deleting the conflict blindly.
 
-- `--agent claude|codex`: required; selects the source format.
-- `--source-home PATH`: source account home. Defaults to the corresponding global
-  `--claude-home`/`--codex-home` option, environment variable, or standard home.
-- `--to HOST`: required SSH destination, or `local` for a local copy.
+Quote remote paths beginning with `~` so the remote machine expands them. SSH
+uses normal keys, configuration, and host verification with batch authentication.
+Each SSH peer needs Git and Python 3.11+, but does not need `aichat` installed.
+`--remote-python /path/to/python3` selects the interpreter for the bundled helper.
+
+## Options and reports
+
+- `--agent claude|codex`: required source format.
+- `--source-home PATH`: explicit account home. For local sources, defaults to
+  the configured global account option/environment; remote defaults to
+  `~/.claude` or `~/.codex` on that peer.
+- `--from HOST`: source SSH alias; defaults to `local`.
+- `--to HOST`: required destination SSH alias, or `local`.
 - `--destination-home PATH`: required destination account home.
 - `--destination-project PATH`: required prepared Git project directory.
-- `--remote-python PATH`: destination interpreter; defaults to `python3`.
-- `--dry-run`: inspect and validate without importing.
-- `--json`: output an explicit `ok` flag and a detailed plan.
+- `--map OLD NEW`: additional absolute source/destination path pair; repeat for
+  descendant worktrees or other operational paths outside the main project.
+- `--remote-python PATH`: SSH helper interpreter; defaults to `python3`.
+- `--apply`: perform the copy after validation.
+- `--dry-run`: explicitly request the default inspection; incompatible with apply.
+- `--recover`: with apply, retry the identical plan after an interrupted import.
+- `--json`: structured plan, checksums, sizes, database records, and check results.
 
-A full UUID is the least ambiguous session reference. Unique names and partial
-UUIDs also work within the selected source home. Ambiguous matches fail and list
-candidate UUIDs.
+Use a full UUID for an exact reference. Unique saved names and ID prefixes also
+work within the selected account. Treat JSON reports as private: selected
+conversation database rows can contain message text. A completed file transfer
+and a successful environment inspection are separate results; inspect individual
+checks and remediation rather than treating a top-level inspection flag as proof
+that every dependency works.
 
-## Included state
+## Included artifacts and path mappings
 
-### Claude
+Claude copies its conversation and subagents, persisted tool results, tasks and
+todos, file-history backups, referenced plans, and shared project memory. Native
+`goal_status` attachments are preserved. Scoped native scratch directories are
+inventoried outside the account home, including surviving files no longer named
+literally in the transcript. Supported scratch links to subagent output are
+materialized as readable files and disclosed in the report.
 
-Transfers the conversation transcript, subagent transcripts, saved tool results,
-session tasks/todos, file-history backups, project memory, and plans explicitly
-referenced by transcript slug. Operational working-directory and file-backup
-metadata are remapped. Historical message text keeps its original paths.
+Codex supports the recognized native SQLite schemas, including selected threads
+and descendants, paginated history, memory records, and native goals. Goal status
+is preserved. Selected session-index and import-provenance records are merged
+without replacing unrelated records. Recognized referenced attachments and
+supporting files are included. Initialize a compatible Codex account schema on
+the destination first; unknown schemas, unfinished turns, queued input, and
+unsupported thread artifacts produce explicit errors.
 
-Project memory and plans may be shared with other conversations. Existing files
-must be absent or byte-identical; differing destination files are never overwritten.
-Multiple recorded project directories, symbolic-link artifacts, malformed records,
-and unknown sidecar types require manual handling and produce an error.
+Structural working-directory, sandbox, and file-backup metadata are translated.
+Codex rollout rewrites also remap paginated-history byte offsets at verified
+record boundaries. Historical message text and saved tool-result contents remain
+unchanged. Additional operational directories require explicit `--map` pairs.
 
-### Codex
+External supporting files are stored under the destination account's
+`transfer-support/SESSION_UUID/`. The printed `path-map.json` tells a resumed
+agent how to translate old artifact references using the longest source prefix.
+Subsequent copies carry supporting files and compose earlier mappings, so a
+round trip does not lose references from the first machine. No global home
+symlink is created. If a resumed agent encounters an old path, ask it to consult
+this guide before declaring the file missing.
 
-Supports the recognized SQLite column schemas from Codex 0.153.4. Initialize a
-matching Codex version in the destination account first. Unknown schemas fail with
-an explicit error rather than discarding history. Older JSONL-only profiles are
-not supported by this command.
+The plan distinguishes `missing_at_source` artifacts from transfer failures.
+Files already deleted before export cannot be recovered by copying. Arbitrary
+external documents are not implicitly included just because their paths appear
+in prose. Shared memories or plans that differ at the destination are conflicts;
+the tool does not overwrite newer shared work.
 
-Transfers the selected thread and its descendants, rollout files, paginated
-history records, per-thread memory records, and goals. Active goals are imported
-paused. Pending queued input, unfinished turns, and unknown thread artifacts
-prevent transfer. Dynamic tool definitions can be retained, but the corresponding
-tool implementations must exist on the destination.
+## Environment checks
 
-Rollout bytes remain unchanged because paginated history stores byte offsets into
-those files. Working-directory and rollout-path database metadata are remapped;
-the resume command explicitly selects the destination project. Historical paths
-in messages remain historical. Destination UI project/section membership is reset.
+Preflight reports native CLI versions/plugin registrations, account overrides,
+the selected hook Python, configured hook launchers and script paths, and Chrome
+loopback availability. Native discovery uses temporary account configuration
+snapshots and does not copy authentication into them. An absent destination
+account is reported as uninitialized rather than created by inspection.
 
-## Boundaries and recovery
+Settings, plugins, credentials, jobs, and machine services are not synchronized.
+Apply reported remedies on the destination. In particular, a copied Chrome MCP
+configuration does not carry a logged-in browser or extension connection.
+A listening port is not proof of browser authentication or a working MCP session.
+Hook scripts are not executed by preflight; path checks do not prove runtime
+imports or every hook's behavior. Use safe synthetic hook tests when diagnosing
+an actual runtime failure.
 
-Settings, credentials, plugins, jobs, terminal processes, and workflow/team runtime
-are not copied. Input-history files and global session indexes are not merged;
-resume by the printed UUID. References to external files in old messages are not
-proof that those files were transferred.
+## Interrupted copies and recovery
 
-Payload files are checksummed before and after import. Existing differing files
-or Codex database rows stop the operation. Ordinary import failures roll back new
-files and database inserts; the source remains intact. If a database commit is
-interrupted or raises an error, verified files and the recovery lock remain for
-inspection. SQLite cannot guarantee
-crash atomicity across multiple WAL databases. If the machine or process crashes,
-inspect the destination before retrying. A retained `.aichat-transfer.lock`
-directory signals that an import may have been interrupted. Do not remove it
-while another transfer is running.
+Payloads are checksummed, existing differing files/records are refused, and
+new files are published atomically. Before import, a private journal and backups
+are retained under `.aichat-transfer-backups/` inside the destination account.
+Unrelated destination database rows and metadata are preserved.
 
-The transfer uses local temporary staging and an in-memory SSH payload. Available
-memory and temporary disk space must accommodate the selected session history.
+After interruption, rerun the same command with `--apply --recover`. Recovery
+requires the same plan and refuses a live competing importer. It verifies
+already-present data and completes missing work rather than deleting files that
+may now belong to a resumed session. Changed source data or conflicting newer
+destination data requires investigation; keep the recorded backups and journal.
+Do not manually remove a transfer lock to force an import past a live owner.
+
+Active-session detection is best effort and cannot prove that every agent process
+is idle. Exit the source and destination copies yourself. A transfer lock only
+coordinates transfer processes. SQLite cannot guarantee a single crash-atomic
+commit across multiple WAL databases; the retained journal and identical-plan
+recovery address partial completion without blindly restoring whole databases.
+
+Local temporary staging and the in-memory SSH payload require enough RAM and
+temporary disk space for the selected artifacts. The destination agent is never
+launched automatically, and terminal tasks are never relocated.

--- a/tests/test_transfer_claude.py
+++ b/tests/test_transfer_claude.py
@@ -184,3 +184,44 @@ def test_inventory_detects_new_file(tmp_path: Path) -> None:
     before = _fingerprint([root])
     (root / "new.txt").write_text("new output")
     assert _fingerprint([root]) != before
+
+
+@pytest.mark.parametrize(
+    "cwd", ["/other/repo", "/old/project-extra", "/old/project/../other", "relative"]
+)
+def test_rejects_unmappable_sidecar_cwd(tmp_path: Path, cwd: str) -> None:
+    """External subagent projects cannot silently retain source-machine cwd."""
+    home, transcript = fixture_home(tmp_path)
+    sidecar = transcript.with_suffix("") / "subagents" / "agent-child.jsonl"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(json.dumps({"type": "user", "cwd": cwd}) + "\n")
+    with pytest.raises(ValueError, match="cwd needs an explicit mapping"):
+        export(home, tmp_path)
+
+
+def test_maps_sidecar_project_subdirectory(tmp_path: Path) -> None:
+    """A subagent inside the selected project retains its relative directory."""
+    home, transcript = fixture_home(tmp_path)
+    sidecar = transcript.with_suffix("") / "subagents" / "agent-child.jsonl"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "cwd": "/old/project/subdir",
+                "message": {"content": "Historical /old/project/subdir"},
+            }
+        )
+        + "\n"
+    )
+    export(home, tmp_path)
+    copied = (
+        tmp_path
+        / "bundle/files/projects/-new-project"
+        / SID
+        / "subagents"
+        / sidecar.name
+    )
+    record = json.loads(copied.read_text())
+    assert record["cwd"] == "/new/project/subdir"
+    assert record["message"]["content"] == "Historical /old/project/subdir"

--- a/tests/test_transfer_claude.py
+++ b/tests/test_transfer_claude.py
@@ -114,3 +114,59 @@ def test_copies_subagent_metadata_and_reports_runtime(tmp_path: Path) -> None:
     )
     assert json.loads(staged.read_text())["cwd"] == "/new/project/sub"
     assert any("Session-linked tasks" in warning for warning in result["warnings"])
+
+
+def test_includes_referenced_plan_only(tmp_path: Path) -> None:
+    home, transcript = fixture_home(tmp_path)
+    with transcript.open("a") as handle:
+        handle.write(json.dumps({"slug": "dancing-quiet-fox"}) + "\n")
+    plans = home / "plans"
+    plans.mkdir()
+    (plans / "dancing-quiet-fox.md").write_text("Continue research")
+    (plans / "unrelated.md").write_text("Other session")
+    result = export(home, tmp_path)
+    assert "plans/dancing-quiet-fox.md" in result["files"]
+    assert "plans/unrelated.md" not in result["files"]
+
+
+def test_detects_changed_and_added_sources(tmp_path: Path) -> None:
+    """Use a real racing writer; export must refuse the unstable snapshot."""
+    import threading
+    import time
+
+    home, transcript = fixture_home(tmp_path)
+    results = transcript.with_suffix("") / "tool-results"
+    results.mkdir(parents=True)
+    # Large enough to hold the copy open while the companion writer runs.
+    (results / "large.txt").write_bytes(b"x" * (32 * 1024 * 1024))
+    stop = threading.Event()
+    started = threading.Event()
+
+    def mutate() -> None:
+        index = 0
+        while not stop.is_set():
+            (results / "changing.txt").write_text(str(index))
+            started.set()
+            index += 1
+            time.sleep(0.0001)
+
+    thread = threading.Thread(target=mutate)
+    thread.start()
+    try:
+        assert started.wait(5)
+        with pytest.raises(ValueError, match="Source changed"):
+            export(home, tmp_path)
+    finally:
+        stop.set()
+        thread.join(5)
+        assert not thread.is_alive()
+
+
+def test_inventory_detects_new_file(tmp_path: Path) -> None:
+    from claude_code_tools.transfer_claude import _fingerprint
+
+    root = tmp_path / "sidecar"
+    root.mkdir()
+    before = _fingerprint([root])
+    (root / "new.txt").write_text("new output")
+    assert _fingerprint([root]) != before

--- a/tests/test_transfer_claude.py
+++ b/tests/test_transfer_claude.py
@@ -17,10 +17,18 @@ def fixture_home(tmp_path: Path) -> tuple[Path, Path]:
     project.mkdir(parents=True)
     records = [
         {"type": "custom-title", "customTitle": "Research", "sessionId": SID},
-        {"type": "user", "cwd": "/old/project", "sessionId": SID,
-         "message": {"content": "Read /old/project/code.py"}},
-        {"type": "file-history-snapshot", "snapshot": {
-            "trackedFileBackups": {"/old/project/code.py": {"version": 1}}}},
+        {
+            "type": "user",
+            "cwd": "/old/project",
+            "sessionId": SID,
+            "message": {"content": "Read /old/project/code.py"},
+        },
+        {
+            "type": "file-history-snapshot",
+            "snapshot": {
+                "trackedFileBackups": {"/old/project/code.py": {"version": 1}}
+            },
+        },
     ]
     transcript = project / f"{SID}.jsonl"
     transcript.write_text("\n".join(json.dumps(r) for r in records) + "\n")
@@ -30,7 +38,10 @@ def fixture_home(tmp_path: Path) -> tuple[Path, Path]:
 def export(home: Path, tmp_path: Path) -> dict:
     """Stage to a destination that need not exist on this machine."""
     return export_session(
-        home, SID, Path("/remote/.claude-work"), Path("/new/project"),
+        home,
+        SID,
+        Path("/remote/.claude-work"),
+        Path("/new/project"),
         tmp_path / "bundle",
     )
 
@@ -109,8 +120,11 @@ def test_copies_subagent_metadata_and_reports_runtime(tmp_path: Path) -> None:
     subagent.write_text(json.dumps({"cwd": "/old/project/sub", "type": "user"}))
     (home / "tasks" / f"session-{SID[:8]}").mkdir(parents=True)
     result = export(home, tmp_path)
-    staged = tmp_path / "bundle/files/projects/-new-project" / SID / (
-        "subagents/agent-123.jsonl"
+    staged = (
+        tmp_path
+        / "bundle/files/projects/-new-project"
+        / SID
+        / ("subagents/agent-123.jsonl")
     )
     assert json.loads(staged.read_text())["cwd"] == "/new/project/sub"
     assert any("Session-linked tasks" in warning for warning in result["warnings"])

--- a/tests/test_transfer_claude.py
+++ b/tests/test_transfer_claude.py
@@ -1,0 +1,116 @@
+"""Real filesystem coverage for Claude transfer staging."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_code_tools.transfer_claude import export_session
+
+SID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
+
+def fixture_home(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a minimal account with an actual transcript and companions."""
+    home = tmp_path / "claude"
+    project = home / "projects" / "-old-project"
+    project.mkdir(parents=True)
+    records = [
+        {"type": "custom-title", "customTitle": "Research", "sessionId": SID},
+        {"type": "user", "cwd": "/old/project", "sessionId": SID,
+         "message": {"content": "Read /old/project/code.py"}},
+        {"type": "file-history-snapshot", "snapshot": {
+            "trackedFileBackups": {"/old/project/code.py": {"version": 1}}}},
+    ]
+    transcript = project / f"{SID}.jsonl"
+    transcript.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    return home, transcript
+
+
+def export(home: Path, tmp_path: Path) -> dict:
+    """Stage to a destination that need not exist on this machine."""
+    return export_session(
+        home, SID, Path("/remote/.claude-work"), Path("/new/project"),
+        tmp_path / "bundle",
+    )
+
+
+def test_complete_payload_and_metadata(tmp_path: Path) -> None:
+    """Transfer companions and memory but retain prose and the original home."""
+    home, transcript = fixture_home(tmp_path)
+    original = transcript.read_bytes()
+    artifacts = {
+        f"projects/-old-project/{SID}/tool-results/result.txt": "tool text",
+        f"file-history/{SID}/backup@v1": "old contents",
+        f"tasks/{SID}/1.json": '{"subject":"continue"}',
+        f"tasks/{SID}/.lock": "lock",
+        f"todos/{SID}-agent-{SID}.json": "[]",
+        "projects/-old-project/memory/MEMORY.md": "/old/project memory",
+        "settings.json": "secret configuration",
+    }
+    for name, content in artifacts.items():
+        path = home / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    result = export(home, tmp_path)
+    assert result["ok"] is True
+    assert len(result["files"]) == 6
+    assert result["shared_files"] == ["projects/-new-project/memory/MEMORY.md"]
+    staged = tmp_path / "bundle/files/projects/-new-project" / transcript.name
+    records = [json.loads(line) for line in staged.read_text().splitlines()]
+    assert records[1]["cwd"] == "/new/project"
+    assert records[1]["message"]["content"] == "Read /old/project/code.py"
+    assert "/new/project/code.py" in records[2]["snapshot"]["trackedFileBackups"]
+    assert transcript.read_bytes() == original
+    assert not any(".lock" in name or "settings" in name for name in result["files"])
+
+
+def test_rejects_ambiguous_cwd(tmp_path: Path) -> None:
+    home, transcript = fixture_home(tmp_path)
+    with transcript.open("a") as handle:
+        handle.write(json.dumps({"cwd": "/unrelated"}) + "\n")
+    with pytest.raises(ValueError, match="exactly one project"):
+        export(home, tmp_path)
+
+
+@pytest.mark.parametrize("artifact", ["memory", f"{SID}/tool-results"])
+def test_rejects_symlink_companions(tmp_path: Path, artifact: str) -> None:
+    home, transcript = fixture_home(tmp_path)
+    target = tmp_path / "outside"
+    target.mkdir()
+    link = transcript.parent / artifact
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(target)
+    with pytest.raises(ValueError, match="symlink"):
+        export(home, tmp_path)
+
+
+def test_rejects_unknown_sidecar(tmp_path: Path) -> None:
+    home, transcript = fixture_home(tmp_path)
+    artifact = transcript.with_suffix("") / "unknown-runtime"
+    artifact.parent.mkdir()
+    artifact.write_text("unknown")
+    with pytest.raises(ValueError, match="Unsupported Claude session sidecar"):
+        export(home, tmp_path)
+
+
+def test_rejects_partial_json(tmp_path: Path) -> None:
+    home, transcript = fixture_home(tmp_path)
+    with transcript.open("a") as handle:
+        handle.write('{"partial":')
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        export(home, tmp_path)
+
+
+def test_copies_subagent_metadata_and_reports_runtime(tmp_path: Path) -> None:
+    home, transcript = fixture_home(tmp_path)
+    subagent = transcript.with_suffix("") / "subagents/agent-123.jsonl"
+    subagent.parent.mkdir(parents=True)
+    subagent.write_text(json.dumps({"cwd": "/old/project/sub", "type": "user"}))
+    (home / "tasks" / f"session-{SID[:8]}").mkdir(parents=True)
+    result = export(home, tmp_path)
+    staged = tmp_path / "bundle/files/projects/-new-project" / SID / (
+        "subagents/agent-123.jsonl"
+    )
+    assert json.loads(staged.read_text())["cwd"] == "/new/project/sub"
+    assert any("Session-linked tasks" in warning for warning in result["warnings"])

--- a/tests/test_transfer_claude.py
+++ b/tests/test_transfer_claude.py
@@ -225,3 +225,106 @@ def test_maps_sidecar_project_subdirectory(tmp_path: Path) -> None:
     record = json.loads(copied.read_text())
     assert record["cwd"] == "/new/project/subdir"
     assert record["message"]["content"] == "Historical /old/project/subdir"
+
+
+@pytest.mark.parametrize(
+    "key", ["/old/project/../outside.py", "/other/repo/file.py", "../outside.py"]
+)
+def test_rejects_unmappable_file_history(tmp_path: Path, key: str) -> None:
+    """File-history keys cannot escape the selected project after normalization."""
+    home, transcript = fixture_home(tmp_path)
+    with transcript.open("a") as stream:
+        stream.write(
+            json.dumps(
+                {
+                    "type": "file-history-snapshot",
+                    "snapshot": {"trackedFileBackups": {key: {"version": 1}}},
+                }
+            )
+            + "\n"
+        )
+    with pytest.raises(ValueError, match="file-history path needs an explicit mapping"):
+        export(home, tmp_path)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("realParentDir", "/old/project/../outside"),
+        ("realParentDir", "/other/repo"),
+        ("backupFileName", "../outside"),
+        ("backupFileName", "/other/backup"),
+    ],
+)
+def test_rejects_unmappable_backup_metadata(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    """The paths inside backup values receive the same containment checks."""
+    home, transcript = fixture_home(tmp_path)
+    with transcript.open("a") as stream:
+        stream.write(
+            json.dumps(
+                {
+                    "type": "file-history-snapshot",
+                    "snapshot": {"trackedFileBackups": {"file.py": {field: value}}},
+                }
+            )
+            + "\n"
+        )
+    with pytest.raises(ValueError, match="(realParentDir|backupFileName)"):
+        export(home, tmp_path)
+
+
+def test_preserves_relative_backup_keys_and_maps_real_parent(tmp_path: Path) -> None:
+    """Native relative keys stay relative and real parent directories relocate."""
+    home, transcript = fixture_home(tmp_path)
+    with transcript.open("a") as stream:
+        stream.write(
+            json.dumps(
+                {
+                    "type": "file-history-snapshot",
+                    "snapshot": {
+                        "trackedFileBackups": {
+                            "src/../file.py": {
+                                "realParentDir": "/old/project/src/..",
+                                "backupFileName": "backup@v1",
+                                "version": 1,
+                            },
+                        }
+                    },
+                }
+            )
+            + "\n"
+        )
+    export(home, tmp_path)
+    copied = tmp_path / "bundle/files/projects/-new-project" / transcript.name
+    record = json.loads(copied.read_text().splitlines()[-1])
+    assert record["snapshot"]["trackedFileBackups"] == {
+        "file.py": {
+            "realParentDir": "/new/project",
+            "backupFileName": "backup@v1",
+            "version": 1,
+        },
+    }
+
+
+def test_rejects_normalized_backup_key_collision(tmp_path: Path) -> None:
+    """Normalization cannot silently discard one of two backup records."""
+    home, transcript = fixture_home(tmp_path)
+    with transcript.open("a") as stream:
+        stream.write(
+            json.dumps(
+                {
+                    "type": "file-history-snapshot",
+                    "snapshot": {
+                        "trackedFileBackups": {
+                            "src/../file.py": {"version": 1},
+                            "file.py": {"version": 2},
+                        }
+                    },
+                }
+            )
+            + "\n"
+        )
+    with pytest.raises(ValueError, match="file-history collision"):
+        export(home, tmp_path)

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -387,3 +387,37 @@ def test_subagent_file_history_backup_gaps_are_reported(tmp_path: Path) -> None:
     )
     copied = tmp_path / "bundle/files" / existing.relative_to(home)
     assert copied.read_bytes() == existing.read_bytes()
+
+
+def test_subagent_only_plan_slugs_copy_and_report_gaps(tmp_path: Path) -> None:
+    """Plan discovery includes selected sidecar records before source snapshotting."""
+    home, transcript = fixture_home(tmp_path)
+    plans = home / "plans"
+    plans.mkdir()
+    existing = plans / "sidecar-existing-plan.md"
+    existing.write_text("the selected subagent plan")
+    missing = plans / "sidecar-missing-plan.md"
+    unrelated = plans / "unrelated-plan.md"
+    unrelated.write_text("another session plan")
+    sidecar = transcript.with_suffix("") / "subagents/agent-planning.jsonl"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        "".join(
+            json.dumps(record) + "\n"
+            for record in [
+                {"cwd": "/old/project", "slug": existing.stem, "type": "user"},
+                {"cwd": "/old/project", "slug": missing.stem, "type": "assistant"},
+            ]
+        )
+    )
+    result = export_session(
+        home, SID, Path("/remote/profile"), Path("/new/project"), tmp_path / "bundle"
+    )
+    relative = existing.relative_to(home)
+    assert str(relative) in result["files"]
+    assert str(relative) in result["shared_files"]
+    assert (tmp_path / "bundle/files" / relative).read_bytes() == existing.read_bytes()
+    assert {"path": str(missing), "reason": "missing_at_source"} in result[
+        "missing_at_source"
+    ]
+    assert str(unrelated.relative_to(home)) not in result["files"]

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -1,6 +1,7 @@
 """Regression coverage for session artifacts discovered during real migrations."""
 
 import json
+import os
 import tempfile
 from pathlib import Path
 
@@ -34,11 +35,14 @@ def test_goal_and_tool_jsonl_preserved(tmp_path: Path) -> None:
     assert (root / SID / "tool-results/output.jsonl").read_bytes() == content
 
 
-def test_scratch_symlink_missing_and_mapping(tmp_path: Path) -> None:
+def test_scratch_symlink_missing_and_mapping(tmp_path: Path, monkeypatch) -> None:
     """Copy session scratch, materialize a log link, and report missing references."""
     home, transcript = fixture_home(tmp_path)
     with tempfile.TemporaryDirectory(prefix="claude-transfer-", dir="/tmp") as name:
-        scratch = Path(name) / "project" / SID / "scratchpad"
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: name)
+        scratch = (
+            Path(name) / f"claude-{os.getuid()}" / "-old-project" / SID / "scratchpad"
+        )
         scratch.mkdir(parents=True)
         (scratch / "plan.txt").write_text("scratch goal")
         log = transcript.with_suffix("") / "subagents/agent-child.jsonl"
@@ -181,14 +185,19 @@ def test_unicode_line_separators_inside_native_jsonl(tmp_path: Path) -> None:
         assert records[-1]["cwd"] == "/new/project"
 
 
-def test_scratch_link_cannot_copy_another_sessions_subagent(tmp_path: Path) -> None:
+def test_scratch_link_cannot_copy_another_sessions_subagent(
+    tmp_path: Path, monkeypatch
+) -> None:
     """A .jsonl/subagents shape alone does not authorize another session's log."""
     home, transcript = fixture_home(tmp_path)
     unrelated = transcript.parent / "another-session/subagents/agent-private.jsonl"
     unrelated.parent.mkdir(parents=True)
     unrelated.write_text("unrelated conversation must not be copied")
     with tempfile.TemporaryDirectory(prefix="claude-transfer-", dir="/tmp") as name:
-        scratch = Path(name) / "project" / SID / "scratchpad"
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: name)
+        scratch = (
+            Path(name) / f"claude-{os.getuid()}" / "-old-project" / SID / "scratchpad"
+        )
         scratch.mkdir(parents=True)
         link = scratch / "task.output"
         link.symlink_to(unrelated)
@@ -211,3 +220,42 @@ def test_scratch_link_cannot_copy_another_sessions_subagent(tmp_path: Path) -> N
                     b"unrelated conversation must not be copied"
                     not in path.read_bytes()
                 )
+
+
+def test_regular_other_session_scratch_is_not_copied(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A literal path into another session's scratch bucket does not authorize it."""
+    home, transcript = fixture_home(tmp_path)
+    with tempfile.TemporaryDirectory(prefix="claude-transfer-", dir="/tmp") as name:
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: name)
+        bucket = Path(name) / f"claude-{os.getuid()}" / "-old-project"
+        selected = bucket / SID / "scratchpad/selected.txt"
+        selected.parent.mkdir(parents=True)
+        selected.write_text("owned scratch")
+        unrelated = bucket / "another-session" / "scratchpad/private.txt"
+        unrelated.parent.mkdir(parents=True)
+        unrelated.write_text("unrelated private scratch")
+        linked_directory = selected.parent / "linked"
+        linked_directory.symlink_to(unrelated.parent, target_is_directory=True)
+        traversed = linked_directory / unrelated.name
+        with transcript.open("a") as stream:
+            stream.write(
+                json.dumps(
+                    {"message": {"content": f"Read {unrelated} and {traversed}"}}
+                )
+                + "\n"
+            )
+        result = export_session(
+            home,
+            SID,
+            Path("/remote/profile"),
+            Path("/new/project"),
+            tmp_path / "bundle",
+        )
+        assert str(selected.resolve()) in result["path_mappings"]
+        assert str(unrelated) not in result["path_mappings"]
+        assert str(traversed) not in result["path_mappings"]
+        for path in (tmp_path / "bundle/files").rglob("*"):
+            if path.is_file():
+                assert b"unrelated private scratch" not in path.read_bytes()

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -128,3 +128,34 @@ def test_unreferenced_native_scratch(tmp_path: Path, monkeypatch) -> None:
     mapped = Path(result["path_mappings"][str(scratch / "goal.txt")])
     copied = tmp_path / "bundle/files" / mapped.relative_to("/remote/profile")
     assert copied.read_text() == "Native scratch without literal reference"
+
+
+def test_prior_transfer_scratch_survives_return(tmp_path: Path) -> None:
+    """Previously relocated scratch and original historical aliases survive a return."""
+    home, _ = fixture_home(tmp_path)
+    support = home / "transfer-support" / SID
+    artifact = support / "scratch/hash/goal.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("goal from the first machine")
+    (support / "path-map.json").write_text(
+        json.dumps(
+            {
+                "path_mappings": {"/tmp/old-original/goal.txt": str(artifact)},
+                "missing_at_source": [
+                    {"path": "/tmp/old-original/gone", "reason": "missing_at_source"}
+                ],
+            }
+        )
+    )
+    result = export_session(
+        home, SID, Path("/return/profile"), Path("/return/project"), tmp_path / "bundle"
+    )
+    target = Path("/return/profile") / artifact.relative_to(home)
+    assert result["path_mappings"]["/tmp/old-original/goal.txt"] == str(target)
+    assert (tmp_path / "bundle/files" / artifact.relative_to(home)).read_text() == (
+        "goal from the first machine"
+    )
+    assert not any(name.endswith("/path-map.json") for name in result["files"])
+    assert any(
+        item["path"] == "/tmp/old-original/gone" for item in result["missing_at_source"]
+    )

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -5,6 +5,8 @@ import os
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from claude_code_tools.transfer_claude import export_session
 from tests.test_transfer_claude import SID, fixture_home
 
@@ -259,3 +261,37 @@ def test_regular_other_session_scratch_is_not_copied(
         for path in (tmp_path / "bundle/files").rglob("*"):
             if path.is_file():
                 assert b"unrelated private scratch" not in path.read_bytes()
+
+
+@pytest.mark.parametrize("linked_component", ["bucket", "project"])
+def test_native_scratch_rejects_symlinked_ancestor(
+    tmp_path: Path, monkeypatch, linked_component: str
+) -> None:
+    """A computed native path cannot designate unrelated files through an ancestor."""
+    home, _ = fixture_home(tmp_path)
+    temporary_base = tmp_path / "temporary"
+    temporary_base.mkdir()
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(temporary_base))
+    bucket = temporary_base / f"claude-{os.getuid()}"
+    external = tmp_path / "unrelated"
+    if linked_component == "bucket":
+        secret = external / "-old-project" / SID / "scratchpad/secret.txt"
+        secret.parent.mkdir(parents=True)
+        bucket.symlink_to(external, target_is_directory=True)
+    else:
+        secret = external / SID / "scratchpad/secret.txt"
+        secret.parent.mkdir(parents=True)
+        bucket.mkdir()
+        (bucket / "-old-project").symlink_to(external, target_is_directory=True)
+    secret.write_text("unrelated data must not enter selected session export")
+    with pytest.raises(ValueError, match="scratch root uses a symlinked ancestor"):
+        export_session(
+            home,
+            SID,
+            Path("/remote/profile"),
+            Path("/new/project"),
+            tmp_path / "bundle",
+        )
+    for path in (tmp_path / "bundle/files").rglob("*"):
+        if path.is_file():
+            assert secret.read_bytes() not in path.read_bytes()

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -1,0 +1,104 @@
+"""Regression coverage for session artifacts discovered during real migrations."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from claude_code_tools.transfer_claude import export_session
+from tests.test_transfer_claude import SID, fixture_home
+
+
+def test_goal_and_tool_jsonl_preserved(tmp_path: Path) -> None:
+    """Native goal attachments and arbitrary persisted output retain their content."""
+    home, transcript = fixture_home(tmp_path)
+    goal = {
+        "type": "attachment",
+        "attachment": {
+            "type": "goal_status",
+            "met": False,
+            "condition": "Read /old/project/report",
+            "sentinel": True,
+        },
+    }
+    with transcript.open("a") as stream:
+        stream.write(json.dumps(goal) + "\n")
+    output = transcript.with_suffix("") / "tool-results" / "output.jsonl"
+    output.parent.mkdir(parents=True)
+    content = b'{"cwd":"/unrelated/data","value": 1}\nnot JSON at all\n'
+    output.write_bytes(content)
+    export_session(
+        home, SID, Path("/remote/profile"), Path("/new/project"), tmp_path / "bundle"
+    )
+    root = tmp_path / "bundle/files/projects/-new-project"
+    assert json.loads((root / transcript.name).read_text().splitlines()[-1]) == goal
+    assert (root / SID / "tool-results/output.jsonl").read_bytes() == content
+
+
+def test_scratch_symlink_missing_and_mapping(tmp_path: Path) -> None:
+    """Copy session scratch, materialize a log link, and report missing references."""
+    home, transcript = fixture_home(tmp_path)
+    with tempfile.TemporaryDirectory(prefix="claude-transfer-", dir="/tmp") as name:
+        scratch = Path(name) / "project" / SID / "scratchpad"
+        scratch.mkdir(parents=True)
+        (scratch / "plan.txt").write_text("scratch goal")
+        log = transcript.with_suffix("") / "subagents/agent-child.jsonl"
+        log.parent.mkdir(parents=True)
+        log.write_text(json.dumps({"cwd": "/old/project", "type": "user"}))
+        (scratch / "child.output").symlink_to(log)
+        missing = scratch / "gone.txt"
+        with transcript.open("a") as stream:
+            stream.write(
+                json.dumps(
+                    {
+                        "message": {
+                            "content": f"Read {scratch}/plan.txt then {missing}"
+                        },
+                        "slug": "missing-plan",
+                    }
+                )
+                + "\n"
+            )
+        result = export_session(
+            home,
+            SID,
+            Path("/remote/profile"),
+            Path("/new/project"),
+            tmp_path / "bundle",
+        )
+        assert str(missing) in {item["path"] for item in result["missing_at_source"]}
+        assert str(home / "plans/missing-plan.md") in {
+            item["path"] for item in result["missing_at_source"]
+        }
+        mapping = result["path_mappings"]
+        for original in (scratch / "plan.txt", scratch / "child.output"):
+            relative = Path(mapping[str(original)]).relative_to("/remote/profile")
+            copied = tmp_path / "bundle/files" / relative
+            assert copied.is_file() and not copied.is_symlink()
+            assert copied.read_bytes() == original.read_bytes()
+
+
+def test_multiple_explicit_projects(tmp_path: Path) -> None:
+    """Explicit mappings support transcript cwd transitions into another worktree."""
+    home, transcript = fixture_home(tmp_path)
+    with transcript.open("a") as stream:
+        stream.write(
+            json.dumps(
+                {"cwd": "/other/tree", "message": {"content": "Historical /other/tree"}}
+            )
+            + "\n"
+        )
+    export_session(
+        home,
+        SID,
+        Path("/remote/profile"),
+        Path("/new/project"),
+        tmp_path / "bundle",
+        path_mappings={"/other/tree": "/new/tree"},
+    )
+    record = json.loads(
+        (tmp_path / "bundle/files/projects/-new-project" / transcript.name)
+        .read_text()
+        .splitlines()[-1]
+    )
+    assert record["cwd"] == "/new/tree"
+    assert record["message"]["content"] == "Historical /other/tree"

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -351,3 +351,39 @@ def test_subagent_secondary_worktree_scratch_and_gaps(
             "source": "/secondary/worktree",
             "destination": "/remote/secondary",
         } in result["operational_cwds"]
+
+
+def test_subagent_file_history_backup_gaps_are_reported(tmp_path: Path) -> None:
+    """Selected sidecar snapshots receive the same missing-backup check as main."""
+    home, transcript = fixture_home(tmp_path)
+    existing = home / "file-history" / SID / "existing@v1"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("preserved historical contents")
+    missing = existing.parent / "missing@v2"
+    sidecar = transcript.with_suffix("") / "subagents/agent-history.jsonl"
+    sidecar.parent.mkdir(parents=True)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "type": "file-history-snapshot",
+                "snapshot": {
+                    "trackedFileBackups": {
+                        "existing.py": {"backupFileName": existing.name, "version": 1},
+                        "missing.py": {"backupFileName": missing.name, "version": 2},
+                    }
+                },
+            }
+        )
+        + "\n"
+    )
+    result = export_session(
+        home, SID, Path("/remote/profile"), Path("/new/project"), tmp_path / "bundle"
+    )
+    assert {"path": str(missing), "reason": "missing_at_source"} in result[
+        "missing_at_source"
+    ]
+    assert not any(
+        item["path"] == str(existing) for item in result["missing_at_source"]
+    )
+    copied = tmp_path / "bundle/files" / existing.relative_to(home)
+    assert copied.read_bytes() == existing.read_bytes()

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -421,3 +422,115 @@ def test_subagent_only_plan_slugs_copy_and_report_gaps(tmp_path: Path) -> None:
         "missing_at_source"
     ]
     assert str(unrelated.relative_to(home)) not in result["files"]
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "account",
+        "subtree",
+        "alias",
+        "alias-missing-tail",
+        "encoded-project",
+        "alias-encoded-project",
+    ],
+)
+@pytest.mark.parametrize("conflicting", [True, False])
+def test_claude_account_mappings_retain_destination_layout(
+    tmp_path: Path, scope: str, conflicting: bool
+) -> None:
+    """Account mappings and aliases cannot redirect copied artifacts elsewhere."""
+    home, transcript = fixture_home(tmp_path)
+    alias = tmp_path / "account-alias"
+    alias.symlink_to(home, target_is_directory=True)
+    relative = Path(".")
+    if scope == "account":
+        old = home
+    elif scope == "subtree":
+        relative = Path("projects")
+        old = home / relative
+    elif scope == "alias":
+        old = alias
+    elif scope in {"encoded-project", "alias-encoded-project"}:
+        relative = Path("projects/-old-project")
+        old = (alias if scope == "alias-encoded-project" else home) / relative
+    else:
+        relative = Path("plans/future")
+        old = alias / relative
+    destination_home = Path("/remote/profile")
+    expected = str(
+        destination_home
+        / (Path("projects/-new-project") if "encoded-project" in scope else relative)
+    )
+    mapped = "/unrelated/destination" if conflicting else expected
+    if conflicting:
+        with pytest.raises(ValueError, match="Account home mapping conflicts"):
+            export_session(
+                home,
+                SID,
+                destination_home,
+                Path("/new/project"),
+                tmp_path / "bundle",
+                path_mappings={str(old): mapped},
+            )
+    else:
+        result = export_session(
+            home,
+            SID,
+            destination_home,
+            Path("/new/project"),
+            tmp_path / "bundle",
+            path_mappings={str(old): mapped},
+        )
+        assert result["ok"]
+        assert result["path_mappings"][str(old)] == expected
+        assert (
+            result["path_mappings"][str(transcript.parent)]
+            == "/remote/profile/projects/-new-project"
+        )
+        if scope == "alias":
+            assert (
+                result["path_mappings"][str(alias / "projects/-old-project")]
+                == "/remote/profile/projects/-new-project"
+            )
+        assert (
+            tmp_path / "bundle/files/projects/-new-project" / transcript.name
+        ).is_file()
+
+
+def test_encoded_project_path_guide_composes_on_second_copy(tmp_path: Path) -> None:
+    """Historical tool-result paths follow the actual encoded folder on both hops."""
+    home, transcript = fixture_home(tmp_path)
+    result_file = transcript.with_suffix("") / "tool-results/result.txt"
+    result_file.parent.mkdir(parents=True)
+    result_file.write_text("persisted output")
+    first_home = tmp_path / "first-destination"
+    first = export_session(
+        home, SID, first_home, Path("/new/project"), tmp_path / "first-bundle"
+    )
+    shutil.copytree(tmp_path / "first-bundle/files", first_home)
+    guide = first_home / "transfer-support" / SID / "path-map.json"
+    guide.parent.mkdir(parents=True)
+    guide.write_text(
+        json.dumps(
+            {
+                "path_mappings": first["path_mappings"],
+                "missing_at_source": first["missing_at_source"],
+            }
+        )
+    )
+    second = export_session(
+        first_home,
+        SID,
+        Path("/returned/profile"),
+        Path("/returned/project"),
+        tmp_path / "second-bundle",
+    )
+    expected_parent = Path("/returned/profile/projects/-returned-project")
+    assert second["path_mappings"][str(transcript.parent)] == str(expected_parent)
+    relative_tail = result_file.relative_to(transcript.parent)
+    destination = expected_parent / relative_tail
+    copied = (
+        tmp_path / "second-bundle/files" / destination.relative_to("/returned/profile")
+    )
+    assert copied.read_bytes() == result_file.read_bytes()

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -295,3 +295,59 @@ def test_native_scratch_rejects_symlinked_ancestor(
     for path in (tmp_path / "bundle/files").rglob("*"):
         if path.is_file():
             assert secret.read_bytes() not in path.read_bytes()
+
+
+def test_subagent_secondary_worktree_scratch_and_gaps(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Subagent records contribute mapped cwd roots and surviving/missing scratch."""
+    home, transcript = fixture_home(tmp_path)
+    sidecar = transcript.with_suffix("") / "subagents/agent-secondary.jsonl"
+    sidecar.parent.mkdir(parents=True)
+    with tempfile.TemporaryDirectory(prefix="claude-transfer-", dir="/tmp") as name:
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: name)
+        bucket = Path(name) / f"claude-{os.getuid()}"
+        scratch = bucket / "-secondary-worktree" / SID / "scratchpad"
+        scratch.mkdir(parents=True)
+        existing = scratch / "retained.txt"
+        existing.write_text("selected subagent scratch")
+        unreferenced = scratch / "goal.txt"
+        unreferenced.write_text("subagent scratch used through a shell variable")
+        missing = scratch / "gone.txt"
+        unrelated = bucket / "-unrelated-worktree" / SID / "scratchpad/private.txt"
+        unrelated.parent.mkdir(parents=True)
+        unrelated.write_text("unrelated worktree must not be included")
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "cwd": "/secondary/worktree",
+                    "message": {
+                        "content": f"Read {existing}, {missing}, and {unrelated}"
+                    },
+                }
+            )
+            + "\n"
+        )
+        result = export_session(
+            home,
+            SID,
+            Path("/remote/profile"),
+            Path("/new/project"),
+            tmp_path / "bundle",
+            path_mappings={"/secondary/worktree": "/remote/secondary"},
+        )
+        for source in (existing, unreferenced):
+            destination = Path(result["path_mappings"][str(source.resolve())])
+            copied = (
+                tmp_path / "bundle/files" / destination.relative_to("/remote/profile")
+            )
+            assert copied.read_bytes() == source.read_bytes()
+        assert {"path": str(missing), "reason": "missing_at_source"} in result[
+            "missing_at_source"
+        ]
+        assert str(unrelated) not in result["path_mappings"]
+        assert {
+            "source": "/secondary/worktree",
+            "destination": "/remote/secondary",
+        } in result["operational_cwds"]

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -102,3 +102,29 @@ def test_multiple_explicit_projects(tmp_path: Path) -> None:
     )
     assert record["cwd"] == "/new/tree"
     assert record["message"]["content"] == "Historical /other/tree"
+
+
+def test_unreferenced_native_scratch(tmp_path: Path, monkeypatch) -> None:
+    """Exact native session scratch survives even when used via shell variables."""
+    import os
+
+    from claude_code_tools import transfer_claude_artifacts
+
+    home, _ = fixture_home(tmp_path)
+    monkeypatch.setattr(
+        transfer_claude_artifacts.tempfile, "gettempdir", lambda: str(tmp_path)
+    )
+    scratch = tmp_path / f"claude-{os.getuid()}" / "-old-project" / SID / "scratchpad"
+    scratch.mkdir(parents=True)
+    (scratch / "goal.txt").write_text("Native scratch without literal reference")
+    result = export_session(
+        home,
+        SID,
+        Path("/remote/profile"),
+        Path("/new/project"),
+        tmp_path / "bundle",
+        path_mappings=[{"source": "/other", "destination": "/remote/other"}],
+    )
+    mapped = Path(result["path_mappings"][str(scratch / "goal.txt")])
+    copied = tmp_path / "bundle/files" / mapped.relative_to("/remote/profile")
+    assert copied.read_text() == "Native scratch without literal reference"

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -159,3 +159,23 @@ def test_prior_transfer_scratch_survives_return(tmp_path: Path) -> None:
     assert any(
         item["path"] == "/tmp/old-original/gone" for item in result["missing_at_source"]
     )
+
+
+def test_unicode_line_separators_inside_native_jsonl(tmp_path: Path) -> None:
+    """JSONL records use LF, not Unicode separators inside conversation strings."""
+    home, transcript = fixture_home(tmp_path)
+    text = "First\u2028second\u2029third\u0085fourth"
+    record = {"type": "user", "cwd": "/old/project", "message": {"content": text}}
+    with transcript.open("a") as stream:
+        stream.write(json.dumps(record, ensure_ascii=False) + "\n")
+    subagent = transcript.with_suffix("") / "subagents/agent-child.jsonl"
+    subagent.parent.mkdir(parents=True)
+    subagent.write_text(json.dumps(record, ensure_ascii=False) + "\n")
+    export_session(
+        home, SID, Path("/remote/profile"), Path("/new/project"), tmp_path / "bundle"
+    )
+    root = tmp_path / "bundle/files/projects/-new-project"
+    for path in (root / transcript.name, root / SID / "subagents/agent-child.jsonl"):
+        records = [json.loads(line) for line in path.read_text().split("\n") if line]
+        assert records[-1]["message"]["content"] == text
+        assert records[-1]["cwd"] == "/new/project"

--- a/tests/test_transfer_claude_artifacts.py
+++ b/tests/test_transfer_claude_artifacts.py
@@ -179,3 +179,35 @@ def test_unicode_line_separators_inside_native_jsonl(tmp_path: Path) -> None:
         records = [json.loads(line) for line in path.read_text().split("\n") if line]
         assert records[-1]["message"]["content"] == text
         assert records[-1]["cwd"] == "/new/project"
+
+
+def test_scratch_link_cannot_copy_another_sessions_subagent(tmp_path: Path) -> None:
+    """A .jsonl/subagents shape alone does not authorize another session's log."""
+    home, transcript = fixture_home(tmp_path)
+    unrelated = transcript.parent / "another-session/subagents/agent-private.jsonl"
+    unrelated.parent.mkdir(parents=True)
+    unrelated.write_text("unrelated conversation must not be copied")
+    with tempfile.TemporaryDirectory(prefix="claude-transfer-", dir="/tmp") as name:
+        scratch = Path(name) / "project" / SID / "scratchpad"
+        scratch.mkdir(parents=True)
+        link = scratch / "task.output"
+        link.symlink_to(unrelated)
+        with transcript.open("a") as stream:
+            stream.write(json.dumps({"message": {"content": f"Read {link}"}}) + "\n")
+        result = export_session(
+            home,
+            SID,
+            Path("/remote/profile"),
+            Path("/new/project"),
+            tmp_path / "bundle",
+        )
+        assert str(link) not in result["path_mappings"]
+        assert {"path": str(link), "reason": "unsupported_symlink_target"} in result[
+            "missing_at_source"
+        ]
+        for path in (tmp_path / "bundle/files").rglob("*"):
+            if path.is_file():
+                assert (
+                    b"unrelated conversation must not be copied"
+                    not in path.read_bytes()
+                )

--- a/tests/test_transfer_cli_environment.py
+++ b/tests/test_transfer_cli_environment.py
@@ -1,0 +1,25 @@
+"""Verify environment differences remain visible in normal transfer output."""
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from claude_code_tools.aichat import main
+from tests.test_transfer_session import arguments
+from tests.test_transfer_session import workspace as make_workspace
+
+
+def test_default_report_names_new_skill_denies(tmp_path: Path) -> None:
+    """A destination permission deny is displayed without requiring JSON output."""
+    workspace = make_workspace.__wrapped__(tmp_path)
+    destination = workspace["destination"]
+    destination.mkdir()
+    (destination / "settings.json").write_text(
+        json.dumps({"permissions": {"deny": ["Skill(fixture-skill)"]}})
+    )
+    args = [arg for arg in arguments(workspace) if arg not in ("--apply", "--json")]
+    result = CliRunner().invoke(main, args)
+    assert result.exit_code == 0, result.output
+    assert "Environment newly_denied_skills: Skill(fixture-skill)" in result.output
+    assert not (destination / "projects").exists()

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -786,3 +786,72 @@ def test_explicit_external_symlink_is_refused(tmp_path: Path) -> None:
                 tmp_path / "stage",
                 [(str(link), "/new/support/linked.txt")],
             )
+
+
+@pytest.mark.parametrize(
+    "representation", ["structured", "quoted", "backtick", "whole_text", "artifact"]
+)
+def test_support_paths_with_spaces_are_not_truncated(
+    tmp_path: Path, representation: str
+) -> None:
+    """Explicit JSON paths and quoted references retain their complete filenames."""
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root", mode="legacy")
+    attachment = source / "attachments/root/goal notes.txt"
+    attachment.parent.mkdir(parents=True)
+    attachment.write_text("COMPLETE SPACED ATTACHMENT")
+    if representation == "structured":
+        payload = {"path": str(attachment)}
+    elif representation == "quoted":
+        payload = {"text": f'Read "{attachment}" and then continue.'}
+    elif representation == "backtick":
+        payload = {"text": f"Read `{attachment}` and then continue."}
+    else:
+        payload = {"text": str(attachment)}
+    if representation == "artifact":
+        insert(
+            source,
+            "state_5.sqlite",
+            "thread_artifacts",
+            {
+                "id": "artifact",
+                "thread_id": "root",
+                "artifact_type": "attachment",
+                "identity_key": "spaced-file",
+                "payload": json.dumps({"path": str(attachment)}),
+            },
+        )
+    else:
+        with (source / "sessions/2026/root.jsonl").open("a") as stream:
+            stream.write(
+                json.dumps({"type": "response_item", "payload": payload}) + "\n"
+            )
+    manifest = export_session(
+        source,
+        "root",
+        tmp_path / "destination",
+        Path("/new/project"),
+        tmp_path / "stage",
+    )
+    assert "attachments/root/goal notes.txt" in manifest["files"]
+    assert not manifest["missing_at_source"]
+    assert (tmp_path / "stage/files/attachments/root/goal notes.txt").read_text() == (
+        "COMPLETE SPACED ATTACHMENT"
+    )
+
+
+def test_reference_parser_preserves_missing_quoted_paths_and_prose() -> None:
+    """Quoted missing files remain one gap; ordinary prose is not a filename."""
+    from claude_code_tools.transfer_codex_artifacts import reference_candidates
+
+    assert reference_candidates(
+        json.dumps(
+            {
+                "text": 'Read "/unavailable/goal notes.txt" and /unavailable/plain.txt afterward.'
+            }
+        )
+    ) == {"/unavailable/goal notes.txt", "/unavailable/plain.txt"}
+    assert reference_candidates(
+        json.dumps({"attachment_path": "/unavailable/missing attachment.txt"})
+    ) == {"/unavailable/missing attachment.txt"}

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -468,3 +468,41 @@ def test_index_rename_exports_only_latest(tmp_path: Path) -> None:
     assert manifest["metadata_updates"][0]["rows"] == [
         {"id": "root", "thread_name": "current name"}
     ]
+
+
+def test_second_transfer_recovers_historical_attachment(tmp_path: Path) -> None:
+    """Round trips resolve preserved prose through the previous transfer map."""
+    source = tmp_path / "second-machine"
+    profile(source)
+    thread(source, "root", mode="legacy")
+    original = "/first-machine/.codex/attachments/root/goal.txt"
+    attachment = source / "attachments/root/goal.txt"
+    attachment.parent.mkdir(parents=True)
+    attachment.write_text("goal attachment")
+    prior = source / "transfer-support/root/path-map.json"
+    prior.parent.mkdir(parents=True)
+    prior.write_text(
+        json.dumps(
+            {
+                "path_mappings": [
+                    {"source": "/first-machine/.codex", "destination": str(source)}
+                ]
+            }
+        )
+    )
+    with (source / "sessions/2026/root.jsonl").open("a") as stream:
+        stream.write(
+            json.dumps(
+                {"type": "response_item", "payload": {"text": "Read " + original}}
+            )
+            + "\n"
+        )
+    destination = tmp_path / "third-machine"
+    manifest = export_session(
+        source, "root", destination, Path("/new/project"), tmp_path / "stage"
+    )
+    assert "attachments/root/goal.txt" in manifest["files"]
+    assert {"source": "/first-machine/.codex", "destination": str(destination)} in (
+        manifest["path_mappings"]
+    )
+    assert not manifest["missing_at_source"]

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -642,3 +642,84 @@ def test_exact_destination_spawn_edges_are_idempotent(tmp_path: Path) -> None:
         assert db.execute(
             "SELECT parent_thread_id, child_thread_id FROM thread_spawn_edges"
         ).fetchall() == [("root", "child")]
+
+
+@pytest.mark.parametrize("explicit_opt_in", [False, True])
+def test_external_temporary_reference_requires_opt_in(
+    tmp_path: Path, explicit_opt_in: bool
+) -> None:
+    """Mentioning an arbitrary tmp file must not include its contents by default."""
+    import tempfile
+
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root", mode="legacy")
+    with tempfile.TemporaryDirectory(
+        prefix="codex-transfer-test-", dir="/tmp"
+    ) as directory:
+        external = Path(directory) / "customer-key.pem"
+        external.write_text("DISPOSABLE SECRET FIXTURE")
+        with (source / "sessions/2026/root.jsonl").open("a") as stream:
+            stream.write(
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {"text": "A document mentions " + str(external)},
+                    }
+                )
+                + "\n"
+            )
+        mappings = (
+            [(str(external), "/new/support/key.pem")] if explicit_opt_in else None
+        )
+        manifest = export_session(
+            source,
+            "root",
+            tmp_path / "destination",
+            Path("/new/project"),
+            tmp_path / "stage",
+            mappings,
+        )
+        copied_support = [path for path in manifest["files"] if path.endswith(".pem")]
+        assert bool(copied_support) is explicit_opt_in
+        assert bool(manifest["excluded_artifacts"]) is not explicit_opt_in
+        if not explicit_opt_in:
+            assert manifest["excluded_artifacts"][0]["path"] == str(external)
+
+
+def test_session_owned_temporary_reference_is_copied(tmp_path: Path) -> None:
+    """Selected-session directories remain automatically portable."""
+    import tempfile
+
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root", mode="legacy")
+    with tempfile.TemporaryDirectory(
+        prefix="codex-transfer-test-", dir="/tmp"
+    ) as directory:
+        scratch = Path(directory) / "root" / "scratch.txt"
+        scratch.parent.mkdir()
+        scratch.write_text("SESSION SCRATCH FIXTURE")
+        with (source / "sessions/2026/root.jsonl").open("a") as stream:
+            stream.write(
+                json.dumps(
+                    {
+                        "type": "response_item",
+                        "payload": {"text": "Read " + str(scratch)},
+                    }
+                )
+                + "\n"
+            )
+        manifest = export_session(
+            source,
+            "root",
+            tmp_path / "destination",
+            Path("/new/project"),
+            tmp_path / "stage",
+        )
+        copied = [path for path in manifest["files"] if path.endswith("scratch.txt")]
+        assert len(copied) == 1
+        assert (
+            tmp_path / "stage/files" / copied[0]
+        ).read_text() == "SESSION SCRATCH FIXTURE"
+        assert not manifest["excluded_artifacts"]

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -299,3 +300,73 @@ def test_remaps_managed_sandbox_metadata(tmp_path: Path) -> None:
     assert entries[0]["path"]["path"] == "/new/.git"
     assert entries[1]["path"]["path"] == "/dest/memories"
     assert entries[2] == policy["file_system"]["entries"][2]
+
+
+@pytest.mark.parametrize("kind", ["descendant", "writable_root", "managed_profile"])
+def test_rejects_parent_escape_in_operational_paths(tmp_path: Path, kind: str) -> None:
+    """A lexical prefix cannot grant containment to a parent-escaping path."""
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root")
+    with sqlite3.connect(source / "state_5.sqlite") as db:
+        if kind == "descendant":
+            thread(source, "child")
+            db.execute(
+                "UPDATE threads SET cwd='/old/project/../outside' WHERE id='child'"
+            )
+            db.execute(
+                "INSERT INTO thread_spawn_edges VALUES ('root','child','completed')"
+            )
+        else:
+            if kind == "writable_root":
+                policy = {
+                    "type": "workspace-write",
+                    "writable_roots": ["/old/project/../outside"],
+                }
+            else:
+                policy = {
+                    "file_system": {
+                        "type": "restricted",
+                        "entries": [
+                            {
+                                "path": {
+                                    "type": "path",
+                                    "path": str(source / "../outside"),
+                                }
+                            }
+                        ],
+                    }
+                }
+            db.execute("UPDATE threads SET sandbox_policy=?", (json.dumps(policy),))
+    with pytest.raises(ValueError, match="needs a mapping"):
+        export_session(
+            source, "root", Path("/new/home"), Path("/new/project"), tmp_path / "bundle"
+        )
+
+
+def test_normalizes_valid_project_paths(tmp_path: Path) -> None:
+    """Normalization preserves valid project-relative cwd and writable roots."""
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root")
+    thread(source, "child")
+    with sqlite3.connect(source / "state_5.sqlite") as db:
+        db.execute("INSERT INTO thread_spawn_edges VALUES ('root','child','completed')")
+        db.execute("UPDATE threads SET cwd='/old/project/sub/../src' WHERE id='child'")
+        policy = {
+            "type": "workspace-write",
+            "writable_roots": ["/old/project/sub/../src"],
+        }
+        db.execute("UPDATE threads SET sandbox_policy=?", (json.dumps(policy),))
+    result = export_session(
+        source, "root", Path("/new/home"), Path("/new/project"), tmp_path / "bundle"
+    )
+    rows = next(
+        table["rows"]
+        for db in result["databases"]
+        for table in db["tables"]
+        if table["name"] == "threads"
+    )
+    child = next(row for row in rows if row["id"] == "child")
+    assert child["cwd"] == "/new/project/src"
+    assert json.loads(child["sandbox_policy"])["writable_roots"] == ["/new/project/src"]

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -164,7 +164,8 @@ def test_roundtrip_preserves_offsets_and_selects_descendants(tmp_path: Path) -> 
     assert manifest["ok"]
     assert manifest["session_ids"] == ["root", "child"]
     assert len(manifest["files"]) == 2
-    assert (tmp_path / "files" / manifest["files"][0]).read_bytes() == original
+    mapped = (tmp_path / "files" / manifest["files"][0]).read_bytes()
+    assert json.loads(mapped)["payload"]["cwd"] == "/new/project"
     validate_databases(manifest, destination)
     assert import_databases(manifest, destination)["ok"]
     with sqlite3.connect(destination / "state_5.sqlite") as connection:
@@ -175,7 +176,7 @@ def test_roundtrip_preserves_offsets_and_selects_descendants(tmp_path: Path) -> 
     with sqlite3.connect(destination / "thread_history_1.sqlite") as connection:
         assert connection.execute(
             'SELECT rollout_byte_offset FROM thread_turns WHERE thread_id="root"'
-        ).fetchone()[0] == len(original)
+        ).fetchone()[0] == len(mapped)
         assert (
             "/old/project"
             in connection.execute(
@@ -184,10 +185,13 @@ def test_roundtrip_preserves_offsets_and_selects_descendants(tmp_path: Path) -> 
         )
     with sqlite3.connect(destination / "goals_1.sqlite") as connection:
         assert connection.execute("SELECT status FROM thread_goals").fetchone()[0] == (
-            "paused"
+            "active"
         )
     assert (source / "sessions/2026/root.jsonl").read_bytes() == original
-    with pytest.raises(ValueError, match="exists"):
+    assert import_databases(manifest, destination)["ok"]
+    with sqlite3.connect(destination / "state_5.sqlite") as connection:
+        connection.execute("UPDATE threads SET title='continued' WHERE id='root'")
+    with pytest.raises(ValueError, match="exists and differs"):
         import_databases(manifest, destination)
 
 
@@ -370,3 +374,75 @@ def test_normalizes_valid_project_paths(tmp_path: Path) -> None:
     child = next(row for row in rows if row["id"] == "child")
     assert child["cwd"] == "/new/project/src"
     assert json.loads(child["sandbox_policy"])["writable_roots"] == ["/new/project/src"]
+
+
+def test_selected_support_and_metadata(tmp_path: Path) -> None:
+    """Preserve prose, native goals and selected attachments with exact offsets."""
+    source, destination = tmp_path / "source", tmp_path / "destination"
+    profile(source)
+    thread(source, "root", mode="legacy")
+    attachment = source / "attachments" / "root" / "goal.txt"
+    attachment.parent.mkdir(parents=True)
+    attachment.write_text("native goal supporting document")
+    missing = source / "attachments" / "root" / "absent.txt"
+    rollout = source / "sessions/2026/root.jsonl"
+    prose = {
+        "type": "response_item",
+        "payload": {
+            "text": f"Read {attachment} and {missing}; /old/project stays historical"
+        },
+    }
+    original_line = (json.dumps(prose) + "\n").encode()
+    with rollout.open("ab") as stream:
+        stream.write(original_line)
+    (source / "session_index.jsonl").write_text(
+        json.dumps({"id": "root", "thread_name": "example"})
+        + "\n"
+        + json.dumps({"id": "unrelated", "thread_name": "private"})
+        + "\n"
+    )
+    (source / "external_agent_session_imports.json").write_text(
+        json.dumps(
+            {"records": [{"imported_thread_id": "root", "source_session_id": "old"}]}
+        )
+    )
+    manifest = export_session(
+        source, "root", destination, Path("/new/project"), tmp_path / "stage"
+    )
+    assert str(missing) in manifest["missing_at_source"]
+    assert "attachments/root/goal.txt" in manifest["files"]
+    assert (
+        (tmp_path / "stage/files/sessions/2026/root.jsonl")
+        .read_bytes()
+        .endswith(original_line)
+    )
+    assert len(manifest["metadata_updates"]) == 2
+    assert manifest["metadata_updates"][0]["rows"] == [
+        {"id": "root", "thread_name": "example"}
+    ]
+
+
+def test_explicit_descendant_mapping(tmp_path: Path) -> None:
+    """Linked-worktree descendants may have explicit independent project mappings."""
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root")
+    thread(source, "child")
+    with sqlite3.connect(source / "state_5.sqlite") as db:
+        db.execute("UPDATE threads SET cwd='/another/worktree' WHERE id='child'")
+    insert(
+        source,
+        "state_5.sqlite",
+        "thread_spawn_edges",
+        {"parent_thread_id": "root", "child_thread_id": "child", "status": "completed"},
+    )
+    manifest = export_session(
+        source,
+        "root",
+        tmp_path / "target",
+        Path("/new/project"),
+        tmp_path / "stage",
+        path_mappings=[("/another/worktree", "/new/linked")],
+    )
+    rows = manifest["databases"][0]["tables"][0]["rows"]
+    assert next(row for row in rows if row["id"] == "child")["cwd"] == "/new/linked"

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -446,3 +446,25 @@ def test_explicit_descendant_mapping(tmp_path: Path) -> None:
     )
     rows = manifest["databases"][0]["tables"][0]["rows"]
     assert next(row for row in rows if row["id"] == "child")["cwd"] == "/new/linked"
+
+
+def test_index_rename_exports_only_latest(tmp_path: Path) -> None:
+    """Append-only native rename history must not become a transfer conflict."""
+    from claude_code_tools.transfer_codex_artifacts import latest_session_index
+
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root")
+    (source / "session_index.jsonl").write_text(
+        json.dumps({"id": "root", "thread_name": "old name"})
+        + "\n"
+        + json.dumps({"id": "root", "thread_name": "current name"})
+        + "\n"
+    )
+    assert latest_session_index(source)["root"]["thread_name"] == "current name"
+    manifest = export_session(
+        source, "root", tmp_path / "target", Path("/new/project"), tmp_path / "stage"
+    )
+    assert manifest["metadata_updates"][0]["rows"] == [
+        {"id": "root", "thread_name": "current name"}
+    ]

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -41,6 +41,12 @@ def profile(path: Path) -> None:
                     )
                 connection.execute(f'CREATE TABLE "{table}" ({",".join(columns)})')
 
+    with sqlite3.connect(path / "queue_1.sqlite") as connection:
+        connection.execute(
+            "CREATE TABLE queued_thread_revisions "
+            "(revision INTEGER PRIMARY KEY, thread_id TEXT NOT NULL UNIQUE)"
+        )
+
 
 def insert(path: Path, database: str, table: str, values: dict[str, Any]) -> None:
     """Insert a fixture row, supplying required scalar fields."""

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -578,3 +578,67 @@ def test_second_transfer_preserves_external_scratch(tmp_path: Path) -> None:
         "path_mappings"
     ]
     assert not manifest["missing_at_source"]
+
+
+@pytest.mark.parametrize("exported_edges", [False, True])
+def test_destination_inbound_spawn_edge_conflict(
+    tmp_path: Path, exported_edges: bool
+) -> None:
+    """An unrelated parent cannot silently acquire a transferred root child."""
+    source, destination = tmp_path / "source", tmp_path / "destination"
+    profile(source)
+    profile(destination)
+    thread(source, "root")
+    if exported_edges:
+        thread(source, "child")
+        insert(
+            source,
+            "state_5.sqlite",
+            "thread_spawn_edges",
+            {
+                "parent_thread_id": "root",
+                "child_thread_id": "child",
+                "status": "completed",
+            },
+        )
+    manifest = export_session(
+        source, "root", destination, Path("/new/project"), tmp_path / "stage"
+    )
+    thread(destination, "unrelated")
+    edge = {
+        "parent_thread_id": "unrelated",
+        "child_thread_id": "root",
+        "status": "completed",
+    }
+    insert(destination, "state_5.sqlite", "thread_spawn_edges", edge)
+    with pytest.raises(ValueError, match="exists and differs"):
+        import_databases(manifest, destination)
+    with sqlite3.connect(destination / "state_5.sqlite") as db:
+        assert db.execute("SELECT id FROM threads").fetchall() == [("unrelated",)]
+        assert db.execute(
+            "SELECT parent_thread_id, child_thread_id FROM thread_spawn_edges"
+        ).fetchall() == [("unrelated", "root")]
+
+
+def test_exact_destination_spawn_edges_are_idempotent(tmp_path: Path) -> None:
+    """Exact selected graph relationships are accepted on repeat import."""
+    source, destination = tmp_path / "source", tmp_path / "destination"
+    profile(source)
+    profile(destination)
+    thread(source, "root")
+    thread(source, "child")
+    insert(
+        source,
+        "state_5.sqlite",
+        "thread_spawn_edges",
+        {"parent_thread_id": "root", "child_thread_id": "child", "status": "completed"},
+    )
+    manifest = export_session(
+        source, "root", destination, Path("/new/project"), tmp_path / "stage"
+    )
+    assert import_databases(manifest, destination)["ok"]
+    assert import_databases(manifest, destination)["ok"]
+    with sqlite3.connect(destination / "state_5.sqlite") as db:
+        assert db.execute(
+            "SELECT parent_thread_id, child_thread_id FROM thread_spawn_edges"
+        ).fetchall() == [("root", "child")]

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -506,3 +506,75 @@ def test_second_transfer_recovers_historical_attachment(tmp_path: Path) -> None:
         manifest["path_mappings"]
     )
     assert not manifest["missing_at_source"]
+
+
+@pytest.mark.parametrize("source_database_present", [True, False])
+def test_destination_only_goal_is_a_conflict(
+    tmp_path: Path, source_database_present: bool
+) -> None:
+    """An empty or absent source goal DB cannot inherit a target active goal."""
+    source, destination = tmp_path / "source", tmp_path / "destination"
+    profile(source)
+    profile(destination)
+    thread(source, "root")
+    if not source_database_present:
+        (source / "goals_1.sqlite").unlink()
+    manifest = export_session(
+        source, "root", destination, Path("/new/project"), tmp_path / "stage"
+    )
+    insert(
+        destination,
+        "goals_1.sqlite",
+        "thread_goals",
+        {
+            "thread_id": "root",
+            "goal_id": "destination-goal",
+            "objective": "new work",
+            "status": "active",
+        },
+    )
+    with pytest.raises(ValueError, match="Destination-only session state"):
+        import_databases(manifest, destination)
+    with sqlite3.connect(destination / "goals_1.sqlite") as db:
+        assert (
+            db.execute("SELECT objective FROM thread_goals").fetchone()[0] == "new work"
+        )
+    with sqlite3.connect(destination / "state_5.sqlite") as db:
+        assert db.execute("SELECT count(*) FROM threads").fetchone()[0] == 0
+
+
+def test_second_transfer_preserves_external_scratch(tmp_path: Path) -> None:
+    """A preserved old tmp literal resolves to previously materialized support."""
+    source = tmp_path / "second-machine"
+    profile(source)
+    thread(source, "root", mode="legacy")
+    original = "/private/tmp/original-session/scratch.txt"
+    scratch = source / "transfer-support/root/external/scratch.txt"
+    scratch.parent.mkdir(parents=True)
+    scratch.write_text("external scratch content")
+    prior = source / "transfer-support/root/path-map.json"
+    prior.write_text(
+        json.dumps(
+            {"path_mappings": [{"source": original, "destination": str(scratch)}]}
+        )
+    )
+    with (source / "sessions/2026/root.jsonl").open("a") as stream:
+        stream.write(
+            json.dumps(
+                {"type": "response_item", "payload": {"text": "Read " + original}}
+            )
+            + "\n"
+        )
+    target = tmp_path / "third-machine"
+    manifest = export_session(
+        source, "root", target, Path("/new/project"), tmp_path / "stage"
+    )
+    relative = "transfer-support/root/external/scratch.txt"
+    assert relative in manifest["files"]
+    assert (
+        tmp_path / "stage/files" / relative
+    ).read_text() == "external scratch content"
+    assert {"source": original, "destination": str(target / relative)} in manifest[
+        "path_mappings"
+    ]
+    assert not manifest["missing_at_source"]

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -723,3 +723,66 @@ def test_session_owned_temporary_reference_is_copied(tmp_path: Path) -> None:
             tmp_path / "stage/files" / copied[0]
         ).read_text() == "SESSION SCRATCH FIXTURE"
         assert not manifest["excluded_artifacts"]
+
+
+@pytest.mark.parametrize("linked_parent", [False, True])
+def test_support_symlink_escape_refused(tmp_path: Path, linked_parent: bool) -> None:
+    """Allowed profile prefixes never authorize reading linked external files."""
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root", mode="legacy")
+    external = tmp_path / "outside"
+    external.mkdir()
+    (external / "payload.txt").write_text("SECRET MUST NOT ENTER BUNDLE")
+    attachments = source / "attachments"
+    if linked_parent:
+        attachments.symlink_to(external, target_is_directory=True)
+    else:
+        attachments.mkdir()
+        (attachments / "payload.txt").symlink_to(external / "payload.txt")
+    reference = attachments / "payload.txt"
+    with (source / "sessions/2026/root.jsonl").open("a") as stream:
+        stream.write(
+            json.dumps(
+                {"type": "response_item", "payload": {"text": "Read " + str(reference)}}
+            )
+            + "\n"
+        )
+    stage = tmp_path / "stage"
+    with pytest.raises(ValueError, match="Symlinked support artifact"):
+        export_session(
+            source, "root", tmp_path / "destination", Path("/new/project"), stage
+        )
+    assert not (stage / "files/attachments/payload.txt").exists()
+
+
+def test_explicit_external_symlink_is_refused(tmp_path: Path) -> None:
+    """An explicit path mapping does not authorize following a linked file."""
+    import tempfile
+
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root", mode="legacy")
+    with tempfile.TemporaryDirectory(
+        prefix="codex-transfer-test-", dir="/tmp"
+    ) as directory:
+        external = Path(directory) / "secret.txt"
+        external.write_text("DISPOSABLE SECRET")
+        link = Path(directory) / "linked.txt"
+        link.symlink_to(external)
+        with (source / "sessions/2026/root.jsonl").open("a") as stream:
+            stream.write(
+                json.dumps(
+                    {"type": "response_item", "payload": {"text": "Read " + str(link)}}
+                )
+                + "\n"
+            )
+        with pytest.raises(ValueError, match="Symlinked support artifact"):
+            export_session(
+                source,
+                "root",
+                tmp_path / "destination",
+                Path("/new/project"),
+                tmp_path / "stage",
+                [(str(link), "/new/support/linked.txt")],
+            )

--- a/tests/test_transfer_codex.py
+++ b/tests/test_transfer_codex.py
@@ -1,0 +1,295 @@
+"""Exercise selective Codex transfer with real isolated SQLite profiles."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from claude_code_tools.transfer_codex import (
+    SCHEMAS,
+    export_session,
+    import_databases,
+    validate_databases,
+)
+
+
+def profile(path: Path) -> None:
+    """Initialize supported column contracts without touching a real account."""
+    path.mkdir()
+    for database, tables in SCHEMAS.items():
+        with sqlite3.connect(path / database) as connection:
+            for table, schema in tables.items():
+                columns = []
+                keys = []
+                for _, name, kind, required, default, key in schema:
+                    column = f'"{name}" {kind}'
+                    if required:
+                        column += " NOT NULL"
+                    if default is not None:
+                        column += f" DEFAULT {default}"
+                    columns.append(column)
+                    if key:
+                        keys.append((key, name))
+                if keys:
+                    columns.append(
+                        "PRIMARY KEY ("
+                        + ",".join(f'"{name}"' for _, name in sorted(keys))
+                        + ")"
+                    )
+                connection.execute(f'CREATE TABLE "{table}" ({",".join(columns)})')
+
+
+def insert(path: Path, database: str, table: str, values: dict[str, Any]) -> None:
+    """Insert a fixture row, supplying required scalar fields."""
+    row = {}
+    for _, name, kind, required, default, _ in SCHEMAS[database][table]:
+        if name in values:
+            row[name] = values[name]
+        elif required and default is None:
+            row[name] = 0 if kind == "INTEGER" else ""
+    columns = ",".join(f'"{name}"' for name in row)
+    placeholders = ",".join("?" for _ in row)
+    with sqlite3.connect(path / database) as connection:
+        connection.execute(
+            f'INSERT INTO "{table}" ({columns}) VALUES ({placeholders})',
+            list(row.values()),
+        )
+
+
+def thread(path: Path, sid: str, mode: str = "paginated") -> bytes:
+    """Build an indexed rollout plus paginated history."""
+    rollout = path / "sessions" / "2026" / f"{sid}.jsonl"
+    rollout.parent.mkdir(parents=True, exist_ok=True)
+    content = b'{"type":"session_meta","payload":{"cwd":"/old/project"}}\n'
+    rollout.write_bytes(content)
+    insert(
+        path,
+        "state_5.sqlite",
+        "threads",
+        {
+            "id": sid,
+            "rollout_path": str(rollout),
+            "cwd": "/old/project",
+            "history_mode": mode,
+            "sandbox_policy": '{"type":"workspace-write","writable_roots":["/old/project"]}',
+        },
+    )
+    if mode == "paginated":
+        insert(
+            path,
+            "thread_history_1.sqlite",
+            "thread_history_projection_state",
+            {
+                "thread_id": sid,
+                "next_rollout_byte_offset": len(content),
+            },
+        )
+        insert(
+            path,
+            "thread_history_1.sqlite",
+            "thread_turns",
+            {
+                "thread_id": sid,
+                "turn_id": "turn1",
+                "status": "completed",
+                "rollout_byte_offset": len(content),
+            },
+        )
+        insert(
+            path,
+            "thread_history_1.sqlite",
+            "thread_items",
+            {
+                "thread_id": sid,
+                "turn_id": "turn1",
+                "item_id": "item1",
+                "item_json": '{"text":"leave /old/project unchanged"}',
+            },
+        )
+    return content
+
+
+def test_roundtrip_preserves_offsets_and_selects_descendants(tmp_path: Path) -> None:
+    """A real export/import retains history and goals without unrelated rows."""
+    source, destination = tmp_path / "source", tmp_path / "destination"
+    profile(source)
+    profile(destination)
+    original = thread(source, "root")
+    thread(source, "child")
+    thread(source, "unrelated")
+    insert(
+        source,
+        "state_5.sqlite",
+        "thread_spawn_edges",
+        {
+            "parent_thread_id": "root",
+            "child_thread_id": "child",
+            "status": "completed",
+        },
+    )
+    insert(
+        source,
+        "goals_1.sqlite",
+        "thread_goals",
+        {
+            "thread_id": "root",
+            "goal_id": "goal",
+            "objective": "keep this",
+            "status": "active",
+        },
+    )
+    insert(
+        source,
+        "memories_1.sqlite",
+        "stage1_outputs",
+        {
+            "thread_id": "root",
+            "raw_memory": "remember",
+            "rollout_summary": "summary",
+        },
+    )
+    manifest = export_session(
+        source, "root", destination, Path("/new/project"), tmp_path
+    )
+    assert manifest["ok"]
+    assert manifest["session_ids"] == ["root", "child"]
+    assert len(manifest["files"]) == 2
+    assert (tmp_path / "files" / manifest["files"][0]).read_bytes() == original
+    validate_databases(manifest, destination)
+    assert import_databases(manifest, destination)["ok"]
+    with sqlite3.connect(destination / "state_5.sqlite") as connection:
+        assert connection.execute("SELECT count(*) FROM threads").fetchone()[0] == 2
+        assert connection.execute(
+            'SELECT cwd,rollout_path FROM threads WHERE id="root"'
+        ).fetchone() == ("/new/project", str(destination / "sessions/2026/root.jsonl"))
+    with sqlite3.connect(destination / "thread_history_1.sqlite") as connection:
+        assert connection.execute(
+            'SELECT rollout_byte_offset FROM thread_turns WHERE thread_id="root"'
+        ).fetchone()[0] == len(original)
+        assert (
+            "/old/project"
+            in connection.execute(
+                'SELECT item_json FROM thread_items WHERE thread_id="root"'
+            ).fetchone()[0]
+        )
+    with sqlite3.connect(destination / "goals_1.sqlite") as connection:
+        assert connection.execute("SELECT status FROM thread_goals").fetchone()[0] == (
+            "paused"
+        )
+    assert (source / "sessions/2026/root.jsonl").read_bytes() == original
+    with pytest.raises(ValueError, match="exists"):
+        import_databases(manifest, destination)
+
+
+@pytest.mark.parametrize("problem", ["active", "queue", "schema", "projection"])
+def test_rejects_incomplete_or_unknown_state(tmp_path: Path, problem: str) -> None:
+    """Unsupported formats and pending work fail before producing a manifest."""
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root")
+    if problem == "active":
+        database, sql = (
+            "thread_history_1.sqlite",
+            ('UPDATE thread_turns SET status="inProgress"'),
+        )
+    elif problem == "schema":
+        database, sql = "state_5.sqlite", "ALTER TABLE threads ADD COLUMN future TEXT"
+    elif problem == "projection":
+        database, sql = (
+            "thread_history_1.sqlite",
+            ("DELETE FROM thread_history_projection_state"),
+        )
+    else:
+        insert(
+            source,
+            "queue_1.sqlite",
+            "queued_items",
+            {
+                "id": "q",
+                "thread_id": "root",
+                "payload_json": "{}",
+            },
+        )
+        database, sql = "queue_1.sqlite", "SELECT 1"
+    with sqlite3.connect(source / database) as connection:
+        connection.execute(sql)
+    with pytest.raises(ValueError):
+        export_session(source, "root", Path("/dest"), Path("/new"), tmp_path)
+
+
+def test_sql_failure_rolls_back_all_databases(tmp_path: Path) -> None:
+    """A target constraint failure leaves even earlier attached inserts undone."""
+    source, destination = tmp_path / "source", tmp_path / "destination"
+    profile(source)
+    profile(destination)
+    thread(source, "root")
+    manifest = export_session(source, "root", destination, Path("/new"), tmp_path)
+    with sqlite3.connect(destination / "thread_history_1.sqlite") as connection:
+        connection.execute(
+            "CREATE TRIGGER refuse BEFORE INSERT ON thread_turns "
+            "BEGIN SELECT RAISE(ABORT, 'fixture failure'); END"
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="fixture failure"):
+        import_databases(manifest, destination)
+    with sqlite3.connect(destination / "state_5.sqlite") as connection:
+        assert connection.execute("SELECT count(*) FROM threads").fetchone()[0] == 0
+
+
+def test_dry_run_and_unknown_destination(tmp_path: Path) -> None:
+    """Validation neither inserts records nor creates missing databases."""
+    source, destination = tmp_path / "source", tmp_path / "destination"
+    profile(source)
+    profile(destination)
+    thread(source, "root", mode="legacy")
+    manifest = export_session(source, "root", destination, Path("/new"), tmp_path)
+    assert import_databases(manifest, destination, dry_run=True)["dry_run"]
+    with sqlite3.connect(destination / "state_5.sqlite") as connection:
+        assert connection.execute("SELECT count(*) FROM threads").fetchone()[0] == 0
+    (destination / "state_5.sqlite").unlink()
+    with pytest.raises(ValueError, match="Initialize"):
+        validate_databases(manifest, destination)
+    assert not (destination / "state_5.sqlite").exists()
+
+
+def test_rejects_projection_beyond_rollout(tmp_path: Path) -> None:
+    """Incomplete rollout bytes cannot satisfy a newer history snapshot."""
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root")
+    with sqlite3.connect(source / "thread_history_1.sqlite") as connection:
+        connection.execute(
+            "UPDATE thread_history_projection_state SET next_rollout_byte_offset=99999"
+        )
+    with pytest.raises(ValueError, match="offset"):
+        export_session(source, "root", Path("/dest"), Path("/new"), tmp_path)
+
+
+def test_remaps_managed_sandbox_metadata(tmp_path: Path) -> None:
+    """Operational policy paths move, including profile memory access."""
+    import json
+
+    source = tmp_path / "source"
+    profile(source)
+    thread(source, "root")
+    policy = {
+        "type": "managed",
+        "file_system": {
+            "type": "restricted",
+            "entries": [
+                {"path": {"type": "path", "path": "/old/project/.git"}},
+                {"path": {"type": "path", "path": str(source / "memories")}},
+                {"path": {"type": "special", "value": {"kind": "project_roots"}}},
+            ],
+        },
+    }
+    with sqlite3.connect(source / "state_5.sqlite") as connection:
+        connection.execute("UPDATE threads SET sandbox_policy=?", (json.dumps(policy),))
+    result = export_session(source, "root", Path("/dest"), Path("/new"), tmp_path)
+    saved = json.loads(result["databases"][0]["tables"][0]["rows"][0]["sandbox_policy"])
+    entries = saved["file_system"]["entries"]
+    assert entries[0]["path"]["path"] == "/new/.git"
+    assert entries[1]["path"]["path"] == "/dest/memories"
+    assert entries[2] == policy["file_system"]["entries"][2]

--- a/tests/test_transfer_codex_native.py
+++ b/tests/test_transfer_codex_native.py
@@ -1,0 +1,231 @@
+"""Opt-in native Codex transfer check without credentials or model requests."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import sqlite3
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any, Self
+
+import pytest
+
+from claude_code_tools.transfer_codex import export_session, import_databases
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("CCT_CODEX_NATIVE_TEST") != "1" or shutil.which("codex") is None,
+    reason="Set CCT_CODEX_NATIVE_TEST=1 with Codex 0.153.4 installed",
+)
+
+
+class NativeServer:
+    """Bounded stdio client that always reaps its isolated native server."""
+
+    def __init__(self, home: Path, account: Path, stderr_path: Path) -> None:
+        self.home = home
+        self.account = account
+        self.stderr_path = stderr_path
+        self.responses: queue.Queue[str | None] = queue.Queue()
+        self.request_id = 0
+
+    def __enter__(self) -> Self:
+        self.stderr = self.stderr_path.open("w")
+        try:
+            self.process = subprocess.Popen(
+                ["codex", "app-server"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=self.stderr,
+                text=True,
+                bufsize=1,
+                cwd=self.home,
+                env={
+                    "PATH": os.environ["PATH"],
+                    "HOME": str(self.home),
+                    "CODEX_HOME": str(self.account),
+                },
+            )
+        except BaseException:
+            self.stderr.close()
+            raise
+        self.reader = threading.Thread(target=self._read, daemon=True)
+        self.reader.start()
+        try:
+            self.request(
+                "initialize",
+                {
+                    "clientInfo": {"name": "transfer-native-test", "version": "1"},
+                    "capabilities": {"experimentalApi": True},
+                },
+            )
+            self._send({"method": "initialized"})
+        except BaseException:
+            self.close()
+            raise
+        return self
+
+    def _read(self) -> None:
+        """Drain stdout independently so RPC deadlines also cover partial lines."""
+        assert self.process.stdout is not None
+        try:
+            for line in self.process.stdout:
+                self.responses.put(line)
+        finally:
+            self.responses.put(None)
+
+    def _send(self, message: dict[str, Any]) -> None:
+        assert self.process.stdin is not None
+        self.process.stdin.write(json.dumps(message) + "\n")
+        self.process.stdin.flush()
+
+    def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Read an explicit successful response within a bounded deadline."""
+        import time
+
+        self.request_id += 1
+        self._send({"id": self.request_id, "method": method, "params": params})
+        deadline = time.monotonic() + 30
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"Native RPC timed out: {method}")
+            try:
+                line = self.responses.get(timeout=remaining)
+            except queue.Empty as exc:
+                raise TimeoutError(f"Native RPC timed out: {method}") from exc
+            if line is None:
+                raise RuntimeError(f"Native server exited during {method}")
+            message = json.loads(line)
+            if message.get("id") != self.request_id:
+                continue
+            if "error" in message:
+                raise RuntimeError(f"Native {method} failed: {message['error']}")
+            result = message.get("result")
+            if not isinstance(result, dict):
+                raise TypeError(f"Native {method} returned no object result")
+            return result
+
+    def close(self) -> None:
+        """Terminate and reap the server even when a test assertion fails."""
+        self.process.terminate()
+        try:
+            self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait(timeout=5)
+        self.reader.join(timeout=5)
+        for stream in (self.process.stdin, self.process.stdout, self.stderr):
+            if stream is not None:
+                stream.close()
+        assert not self.reader.is_alive()
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+
+def start_fixture(server: NativeServer, cwd: Path) -> dict[str, Any]:
+    """Persist native history by injection, without asking a model to execute."""
+    thread = server.request(
+        "thread/start", {"cwd": str(cwd), "experimentalRawEvents": False}
+    )["thread"]
+    server.request(
+        "thread/inject_items",
+        {
+            "threadId": thread["id"],
+            "items": [{
+                "type": "message", "role": "user",
+                "content": [{"type": "input_text", "text": "Native fixture"}],
+            }],
+        },
+    )
+    return thread
+
+
+def add_paginated_fixture(account: Path, thread: dict[str, Any]) -> None:
+    """Populate protocol-valid synthetic UI history in native-created tables."""
+    with sqlite3.connect(account / "thread_history_1.sqlite") as connection:
+        connection.execute(
+            "INSERT INTO thread_turns("
+            "thread_id,turn_id,rollout_ordinal,status,started_at,completed_at,"
+            "duration_ms,first_user_item_id,final_agent_item_id,"
+            "rollout_byte_offset,rollout_end_byte_offset) "
+            "VALUES(?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                thread["id"], "fixture-turn", 1, "completed", 1788707000,
+                1788707001, 1000, "fixture-user", "fixture-agent", 0,
+                Path(thread["path"]).stat().st_size,
+            ),
+        )
+        items = [
+            {
+                "type": "userMessage", "id": "fixture-user", "clientId": None,
+                "content": [{
+                    "type": "text", "text": "PORTABLE USER MARKER",
+                    "text_elements": [],
+                }],
+            },
+            {
+                "type": "agentMessage", "id": "fixture-agent",
+                "text": "PORTABLE AGENT MARKER", "phase": "final_answer",
+                "memoryCitation": None,
+            },
+        ]
+        for ordinal, item in enumerate(items, 1):
+            connection.execute(
+                "INSERT INTO thread_items(thread_id,turn_id,item_id,"
+                "rollout_ordinal,created_at_ms,item_json,item_type,"
+                "updated_at_ordinal) VALUES(?,?,?,?,?,?,?,?)",
+                (
+                    thread["id"], "fixture-turn", item["id"], ordinal,
+                    1788707000000 + ordinal, json.dumps(item), item["type"], ordinal,
+                ),
+            )
+
+
+def test_native_codex_reads_transferred_paginated_history(tmp_path: Path) -> None:
+    """Native resume must hydrate imported markers and honor destination cwd."""
+    version = subprocess.run(
+        ["codex", "--version"], check=True, capture_output=True, text=True,
+        timeout=10,
+    ).stdout.strip()
+    if version != "codex-cli 0.153.4":
+        pytest.skip(f"Native schema fixture requires 0.153.4; installed {version}")
+    source, destination = tmp_path / "source", tmp_path / "destination"
+    old, new = tmp_path / "old", tmp_path / "new"
+    for directory in (source, destination, old, new):
+        directory.mkdir()
+    with NativeServer(tmp_path, source, tmp_path / "source.stderr") as server:
+        thread = start_fixture(server, old)
+    add_paginated_fixture(source, thread)
+    with NativeServer(tmp_path, destination, tmp_path / "init.stderr") as server:
+        start_fixture(server, new)
+    staging = tmp_path / "bundle"
+    manifest = export_session(source, thread["id"], destination, new, staging)
+    assert manifest["ok"] is True
+    for relative in manifest["files"]:
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(staging / "files" / relative, target)
+    assert import_databases(manifest, destination)["ok"] is True
+    with NativeServer(tmp_path, destination, tmp_path / "resume.stderr") as server:
+        resumed = server.request(
+            "thread/resume", {"threadId": thread["id"], "cwd": str(new)}
+        )
+        assert Path(resumed["cwd"]).resolve() == new.resolve()
+        assert Path(resumed["thread"]["cwd"]).resolve() == new.resolve()
+        turns = server.request("thread/turns/list", {"threadId": thread["id"]})
+        items = server.request(
+            "thread/items/list",
+            {"threadId": thread["id"], "turnId": "fixture-turn"},
+        )
+        assert [turn["id"] for turn in turns["data"]] == ["fixture-turn"]
+        assert items["nextCursor"] is None
+        assert len(items["data"]) == 2
+        user, agent = [row["item"] for row in items["data"]]
+        assert user["content"][0]["text"] == "PORTABLE USER MARKER"
+        assert agent["text"] == "PORTABLE AGENT MARKER"
+        assert "PORTABLE USER MARKER" in json.dumps(resumed["thread"]["turns"])

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -251,3 +251,61 @@ def test_plugin_root_direct_executable_with_spaces(tmp_path: Path, monkeypatch) 
     assert checks[0]["script_paths_checked"] == 1
     assert checks[0]["missing_script_paths"] == 0
     assert not marker.exists()
+
+
+def test_hook_assignment_prefix_does_not_hide_launcher(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Leading shell assignments are metadata, never the executable to locate."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    executable = bindir / "python"
+    executable.write_text("#!/bin/sh\nexit 73\n")
+    executable.chmod(0o700)
+    script = tmp_path / "hook.py"
+    script.write_text('raise AssertionError("must not run")\n')
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "command": f'PYTHONPATH="/some path" MODE=test python "{script}"'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("PATH", str(bindir))
+    checks = inspect_environment("claude", home)["checks"]["configured_hooks"]
+    assert len(checks) == 1
+    assert checks[0]["ran"] and checks[0]["ok"]
+    assert checks[0]["launcher_available"]
+    assert checks[0]["script_paths_checked"] == 1
+    assert not checks[0]["runtime_executed"]
+
+
+def test_plugin_hooks_array_reports_warning(tmp_path: Path, monkeypatch) -> None:
+    """Valid JSON with a non-object root produces diagnostics instead of a crash."""
+    home = tmp_path / "profile"
+    plugin = home / "plugins/cache/example/1"
+    hooks = plugin / "hooks/hooks.json"
+    hooks.parent.mkdir(parents=True)
+    hooks.write_text("[]")
+    (home / "plugins/installed_plugins.json").write_text(
+        json.dumps({"plugins": {"example@fixture": [{"installPath": str(plugin)}]}})
+    )
+    monkeypatch.setenv("PATH", str(tmp_path / "no-native-cli"))
+    report = inspect_environment("claude", home)
+    assert report["ran"] and report["ok"]
+    assert report["checks"]["configured_hooks"] == []
+    assert any(
+        "hooks.json must contain an object" in item for item in report["warnings"]
+    )

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -1,0 +1,65 @@
+"""Isolated real executable checks for environment preflight."""
+
+import json
+from pathlib import Path
+
+from claude_code_tools.transfer_environment import inspect_environment
+
+
+def test_real_probe_and_secret_redaction(tmp_path: Path, monkeypatch) -> None:
+    """Run fake native executables, never the user's agents or hooks."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    for name, body in {
+        "claude": """#!/bin/sh
+if [ "$1" = --version ]; then echo '2.1.263 (Claude Code)'; else
+ echo '[{"id":"example@market","enabled":true,"token":"TOPSECRET"}]'; fi
+""",
+        "python3": '#!/bin/sh\necho "Python 3.9.6"\n',
+        "bash": "#!/bin/sh\nexit 42\n",
+    }.items():
+        executable = bindir / name
+        executable.write_text(body)
+        executable.chmod(0o700)
+    monkeypatch.setenv("PATH", str(bindir))
+    home = tmp_path / "account"
+    home.mkdir()
+    (home / "settings.json").write_text(
+        json.dumps(
+            {
+                "apiKey": "TOPSECRET",
+                "enabledPlugins": {"example@market": True},
+                "permissions": {"deny": ["Skill(private-tool)", "Bash(secret)"]},
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {"command": "bash /missing/script.py --token TOPSECRET"}
+                            ]
+                        }
+                    ]
+                },
+            }
+        )
+    )
+    result = inspect_environment("claude", home)
+    assert result["ran"] and result["ok"]
+    checks = result["checks"]
+    assert checks["native_plugins"]["ran"] and checks["native_plugins"]["ok"]
+    assert checks["native_plugins"]["count"] == 1
+    assert checks["hook_python"]["version"] == "3.9.6"
+    assert not checks["hook_python"]["ok"]
+    assert checks["configured_hooks"][0]["missing_script_paths"] == 1
+    assert not checks["configured_hooks"][0]["runtime_executed"]
+    assert "TOPSECRET" not in json.dumps(result)
+    assert checks["skill_overrides"] == ["Skill(private-tool)"]
+
+
+def test_missing_cli_and_bad_settings(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "nonexistent"))
+    (tmp_path / "settings.json").write_text("{broken")
+    result = inspect_environment("claude", tmp_path)
+    assert result["ran"]
+    assert not result["checks"]["native_cli"]["ok"]
+    assert not result["checks"]["configuration"]["ok"]
+    assert result["remediation"]

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -101,3 +101,49 @@ if [ "$1" = --version ]; then echo 2.1.263; else echo '[]'; fi
     result = inspect_environment("claude", home)
     assert result["checks"]["native_plugins"]["ran"]
     assert settings.read_text() == "{}"
+
+
+def test_native_empty_plugin_collection_is_recognized(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A successful empty native collection differs from an unknown result schema."""
+    executable = tmp_path / "codex"
+    home = tmp_path / "account"
+    home.mkdir()
+    monkeypatch.setenv("PATH", str(tmp_path))
+    for payload, expected in [
+        ({"installed": [], "available": []}, True),
+        ({"installed": [{"unknown_field": True}], "available": []}, False),
+    ]:
+        executable.write_text(
+            '#!/bin/sh\nif [ "$1" = --version ]; then echo 0.153.4; else\n'
+            + "echo '"
+            + json.dumps(payload)
+            + "'\nfi\n"
+        )
+        executable.chmod(0o700)
+        result = inspect_environment("codex", home)
+        assert result["checks"]["native_plugins"]["ran"] is True
+        assert result["checks"]["native_plugins"]["ok"] is expected
+
+
+def test_environment_comparison_distinguishes_unknown_from_match() -> None:
+    from claude_code_tools.transfer_environment import compare_environments
+
+    def environment(enabled: bool) -> dict:
+        return {
+            "checks": {
+                "native_plugins": {
+                    "ran": True,
+                    "ok": True,
+                    "registrations": [{"id": "example@market", "enabled": enabled}],
+                }
+            }
+        }
+
+    assert compare_environments(environment(True), environment(True))["ok"]
+    difference = compare_environments(environment(True), environment(False))
+    assert difference["ran"] and not difference["ok"]
+    assert difference["missing_or_disabled_plugins"] == ["example@market"]
+    unknown = compare_environments(environment(True), {})
+    assert not unknown["ran"] and not unknown["ok"]

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -144,6 +144,7 @@ def test_environment_comparison_distinguishes_unknown_from_match() -> None:
     assert compare_environments(environment(True), environment(True))["ok"]
     difference = compare_environments(environment(True), environment(False))
     assert difference["ran"] and not difference["ok"]
+    assert difference["runtime_parity_verified"] is False
     assert difference["missing_or_disabled_plugins"] == ["example@market"]
     unknown = compare_environments(environment(True), {})
     assert not unknown["ran"] and not unknown["ok"]

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -346,31 +346,37 @@ def test_compound_and_builtin_hooks_are_unverified(tmp_path: Path, monkeypatch) 
     assert not marker.exists()
 
 
-def test_quoted_bash_wrapper_remains_inspectable(tmp_path: Path, monkeypatch) -> None:
-    """Operators inside a quoted bash argument do not become outer composition."""
+def test_shell_inline_hooks_remain_unverified(tmp_path: Path, monkeypatch) -> None:
+    """Shell availability cannot establish that an inline hook command exists."""
     home = tmp_path / "profile"
     home.mkdir()
+    commands = [
+        '/bin/bash -c "echo hello && echo world"',
+        '/bin/bash -c "definitely-missing-hook-command"',
+        '/bin/sh -c "definitely-missing-hook-command"',
+    ]
     (home / "settings.json").write_text(
         json.dumps(
             {
                 "hooks": {
                     "PreToolUse": [
-                        {
-                            "hooks": [
-                                {"command": '/bin/bash -c "echo hello && echo world"'}
-                            ]
-                        }
+                        {"hooks": [{"command": command} for command in commands]}
                     ]
                 }
             }
         )
     )
     monkeypatch.setenv("PATH", str(tmp_path / "no-native-cli"))
-    checks = inspect_environment("claude", home)["checks"]["configured_hooks"]
-    assert len(checks) == 1
-    assert checks[0]["ran"] and checks[0]["ok"]
-    assert checks[0]["launcher_available"]
-    assert checks[0]["runtime_executed"] is False
+    result = inspect_environment("claude", home)
+    checks = result["checks"]["configured_hooks"]
+    assert len(checks) == len(commands)
+    for check in checks:
+        assert not check["ran"] and not check["ok"]
+        assert check["reason"] == "Interpreter hook operand is unverified"
+        assert "launcher_available" not in check
+        assert check["runtime_executed"] is False
+        assert check["remediation"]
+    assert any("inline program" in item for item in result["remediation"])
 
 
 def test_failed_simple_hooks_surface_sanitized_summary(

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -147,3 +147,65 @@ def test_environment_comparison_distinguishes_unknown_from_match() -> None:
     assert difference["missing_or_disabled_plugins"] == ["example@market"]
     unknown = compare_environments(environment(True), {})
     assert not unknown["ran"] and not unknown["ok"]
+
+
+def test_codex_git_marketplace_probe_and_incomplete_cache(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Snapshot git sources resolve locally; auth-dependent cache stays unverified."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    cli = bindir / "codex"
+    cli.write_text("""#!/bin/sh
+if [ "$1" = --version ]; then echo 0.153.4; exit 0; fi
+case "$*" in *marketplaces.fixture.source_type*) ;; *) exit 5;; esac
+if [ ! -f "$CODEX_HOME/plugins/cache/fixture/tool/1/.codex-plugin/plugin.json" ]; then exit 6; fi
+echo '{"installed":[{"name":"tool","pluginId":"tool@fixture","enabled":true}],"available":[]}'
+""")
+    cli.chmod(0o700)
+    monkeypatch.setenv("PATH", str(bindir))
+    home = tmp_path / "profile"
+    (home / ".tmp/marketplaces/fixture").mkdir(parents=True)
+    (home / "config.toml").write_text(
+        '[marketplaces.fixture]\nsource_type="git"\nsource="https://example.invalid/repo"\n'
+    )
+    for marketplace, name in [("fixture", "tool"), ("bundled", "account-only")]:
+        manifest = (
+            home / "plugins/cache" / marketplace / name / "1/.codex-plugin/plugin.json"
+        )
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(json.dumps({"name": name, "version": "1"}))
+    check = inspect_environment("codex", home)["checks"]["native_plugins"]
+    assert check["ran"] and check["command_ok"]
+    assert check["registrations"][0]["id"] == "tool@fixture"
+    assert not check["complete"] and not check["ok"]
+    assert check["cached_not_in_native_probe"] == ["account-only@bundled"]
+
+
+def test_partial_native_parity_does_not_invent_missing_plugins() -> None:
+    from claude_code_tools.transfer_environment import compare_environments
+
+    source = {
+        "checks": {
+            "native_plugins": {
+                "ran": True,
+                "ok": False,
+                "registrations": [{"id": "visible@market"}],
+                "cached_registrations": ["visible@market", "hidden@bundled"],
+            }
+        }
+    }
+    target = {
+        "checks": {
+            "native_plugins": {
+                "ran": True,
+                "ok": False,
+                "registrations": [],
+                "cached_registrations": ["hidden@bundled"],
+            }
+        }
+    }
+    result = compare_environments(source, target)
+    assert not result["runtime_parity_verified"]
+    assert result["missing_or_disabled_plugins"] == []
+    assert result["static_cache_only_in_source"] == ["visible@market"]

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -405,3 +405,59 @@ def test_failed_simple_hooks_surface_sanitized_summary(
     assert "TOPSECRET" not in json.dumps(result)
     assert "nonexistent-hook-launcher" not in summary
     assert "/missing/private-hook.sh" not in summary
+
+
+def test_added_skill_permission_denies_prevent_parity() -> None:
+    """Matching plugins do not imply parity when destination denies another skill."""
+    from claude_code_tools.transfer_environment import compare_environments
+
+    native = {"ran": True, "ok": True, "registrations": [{"id": "tool@fixture"}]}
+    source = {
+        "checks": {"native_plugins": native, "skill_overrides": ["Skill(existing)"]}
+    }
+    target = {
+        "checks": {
+            "native_plugins": native,
+            "skill_overrides": ["Skill(existing)", "Skill(newly-denied)"],
+        }
+    }
+    result = compare_environments(source, target)
+    assert result["ran"]
+    assert not result["ok"] and not result["runtime_parity_verified"]
+    assert result["newly_denied_skills"] == ["Skill(newly-denied)"]
+    assert result["remediation"]
+    same = compare_environments(source, source)
+    assert same["ok"] and same["newly_denied_skills"] == []
+
+
+def test_env_hook_wrapper_cannot_prove_interpreter_available(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An available env binary does not prove its wrapped interpreter exists."""
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "command": "/usr/bin/env definitely-missing-python hook.py"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("PATH", str(tmp_path / "no-interpreters"))
+    checks = inspect_environment("claude", home)["checks"]["configured_hooks"]
+    assert len(checks) == 1
+    assert not checks[0]["ran"] and not checks[0]["ok"]
+    assert checks[0]["reason"] == "Environment-wrapper hook is unverified"
+    assert "launcher_available" not in checks[0]
+    assert checks[0]["remediation"]
+    assert not checks[0]["runtime_executed"]

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -63,3 +63,19 @@ def test_missing_cli_and_bad_settings(tmp_path: Path, monkeypatch) -> None:
     assert not result["checks"]["native_cli"]["ok"]
     assert not result["checks"]["configuration"]["ok"]
     assert result["remediation"]
+
+
+def test_missing_account_never_runs_plugin_listing(tmp_path: Path, monkeypatch) -> None:
+    """A listing that would create its account must not run for a dry-run target."""
+    executable = tmp_path / "claude"
+    executable.write_text("""#!/bin/sh
+if [ "$1" = --version ]; then echo 2.1.263; exit 0; fi
+/bin/mkdir -p "$CLAUDE_CONFIG_DIR"
+echo '[]'
+""")
+    executable.chmod(0o700)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    home = tmp_path / "absent"
+    result = inspect_environment("claude", home)
+    assert not home.exists()
+    assert result["checks"]["native_plugins"]["ran"] is False

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -371,3 +371,37 @@ def test_quoted_bash_wrapper_remains_inspectable(tmp_path: Path, monkeypatch) ->
     assert checks[0]["ran"] and checks[0]["ok"]
     assert checks[0]["launcher_available"]
     assert checks[0]["runtime_executed"] is False
+
+
+def test_failed_simple_hooks_surface_sanitized_summary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Normal-output warning fields expose failed hooks without leaking commands."""
+    home = tmp_path / "profile"
+    home.mkdir()
+    commands = [
+        "nonexistent-hook-launcher --token TOPSECRET",
+        "/bin/bash /missing/private-hook.sh --token TOPSECRET",
+        '"unterminated TOPSECRET',
+    ]
+    (home / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {"hooks": [{"command": command} for command in commands]}
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("PATH", str(tmp_path / "no-native-cli"))
+    result = inspect_environment("claude", home)
+    summary = "\n".join(result["warnings"] + result["remediation"])
+    assert "3 configured hook check(s) failed" in summary
+    assert "install missing launchers" in summary
+    assert "missing script paths" in summary
+    assert "repair invalid quoting" in summary
+    assert "TOPSECRET" not in json.dumps(result)
+    assert "nonexistent-hook-launcher" not in summary
+    assert "/missing/private-hook.sh" not in summary

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -79,3 +79,25 @@ echo '[]'
     result = inspect_environment("claude", home)
     assert not home.exists()
     assert result["checks"]["native_plugins"]["ran"] is False
+
+
+def test_existing_account_native_writes_are_isolated(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Even a native version command writing preferences cannot mutate the account."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    executable = bindir / "claude"
+    executable.write_text("""#!/bin/sh
+printf changed > "$CLAUDE_CONFIG_DIR/settings.json"
+if [ "$1" = --version ]; then echo 2.1.263; else echo '[]'; fi
+""")
+    executable.chmod(0o700)
+    monkeypatch.setenv("PATH", str(bindir))
+    home = tmp_path / "profile"
+    home.mkdir()
+    settings = home / "settings.json"
+    settings.write_text("{}")
+    result = inspect_environment("claude", home)
+    assert result["checks"]["native_plugins"]["ran"]
+    assert settings.read_text() == "{}"

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -210,3 +210,44 @@ def test_partial_native_parity_does_not_invent_missing_plugins() -> None:
     assert not result["runtime_parity_verified"]
     assert result["missing_or_disabled_plugins"] == []
     assert result["static_cache_only_in_source"] == ["visible@market"]
+
+
+def test_plugin_root_direct_executable_with_spaces(tmp_path: Path, monkeypatch) -> None:
+    """A quoted direct plugin script resolves after plugin-root expansion."""
+    home = tmp_path / "account"
+    root = home / "plugins/cache/test plugin/1"
+    script = root / "scripts/pretooluse.sh"
+    script.parent.mkdir(parents=True)
+    marker = tmp_path / "must-not-run"
+    script.write_text("#!/bin/sh\ntouch " + str(marker) + "\n")
+    script.chmod(0o700)
+    hooks = root / "hooks/hooks.json"
+    hooks.parent.mkdir()
+    hooks.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "command": '"${CLAUDE_PLUGIN_ROOT}/scripts/pretooluse.sh"'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    (home / "plugins/installed_plugins.json").write_text(
+        json.dumps({"plugins": {"test@fixture": [{"installPath": str(root)}]}})
+    )
+    monkeypatch.setenv("PATH", str(tmp_path / "no-native-cli"))
+    checks = inspect_environment("claude", home)["checks"]["configured_hooks"]
+    assert len(checks) == 1
+    assert checks[0]["ran"] and checks[0]["ok"]
+    assert checks[0]["launcher_available"]
+    assert checks[0]["script_paths_checked"] == 1
+    assert checks[0]["missing_script_paths"] == 0
+    assert not marker.exists()

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -461,3 +461,32 @@ def test_env_hook_wrapper_cannot_prove_interpreter_available(
     assert "launcher_available" not in checks[0]
     assert checks[0]["remediation"]
     assert not checks[0]["runtime_executed"]
+
+
+def test_relative_hook_script_is_not_verified_from_launcher_only(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An installed interpreter cannot prove a cwd-relative hook script is present."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    executable = bindir / "python"
+    executable.write_text("#!/bin/sh\nexit 87\n")
+    executable.chmod(0o700)
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [{"hooks": [{"command": "python missing-hook.py"}]}]
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("PATH", str(bindir))
+    result = inspect_environment("claude", home)
+    check = result["checks"]["configured_hooks"][0]
+    assert check["ran"] is False and check["ok"] is False
+    assert "Relative hook script path" in check["reason"]
+    assert check["runtime_executed"] is False
+    assert any("actual working directory" in item for item in result["remediation"])

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -540,3 +540,31 @@ def test_javascript_hook_operands_are_checked(tmp_path: Path, monkeypatch) -> No
         assert valid["missing_script_paths"] == 0
     assert all(not check["runtime_executed"] for check in checks)
     assert not marker.exists()
+
+
+def test_skill_override_disabled_representations_are_equivalent() -> None:
+    """Boolean/string enabled and disabled forms compare consistently both ways."""
+    from claude_code_tools.transfer_environment import compare_environments
+
+    def environment(value):
+        return {
+            "checks": {
+                "native_plugins": {"ran": True, "ok": True, "registrations": []},
+                "skill_registration_overrides": {}
+                if value is None
+                else {"example": value},
+            }
+        }
+
+    for source in (None, True, "on", False, "off"):
+        for destination in (None, True, "on", False, "off"):
+            newly_disabled = (destination is False or destination == "off") and not (
+                source is False or source == "off"
+            )
+            result = compare_environments(environment(source), environment(destination))
+            assert result["ran"]
+            assert result["newly_disabled_skills"] == (
+                ["example"] if newly_disabled else []
+            )
+            assert result["ok"] is (not newly_disabled)
+            assert result["runtime_parity_verified"] is (not newly_disabled)

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -568,3 +568,60 @@ def test_skill_override_disabled_representations_are_equivalent() -> None:
             )
             assert result["ok"] is (not newly_disabled)
             assert result["runtime_parity_verified"] is (not newly_disabled)
+
+
+def test_nonobject_account_hooks_report_malformed(tmp_path: Path, monkeypatch) -> None:
+    """An account JSON array is not an empty successfully inspected hook object."""
+    monkeypatch.setenv("PATH", str(tmp_path / "no-native-cli"))
+    for index, content in enumerate(("[]", "null", '"not an object"')):
+        home = tmp_path / f"profile-{index}"
+        home.mkdir()
+        (home / "hooks.json").write_text(content)
+        report = inspect_environment("claude", home)
+        assert report["ran"]
+        assert any(
+            "account hooks.json must contain an object" in warning
+            for warning in report["warnings"]
+        )
+        assert report["checks"]["configured_hooks"] == []
+
+
+def test_extensionless_interpreter_scripts(tmp_path: Path, monkeypatch) -> None:
+    """Direct script operands are validated regardless of filename extension."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    launcher = bindir / "bash"
+    launcher.write_text("#!/bin/sh\nexit 73\n")
+    launcher.chmod(0o700)
+    script = tmp_path / "real hook"
+    script.write_text("exit 89\n")
+    home = tmp_path / "profile"
+    home.mkdir()
+    commands = [
+        f'bash "{script}"',
+        f'bash "{tmp_path}/missing"',
+        "bash relative-script",
+        f'bash -u "{script}"',
+    ]
+    (home / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {"hooks": [{"command": command} for command in commands]}
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("PATH", str(bindir))
+    checks = inspect_environment("claude", home)["checks"]["configured_hooks"]
+    assert checks[0]["ran"] and checks[0]["ok"]
+    assert checks[0]["script_paths_checked"] == 1
+    assert checks[1]["ran"] and not checks[1]["ok"]
+    assert checks[1]["missing_script_paths"] == 1
+    assert not checks[2]["ran"] and not checks[2]["ok"]
+    assert "Relative hook script" in checks[2]["reason"]
+    assert not checks[3]["ran"] and not checks[3]["ok"]
+    assert "Interpreter hook operand" in checks[3]["reason"]
+    assert all(not check["runtime_executed"] for check in checks)

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -490,3 +490,53 @@ def test_relative_hook_script_is_not_verified_from_launcher_only(
     assert "Relative hook script path" in check["reason"]
     assert check["runtime_executed"] is False
     assert any("actual working directory" in item for item in result["remediation"])
+
+
+def test_javascript_hook_operands_are_checked(tmp_path: Path, monkeypatch) -> None:
+    """A node launcher alone cannot verify missing or cwd-relative JS hook files."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    node = bindir / "node"
+    marker = tmp_path / "must-not-run"
+    node.write_text('#!/bin/sh\ntouch "' + str(marker) + '"\n')
+    node.chmod(0o700)
+    home = tmp_path / "profile"
+    home.mkdir()
+    commands = []
+    for extension in ("js", "mjs", "cjs"):
+        valid = tmp_path / f"valid hook.{extension}"
+        valid.write_text('throw new Error("must not execute");\n')
+        commands.extend(
+            [
+                f'node "{tmp_path}/missing.{extension}"',
+                f"node relative-hook.{extension}",
+                f'node "{valid}"',
+            ]
+        )
+    (home / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {"hooks": [{"command": command} for command in commands]}
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("PATH", str(bindir))
+    result = inspect_environment("claude", home)
+    checks = result["checks"]["configured_hooks"]
+    assert len(checks) == 9
+    for index in (0, 3, 6):
+        missing, relative, valid = checks[index : index + 3]
+        assert missing["ran"] and not missing["ok"]
+        assert missing["launcher_available"]
+        assert missing["missing_script_paths"] == 1
+        assert not relative["ran"] and not relative["ok"]
+        assert "Relative hook script path" in relative["reason"]
+        assert valid["ran"] and valid["ok"]
+        assert valid["script_paths_checked"] == 1
+        assert valid["missing_script_paths"] == 0
+    assert all(not check["runtime_executed"] for check in checks)
+    assert not marker.exists()

--- a/tests/test_transfer_environment.py
+++ b/tests/test_transfer_environment.py
@@ -309,3 +309,65 @@ def test_plugin_hooks_array_reports_warning(tmp_path: Path, monkeypatch) -> None
     assert any(
         "hooks.json must contain an object" in item for item in report["warnings"]
     )
+
+
+def test_compound_and_builtin_hooks_are_unverified(tmp_path: Path, monkeypatch) -> None:
+    """Shell composition is not mistaken for a missing executable or executed."""
+    home = tmp_path / "profile"
+    home.mkdir()
+    marker = tmp_path / "must-not-exist"
+    commands = [
+        f'cd "{tmp_path}" && python hook.py',
+        f'cd "{tmp_path}"&&python hook.py',
+        f'echo test > "{marker}"',
+        "export EXAMPLE=value",
+    ]
+    (home / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {"hooks": [{"command": command} for command in commands]}
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("PATH", str(tmp_path / "no-native-cli"))
+    report = inspect_environment("claude", home)
+    checks = report["checks"]["configured_hooks"]
+    assert len(checks) == len(commands)
+    for check in checks:
+        assert check["ran"] is False and check["ok"] is False
+        assert "unverified" in check["reason"]
+        assert "launcher_available" not in check
+        assert check["runtime_executed"] is False
+        assert check["remediation"]
+    assert not marker.exists()
+
+
+def test_quoted_bash_wrapper_remains_inspectable(tmp_path: Path, monkeypatch) -> None:
+    """Operators inside a quoted bash argument do not become outer composition."""
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {"command": '/bin/bash -c "echo hello && echo world"'}
+                            ]
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("PATH", str(tmp_path / "no-native-cli"))
+    checks = inspect_environment("claude", home)["checks"]["configured_hooks"]
+    assert len(checks) == 1
+    assert checks[0]["ran"] and checks[0]["ok"]
+    assert checks[0]["launcher_available"]
+    assert checks[0]["runtime_executed"] is False

--- a/tests/test_transfer_path_mappings.py
+++ b/tests/test_transfer_path_mappings.py
@@ -86,3 +86,53 @@ def test_cli_refuses_semantic_duplicate_before_access(tmp_path: Path) -> None:
     assert result.exit_code == 2
     assert "Conflicting destinations" in result.output
     assert not (tmp_path / "target").exists()
+
+
+@pytest.mark.parametrize("suffix", ["", "/", "/.", "/attachments"])
+@pytest.mark.parametrize("conflict", [False, True])
+def test_codex_home_mapping_cannot_override_profile_destination(
+    tmp_path: Path, suffix: str, conflict: bool
+) -> None:
+    """Operational profile paths agree with where transfer installs profile files."""
+    import json
+
+    from claude_code_tools.transfer_codex import export_session
+    from tests.test_transfer_codex import profile, thread
+
+    home, destination = tmp_path / "source", tmp_path / "destination"
+    profile(home)
+    thread(home, "root", mode="legacy")
+    rollout = home / "sessions/2026/root.jsonl"
+    rollout.write_text(
+        json.dumps(
+            {
+                "type": "session_meta",
+                "payload": {
+                    "cwd": "/old/project",
+                    "sandbox_policy": {
+                        "type": "workspace-write",
+                        "writable_roots": [str(home / "attachments")],
+                    },
+                },
+            }
+        )
+        + "\n"
+    )
+    expected = str(destination) + suffix
+    mappings = [(str(home) + suffix, "/wrong/profile" if conflict else expected)]
+    args = (home, "root", destination, Path("/new/project"), tmp_path / "stage")
+    if conflict:
+        with pytest.raises(ValueError, match="Account home mapping conflicts"):
+            export_session(*args, path_mappings=mappings)
+        assert not (tmp_path / "stage").exists()
+    else:
+        manifest = export_session(*args, path_mappings=mappings)
+        copied = json.loads(
+            (tmp_path / "stage/files/sessions/2026/root.jsonl").read_text()
+        )
+        assert copied["payload"]["sandbox_policy"]["writable_roots"] == [
+            str(destination / "attachments")
+        ]
+        assert [
+            item for item in manifest["path_mappings"] if item["source"] == str(home)
+        ] == [{"source": str(home), "destination": str(destination)}]

--- a/tests/test_transfer_path_mappings.py
+++ b/tests/test_transfer_path_mappings.py
@@ -188,3 +188,93 @@ def test_codex_account_alias_mapping_guard(
         assert {"source": referenced, "destination": expected} in manifest[
             "path_mappings"
         ]
+
+
+@pytest.mark.parametrize("suffix", ["", "/attachments", "/not-created-yet"])
+def test_public_export_accepts_valid_tmp_account_alias(
+    tmp_path: Path, suffix: str
+) -> None:
+    """A tmp account alias remains operational, with real attachment bytes copied."""
+    import json
+    import sqlite3
+    import tempfile
+
+    from claude_code_tools.transfer_source import export_request
+    from tests.test_transfer_codex import profile, thread
+    from tests.test_transfer_session import git
+
+    project = tmp_path / "project"
+    project.mkdir()
+    git(project, "init")
+    (project / "README").write_text("fixture")
+    git(project, "add", "README")
+    git(
+        project,
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=f@example.test",
+        "commit",
+        "-m",
+        "fixture",
+    )
+    home = tmp_path / "source"
+    profile(home)
+    thread(home, "root", mode="legacy")
+    attachment = home / "attachments/note.txt"
+    attachment.parent.mkdir()
+    attachment.write_text("ALIAS PAYLOAD")
+    destination = tmp_path / "destination"
+    with tempfile.TemporaryDirectory(
+        prefix="codex-account-alias-", dir="/tmp"
+    ) as directory:
+        alias = Path(directory) / "alias"
+        alias.symlink_to(home, target_is_directory=True)
+        reference = str(alias) + suffix
+        with sqlite3.connect(home / "state_5.sqlite") as db:
+            db.execute(
+                "UPDATE threads SET cwd=?,sandbox_policy=?",
+                (
+                    str(project),
+                    json.dumps(
+                        {"type": "workspace-write", "writable_roots": [reference]}
+                    ),
+                ),
+            )
+        rollout = home / "sessions/2026/root.jsonl"
+        rollout.write_text(
+            json.dumps(
+                {
+                    "type": "session_meta",
+                    "payload": {
+                        "cwd": str(project),
+                        "sandbox_policy": {"writable_roots": [reference]},
+                    },
+                }
+            )
+            + "\n"
+            + json.dumps(
+                {
+                    "type": "response_item",
+                    "payload": {"text": str(alias / "attachments/note.txt")},
+                }
+            )
+            + "\n"
+        )
+        mappings = {str(alias): str(destination), reference: str(destination) + suffix}
+        result = export_request(
+            {
+                "agent": "codex",
+                "source_home": str(home),
+                "session": "root",
+                "destination_home": str(destination),
+                "destination_project": str(project),
+                "path_mappings": mappings,
+            }
+        )
+        assert result["ran"] and result["ok"]
+        assert "attachments/note.txt" in result["manifest"]["files"]
+        assert not result["manifest"]["excluded_artifacts"]
+        assert {"source": str(alias), "destination": str(destination)} in result[
+            "manifest"
+        ]["path_mappings"]

--- a/tests/test_transfer_path_mappings.py
+++ b/tests/test_transfer_path_mappings.py
@@ -136,3 +136,55 @@ def test_codex_home_mapping_cannot_override_profile_destination(
         assert [
             item for item in manifest["path_mappings"] if item["source"] == str(home)
         ] == [{"source": str(home), "destination": str(destination)}]
+
+
+@pytest.mark.parametrize("suffix", ["", "/attachments", "/not-created-yet"])
+@pytest.mark.parametrize("conflict", [False, True])
+def test_codex_account_alias_mapping_guard(
+    tmp_path: Path, suffix: str, conflict: bool
+) -> None:
+    """An account symlink cannot reroute operational metadata outside its profile."""
+    import json
+
+    from claude_code_tools.transfer_codex import export_session
+    from tests.test_transfer_codex import profile, thread
+
+    home, destination = tmp_path / "real-source", tmp_path / "destination"
+    profile(home)
+    thread(home, "root", mode="legacy")
+    (home / "attachments").mkdir()
+    alias = tmp_path / "account-alias"
+    alias.symlink_to(home, target_is_directory=True)
+    referenced = str(alias) + suffix
+    rollout = home / "sessions/2026/root.jsonl"
+    rollout.write_text(
+        json.dumps(
+            {
+                "type": "session_meta",
+                "payload": {
+                    "cwd": "/old/project",
+                    "sandbox_policy": {
+                        "type": "workspace-write",
+                        "writable_roots": [referenced],
+                    },
+                },
+            }
+        )
+        + "\n"
+    )
+    expected = str(destination) + suffix
+    mappings = [(referenced, "/wrong/profile" if conflict else expected)]
+    args = (alias, "root", destination, Path("/new/project"), tmp_path / "stage")
+    if conflict:
+        with pytest.raises(ValueError, match="Account home mapping conflicts"):
+            export_session(*args, path_mappings=mappings)
+        assert not (tmp_path / "stage").exists()
+    else:
+        manifest = export_session(*args, path_mappings=mappings)
+        copied = json.loads(
+            (tmp_path / "stage/files/sessions/2026/root.jsonl").read_text()
+        )
+        assert copied["payload"]["sandbox_policy"]["writable_roots"] == [expected]
+        assert {"source": referenced, "destination": expected} in manifest[
+            "path_mappings"
+        ]

--- a/tests/test_transfer_path_mappings.py
+++ b/tests/test_transfer_path_mappings.py
@@ -1,0 +1,88 @@
+"""Equivalent lexical paths cannot select conflicting transfer destinations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from claude_code_tools.aichat import main
+from claude_code_tools.transfer_paths import normalize_path_mappings
+
+
+@pytest.mark.parametrize(
+    "alias", ["/secondary/", "/secondary/.", "/x/../secondary", "//secondary"]
+)
+def test_semantic_duplicate_mapping_conflicts(alias: str) -> None:
+    """Normalize before checking duplicate source keys."""
+    with pytest.raises(ValueError, match="Conflicting destinations"):
+        normalize_path_mappings([("/secondary", "/dest-a"), (alias, "/dest-b")])
+    assert normalize_path_mappings(
+        [("/secondary", "/dest-a"), (alias, "/dest-a/.")]
+    ) == {"/secondary": "/dest-a"}
+
+
+@pytest.mark.parametrize("agent", ["claude", "codex"])
+@pytest.mark.parametrize("conflict", [False, True])
+def test_adapters_normalize_mapping_aliases(
+    tmp_path: Path, agent: str, conflict: bool
+) -> None:
+    """Direct and remote adapter entry points share the same mapping semantics."""
+    from claude_code_tools import transfer_claude, transfer_codex
+    from tests.test_transfer_claude import SID, fixture_home
+    from tests.test_transfer_codex import profile, thread
+
+    if agent == "claude":
+        home, _ = fixture_home(tmp_path)
+        sid = SID
+        adapter = transfer_claude
+    else:
+        home = tmp_path / "codex"
+        profile(home)
+        thread(home, "root")
+        sid = "root"
+        adapter = transfer_codex
+    mappings = {
+        "/secondary": "/dest-a",
+        "/secondary/": "/dest-b" if conflict else "/dest-a/.",
+    }
+    args = (home, sid, tmp_path / "target", Path("/new/project"), tmp_path / "stage")
+    if conflict:
+        with pytest.raises(ValueError, match="Conflicting destinations"):
+            adapter.export_session(*args, path_mappings=mappings)
+    else:
+        manifest = adapter.export_session(*args, path_mappings=mappings)
+        actual = manifest["path_mappings"]
+        if isinstance(actual, list):
+            actual = {row["source"]: row["destination"] for row in actual}
+        assert actual["/secondary"] == "/dest-a"
+        assert "/secondary/" not in actual
+
+
+def test_cli_refuses_semantic_duplicate_before_access(tmp_path: Path) -> None:
+    """Conflicting aliases are a usage error before account or SSH inspection."""
+    result = CliRunner().invoke(
+        main,
+        [
+            "transfer",
+            "unused",
+            "--agent",
+            "codex",
+            "--to",
+            "unused-host",
+            "--destination-home",
+            str(tmp_path / "target"),
+            "--destination-project",
+            str(tmp_path / "repo"),
+            "--map",
+            "/secondary",
+            "/dest-a",
+            "--map",
+            "/secondary/",
+            "/dest-b",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "Conflicting destinations" in result.output
+    assert not (tmp_path / "target").exists()

--- a/tests/test_transfer_primary_mapping.py
+++ b/tests/test_transfer_primary_mapping.py
@@ -1,0 +1,57 @@
+"""Both native adapters keep operational cwd aligned with the verified project."""
+
+from pathlib import Path
+
+import pytest
+
+from claude_code_tools import transfer_claude, transfer_codex
+from tests.test_transfer_claude import SID, fixture_home
+from tests.test_transfer_codex import profile, thread
+
+
+def export_fixture(agent: str, tmp_path: Path, mappings: dict[str, str]) -> dict:
+    """Export a native-format isolated fixture through its public adapter."""
+    if agent == "claude":
+        home, _ = fixture_home(tmp_path)
+        adapter = transfer_claude
+    else:
+        home = tmp_path / "codex"
+        profile(home)
+        thread(home, SID)
+        adapter = transfer_codex
+    return adapter.export_session(
+        home,
+        SID,
+        Path("/destination/account"),
+        Path("/new/project"),
+        tmp_path / "staging",
+        path_mappings=mappings,
+    )
+
+
+@pytest.mark.parametrize("agent", ["claude", "codex"])
+@pytest.mark.parametrize(
+    "source", ["/old/project", "/old/project/", "/old/project/../project"]
+)
+def test_rejects_conflicting_normalized_primary_map(
+    tmp_path: Path, agent: str, source: str
+) -> None:
+    with pytest.raises(ValueError, match="Primary project mapping conflicts"):
+        export_fixture(agent, tmp_path, {source: "/other/project"})
+
+
+@pytest.mark.parametrize("agent", ["claude", "codex"])
+def test_accepts_matching_primary_and_descendant_maps(
+    tmp_path: Path, agent: str
+) -> None:
+    mappings = {
+        "/old/project": "/new/unused/../project",
+        "/old/project/subtree": "/separate/subtree",
+    }
+    result = export_fixture(agent, tmp_path, mappings)
+    assert result["ok"]
+    exported = result["path_mappings"]
+    if isinstance(exported, list):
+        exported = {item["source"]: item["destination"] for item in exported}
+    assert exported["/old/project/subtree"] == "/separate/subtree"
+    assert exported["/old/project"] == "/new/project"

--- a/tests/test_transfer_recovery.py
+++ b/tests/test_transfer_recovery.py
@@ -1,0 +1,92 @@
+"""Real crash recovery and conservative destination metadata preservation."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from claude_code_tools.transfer_journal import (
+    TransferJournal,
+    atomic_write,
+    metadata_content,
+)
+
+
+def test_recover_killed_owner(tmp_path: Path) -> None:
+    """A killed importer leaves flushed evidence and only identical retry is allowed."""
+    home = tmp_path / "account"
+    script = tmp_path / "crash.py"
+    script.write_text("""import os, signal, sys
+from pathlib import Path
+from claude_code_tools.transfer_journal import TransferJournal, atomic_write
+home = Path(sys.argv[1])
+journal = TransferJournal(home, {"artifacts": {}}, False)
+journal.backup({})
+atomic_write(home / "session.jsonl", b"complete artifact")
+journal.save("publishing_files")
+os.kill(os.getpid(), signal.SIGKILL)
+""")
+    result = subprocess.run(
+        [sys.executable, str(script), str(home)],
+        env={**os.environ, "PYTHONPATH": str(Path.cwd())},
+        timeout=10,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == -9
+    assert (home / "session.jsonl").read_bytes() == b"complete artifact"
+    with pytest.raises(ValueError, match="identical"):
+        TransferJournal(home, {"artifacts": {"different": {}}}, True)
+    journal = TransferJournal(home, {"artifacts": {}}, True)
+    assert journal.record["backups_complete"] is True
+    retained = journal.directory
+    journal.complete()
+    assert not (home / ".aichat-transfer.lock").exists()
+    assert json.loads((retained / "journal.json").read_text())["phase"] == "complete"
+    assert (home / "session.jsonl").read_bytes() == b"complete artifact"
+
+
+def test_live_owner_refused(tmp_path: Path) -> None:
+    """Two importers cannot claim the account, even with recovery requested."""
+    journal = TransferJournal(tmp_path, {}, False)
+    try:
+        with pytest.raises(ValueError, match="still alive"):
+            TransferJournal(tmp_path, {}, True)
+    finally:
+        journal.complete()
+
+
+def test_metadata_merge_preserves_unrelated_and_rejects_newer(tmp_path: Path) -> None:
+    """Selected same-key divergence never overwrites destination metadata."""
+    path = tmp_path / "session_index.jsonl"
+    original = {"id": "other", "thread_name": "local"}
+    path.write_text(json.dumps(original) + "\n")
+    update = {
+        "format": "jsonl",
+        "key": "id",
+        "container": None,
+        "rows": [{"id": "selected", "thread_name": "copied"}],
+    }
+    data = metadata_content(path, update)
+    atomic_write(path, data, replace=True)
+    assert json.loads(path.read_text().splitlines()[0]) == original
+    assert metadata_content(path, update) == data
+    update["rows"][0]["thread_name"] = "different"
+    with pytest.raises(ValueError, match="differs"):
+        metadata_content(path, update)
+    assert path.read_bytes() == data
+
+
+def test_atomic_publication_never_overwrites(tmp_path: Path) -> None:
+    """An existing user artifact survives publication races unchanged."""
+    path = tmp_path / "artifact"
+    atomic_write(path, b"newer user work")
+    with pytest.raises(FileExistsError):
+        atomic_write(path, b"old transferred work")
+    assert path.read_bytes() == b"newer user work"
+    assert not list(tmp_path.glob(".transfer-*"))

--- a/tests/test_transfer_recovery.py
+++ b/tests/test_transfer_recovery.py
@@ -143,3 +143,90 @@ def test_incomplete_index_tail_requires_inspection(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="Incomplete destination index"):
         missing_jsonl_rows(path, {"key": "id", "rows": []})
     assert path.read_bytes() == partial
+
+
+def test_shared_json_additions_refused_without_modifying_other_records(
+    tmp_path: Path,
+) -> None:
+    """Existing native-owned JSON cannot safely receive selected-row additions."""
+    from claude_code_tools.transfer_journal import publish_json_metadata
+
+    path = tmp_path / "external_agent_session_imports.json"
+    original = b'{ "records": [{"id":"other","note":"native work"}] }\n'
+    path.write_bytes(original)
+    update = {
+        "format": "json",
+        "container": "records",
+        "key": "id",
+        "rows": [{"id": "selected"}],
+    }
+    with pytest.raises(ValueError, match="separate destination account"):
+        metadata_content(path, update)
+    with pytest.raises(ValueError, match="separate destination account"):
+        publish_json_metadata(path, update)
+    assert path.read_bytes() == original
+
+
+def test_shared_json_identical_selected_records_are_not_rewritten(
+    tmp_path: Path,
+) -> None:
+    """Semantic equality preserves original bytes, inode and write timestamp."""
+    from claude_code_tools.transfer_journal import publish_json_metadata
+
+    path = tmp_path / "external_agent_session_imports.json"
+    original = b'{ "extra": true, "records": [{"id":"other"},{"id":"selected"}] }\n'
+    path.write_bytes(original)
+    before = path.stat()
+    update = {
+        "format": "json",
+        "container": "records",
+        "key": "id",
+        "rows": [{"id": "selected"}],
+    }
+    assert metadata_content(path, update) == original
+    publish_json_metadata(path, update)
+    after = path.stat()
+    assert path.read_bytes() == original
+    assert (before.st_ino, before.st_mtime_ns) == (after.st_ino, after.st_mtime_ns)
+
+
+def test_shared_json_publish_preserves_concurrent_creation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A native creation at publication wins; atomic no-clobber refuses the copy."""
+    from claude_code_tools import transfer_journal
+
+    path = tmp_path / "external_agent_session_imports.json"
+    original_link = transfer_journal.os.link
+    native = b'{"records":[{"id":"native-created"}]}'
+
+    def concurrent_link(source, destination):
+        Path(destination).write_bytes(native)
+        return original_link(source, destination)
+
+    monkeypatch.setattr(transfer_journal.os, "link", concurrent_link)
+    update = {
+        "format": "json",
+        "container": "records",
+        "key": "id",
+        "rows": [{"id": "selected"}],
+    }
+    with pytest.raises(ValueError, match="appeared during publication"):
+        transfer_journal.publish_json_metadata(path, update)
+    assert path.read_bytes() == native
+    assert not list(tmp_path.glob(".transfer-*"))
+
+
+def test_shared_json_absent_document_is_published(tmp_path: Path) -> None:
+    """An absent metadata document can receive selected records without replacement."""
+    from claude_code_tools.transfer_journal import publish_json_metadata
+
+    path = tmp_path / "external_agent_session_imports.json"
+    update = {
+        "format": "json",
+        "container": "records",
+        "key": "id",
+        "rows": [{"id": "selected"}],
+    }
+    publish_json_metadata(path, update)
+    assert json.loads(path.read_text()) == {"records": [{"id": "selected"}]}

--- a/tests/test_transfer_recovery.py
+++ b/tests/test_transfer_recovery.py
@@ -90,3 +90,56 @@ def test_atomic_publication_never_overwrites(tmp_path: Path) -> None:
         atomic_write(path, b"old transferred work")
     assert path.read_bytes() == b"newer user work"
     assert not list(tmp_path.glob(".transfer-*"))
+
+
+def test_index_publication_preserves_interleaved_append(tmp_path: Path) -> None:
+    """A native append after planning survives selected-row publication byte-exactly."""
+    from claude_code_tools.transfer_journal import append_jsonl_rows, missing_jsonl_rows
+
+    path = tmp_path / "session_index.jsonl"
+    original = b'{"id":"existing", "thread_name":"preserve formatting"}\n'
+    native = b'{"id":"concurrent", "thread_name":"native append"}\n'
+    path.write_bytes(original)
+    update = {"key": "id", "rows": [{"id": "selected", "thread_name": "copied"}]}
+    pending = missing_jsonl_rows(path, update)
+    descriptor = os.open(path, os.O_WRONLY | os.O_APPEND)
+    try:
+        assert os.write(descriptor, native) == len(native)
+    finally:
+        os.close(descriptor)
+    append_jsonl_rows(path, update, pending)
+    result = path.read_bytes()
+    assert result.startswith(original + native)
+    assert [json.loads(line)["id"] for line in result.splitlines()] == [
+        "existing",
+        "concurrent",
+        "selected",
+    ]
+    append_jsonl_rows(path, update, missing_jsonl_rows(path, update))
+    assert path.read_bytes() == result
+
+
+def test_index_publication_refuses_selected_conflict(tmp_path: Path) -> None:
+    """A same-session rename between planning and publication is never replaced."""
+    from claude_code_tools.transfer_journal import append_jsonl_rows, missing_jsonl_rows
+
+    path = tmp_path / "session_index.jsonl"
+    update = {"key": "id", "rows": [{"id": "selected", "thread_name": "copied"}]}
+    pending = missing_jsonl_rows(path, update)
+    newer = b'{"id":"selected","thread_name":"newer native name"}\n'
+    path.write_bytes(newer)
+    with pytest.raises(ValueError, match="differs"):
+        append_jsonl_rows(path, update, pending)
+    assert path.read_bytes() == newer
+
+
+def test_incomplete_index_tail_requires_inspection(tmp_path: Path) -> None:
+    """Interrupted appends are preserved rather than trimmed during recovery."""
+    from claude_code_tools.transfer_journal import missing_jsonl_rows
+
+    path = tmp_path / "session_index.jsonl"
+    partial = b'{"id":"unfinished'
+    path.write_bytes(partial)
+    with pytest.raises(ValueError, match="Incomplete destination index"):
+        missing_jsonl_rows(path, {"key": "id", "rows": []})
+    assert path.read_bytes() == partial

--- a/tests/test_transfer_secondary_worktrees.py
+++ b/tests/test_transfer_secondary_worktrees.py
@@ -1,0 +1,155 @@
+"""Validate every operational worktree used by transferred session metadata."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_code_tools.transfer_remote import handle_request
+from claude_code_tools.transfer_session import prepare_transfer
+from claude_code_tools.transfer_source import export_request
+from tests.test_transfer_codex import insert, profile, thread
+from tests.test_transfer_session import SID, git
+
+
+@pytest.mark.parametrize("agent", ["claude", "codex"])
+@pytest.mark.parametrize("exporter", ["local", "ssh_handler"])
+@pytest.mark.parametrize("problem", ["dirty", "revision", "missing", "none"])
+def test_secondary_operational_worktree_checked(
+    tmp_path: Path, agent: str, exporter: str, problem: str
+) -> None:
+    """Matching primary repos cannot mask a bad subagent/descendant worktree."""
+    source, target = tmp_path / "source", tmp_path / "target"
+    source.mkdir()
+    git(source, "init")
+    (source / "README").write_text("fixture")
+    git(source, "add", "README")
+    git(
+        source,
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=f@example.test",
+        "commit",
+        "-m",
+        "fixture",
+    )
+    git(tmp_path, "clone", str(source), str(target))
+    secondary, target_secondary = tmp_path / "secondary", tmp_path / "target-secondary"
+    git(source, "worktree", "add", "--detach", str(secondary), "HEAD")
+    git(target, "worktree", "add", "--detach", str(target_secondary), "HEAD")
+    home, destination = tmp_path / "profile", tmp_path / "destination"
+    if agent == "codex":
+        profile(home)
+        profile(destination)
+        for sid, cwd in ((SID, source), ("child", secondary)):
+            thread(home, sid, mode="legacy")
+            import sqlite3
+
+            with sqlite3.connect(home / "state_5.sqlite") as db:
+                db.execute(
+                    "UPDATE threads SET cwd=?,sandbox_policy=? WHERE id=?",
+                    (str(cwd), '{"type":"read-only"}', sid),
+                )
+            (home / "sessions/2026" / f"{sid}.jsonl").write_text(
+                json.dumps({"type": "session_meta", "payload": {"cwd": str(cwd)}})
+                + "\n"
+            )
+        insert(
+            home,
+            "state_5.sqlite",
+            "thread_spawn_edges",
+            {
+                "parent_thread_id": SID,
+                "child_thread_id": "child",
+                "status": "completed",
+            },
+        )
+    else:
+        parent = home / "projects/encoded"
+        parent.mkdir(parents=True)
+        (parent / f"{SID}.jsonl").write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "sessionId": SID,
+                    "cwd": str(source),
+                    "message": {"content": "fixture"},
+                }
+            )
+            + "\n"
+        )
+        sidecar = parent / SID / "subagents"
+        sidecar.mkdir(parents=True)
+        (sidecar / "agent-example.jsonl").write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "sessionId": "child",
+                    "cwd": str(secondary),
+                    "message": {"content": "subagent fixture"},
+                }
+            )
+            + "\n"
+        )
+    mappings = {str(secondary): str(target_secondary), "/artifact-only": "/unavailable"}
+    if exporter == "local":
+        manifest = prepare_transfer(
+            agent,
+            home,
+            SID,
+            destination,
+            target,
+            tmp_path / "stage",
+            path_mappings=mappings,
+        )
+    else:
+        response = export_request(
+            {
+                "agent": agent,
+                "source_home": str(home),
+                "session": SID,
+                "destination_home": str(destination),
+                "destination_project": str(target),
+                "path_mappings": mappings,
+            }
+        )
+        assert response["ran"] and response["ok"]
+        manifest = response["manifest"]
+    assert {row["source"]["path"] for row in manifest["operational_projects"]} == {
+        str(source),
+        str(secondary),
+    }
+    if problem == "dirty":
+        (target_secondary / "untracked").write_text("new local work")
+    elif problem == "revision":
+        (target_secondary / "README").write_text("different revision")
+        git(target_secondary, "add", "README")
+        git(
+            target_secondary,
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=f@example.test",
+            "commit",
+            "-m",
+            "different",
+        )
+    elif problem == "missing":
+        git(target, "worktree", "remove", str(target_secondary))
+    request = {
+        "operation": "validate",
+        "destination_home": str(destination),
+        "destination_project": str(target),
+        "manifest": manifest,
+    }
+    if problem == "none":
+        assert handle_request(request)["ok"]
+    else:
+        with pytest.raises(
+            ValueError, match="Operational worktree|Project does not exist"
+        ):
+            handle_request(request)
+    assert not (destination / ".aichat-transfer.lock").exists()

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -1,0 +1,230 @@
+"""Exercise the public transfer CLI and destination protocol on real worktrees."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from claude_code_tools.aichat import main
+from claude_code_tools.transfer_remote import handle_request, project_state
+from claude_code_tools.transfer_session import remote_bootstrap
+
+SID = "f247a9f0-6196-4c19-a77a-e99c14474e8c"
+
+
+def git(directory: Path, *args: str) -> str:
+    """Run isolated fixture Git commands without user hooks or signing."""
+    return subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(directory),
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        text=True,
+        stderr=subprocess.DEVNULL,
+    ).strip()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> dict[str, Path]:
+    """Create matching clean worktrees and one saved Claude conversation."""
+    source = tmp_path / "source project"
+    target = tmp_path / "target project"
+    source.mkdir()
+    git(source, "init")
+    (source / "README.md").write_text("fixture\n")
+    git(source, "add", "README.md")
+    git(
+        source,
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=f@example.test",
+        "commit",
+        "-m",
+        "fixture",
+    )
+    git(tmp_path, "clone", str(source), str(target))
+    home = tmp_path / "source profile"
+    transcript = home / "projects" / "encoded" / f"{SID}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "sessionId": SID,
+                "cwd": str(source),
+                "message": {"role": "user", "content": "Remember the fixture"},
+            }
+        )
+        + "\n"
+    )
+    return {
+        "source": source,
+        "target": target,
+        "home": home,
+        "destination": tmp_path / "destination profile",
+        "transcript": transcript,
+    }
+
+
+def arguments(workspace: dict[str, Path]) -> list[str]:
+    """Return the public command for a local fixture transfer."""
+    return [
+        "transfer",
+        SID,
+        "--agent",
+        "claude",
+        "--source-home",
+        str(workspace["home"]),
+        "--to",
+        "local",
+        "--destination-home",
+        str(workspace["destination"]),
+        "--destination-project",
+        str(workspace["target"]),
+        "--json",
+    ]
+
+
+def test_dry_run_then_copy_and_repeat(workspace: dict[str, Path]) -> None:
+    """Dry-run is read-only; copying is verified and does not remove source."""
+    runner = CliRunner()
+    before = workspace["transcript"].read_bytes()
+    result = runner.invoke(main, arguments(workspace) + ["--dry-run"])
+    assert result.exit_code == 0, result.output
+    plan = json.loads(result.output)["plan"]
+    assert not workspace["destination"].exists()
+    assert plan["artifacts"]
+    assert "CLAUDE_CONFIG_DIR=" in plan["resume_command"]
+    result = runner.invoke(main, arguments(workspace))
+    assert result.exit_code == 0, result.output
+    report = json.loads(result.output)
+    assert report["ok"] is True
+    assert report["destination"]["verified_files"] == 1
+    copied = next(workspace["destination"].glob("projects/*/*.jsonl"))
+    assert json.loads(copied.read_text())["cwd"] == str(workspace["target"])
+    assert workspace["transcript"].read_bytes() == before
+    assert copied.stat().st_mode & 0o777 == 0o600
+    repeated = runner.invoke(main, arguments(workspace))
+    assert repeated.exit_code == 0, repeated.output
+    assert json.loads(repeated.output)["destination"]["imported_files"] == 0
+
+
+def test_dirty_or_wrong_revision_refused(workspace: dict[str, Path]) -> None:
+    """A copied conversation cannot silently resume against different code."""
+    (workspace["target"] / "untracked.txt").write_text("unsynced")
+    result = CliRunner().invoke(main, arguments(workspace))
+    assert result.exit_code == 1
+    assert "clean" in json.loads(result.output)["error"]
+    assert not workspace["destination"].exists()
+    (workspace["target"] / "untracked.txt").unlink()
+    git(
+        workspace["target"],
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=f@example.test",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "new",
+    )
+    result = CliRunner().invoke(main, arguments(workspace))
+    assert result.exit_code == 1
+    assert "revision" in json.loads(result.output)["error"]
+
+
+def test_destination_conflict_preserved(workspace: dict[str, Path]) -> None:
+    """Existing history is never overwritten by another source copy."""
+    runner = CliRunner()
+    assert runner.invoke(main, arguments(workspace)).exit_code == 0
+    copied = next(workspace["destination"].glob("projects/*/*.jsonl"))
+    copied.write_text("existing conversation")
+    result = runner.invoke(main, arguments(workspace))
+    assert result.exit_code == 1
+    assert copied.read_text() == "existing conversation"
+
+
+def test_remote_bootstrap_without_installed_package(
+    workspace: dict[str, Path], tmp_path: Path
+) -> None:
+    """The SSH helper runs in a clean Python process with only stdlib available."""
+    request = {
+        "operation": "probe",
+        "destination_home": str(workspace["destination"]),
+        "destination_project": str(workspace["target"]),
+    }
+    result = subprocess.run(
+        [sys.executable, "-I", "-c", remote_bootstrap()],
+        input=json.dumps(request),
+        text=True,
+        capture_output=True,
+        check=False,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["ok"] is True
+    assert not workspace["destination"].exists()
+
+
+def request_with_files(workspace: dict[str, Path]) -> dict[str, Any]:
+    """Build a destination import with independent integrity metadata."""
+    data = b"artifact"
+    metadata = {"size": len(data), "sha256": hashlib.sha256(data).hexdigest()}
+    return {
+        "operation": "import",
+        "destination_home": str(workspace["destination"]),
+        "destination_project": str(workspace["target"]),
+        "manifest": {
+            "agent": "claude",
+            "project_state": project_state(workspace["source"]),
+            "artifacts": {"projects/a/one": metadata, "projects/a/two": metadata},
+        },
+        "data": {
+            "projects/a/one": base64.b64encode(data).decode(),
+            "projects/a/two": base64.b64encode(b"corrupt").decode(),
+        },
+    }
+
+
+def test_corrupt_bundle_rolls_back_created_files(workspace: dict[str, Path]) -> None:
+    """A late integrity failure removes files created earlier in the import."""
+    with pytest.raises(ValueError, match="integrity"):
+        handle_request(request_with_files(workspace))
+    assert not list(workspace["destination"].rglob("one"))
+    assert not (workspace["destination"] / ".aichat-transfer.lock").exists()
+
+
+def test_symlink_and_traversal_refused(workspace: dict[str, Path]) -> None:
+    """Artifact paths stay under the explicit account home."""
+    request = request_with_files(workspace)
+    home = workspace["destination"]
+    home.mkdir()
+    (home / "projects").symlink_to(workspace["target"], target_is_directory=True)
+    with pytest.raises(ValueError, match="symlink"):
+        handle_request(request)
+    (home / "projects").unlink()
+    request["manifest"]["artifacts"] = {"../escape": {}}
+    with pytest.raises(ValueError, match="Unsafe"):
+        handle_request(request)
+
+
+def test_command_is_registered() -> None:
+    """The shipped entry point exposes transfer rather than falling into menu."""
+    result = CliRunner().invoke(main, ["transfer", "--help"])
+    assert result.exit_code == 0
+    assert "--destination-project" in result.output

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -513,3 +513,35 @@ def test_duplicate_claude_uuid_in_other_project_is_refused(
     assert existing.read_bytes() == content
     assert list((destination / "projects").glob("*/*.jsonl")) == [existing]
     assert not (destination / ".aichat-transfer.lock").exists()
+
+
+def test_default_report_exposes_failed_destination_hook(
+    workspace: dict[str, Path],
+) -> None:
+    """A missing destination hook launcher is visible without JSON output."""
+    destination = workspace["destination"]
+    destination.mkdir()
+    (destination / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "command": "aichat-fixture-missing-launcher --token PRIVATE_HOOK_TOKEN"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    args = [arg for arg in arguments(workspace) if arg not in ("--apply", "--json")]
+    result = CliRunner().invoke(main, args)
+    assert result.exit_code == 0, result.output
+    assert "1 configured hook check(s) failed" in result.output
+    assert "Remediation:" in result.output
+    assert "PRIVATE_HOOK_TOKEN" not in result.output
+    assert not (destination / "projects").exists()

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -38,6 +38,24 @@ def git(directory: Path, *args: str) -> str:
     ).strip()
 
 
+def relocate_codex_fixture(home: Path, source: Path) -> None:
+    """Keep native rollout cwd and byte offsets consistent with a real test repo."""
+    import sqlite3
+
+    rollout = home / "sessions/2026" / f"{SID}.jsonl"
+    original = rollout.read_bytes()
+    record = json.loads(original)
+    record["payload"]["cwd"] = str(source)
+    rewritten = (json.dumps(record) + "\n").encode()
+    rollout.write_bytes(rewritten)
+    with sqlite3.connect(home / "thread_history_1.sqlite") as db:
+        db.execute("UPDATE thread_turns SET rollout_byte_offset=?", (len(rewritten),))
+        db.execute(
+            "UPDATE thread_history_projection_state SET next_rollout_byte_offset=?",
+            (len(rewritten),),
+        )
+
+
 @pytest.fixture
 def workspace(tmp_path: Path) -> dict[str, Path]:
     """Create matching clean worktrees and one saved Claude conversation."""
@@ -247,6 +265,7 @@ def test_archived_codex_session_resolves(
     profile(home)
     profile(destination)
     thread(home, SID)
+    relocate_codex_fixture(home, workspace["source"])
     original = home / "sessions" / "2026" / f"{SID}.jsonl"
     archived = home / "archived_sessions" / original.name
     archived.parent.mkdir()
@@ -301,6 +320,7 @@ def test_interrupt_after_real_database_commit_preserves_rollouts(
     profile(home)
     profile(destination)
     thread(home, SID)
+    relocate_codex_fixture(home, workspace["source"])
     with sqlite3.connect(home / "state_5.sqlite") as db:
         db.execute(
             "UPDATE threads SET cwd=?,sandbox_policy=?",
@@ -454,6 +474,7 @@ def test_codex_artifact_disclosures_in_normal_report(
     profile(home)
     profile(destination)
     thread(home, SID)
+    relocate_codex_fixture(home, workspace["source"])
     missing = (
         Path("/tmp/aichat-unowned-fixture.txt")
         if excluded

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -390,3 +390,32 @@ def test_remote_source_bootstrap_exports_without_installed_package(
     assert report["manifest"]["session_id"] == SID
     assert report["data"]
     assert not workspace["destination"].exists()
+
+
+def test_public_report_omits_private_record_contents() -> None:
+    """CLI inspection must not print message/goal/token material from payload rows."""
+    from claude_code_tools.transfer_session import public_report
+
+    report = {
+        "ok": True,
+        "plan": {
+            "databases": [
+                {
+                    "tables": [
+                        {
+                            "name": "goals",
+                            "rows": [
+                                {"objective": "PRIVATE_CONVERSATION_TOKEN"},
+                            ],
+                        }
+                    ]
+                }
+            ],
+            "metadata_updates": [{"rows": [{"text": "PRIVATE_CONVERSATION_TOKEN"}]}],
+        },
+    }
+    rendered = public_report(report)
+    assert "PRIVATE_CONVERSATION_TOKEN" not in json.dumps(rendered)
+    assert rendered["plan"]["databases"][0]["tables"][0]["row_count"] == 1
+    assert rendered["plan"]["metadata_updates"][0]["row_count"] == 1
+    assert report["plan"]["databases"][0]["tables"][0]["rows"]

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -85,6 +85,7 @@ def arguments(workspace: dict[str, Path]) -> list[str]:
     """Return the public command for a local fixture transfer."""
     return [
         "transfer",
+        "--apply",
         SID,
         "--agent",
         "claude",
@@ -104,7 +105,9 @@ def test_dry_run_then_copy_and_repeat(workspace: dict[str, Path]) -> None:
     """Dry-run is read-only; copying is verified and does not remove source."""
     runner = CliRunner()
     before = workspace["transcript"].read_bytes()
-    result = runner.invoke(main, arguments(workspace) + ["--dry-run"])
+    result = runner.invoke(
+        main, [arg for arg in arguments(workspace) if arg != "--apply"]
+    )
     assert result.exit_code == 0, result.output
     plan = json.loads(result.output)["plan"]
     assert not workspace["destination"].exists()
@@ -114,7 +117,7 @@ def test_dry_run_then_copy_and_repeat(workspace: dict[str, Path]) -> None:
     assert result.exit_code == 0, result.output
     report = json.loads(result.output)
     assert report["ok"] is True
-    assert report["destination"]["verified_files"] == 1
+    assert report["destination"]["verified_files"] == 2
     copied = next(workspace["destination"].glob("projects/*/*.jsonl"))
     assert json.loads(copied.read_text())["cwd"] == str(workspace["target"])
     assert workspace["transcript"].read_bytes() == before
@@ -261,6 +264,9 @@ def test_archived_codex_session_resolves(
         SID,
         "--agent",
         "codex",
+        "--map",
+        "/old/project",
+        str(workspace["target"]),
         "--source-home",
         str(home),
         "--to",
@@ -275,7 +281,8 @@ def test_archived_codex_session_resolves(
     result = CliRunner().invoke(main, args)
     assert result.exit_code == 0, result.output
     assert json.loads(result.output)["plan"]["files"] == [
-        f"archived_sessions/{SID}.jsonl"
+        f"archived_sessions/{SID}.jsonl",
+        f"transfer-support/{SID}/path-map.json",
     ]
 
 
@@ -303,7 +310,13 @@ def test_interrupt_after_real_database_commit_preserves_rollouts(
         )
     staging = tmp_path / "staging"
     manifest = prepare_transfer(
-        "codex", home, SID, destination, workspace["target"], staging
+        "codex",
+        home,
+        SID,
+        destination,
+        workspace["target"],
+        staging,
+        path_mappings={"/old/project": str(workspace["target"])},
     )
     request = {
         "operation": "import",
@@ -343,3 +356,37 @@ def test_interrupt_after_real_database_commit_preserves_rollouts(
             staging / "files" / relative
         ).read_bytes()
     assert (destination / ".aichat-transfer.lock").is_dir()
+
+
+def test_apply_and_dry_run_are_mutually_exclusive(workspace: dict[str, Path]) -> None:
+    """Ambiguous execution intent never writes destination data."""
+    result = CliRunner().invoke(main, arguments(workspace) + ["--dry-run"])
+    assert result.exit_code == 2
+    assert "either --apply or --dry-run" in result.output
+    assert not workspace["destination"].exists()
+
+
+def test_remote_source_bootstrap_exports_without_installed_package(
+    workspace: dict[str, Path],
+) -> None:
+    """The shipped stdlib helper can read a remote source and return its bundle."""
+    request = {
+        "operation": "export",
+        "agent": "claude",
+        "session": SID,
+        "source_home": str(workspace["home"]),
+        "destination_home": str(workspace["destination"]),
+        "destination_project": str(workspace["target"]),
+    }
+    result = subprocess.run(
+        [sys.executable, "-I", "-c", remote_bootstrap()],
+        input=json.dumps(request),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    report = json.loads(result.stdout)
+    assert report["ran"] is True and report["ok"] is True
+    assert report["manifest"]["session_id"] == SID
+    assert report["data"]
+    assert not workspace["destination"].exists()

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -194,6 +194,7 @@ def request_with_files(workspace: dict[str, Path]) -> dict[str, Any]:
         "destination_project": str(workspace["target"]),
         "manifest": {
             "agent": "claude",
+            "session_id": SID,
             "project_state": project_state(workspace["source"]),
             "artifacts": {"projects/a/one": metadata, "projects/a/two": metadata},
         },
@@ -491,3 +492,24 @@ def test_codex_missing_artifact_in_normal_report(
     result = CliRunner().invoke(main, args)
     assert result.exit_code == 0, result.output
     assert f"Missing at source (not copied): {missing}" in result.output
+
+
+@pytest.mark.parametrize("apply", [False, True])
+def test_duplicate_claude_uuid_in_other_project_is_refused(
+    workspace: dict[str, Path], apply: bool
+) -> None:
+    """An account cannot gain a second transcript for the same Claude UUID."""
+    destination = workspace["destination"]
+    existing = destination / "projects/other-project" / f"{SID}.jsonl"
+    existing.parent.mkdir(parents=True)
+    content = workspace["transcript"].read_bytes()
+    existing.write_bytes(content)
+    args = arguments(workspace)
+    if not apply:
+        args.remove("--apply")
+    result = CliRunner().invoke(main, args)
+    assert result.exit_code == 1, result.output
+    assert "already exists in another project" in json.loads(result.output)["error"]
+    assert existing.read_bytes() == content
+    assert list((destination / "projects").glob("*/*.jsonl")) == [existing]
+    assert not (destination / ".aichat-transfer.lock").exists()

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -545,3 +545,24 @@ def test_default_report_exposes_failed_destination_hook(
     assert "Remediation:" in result.output
     assert "PRIVATE_HOOK_TOKEN" not in result.output
     assert not (destination / "projects").exists()
+
+
+@pytest.mark.parametrize("existing", [False, True])
+def test_account_home_permissions_are_private_on_creation(
+    workspace: dict[str, Path], existing: bool
+) -> None:
+    """New homes are private even with umask 022; existing modes are preserved."""
+    import os
+    import stat
+
+    destination = workspace["destination"]
+    if existing:
+        destination.mkdir()
+        destination.chmod(0o750)
+    previous = os.umask(0o022)
+    try:
+        result = CliRunner().invoke(main, arguments(workspace))
+    finally:
+        os.umask(previous)
+    assert result.exit_code == 0, result.output
+    assert stat.S_IMODE(destination.stat().st_mode) == (0o750 if existing else 0o700)

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -419,3 +419,20 @@ def test_public_report_omits_private_record_contents() -> None:
     assert rendered["plan"]["databases"][0]["tables"][0]["row_count"] == 1
     assert rendered["plan"]["metadata_updates"][0]["row_count"] == 1
     assert report["plan"]["databases"][0]["tables"][0]["rows"]
+
+
+def test_default_report_displays_missing_source_artifacts(
+    workspace: dict[str, Path],
+) -> None:
+    """A normal dry run exposes source gaps without requiring JSON output."""
+    transcript = workspace["transcript"]
+    record = json.loads(transcript.read_text())
+    record["slug"] = "missing-fixture-plan"
+    transcript.write_text(json.dumps(record) + "\n")
+    args = [arg for arg in arguments(workspace) if arg not in ("--apply", "--json")]
+    result = CliRunner().invoke(main, args)
+    assert result.exit_code == 0, result.output
+    assert "Transfer plan verified." in result.output
+    missing = workspace["home"] / "plans/missing-fixture-plan.md"
+    assert f"Missing at source (not copied): {missing}" in result.output
+    assert not workspace["destination"].exists()

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -440,10 +440,11 @@ def test_default_report_displays_missing_source_artifacts(
 
 
 @pytest.mark.parametrize("apply", [False, True])
-def test_codex_missing_artifact_in_normal_report(
-    workspace: dict[str, Path], tmp_path: Path, apply: bool
+@pytest.mark.parametrize("excluded", [False, True])
+def test_codex_artifact_disclosures_in_normal_report(
+    workspace: dict[str, Path], tmp_path: Path, apply: bool, excluded: bool
 ) -> None:
-    """Codex string-shaped source gaps render on both inspection and copy."""
+    """Codex gaps and exclusions render on both inspection and copy."""
     import sqlite3
 
     from tests.test_transfer_codex import profile, thread
@@ -453,7 +454,11 @@ def test_codex_missing_artifact_in_normal_report(
     profile(home)
     profile(destination)
     thread(home, SID)
-    missing = home / "attachments/missing.txt"
+    missing = (
+        Path("/tmp/aichat-unowned-fixture.txt")
+        if excluded
+        else home / "attachments/missing.txt"
+    )
     rollout = home / "sessions/2026" / f"{SID}.jsonl"
     with rollout.open("a") as stream:
         stream.write(
@@ -491,7 +496,10 @@ def test_codex_missing_artifact_in_normal_report(
         args.append("--apply")
     result = CliRunner().invoke(main, args)
     assert result.exit_code == 0, result.output
-    assert f"Missing at source (not copied): {missing}" in result.output
+    label = (
+        "Excluded external artifact" if excluded else "Missing at source (not copied)"
+    )
+    assert f"{label}: {missing}" in result.output
 
 
 @pytest.mark.parametrize("apply", [False, True])

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -277,3 +277,69 @@ def test_archived_codex_session_resolves(
     assert json.loads(result.output)["plan"]["files"] == [
         f"archived_sessions/{SID}.jsonl"
     ]
+
+
+def test_interrupt_after_real_database_commit_preserves_rollouts(
+    workspace: dict[str, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A late interrupt cannot delete rollouts referenced by committed rows."""
+    import sqlite3
+
+    from claude_code_tools.transfer_session import prepare_transfer
+    from tests.test_transfer_codex import profile, thread
+
+    home = tmp_path / "codex"
+    destination = tmp_path / "codex-destination"
+    profile(home)
+    profile(destination)
+    thread(home, SID)
+    with sqlite3.connect(home / "state_5.sqlite") as db:
+        db.execute(
+            "UPDATE threads SET cwd=?,sandbox_policy=?",
+            (
+                str(workspace["source"]),
+                json.dumps({"type": "workspace-write", "writable_roots": []}),
+            ),
+        )
+    staging = tmp_path / "staging"
+    manifest = prepare_transfer(
+        "codex", home, SID, destination, workspace["target"], staging
+    )
+    request = {
+        "operation": "import",
+        "destination_home": str(destination),
+        "destination_project": str(workspace["target"]),
+        "manifest": manifest,
+        "data": {
+            relative: base64.b64encode(
+                (staging / "files" / relative).read_bytes()
+            ).decode()
+            for relative in manifest["files"]
+        },
+    }
+    original_connect = sqlite3.connect
+
+    class InterruptedCommit(sqlite3.Connection):
+        """Commit real SQLite data, then simulate deferred signal delivery."""
+
+        def commit(self) -> None:
+            super().commit()
+            raise KeyboardInterrupt
+
+    def connect(database: Any, *args: Any, **kwargs: Any) -> sqlite3.Connection:
+        if database == ":memory:":
+            kwargs["factory"] = InterruptedCommit
+        return original_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+    with pytest.raises(ValueError, match="commit outcome may be uncertain"):
+        handle_request(request)
+    with original_connect(destination / "state_5.sqlite") as db:
+        assert db.execute("SELECT count(*) FROM threads WHERE id=?", (SID,)).fetchone()[
+            0
+        ]
+    for relative in manifest["files"]:
+        assert (destination / relative).read_bytes() == (
+            staging / "files" / relative
+        ).read_bytes()
+    assert (destination / ".aichat-transfer.lock").is_dir()

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -436,3 +436,58 @@ def test_default_report_displays_missing_source_artifacts(
     missing = workspace["home"] / "plans/missing-fixture-plan.md"
     assert f"Missing at source (not copied): {missing}" in result.output
     assert not workspace["destination"].exists()
+
+
+@pytest.mark.parametrize("apply", [False, True])
+def test_codex_missing_artifact_in_normal_report(
+    workspace: dict[str, Path], tmp_path: Path, apply: bool
+) -> None:
+    """Codex string-shaped source gaps render on both inspection and copy."""
+    import sqlite3
+
+    from tests.test_transfer_codex import profile, thread
+
+    home = tmp_path / "codex"
+    destination = tmp_path / "codex-destination"
+    profile(home)
+    profile(destination)
+    thread(home, SID)
+    missing = home / "attachments/missing.txt"
+    rollout = home / "sessions/2026" / f"{SID}.jsonl"
+    with rollout.open("a") as stream:
+        stream.write(
+            json.dumps(
+                {
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "content": [{"type": "input_text", "text": str(missing)}],
+                    },
+                }
+            )
+            + "\n"
+        )
+    with sqlite3.connect(home / "state_5.sqlite") as db:
+        db.execute("UPDATE threads SET cwd=?", (str(workspace["source"]),))
+    args = [
+        "transfer",
+        SID,
+        "--agent",
+        "codex",
+        "--source-home",
+        str(home),
+        "--to",
+        "local",
+        "--destination-home",
+        str(destination),
+        "--destination-project",
+        str(workspace["target"]),
+        "--map",
+        "/old/project",
+        str(workspace["target"]),
+    ]
+    if apply:
+        args.append("--apply")
+    result = CliRunner().invoke(main, args)
+    assert result.exit_code == 0, result.output
+    assert f"Missing at source (not copied): {missing}" in result.output

--- a/tests/test_transfer_session.py
+++ b/tests/test_transfer_session.py
@@ -228,3 +228,52 @@ def test_command_is_registered() -> None:
     result = CliRunner().invoke(main, ["transfer", "--help"])
     assert result.exit_code == 0
     assert "--destination-project" in result.output
+
+
+def test_archived_codex_session_resolves(
+    workspace: dict[str, Path], tmp_path: Path
+) -> None:
+    """Archived SQLite-indexed threads remain eligible for public transfer."""
+    import sqlite3
+
+    from tests.test_transfer_codex import profile, thread
+
+    home = tmp_path / "codex"
+    destination = tmp_path / "codex-destination"
+    profile(home)
+    profile(destination)
+    thread(home, SID)
+    original = home / "sessions" / "2026" / f"{SID}.jsonl"
+    archived = home / "archived_sessions" / original.name
+    archived.parent.mkdir()
+    original.rename(archived)
+    with sqlite3.connect(home / "state_5.sqlite") as db:
+        db.execute(
+            "UPDATE threads SET cwd=?,rollout_path=?,sandbox_policy=?,archived=1",
+            (
+                str(workspace["source"]),
+                str(archived),
+                json.dumps({"type": "workspace-write", "writable_roots": []}),
+            ),
+        )
+    args = [
+        "transfer",
+        SID,
+        "--agent",
+        "codex",
+        "--source-home",
+        str(home),
+        "--to",
+        "local",
+        "--destination-home",
+        str(destination),
+        "--destination-project",
+        str(workspace["target"]),
+        "--dry-run",
+        "--json",
+    ]
+    result = CliRunner().invoke(main, args)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["plan"]["files"] == [
+        f"archived_sessions/{SID}.jsonl"
+    ]


### PR DESCRIPTION
`aichat transfer` copies saved Claude and Codex sessions between local and SSH account homes without moving the source or copying credentials. It defaults to a dry-run plan; `--apply` performs the copy, `--from` supports pulling a remote session, and explicit path pairs support different project locations.

The copy includes supported conversation state, native goals, selected database/index records, memory, and supporting artifacts. A persistent path guide carries historical scratch/attachment references through subsequent copies. Differing destination state is refused. Atomic file publication, private backups, a journal, and identical-plan recovery preserve partial work after interruption. Environment checks report tool/interpreter and plugin configuration gaps without overwriting account settings.

Validation: 191 transfer tests passed, including the native Codex test. Ruff and the 48-page Starlight build passed. Additional validation includes a killed-process recovery test, a real Codex semantic local→SSH→local round trip, and Claude native source creation/outbound context recall plus structural return checks for goal, memory, tool results, and scratch references. Claude's return semantic request received an API refusal; that check is explicitly not claimed as passing. Starlight documentation and its build are updated.

Boundaries: prepared matching Git worktrees are required for every operational working directory; active-process detection is best effort, so users must exit the copies before transfer. Diverged conversations are not automatically merged. Hook preflight does not execute arbitrary hooks, and a Chrome port probe does not prove authentication. Unknown Codex schemas/unsupported artifacts fail explicitly. No merge, release, or global development installation is included.


Final independent review passed for `3667358`. All findings from earlier GitHub reviews are fixed and resolved; no deferred findings. Fresh GitHub review of this head is requested. Isolated Codex plugin discovery can be incomplete without account auth; the report labels this unverified and provides the native command for checking the original account.


External temporary files require session ownership or explicit narrow `--map` opt-in; exclusions appear in the plan. Existing shared Codex import JSON requiring additional records is refused with separate-account guidance, since native writers provide no safe concurrent merge. Identical metadata is left untouched; new JSON is published without clobbering.
