### PR TITLE
fix: support diagnostic waits on macOS Python without os.waitid

### DIFF
--- a/claude_code_tools/codex_server_process.py
+++ b/claude_code_tools/codex_server_process.py
@@ -33,6 +33,9 @@ from claude_code_tools.codex_server_models import (
 )
 
 
+from claude_code_tools.codex_server_wait import child_exited_without_reaping
+
+
 DIAGNOSTIC_OUTPUT_MAX_BYTES = 64 * 1024
 _LINUX_BOOT_ID = "/proc/sys/kernel/random/boot_id"
 _PROC_PIDTBSDINFO = 3
@@ -203,16 +206,15 @@ def _wait_process_exit_without_reaping(
     deadline: float,
 ) -> bool:
     """Observe child exit while preserving its PID through group cleanup."""
-    wait_flags = os.WEXITED | os.WNOHANG | os.WNOWAIT
     while True:
         try:
-            result = os.waitid(os.P_PID, process.pid, wait_flags)
+            exited = child_exited_without_reaping(process.pid)
         except ChildProcessError:
             process.poll()
             return False
         except InterruptedError:
             continue
-        if result is not None:
+        if exited:
             return True
         remaining = deadline - time.monotonic()
         if remaining <= 0:

--- a/claude_code_tools/codex_server_wait.py
+++ b/claude_code_tools/codex_server_wait.py
@@ -1,0 +1,59 @@
+"""Non-reaping child-exit observation across supported POSIX platforms."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+
+
+class _DarwinSiginfo(ctypes.Structure):
+    """Darwin siginfo_t from sys/signal.h (including reserved ABI fields)."""
+
+    _fields_ = [
+        ("si_signo", ctypes.c_int),
+        ("si_errno", ctypes.c_int),
+        ("si_code", ctypes.c_int),
+        ("si_pid", ctypes.c_int),
+        ("si_uid", ctypes.c_uint),
+        ("si_status", ctypes.c_int),
+        ("si_addr", ctypes.c_void_p),
+        ("si_value", ctypes.c_void_p),
+        ("si_band", ctypes.c_long),
+        ("padding", ctypes.c_ulong * 7),
+    ]
+
+
+def child_exited_without_reaping(pid: int) -> bool:
+    """Observe an exited child while keeping its PID reserved for cleanup.
+
+    Args:
+        pid: PID of a direct child that this caller has not reaped.
+
+    Returns:
+        Whether the child has exited. A running child returns False.
+
+    Raises:
+        OSError: The OS cannot observe this child, including ECHILD or EINTR.
+        NotImplementedError: No supported non-reaping API is available.
+    """
+    flags = os.WEXITED | os.WNOHANG | os.WNOWAIT
+    waitid = getattr(os, "waitid", None)
+    if waitid is not None:
+        return waitid(os.P_PID, pid, flags) is not None
+    if sys.platform != "darwin":
+        raise NotImplementedError("non-reaping child observation needs waitid")
+
+    # Some macOS Python builds omit os.waitid although libSystem provides it.
+    # P_PID is 1 in Darwin's sys/wait.h; Python may omit that constant too.
+    library = ctypes.CDLL(None, use_errno=True)
+    native_waitid = library.waitid
+    native_waitid.argtypes = [
+        ctypes.c_int, ctypes.c_uint, ctypes.POINTER(_DarwinSiginfo), ctypes.c_int
+    ]
+    native_waitid.restype = ctypes.c_int
+    info = _DarwinSiginfo()
+    if native_waitid(1, pid, ctypes.byref(info), flags) == -1:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+    return info.si_pid == pid

--- a/tests/test_codex_server_darwin_wait.py
+++ b/tests/test_codex_server_darwin_wait.py
@@ -1,0 +1,63 @@
+"""Real process regressions for Python builds without os.waitid on macOS."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+from claude_code_tools.codex_server_process import run_diagnostic
+from claude_code_tools.codex_server_wait import child_exited_without_reaping
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="Darwin ABI")
+
+
+@pytest.fixture(autouse=True)
+def missing_python_waitid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the actual native API used by affected Python builds."""
+    monkeypatch.delattr(os, "waitid", raising=False)
+    monkeypatch.delattr(os, "P_PID", raising=False)
+
+
+def test_native_observation_preserves_exit_status() -> None:
+    """Observe running/finished children without consuming their wait status."""
+    with subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.stdin.read(); sys.exit(7)"],
+        stdin=subprocess.PIPE,
+    ) as process:
+        assert not child_exited_without_reaping(process.pid)
+        assert process.stdin is not None
+        process.stdin.close()
+        deadline = time.monotonic() + 5
+        while not child_exited_without_reaping(process.pid):
+            assert time.monotonic() < deadline
+            time.sleep(0.01)
+        assert child_exited_without_reaping(process.pid)
+        assert process.wait(timeout=2) == 7
+        with pytest.raises(ChildProcessError):
+            child_exited_without_reaping(process.pid)
+
+
+def test_diagnostic_without_python_waitid() -> None:
+    """A version-like diagnostic succeeds and preserves stdout and status."""
+    result = run_diagnostic(
+        [sys.executable, "-c", "print('codex-cli 0.153.4')"], os.environ
+    )
+    assert result is not None
+    assert result.returncode == 0
+    assert result.stdout.strip() == "codex-cli 0.153.4"
+
+
+def test_closed_pipes_do_not_hide_running_process() -> None:
+    """A child closing its pipes must still time out and be cleaned up."""
+    started = time.monotonic()
+    result = run_diagnostic(
+        [sys.executable, "-c", "import os,time; os.close(1); os.close(2); time.sleep(30)"],
+        os.environ,
+        timeout=0.2,
+    )
+    assert result is None
+    assert time.monotonic() - started < 5

--- a/uv.lock
+++ b/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.26.5"
+version = "1.26.4"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },

--- a/uv.lock
+++ b/uv.lock
@@ -450,7 +450,7 @@ wheels = [
 
 [[package]]
 name = "claude-code-tools"
-version = "1.26.4"
+version = "1.26.5"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
macOS Python builds that omit `os.waitid` crash while collecting diagnostic
commands such as `codex --version`, preventing server startup. Use Darwin's native
`waitid` through ctypes when the Python binding is unavailable, preserving the
child's unreaped PID until process-group cleanup finishes.

Validation:

- Diagnostic, hardening, and review regression tests: 48 passed, 2 skipped.
- Three real-process Darwin fallback tests pass, including exit-status retention
  and cleanup after a child closes its output pipes but keeps running.
- Native fallback verified on Moby's Python 3.12.14, which lacks `os.waitid`.
- Ruff passes for both new files; independent cold review reports no findings.
